### PR TITLE
fix(orchestrator): remove average duration from workflow table and overview page

### DIFF
--- a/workspaces/orchestrator/.changeset/great-students-melt.md
+++ b/workspaces/orchestrator/.changeset/great-students-melt.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+remove average duration from workflow table and overview page

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionDetailsCard.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowDefinitionViewerPage/WorkflowDefinitionDetailsCard.tsx
@@ -60,10 +60,7 @@ const WorkflowDefinitionDetailsCard = ({
         label: 'type',
         value: formattedWorkflowOverview?.category,
       },
-      {
-        label: 'average duration',
-        value: formattedWorkflowOverview?.avgDuration,
-      },
+
       {
         label: 'last run',
         value: formattedWorkflowOverview?.lastTriggered,

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowsTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowsTable.tsx
@@ -135,7 +135,6 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
             VALUE_UNAVAILABLE
           ),
       },
-      { title: 'Avg. duration', field: 'avgDuration' },
       { title: 'Description', field: 'description', minWidth: '25vw' },
     ],
     [definitionLink],

--- a/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
@@ -32,7 +32,6 @@ describe('WorkflowOverviewAdapter', () => {
       lastTriggeredMs: 1697276096000,
       lastRunStatus: ProcessInstanceStatusDTO.Completed,
       category: WorkflowCategoryDTO.Infrastructure,
-      avgDurationMs: 150000,
       description: 'Sample description',
       format: 'yaml',
     };
@@ -47,7 +46,6 @@ describe('WorkflowOverviewAdapter', () => {
     );
     expect(adaptedData.lastRunStatus).toBe(mockWorkflowOverview.lastRunStatus);
     expect(adaptedData.category).toBe(mockWorkflowOverview.category);
-    expect(adaptedData.avgDuration).toBe('3 minutes');
     expect(adaptedData.description).toBe(mockWorkflowOverview.description);
     expect(adaptedData.format).toBe('yaml'); // Adjust based on your expected value
   });
@@ -66,7 +64,6 @@ describe('WorkflowOverviewAdapter', () => {
     expect(adaptedData.lastTriggered).toBe('---');
     expect(adaptedData.lastRunStatus).toBe('---');
     expect(adaptedData.category).toBe('---');
-    expect(adaptedData.avgDuration).toBe('---');
     expect(adaptedData.description).toBe('---');
     expect(adaptedData.format).toBe('yaml');
   });

--- a/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
@@ -30,13 +30,9 @@ export interface FormattedWorkflowOverview {
   readonly lastRunStatus: string;
   readonly lastRunId: string;
   readonly category: string;
-  readonly avgDuration: string;
   readonly description: string;
   readonly format: WorkflowFormatDTO;
 }
-
-const formatDuration = (milliseconds: number): string =>
-  moment.duration(milliseconds).humanize();
 
 const WorkflowOverviewFormatter: DataFormatter<
   WorkflowOverviewDTO,
@@ -52,9 +48,6 @@ const WorkflowOverviewFormatter: DataFormatter<
       lastRunStatus: data.lastRunStatus?.toString() ?? VALUE_UNAVAILABLE,
       lastRunId: data.lastRunId ?? VALUE_UNAVAILABLE,
       category: data.category ?? VALUE_UNAVAILABLE,
-      avgDuration: data.avgDurationMs
-        ? formatDuration(data.avgDurationMs)
-        : VALUE_UNAVAILABLE,
       description: data.description ?? VALUE_UNAVAILABLE,
       format: data.format,
     };


### PR DESCRIPTION
Due to performance limitations, backend API cannot return the average duration.
This is a follow up on https://github.com/redhat-developer/rhdh-plugins/pull/84/files