### PR TITLE
fix(theme): add missing shadow to action menus/dropdowns that uses the Popover component

### DIFF
--- a/workspaces/theme/.changeset/fifty-hotels-joke.md
+++ b/workspaces/theme/.changeset/fifty-hotels-joke.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+add missing shadow to action menus/dropdowns that uses the Popover component

--- a/workspaces/theme/plugins/theme/report.api.md
+++ b/workspaces/theme/plugins/theme/report.api.md
@@ -46,6 +46,7 @@ export interface RHDHThemePalette {
     disabledBackground: string;
     paperBackgroundImage: string;
     paperBorderColor: string;
+    popoverBoxShadow: string;
     cardBackgroundColor: string;
     cardBorderColor: string;
     headerBottomBorderColor: string;

--- a/workspaces/theme/plugins/theme/src/darkTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.test.ts
@@ -98,6 +98,9 @@ describe('customDarkTheme', () => {
           paperBackgroundImage: 'none',
           paperBorderColor: '#A3A3A3',
 
+          popoverBoxShadow:
+            '0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.48), 0 0 0.25rem 0 rgba(3, 3, 3, 0.24)',
+
           cardBackgroundColor: '#1b1d21',
           cardBorderColor: '#A3A3A3',
 

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -52,6 +52,10 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         paperBackgroundImage: 'none',
         paperBorderColor: '#A3A3A3',
 
+        // Box shadow from PatternFly 5 (--pf-v5-global--BoxShadow--sm)
+        popoverBoxShadow:
+          '0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.48), 0 0 0.25rem 0 rgba(3, 3, 3, 0.24)',
+
         cardBackgroundColor: '#1b1d21',
         cardBorderColor: '#A3A3A3',
 

--- a/workspaces/theme/plugins/theme/src/lightTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.test.ts
@@ -102,6 +102,9 @@ describe('customLightTheme', () => {
           paperBackgroundImage: 'none',
           paperBorderColor: '#C7C7C7',
 
+          popoverBoxShadow:
+            '0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.12), 0 0 0.25rem 0 rgba(3, 3, 3, 0.06)',
+
           cardBackgroundColor: '#FFF',
           cardBorderColor: '#C7C7C7',
 

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -56,6 +56,10 @@ export const customLightTheme = (): ThemeConfigPalette => {
         paperBackgroundImage: 'none',
         paperBorderColor: '#C7C7C7',
 
+        // Box shadow from PatternFly 5 (--pf-v5-global--BoxShadow--sm)
+        popoverBoxShadow:
+          '0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.12), 0 0 0.25rem 0 rgba(3, 3, 3, 0.06)',
+
         cardBackgroundColor: '#FFF',
         cardBorderColor: '#C7C7C7',
 

--- a/workspaces/theme/plugins/theme/src/types.ts
+++ b/workspaces/theme/plugins/theme/src/types.ts
@@ -25,6 +25,8 @@ export interface RHDHThemePalette {
     paperBackgroundImage: string;
     paperBorderColor: string;
 
+    popoverBoxShadow: string;
+
     cardBackgroundColor: string;
     cardBorderColor: string;
 

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -102,6 +102,17 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
         elevation0: noElevationStyle,
       },
     };
+    components.MuiPopover = {
+      styleOverrides: {
+        paper: {
+          // Box shadow from PatternFly 5 (--pf-v5-global--BoxShadow--sm)
+          boxShadow: general.popoverBoxShadow,
+          // `Popover` has no outline by default, but since we're adding it to the `Paper`
+          // components, this ensures that the `Popover` doesn't has a shadow and an outline.
+          outline: 0,
+        },
+      },
+    };
 
     // Required for MUI v4, not MUI v5
     const elevations = Array.from(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With recent change #126 we changed all `Paper`s from a box shadow to an outline.

But in a Popover, the Paper component also applies `outline: 0` so that we no border was shown.

This fix adds a box shadow to popovers again because it is more aligned with the [PatternFly 5 Popover](https://v5-archive.patternfly.org/components/popover) than just a border.

**Before:**

Catalog entity action button:

![image](https://github.com/user-attachments/assets/87915495-2566-4e63-b234-75f89ca21833)

Settings page:

![image](https://github.com/user-attachments/assets/76910eef-e53f-4507-8617-2d8cdb7b5ed9)

**With this PR:**

Catalog entity action button:

![image](https://github.com/user-attachments/assets/a77fc772-d239-4b5a-8f94-7ca1d2836379)

Settings page:

![image](https://github.com/user-attachments/assets/87940e13-c594-4a37-b6ee-30fbec02dd16)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
