### PR TITLE
fix(theme): add style-inject(ion) issue with the published package

### DIFF
--- a/workspaces/theme/.changeset/fresh-jeans-rest.md
+++ b/workspaces/theme/.changeset/fresh-jeans-rest.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+add workaround for `style-inject`(ion) issue with the published package

--- a/workspaces/theme/plugins/theme/fix-style-inject-imports.sh
+++ b/workspaces/theme/plugins/theme/fix-style-inject-imports.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright 2024 The Backstage Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+glob='*.css.esm.js'
+replace="import styleInject from '\.\.\/\.\.\/\.\.\/node_modules\/style-inject\/dist\/style-inject\.es\.esm\.js';"
+with="import styleInject from 'style-inject';"
+
+find dist -name "$glob" -exec sed -i "s/$replace/$with/" {} \;

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "start": "backstage-cli package start",
-    "build": "backstage-cli package build",
+    "build": "backstage-cli package build && ./fix-style-inject-imports.sh",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix a `style-inject`(ion) issue with the published package that I noticed in https://github.com/janus-idp/backstage-showcase/pull/2033

See build log: https://github.com/janus-idp/backstage-showcase/actions/runs/12196430482/job/34023993902?pr=2033

An update of `@backstage/cli` with PR https://github.com/backstage/backstage/pull/27547 should also fix this problem, but #141 failed on our CI.

So this adds a workaround similar to https://github.com/backstage/community-plugins/pull/1931.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
