### PR TITLE
fix(theme): align disabled tabs background color more with patternfly (5 for now)

### DIFF
--- a/workspaces/theme/.changeset/gold-scissors-trade.md
+++ b/workspaces/theme/.changeset/gold-scissors-trade.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+align disabled tabs background color more with patternfly (5 for now)

--- a/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
@@ -38,15 +38,28 @@ export const TabExamples = () => {
             indicatorColor="primary"
             textColor="primary"
             onChange={handleChange}
-            aria-label="disabled tabs example"
           >
-            <Tab label="One" />
+            <Tab label={`color: ${color}`} />
             <Tab label="Two" />
             <Tab label="Three" />
             <Tab label="Disabled" disabled />
           </Tabs>
         </div>
       ))}
+
+      <Tabs
+        orientation="vertical"
+        value={selectedTab}
+        indicatorColor="primary"
+        textColor="primary"
+        onChange={handleChange}
+        aria-label="disabled tabs example"
+      >
+        <Tab label="Vertical test" />
+        <Tab label="Two" />
+        <Tab label="Three" />
+        <Tab label="Disabled" disabled />
+      </Tabs>
     </div>
   );
 };

--- a/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
@@ -38,7 +38,6 @@ export const TabExamples = () => {
             indicatorColor="primary"
             textColor="primary"
             onChange={handleChange}
-            aria-label="disabled tabs example"
           >
             <Tab label="One" />
             <Tab label="Two" />
@@ -47,6 +46,20 @@ export const TabExamples = () => {
           </Tabs>
         </div>
       ))}
+
+      <Tabs
+        orientation="vertical"
+        value={selectedTab}
+        indicatorColor="primary"
+        textColor="primary"
+        onChange={handleChange}
+        aria-label="disabled tabs example"
+      >
+        <Tab label="Vertical test" />
+        <Tab label="Two" />
+        <Tab label="Three" />
+        <Tab label="Disabled" disabled />
+      </Tabs>
     </div>
   );
 };

--- a/workspaces/theme/plugins/theme/report.api.md
+++ b/workspaces/theme/plugins/theme/report.api.md
@@ -58,6 +58,7 @@ export interface RHDHThemePalette {
     tableRowHover: string;
     tableBorderColor: string;
     tableBackgroundColor: string;
+    tabsDisabledBackgroundColor: string;
     tabsBottomBorderColor: string;
     contrastText: string;
   };

--- a/workspaces/theme/plugins/theme/src/darkTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.test.ts
@@ -107,6 +107,7 @@ describe('customDarkTheme', () => {
           tableRowHover: '#0f1214',
           tableBorderColor: '#515151',
           tableBackgroundColor: '#1b1d21',
+          tabsDisabledBackgroundColor: '#444548',
           tabsBottomBorderColor: '#444548',
           contrastText: '#FFF',
         },

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -57,6 +57,7 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         tableRowHover: '#0f1214',
         tableBorderColor: '#515151',
         tableBackgroundColor: '#1b1d21',
+        tabsDisabledBackgroundColor: '#444548',
         tabsBottomBorderColor: '#444548',
         contrastText: '#FFF',
       },

--- a/workspaces/theme/plugins/theme/src/lightTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.test.ts
@@ -111,6 +111,7 @@ describe('customLightTheme', () => {
           tableRowHover: '#F5F5F5',
           tableBorderColor: '#E0E0E0',
           tableBackgroundColor: '#FFF',
+          tabsDisabledBackgroundColor: '#f5f5f5',
           tabsBottomBorderColor: '#D2D2D2',
           contrastText: '#FFF',
         },

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -61,6 +61,7 @@ export const customLightTheme = (): ThemeConfigPalette => {
         tableRowHover: '#F5F5F5',
         tableBorderColor: '#E0E0E0',
         tableBackgroundColor: '#FFF',
+        tabsDisabledBackgroundColor: '#f5f5f5',
         tabsBottomBorderColor: '#D2D2D2',
         contrastText: '#FFF',
       },

--- a/workspaces/theme/plugins/theme/src/types.ts
+++ b/workspaces/theme/plugins/theme/src/types.ts
@@ -36,6 +36,7 @@ export interface RHDHThemePalette {
     tableRowHover: string;
     tableBorderColor: string;
     tableBackgroundColor: string;
+    tabsDisabledBackgroundColor: string;
     tabsBottomBorderColor: string;
     contrastText: string;
   };

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -158,7 +158,6 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
         },
         outlined: {
           border: `1px solid color-mix(in srgb, currentColor 50%, transparent)`,
-          borderOpacity: 0.5,
           '&:hover': {
             backgroundColor: 'transparent',
             border: `1px solid`,
@@ -421,7 +420,7 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
       },
       styleOverrides: {
         root: {
-          boxShadow: `0 -1px ${general.tabsBottomBorderColor} inset`,
+          borderBottom: `1px solid ${general.tabsBottomBorderColor}`,
           padding: '0 1.5rem',
         },
         flexContainerVertical: {
@@ -440,7 +439,7 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           textTransform: 'none',
           minWidth: 'initial !important',
           '&:disabled': {
-            backgroundColor: general.disabledBackground,
+            backgroundColor: general.tabsDisabledBackgroundColor,
           },
         },
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Always before and with this PR:

MUI v4 Light theme

![image](https://github.com/user-attachments/assets/62b9567d-f26a-4ba4-ad45-8b3061960045)

![image](https://github.com/user-attachments/assets/46ddd613-3c33-4f21-b74a-53f4a44e3ec3)

MUI v4 Dark theme

![image](https://github.com/user-attachments/assets/3a9cb7fc-9b0e-4072-acd2-cbbe9397c87a)

![image](https://github.com/user-attachments/assets/f7a895cb-85ac-44ba-812f-8e56b5006292)

MUI v5 Light theme

![image](https://github.com/user-attachments/assets/f030c763-0754-45ac-abf6-296f8ffb6a36)

![image](https://github.com/user-attachments/assets/cc9446d9-f258-4ec6-820f-966f0bb86ac7)

MUI v4 Dark theme

![image](https://github.com/user-attachments/assets/17dc2efc-c7c7-459c-b29e-81f0b34639a7)

![image](https://github.com/user-attachments/assets/d2cdd005-bab8-4995-ac2d-728d6675ef4d)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
