### PR TITLE
chore(orchestrator): resolve dependencies issue

### DIFF
--- a/workspaces/orchestrator/.changeset/empty-plants-dream.md
+++ b/workspaces/orchestrator/.changeset/empty-plants-dream.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+resolve dependency issues

--- a/workspaces/orchestrator/plugins/orchestrator-backend/__fixtures__/mockComposedGreetingWorfklow.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/__fixtures__/mockComposedGreetingWorfklow.ts
@@ -15,7 +15,7 @@
  */
 import type { JsonObject } from '@backstage/types';
 
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 
 import { WorkflowDefinition } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 

--- a/workspaces/orchestrator/plugins/orchestrator-backend/__fixtures__/mockGreetingWorkflowData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/__fixtures__/mockGreetingWorkflowData.ts
@@ -15,7 +15,7 @@
  */
 import type { JsonObject } from '@backstage/types';
 
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 
 import { WorkflowDefinition } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 

--- a/workspaces/orchestrator/plugins/orchestrator-backend/__fixtures__/mockSpringBootWorkflowData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/__fixtures__/mockSpringBootWorkflowData.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 
 import { WorkflowDefinition } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 

--- a/workspaces/orchestrator/plugins/orchestrator-backend/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/package.json
@@ -85,7 +85,6 @@
     "express-promise-router": "^4.1.1",
     "fs-extra": "^10.1.0",
     "isomorphic-git": "^1.23.0",
-    "json-schema": "^0.4.0",
     "moment": "^2.29.4",
     "openapi-backend": "^5.10.5",
     "yn": "^5.0.0"

--- a/workspaces/orchestrator/plugins/orchestrator-common/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-common/package.json
@@ -56,24 +56,18 @@
     "openapi:generate": "./scripts/openapi.sh generate",
     "openapi:check": "./scripts/openapi.sh check"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@backstage/plugin-permission-common": "^0.8.1",
-    "@backstage/types": "^1.1.1",
     "@severlessworkflow/sdk-typescript": "^3.0.3",
     "axios": "^1.7.4",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",
-    "@backstage/plugin-permission-common": "^0.8.1",
-    "@backstage/types": "1.1.1",
+    "@backstage/types": "^1.1.1",
     "@openapitools/openapi-generator-cli": "2.13.4",
-    "@severlessworkflow/sdk-typescript": "3.0.3",
-    "axios": "^1.7.4",
-    "js-yaml": "^4.1.0",
-    "js-yaml-cli": "0.6.0",
-    "json-schema": "0.4.0",
-    "prettier": "3.3.3"
+    "@types/json-schema": "7.0.15",
+    "js-yaml-cli": "0.6.0"
   },
   "maintainers": [
     "@mlibra",

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@backstage/core-plugin-api": "^1.10.0",
-    "@backstage/types": "^1.1.1",
     "@rjsf/core": "^5.21.2",
     "@rjsf/utils": "^5.21.2"
   },
@@ -37,6 +36,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",
+    "@backstage/types": "^1.1.1",
     "@types/json-schema": "7.0.15",
     "@types/react": "^18.2.58",
     "prettier": "3.3.3",

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",
-    "@backstage/types": "^1.1.1",
     "@material-ui/core": "^4.12.4",
     "@red-hat-developer-hub/backstage-plugin-orchestrator-form-api": "workspace:^",
     "@rjsf/core": "^5.21.2",
@@ -50,6 +49,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",
+    "@backstage/types": "^1.1.1",
     "@types/json-schema": "7.0.15",
     "@types/lodash": "^4.14.151",
     "@types/react": "^18.2.58",

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -11955,7 +11955,6 @@ __metadata:
     express-promise-router: ^4.1.1
     fs-extra: ^10.1.0
     isomorphic-git: ^1.23.0
-    json-schema: ^0.4.0
     moment: ^2.29.4
     openapi-backend: ^5.10.5
     prettier: 3.3.3
@@ -11972,20 +11971,13 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/types": 1.1.1
+    "@backstage/types": ^1.1.1
     "@openapitools/openapi-generator-cli": 2.13.4
-    "@severlessworkflow/sdk-typescript": 3.0.3
+    "@severlessworkflow/sdk-typescript": ^3.0.3
+    "@types/json-schema": 7.0.15
     axios: ^1.7.4
     js-yaml: ^4.1.0
     js-yaml-cli: 0.6.0
-    json-schema: 0.4.0
-    prettier: 3.3.3
-  peerDependencies:
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/types": ^1.1.1
-    "@severlessworkflow/sdk-typescript": ^3.0.3
-    axios: ^1.7.4
-    js-yaml: ^4.1.0
   languageName: unknown
   linkType: soft
 
@@ -12599,7 +12591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@severlessworkflow/sdk-typescript@npm:3.0.3, @severlessworkflow/sdk-typescript@npm:^3.0.3":
+"@severlessworkflow/sdk-typescript@npm:^3.0.3":
   version: 3.0.3
   resolution: "@severlessworkflow/sdk-typescript@npm:3.0.3"
   dependencies:


### PR DESCRIPTION
orchestrator-common dependencies moved during migration between repos to peerDependencies for some reason. resulting in a broken dynamic-plugin build. The fix moves these packages back to dependencies. The fix also includes cleanup of unneeded dependency on 'json-schema' package as only '@types/json-schema' packages is needed in devDependencies.

