### PR TITLE
 fix autoscroll issue on first response

### DIFF
--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -134,11 +134,9 @@ export const LightspeedChat = ({
 
   // Auto-scrolls to the latest message
   React.useEffect(() => {
-    if (messages.length > 2) {
-      setTimeout(() => {
-        scrollToBottomRef.current?.scrollIntoView({ behavior: 'auto' });
-      }, 10);
-    }
+    setTimeout(() => {
+      scrollToBottomRef.current?.scrollIntoView({ behavior: 'auto' });
+    }, 10);
     // eslint-disable-next-line
   }, [messages, scrollToBottomRef.current]);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The very first AI response is not auto-scrolled due to a check, removed that check in this PR.



![auto-scroll](https://github.com/user-attachments/assets/60ca4f4e-9198-4f5f-be51-9f1ae8aa04ac)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->



- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
