### PR TITLE
chore(ci): add automation that asks/enforce PR title to incl. a workspace and change type

### DIFF
--- a/.github/workflows/automate_pr-title_feedback.yaml
+++ b/.github/workflows/automate_pr-title_feedback.yaml
@@ -1,0 +1,82 @@
+name: Automate PR title feedback
+on:
+  pull_request_target:
+    branches: ['main']
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+# Sets permissions of the GITHUB_TOKEN to allow comments
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  title:
+    name: Conventional Commits
+    # prevent running towards forks and version packages
+    if: github.repository == 'redhat-developer/rhdh-plugins' && github.event.pull_request.user.login != 'rhdh-bot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          # Since we use `conventionalcommits` preset for
+          # `@semantic-release/commit-analyzer`, this list has to match allowed types
+          # Ref: https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            revert
+          requireScope: true
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          ignoreLabels: |
+            ignore-semantic-pull-request
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+
+      - uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the [Conventional Commits](https://www.conventionalcommits.org/) convention to this repository, as we had already in backstage-showcase.

But here, with our workspaces, I set `requireScope` to `true`.

This will request that all PR titles starts with a type and a scope (workspace) like:

* feat(bulk-import): awesome new feature
* fix(repo-tools): some bugfixes
* ...

All types:

* feat
* fix
* chore
* docs
*  style
* refactor
* perf
* test
* revert

It should ignore the Version PRs from @rhdh-bot 

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
