### PR TITLE
chore(orchestrator): fix release action

### DIFF
--- a/workspaces/orchestrator/.changeset/cold-phones-raise.md
+++ b/workspaces/orchestrator/.changeset/cold-phones-raise.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-swf-editor-envelope': patch
+---
+
+make package public

--- a/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope/package.json
@@ -6,7 +6,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "private": true,
   "workspaces": {
     "nohoist": [
       "@kie-tools/**"


### PR DESCRIPTION
fix failing release action - https://github.com/redhat-developer/rhdh-plugins/actions/runs/12120055908/job/33787933673

failed since changeset in https://github.com/redhat-developer/rhdh-plugins/pull/95 included a private package @red-hat-developer-hub/backstage-plugin-orchestrator-swf-editor-envelope 
since this PR also included fixing the build, we can make the package public