### PR TITLE
feat(theme): apply theme changes from RHDH 1.3

### DIFF
--- a/workspaces/theme/.changeset/wild-candles-approve.md
+++ b/workspaces/theme/.changeset/wild-candles-approve.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': minor
+---
+
+Align the 0.3.x theme with the 1.3.x RHDH theme. It's based on @redhat-developer/red-hat-developer-hub-theme@0.3.0 and the sourcecode is migrated from https://github.com/redhat-developer/red-hat-developer-hub-theme/tree/1cd29db2abb807f94a2edb09688157b316bf6ff8/src/themes/rhdh and aligned with linter and prettier rules in rhdh-plugins.

--- a/workspaces/theme/plugins/theme/src/darkTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.test.ts
@@ -98,7 +98,7 @@ describe('customDarkTheme', () => {
           formControlBackgroundColor: '#36373A',
           mainSectionBackgroundColor: '#0f1214',
           headerBottomBorderColor: '#A3A3A3',
-          cardBackgroundColor: '#292929',
+          cardBackgroundColor: '#1b1d21',
           sideBarBackgroundColor: '#1b1d21',
           cardBorderColor: '#A3A3A3',
           tableTitleColor: '#E0E0E0',

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -47,7 +47,7 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         formControlBackgroundColor: '#36373A',
         mainSectionBackgroundColor: '#0f1214',
         headerBottomBorderColor: '#A3A3A3',
-        cardBackgroundColor: '#292929',
+        cardBackgroundColor: '#1b1d21',
         sideBarBackgroundColor: '#1b1d21',
         cardBorderColor: '#A3A3A3',
         tableTitleColor: '#E0E0E0',

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.ts
@@ -37,6 +37,12 @@ export const useThemeConfig = (themeName: string): ThemeConfig => {
     if (!themeConfig.mode) {
       themeConfig.mode = themeName.includes('dark') ? 'dark' : 'light';
     }
+
+    if (Array.isArray(themeConfig?.pageTheme?.default.fontColor)) {
+      themeConfig.pageTheme.default.fontColor =
+        themeConfig.pageTheme.default.fontColor[0];
+    }
+
     return themeConfig;
   }, [themeName, configApi]);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Apply the 1.3.x RHDH theme changes from @redhat-developer/red-hat-developer-hub-theme@0.3.0.

This will also release also a 0.3.0 version. :)

https://github.com/user-attachments/assets/49314442-460d-4d5b-bcd9-84be879097c9

It shows some theming issues we also have in our main branch, which we didn't had earlier.

These issues are likely related to a Backstage or MUI update?

This PR restores just the old release. I will fix that issue asap after I also applied the current RHDH 1.4 / theme 0.4.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
