### PR TITLE
fix(orchestrator): fix scalprum config

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator/package.json
@@ -111,7 +111,7 @@
     "react-router-dom": "^6.0.0"
   },
   "scalprum": {
-    "name": "janus-idp.backstage-plugin-orchestrator",
+    "name": "red-hat-developer-hub.backstage-plugin-orchestrator",
     "exposedModules": {
       "OrchestratorPlugin": "./src/index.ts"
     }


### PR DESCRIPTION
fix scalprum name following move to new repository, to match name in https://github.com/redhat-developer/rhdh-plugins/blob/fixscalprum/workspaces/orchestrator/plugins/orchestrator/app-config.yaml#L3