### PR TITLE
fix(theme): fix/remove different paper background colors/shades in MUI v5

### DIFF
--- a/workspaces/theme/.changeset/rare-pears-tap.md
+++ b/workspaces/theme/.changeset/rare-pears-tap.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+fix/remove different paper background colors/shades in MUI v5

--- a/workspaces/theme/plugins/theme/report.api.md
+++ b/workspaces/theme/plugins/theme/report.api.md
@@ -42,16 +42,18 @@ export interface RHDHThemePalette {
   };
   // (undocumented)
   general: {
-    disabledBackground: string;
     disabled: string;
-    formControlBackgroundColor: string;
-    mainSectionBackgroundColor: string;
-    headerBottomBorderColor: string;
+    disabledBackground: string;
+    paperBackgroundImage: string;
+    paperBorderColor: string;
     cardBackgroundColor: string;
+    cardBorderColor: string;
+    headerBottomBorderColor: string;
+    mainSectionBackgroundColor: string;
+    formControlBackgroundColor: string;
     sideBarBackgroundColor?: string;
     sidebarBackgroundColor: string;
     sidebarItemSelectedBackgroundColor: string;
-    cardBorderColor: string;
     tableTitleColor: string;
     tableSubtitleColor: string;
     tableColumnTitleColor: string;

--- a/workspaces/theme/plugins/theme/src/darkTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.test.ts
@@ -20,7 +20,7 @@ describe('customDarkTheme', () => {
     expect(customDarkTheme()).toEqual({
       background: {
         default: '#333333',
-        paper: '#424242',
+        paper: '#1b1d21',
       },
       banner: {
         closeButtonColor: '#FFFFFF',
@@ -92,15 +92,22 @@ describe('customDarkTheme', () => {
 
       rhdh: {
         general: {
-          disabledBackground: '#444548',
           disabled: '#AAABAC',
-          formControlBackgroundColor: '#36373A',
-          mainSectionBackgroundColor: '#0f1214',
-          headerBottomBorderColor: '#A3A3A3',
+          disabledBackground: '#444548',
+
+          paperBackgroundImage: 'none',
+          paperBorderColor: '#A3A3A3',
+
           cardBackgroundColor: '#1b1d21',
+          cardBorderColor: '#A3A3A3',
+
+          headerBottomBorderColor: '#A3A3A3',
+          mainSectionBackgroundColor: '#0f1214',
+          formControlBackgroundColor: '#36373A',
+
           sidebarBackgroundColor: '#1b1d21',
           sidebarItemSelectedBackgroundColor: '#4F5255',
-          cardBorderColor: '#A3A3A3',
+
           tableTitleColor: '#E0E0E0',
           tableSubtitleColor: '#E0E0E0',
           tableColumnTitleColor: '#E0E0E0',
@@ -108,6 +115,7 @@ describe('customDarkTheme', () => {
           tableBorderColor: '#515151',
           tableBackgroundColor: '#1b1d21',
           tabsBottomBorderColor: '#444548',
+
           contrastText: '#FFF',
         },
         primary: {

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -40,17 +40,28 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         background: '#0f1214',
       },
     },
+    background: {
+      default: '#333333',
+      paper: '#1b1d21',
+    },
     rhdh: {
       general: {
-        disabledBackground: '#444548',
         disabled: '#AAABAC',
-        formControlBackgroundColor: '#36373A',
-        mainSectionBackgroundColor: '#0f1214',
-        headerBottomBorderColor: '#A3A3A3',
+        disabledBackground: '#444548',
+
+        paperBackgroundImage: 'none',
+        paperBorderColor: '#A3A3A3',
+
         cardBackgroundColor: '#1b1d21',
+        cardBorderColor: '#A3A3A3',
+
+        headerBottomBorderColor: '#A3A3A3',
+        mainSectionBackgroundColor: '#0f1214',
+        formControlBackgroundColor: '#36373A',
+
         sidebarBackgroundColor: '#1b1d21',
         sidebarItemSelectedBackgroundColor: '#4F5255',
-        cardBorderColor: '#A3A3A3',
+
         tableTitleColor: '#E0E0E0',
         tableSubtitleColor: '#E0E0E0',
         tableColumnTitleColor: '#E0E0E0',
@@ -58,6 +69,7 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         tableBorderColor: '#515151',
         tableBackgroundColor: '#1b1d21',
         tabsBottomBorderColor: '#444548',
+
         contrastText: '#FFF',
       },
       primary: {

--- a/workspaces/theme/plugins/theme/src/lightTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.test.ts
@@ -96,15 +96,22 @@ describe('customLightTheme', () => {
       },
       rhdh: {
         general: {
-          disabledBackground: '#D2D2D2',
           disabled: '#6A6E73',
-          formControlBackgroundColor: '#FFF',
-          mainSectionBackgroundColor: '#FFF',
-          headerBottomBorderColor: '#C7C7C7',
+          disabledBackground: '#D2D2D2',
+
+          paperBackgroundImage: 'none',
+          paperBorderColor: '#C7C7C7',
+
           cardBackgroundColor: '#FFF',
+          cardBorderColor: '#C7C7C7',
+
+          headerBottomBorderColor: '#C7C7C7',
+          mainSectionBackgroundColor: '#FFF',
+          formControlBackgroundColor: '#FFF',
+
           sidebarBackgroundColor: '#212427',
           sidebarItemSelectedBackgroundColor: '#4F5255',
-          cardBorderColor: '#C7C7C7',
+
           tableTitleColor: '#181818',
           tableSubtitleColor: '#616161',
           tableColumnTitleColor: '#151515',
@@ -112,6 +119,7 @@ describe('customLightTheme', () => {
           tableBorderColor: '#E0E0E0',
           tableBackgroundColor: '#FFF',
           tabsBottomBorderColor: '#D2D2D2',
+
           contrastText: '#FFF',
         },
         primary: {

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -44,17 +44,28 @@ export const customLightTheme = (): ThemeConfigPalette => {
       primary: '#151515',
       secondary: '#757575',
     },
+    background: {
+      default: '#F8F8F8',
+      paper: '#FFFFFF',
+    },
     rhdh: {
       general: {
-        disabledBackground: '#D2D2D2',
         disabled: '#6A6E73',
-        formControlBackgroundColor: '#FFF',
-        mainSectionBackgroundColor: '#FFF',
-        headerBottomBorderColor: '#C7C7C7',
+        disabledBackground: '#D2D2D2',
+
+        paperBackgroundImage: 'none',
+        paperBorderColor: '#C7C7C7',
+
         cardBackgroundColor: '#FFF',
+        cardBorderColor: '#C7C7C7',
+
+        headerBottomBorderColor: '#C7C7C7',
+        mainSectionBackgroundColor: '#FFF',
+        formControlBackgroundColor: '#FFF',
+
         sidebarBackgroundColor: '#212427',
         sidebarItemSelectedBackgroundColor: '#4F5255',
-        cardBorderColor: '#C7C7C7',
+
         tableTitleColor: '#181818',
         tableSubtitleColor: '#616161',
         tableColumnTitleColor: '#151515',
@@ -62,6 +73,7 @@ export const customLightTheme = (): ThemeConfigPalette => {
         tableBorderColor: '#E0E0E0',
         tableBackgroundColor: '#FFF',
         tabsBottomBorderColor: '#D2D2D2',
+
         contrastText: '#FFF',
       },
       primary: {

--- a/workspaces/theme/plugins/theme/src/types.ts
+++ b/workspaces/theme/plugins/theme/src/types.ts
@@ -19,17 +19,24 @@ export type BackstageThemePalette = UnifiedThemeOptions['palette'];
 
 export interface RHDHThemePalette {
   general: {
-    disabledBackground: string;
     disabled: string;
-    formControlBackgroundColor: string;
-    mainSectionBackgroundColor: string;
-    headerBottomBorderColor: string;
+    disabledBackground: string;
+
+    paperBackgroundImage: string;
+    paperBorderColor: string;
+
     cardBackgroundColor: string;
+    cardBorderColor: string;
+
+    headerBottomBorderColor: string;
+    mainSectionBackgroundColor: string;
+    formControlBackgroundColor: string;
+
     /** @deprecated please use `sidebarBackgroundColor` instead */
     sideBarBackgroundColor?: string;
     sidebarBackgroundColor: string;
     sidebarItemSelectedBackgroundColor: string;
-    cardBorderColor: string;
+
     tableTitleColor: string;
     tableSubtitleColor: string;
     tableColumnTitleColor: string;
@@ -37,6 +44,7 @@ export interface RHDHThemePalette {
     tableBorderColor: string;
     tableBackgroundColor: string;
     tabsBottomBorderColor: string;
+
     contrastText: string;
   };
 

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -83,17 +83,6 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
             height: 0,
           },
         },
-        elevation0: {
-          '& div[class*="Mui-disabled"]': {
-            backgroundColor: 'unset',
-          },
-          '& span[class*="Mui-disabled"]': {
-            backgroundColor: 'unset',
-          },
-          '& input[class*="Mui-disabled"]': {
-            backgroundColor: 'unset',
-          },
-        },
         elevation1: {
           boxShadow: 'none',
           outline: `1px solid ${general.paperBorderColor}`,

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -77,7 +77,7 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         root: {
           boxShadow: 'none',
-          backgroundColor: general.cardBackgroundColor,
+          backgroundImage: general.paperBackgroundImage,
           // hide the first child element which is a divider with MuiDivider-root classname in MuiPaper
           '& > hr:first-child[class|="MuiDivider-root"]': {
             height: 0,
@@ -96,17 +96,14 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
         },
         elevation1: {
           boxShadow: 'none',
-          borderRadius: '0',
-          outline: `1px solid ${general.cardBorderColor}`,
+          outline: `1px solid ${general.paperBorderColor}`,
           '& > hr[class|="MuiDivider-root"]': {
-            backgroundColor: general.cardBorderColor,
+            backgroundColor: general.paperBorderColor,
           },
         },
         elevation2: {
-          backgroundColor: general.tableBackgroundColor,
           boxShadow: 'none',
-          outline: `1px solid ${general.cardBorderColor}`,
-          padding: '1rem',
+          outline: `1px solid ${general.paperBorderColor}`,
         },
       },
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changes:

1. Removes the extra padding from Paper elevation=2
2. Introduce a new `paperBorderColor` option with the same default color as `cardBorderColor` that is still used for Paper elevation=1 or elevation=2.
3. Introduce a new `paperBackgroundImage` which is `none` by default because the gradient image of a paper overrides the `backgroundColor`. This removes the different grayscale of MUI v5 Papers and align it with MUI v4.
4. The 2nd commit removed a workaround that hides an issue with `Mui-Disabled` after #122 was merged.

### MUI v4

#### Light before

![image](https://github.com/user-attachments/assets/8214c10b-17ed-4502-b286-477a5907304e)

#### Light with this PR

![image](https://github.com/user-attachments/assets/316a3545-8dc1-4e04-9566-b40bc965876c)

#### Dark before

![image](https://github.com/user-attachments/assets/4cad3747-c783-4049-99b0-52a3f47a5b40)

#### Dark with this PR

![image](https://github.com/user-attachments/assets/7229643b-847b-43bb-8f89-925e0e65ea31)

### MUI v5

#### Light before

![image](https://github.com/user-attachments/assets/af70ad27-8705-44a4-aeeb-463d02eb949b)

#### Light with this PR

![image](https://github.com/user-attachments/assets/ba2b3dad-28bd-4e68-bc1d-d3d76e573f1a)

#### Dark before

![image](https://github.com/user-attachments/assets/664aec28-53a1-4512-b072-b936b0c158d0)

#### Dark with this PR

![image](https://github.com/user-attachments/assets/7231d31e-d70c-4539-8673-a539e2b59d52)


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
