### PR TITLE
fix(theme): add sideeffect configuration to load Red Hat font from the plugin

### DIFF
--- a/workspaces/theme/.changeset/fuzzy-singers-move.md
+++ b/workspaces/theme/.changeset/fuzzy-singers-move.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+add sideeffect configuration to load Red Hat font from the plugin

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -17,7 +17,9 @@
   "backstage": {
     "role": "web-library"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./fons/*.css"
+  ],
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Without this change:

![Screenshot From 2024-12-04 08-54-09](https://github.com/user-attachments/assets/67c183d8-b79f-4502-8cbb-9dd7daa9ec79)

With this change:

![Screenshot From 2024-12-04 08-55-02](https://github.com/user-attachments/assets/8424ee84-ef5e-411e-b70c-51a284a52fa6)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
