### PR TITLE
fix(orchestrator): pass also initial form data to custom decorator

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -20,7 +20,7 @@ export type FormDecoratorProps = Pick<FormProps<JsonObject, JSONSchema7>, 'formD
 
 // @public
 export interface OrchestratorFormApi {
-    getFormDecorator(schema: JSONSchema7, uiSchema: UiSchema<JsonObject, JSONSchema7>): OrchestratorFormDecorator;
+    getFormDecorator(schema: JSONSchema7, uiSchema: UiSchema<JsonObject, JSONSchema7>, initialFormData?: JsonObject): OrchestratorFormDecorator;
 }
 
 // @public

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
@@ -74,6 +74,7 @@ export interface OrchestratorFormApi {
   getFormDecorator(
     schema: JSONSchema7,
     uiSchema: UiSchema<JsonObject, JSONSchema7>,
+    initialFormData?: JsonObject,
   ): OrchestratorFormDecorator;
 }
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -150,16 +150,19 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
 const OrchestratorFormWrapper = ({
   schema,
   uiSchema,
+  formData,
   ...props
 }: OrchestratorFormWrapperProps) => {
   const formApi =
     useApiHolder().get(orchestratorFormApiRef) || defaultFormExtensionsApi;
   const NewComponent = React.useMemo(() => {
-    const formDecorator = formApi.getFormDecorator(schema, uiSchema);
+    const formDecorator = formApi.getFormDecorator(schema, uiSchema, formData);
     return formDecorator(FormComponent);
-  }, [schema, formApi, uiSchema]);
+  }, [schema, formApi, uiSchema, formData]);
   return (
-    <WrapperFormPropsContext.Provider value={{ schema, uiSchema, ...props }}>
+    <WrapperFormPropsContext.Provider
+      value={{ schema, uiSchema, formData, ...props }}
+    >
       <NewComponent />
     </WrapperFormPropsContext.Provider>
   );


### PR DESCRIPTION
backport https://github.com/janus-idp/backstage-plugins/pull/2561

The plugin containing the custom form decorator needs the initial form data to initialize the custom widgets correctly.
This change will enable resolving https://issues.redhat.com/browse/FLPATH-1878
