### PR TITLE
fix(theme): remove bottom border and vertical padding from vertical tabs

### DIFF
--- a/workspaces/theme/.changeset/moody-camels-design.md
+++ b/workspaces/theme/.changeset/moody-camels-design.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+remove bottom border and vertical padding from vertical tabs

--- a/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
@@ -32,14 +32,15 @@ export const TabExamples = () => {
   return (
     <div>
       {colors.map(color => (
-        <div key={color} style={{ padding: '20px 0' }}>
+        <div key={color}>
+          <div style={{ padding: '20px 0' }}>color: {color ?? 'undefined'}</div>
           <Tabs
             value={selectedTab}
             indicatorColor="primary"
             textColor="primary"
             onChange={handleChange}
           >
-            <Tab label={`color: ${color}`} />
+            <Tab label="One" />
             <Tab label="Two" />
             <Tab label="Three" />
             <Tab label="Disabled" disabled />
@@ -47,6 +48,7 @@ export const TabExamples = () => {
         </div>
       ))}
 
+      <div style={{ padding: '20px 0' }}>Vertical test</div>
       <Tabs
         orientation="vertical"
         value={selectedTab}
@@ -55,7 +57,7 @@ export const TabExamples = () => {
         onChange={handleChange}
         aria-label="disabled tabs example"
       >
-        <Tab label="Vertical test" />
+        <Tab label="One" />
         <Tab label="Two" />
         <Tab label="Three" />
         <Tab label="Disabled" disabled />

--- a/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
@@ -32,7 +32,8 @@ export const TabExamples = () => {
   return (
     <div>
       {colors.map(color => (
-        <div key={color} style={{ padding: '20px 0' }}>
+        <div key={color}>
+          <div style={{ padding: '20px 0' }}>color: {color ?? 'undefined'}</div>
           <Tabs
             value={selectedTab}
             indicatorColor="primary"
@@ -47,6 +48,7 @@ export const TabExamples = () => {
         </div>
       ))}
 
+      <div style={{ padding: '20px 0' }}>Vertical test</div>
       <Tabs
         orientation="vertical"
         value={selectedTab}
@@ -55,7 +57,7 @@ export const TabExamples = () => {
         onChange={handleChange}
         aria-label="disabled tabs example"
       >
-        <Tab label="Vertical test" />
+        <Tab label="One" />
         <Tab label="Two" />
         <Tab label="Three" />
         <Tab label="Disabled" disabled />

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -423,6 +423,10 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           borderBottom: `1px solid ${general.tabsBottomBorderColor}`,
           padding: '0 1.5rem',
         },
+        vertical: {
+          borderBottom: `none`,
+          padding: 0,
+        },
         flexContainerVertical: {
           '& > button:hover': {
             boxShadow: `-3px 0 ${general.tabsBottomBorderColor} inset`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes the border below the vertical tests and the vertical padding (because both aren't there in the backstage theme)

**Main:**

![image](https://github.com/user-attachments/assets/614071e6-6538-4d7d-9baa-f7c88ae5a5f0)

![image](https://github.com/user-attachments/assets/4ea84c18-8d37-47f0-8587-4cb612ee970a)

**With this PR:**

![image](https://github.com/user-attachments/assets/7b67880a-3f27-4cea-b5c5-31b40d0511d3)

![image](https://github.com/user-attachments/assets/05ee6c5e-b30f-4805-b893-d27d5c15d18d)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
