### PR TITLE
fix(theme): match tabs style with PF design

### DIFF
--- a/workspaces/theme/.changeset/smooth-berries-cover.md
+++ b/workspaces/theme/.changeset/smooth-berries-cover.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Add hover style to tabs, move vertical tabs indicator to left to match PF style.

--- a/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
@@ -16,6 +16,8 @@
 import React from 'react';
 import Tabs, { TabsProps } from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 
 export const TabExamples = () => {
   const colors: TabsProps['indicatorColor'][] = [
@@ -49,19 +51,30 @@ export const TabExamples = () => {
       ))}
 
       <div style={{ padding: '20px 0' }}>Vertical test</div>
-      <Tabs
-        orientation="vertical"
-        value={selectedTab}
-        indicatorColor="primary"
-        textColor="primary"
-        onChange={handleChange}
-        aria-label="disabled tabs example"
-      >
-        <Tab label="One" />
-        <Tab label="Two" />
-        <Tab label="Three" />
-        <Tab label="Disabled" disabled />
-      </Tabs>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+        <Box sx={{ p: 2 }}>
+          <Tabs
+            orientation="vertical"
+            value={selectedTab}
+            indicatorColor="primary"
+            textColor="primary"
+            onChange={handleChange}
+            aria-label="disabled tabs example"
+          >
+            <Tab label="One" />
+            <Tab label="Two" />
+            <Tab label="Extra long label Three" />
+            <Tab label="Disabled" disabled />
+          </Tabs>
+        </Box>
+        <Box
+          sx={{ height: 200, width: '100%', border: '1px solid #ccc', m: 2 }}
+        >
+          <Typography variant="h6" style={{ padding: '20px' }}>{`selectedTab: ${
+            selectedTab + 1
+          }`}</Typography>
+        </Box>
+      </Box>
     </div>
   );
 };

--- a/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
@@ -16,6 +16,8 @@
 import React from 'react';
 import Tabs, { TabsProps } from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 
 export const TabExamples = () => {
   const colors: TabsProps['indicatorColor'][] = [
@@ -49,19 +51,30 @@ export const TabExamples = () => {
       ))}
 
       <div style={{ padding: '20px 0' }}>Vertical test</div>
-      <Tabs
-        orientation="vertical"
-        value={selectedTab}
-        indicatorColor="primary"
-        textColor="primary"
-        onChange={handleChange}
-        aria-label="disabled tabs example"
-      >
-        <Tab label="One" />
-        <Tab label="Two" />
-        <Tab label="Three" />
-        <Tab label="Disabled" disabled />
-      </Tabs>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+        <Box sx={{ p: 2 }}>
+          <Tabs
+            orientation="vertical"
+            value={selectedTab}
+            indicatorColor="primary"
+            textColor="primary"
+            onChange={handleChange}
+            aria-label="disabled tabs example"
+          >
+            <Tab label="One" />
+            <Tab label="Two" />
+            <Tab label="Extra long label Three" />
+            <Tab label="Disabled" disabled />
+          </Tabs>
+        </Box>
+        <Box
+          sx={{ height: 200, width: '100%', border: '1px solid #ccc', m: 2 }}
+        >
+          <Typography variant="h6" p={2}>{`selectedTab: ${
+            selectedTab + 1
+          }`}</Typography>
+        </Box>
+      </Box>
     </div>
   );
 };

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -424,13 +424,25 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           padding: '0 1.5rem',
         },
         vertical: {
+          '& > div > div > button[class*="v5"]': {
+            alignItems: 'baseline',
+            textAlign: 'left',
+          },
+          '& > div > div > button > span': {
+            alignItems: 'baseline',
+            textAlign: 'left',
+          },
           borderBottom: `none`,
+          borderLeft: `1px solid ${general.tabsBottomBorderColor}`,
           padding: 0,
         },
         flexContainerVertical: {
           '& > button:hover': {
-            boxShadow: `-3px 0 ${general.tabsBottomBorderColor} inset`,
+            boxShadow: `2px 0 ${general.tabsBottomBorderColor} inset`,
           },
+        },
+        indicator: {
+          left: 0,
         },
       },
     };
@@ -444,6 +456,9 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           minWidth: 'initial !important',
           '&:disabled': {
             backgroundColor: general.tabsDisabledBackgroundColor,
+          },
+          '&:hover': {
+            boxShadow: `0 -2px ${general.tabsBottomBorderColor} inset`,
           },
         },
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
For [RHIDP-5176](https://issues.redhat.com/browse/RHIDP-5176), 

- added hover border bottom for default tabs
- moved indicator to left for vertical tabs, referring PF vertical tabs style
- added a content box for better preview on vertical tabs tests

![image](https://github.com/user-attachments/assets/1a752daa-7583-4da2-b407-0072c71f54d5)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

Before
![image](https://github.com/user-attachments/assets/0687f442-0258-4651-9368-eeff46f77d56)

After

https://github.com/user-attachments/assets/a1a30b20-9413-411b-a755-3ad0332bf1c7

