### PR TITLE
feat(marketplace): use catalogApi to fetch marketplace plugins

### DIFF
--- a/workspaces/marketplace/plugins/marketplace/package.json
+++ b/workspaces/marketplace/plugins/marketplace/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",
+    "@backstage/plugin-catalog-react": "^1.14.0",
     "@backstage/theme": "^0.6.0",
     "@mui/icons-material": "^5.16.7",
     "@mui/material": "^5.12.2",

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceBackendClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceBackendClient.tsx
@@ -27,7 +27,7 @@ export type Options = {
   fetchApi: FetchApi;
 };
 
-export class MarketplaceClient implements MarketplaceApi {
+export class MarketplaceBackendClient implements MarketplaceApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly fetchApi: FetchApi;
 

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 
 import {
   MarketplacePluginEntry,
@@ -21,46 +20,35 @@ import {
 } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 
 import { MarketplaceApi } from './MarketplaceApi';
+import { CatalogApi } from '@backstage/plugin-catalog-react';
 
-type Options = {
-  discoveryApi: DiscoveryApi;
-  fetchApi: FetchApi;
+type CatalogApiOptions = {
+  catalogApi: CatalogApi;
 };
 
 export class MarketplaceCatalogClient implements MarketplaceApi {
-  private readonly discoveryApi: DiscoveryApi;
-  private readonly fetchApi: FetchApi;
+  private readonly catalogApi: CatalogApi;
 
-  constructor(options: Options) {
-    this.discoveryApi = options.discoveryApi;
-    this.fetchApi = options.fetchApi;
+  constructor(options: CatalogApiOptions) {
+    this.catalogApi = options.catalogApi;
   }
 
   async getPlugins(): Promise<MarketplacePluginEntry[]> {
-    const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
-    const url = `${baseUrl}/entities?filter=kind=plugin`;
+    const result = await this.catalogApi.getEntities({
+      filter: {
+        kind: 'plugin',
+      },
+    });
 
-    const response = await this.fetchApi.fetch(url);
-    if (!response.ok) {
-      throw new Error(
-        `Unexpected status code: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return response.json();
+    return result?.items as MarketplacePluginEntry[];
   }
 
   async getPluginList(): Promise<MarketplacePluginList[]> {
-    const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
-    const url = `${baseUrl}/entities?filter=kind=pluginList`;
-
-    const response = await this.fetchApi.fetch(url);
-    if (!response.ok) {
-      throw new Error(
-        `Unexpected status code: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return response.json();
+    const result = await this.catalogApi.getEntities({
+      filter: {
+        kind: 'pluginList',
+      },
+    });
+    return result.items as MarketplacePluginList[];
   }
 }

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+
+import {
+  MarketplacePluginEntry,
+  MarketplacePluginList,
+} from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+
+import { MarketplaceApi } from './MarketplaceApi';
+
+type Options = {
+  discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
+};
+
+export class MarketplaceCatalogClient implements MarketplaceApi {
+  private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
+
+  constructor(options: Options) {
+    this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
+  }
+
+  async getPlugins(): Promise<MarketplacePluginEntry[]> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
+    const url = `${baseUrl}/entities?filter=kind=plugin`;
+
+    const response = await this.fetchApi.fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Unexpected status code: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async getPluginList(): Promise<MarketplacePluginList[]> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
+    const url = `${baseUrl}/entities?filter=kind=pluginList`;
+
+    const response = await this.fetchApi.fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Unexpected status code: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+}

--- a/workspaces/marketplace/plugins/marketplace/src/api/index.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/api/index.ts
@@ -18,7 +18,8 @@ import { createApiRef } from '@backstage/core-plugin-api';
 import { MarketplaceApi } from './MarketplaceApi';
 
 export * from './MarketplaceApi';
-export * from './MarketplaceClient';
+export * from './MarketplaceBackendClient';
+export * from './MarketplaceCatalogClient';
 
 export const marketplaceApiRef = createApiRef<MarketplaceApi>({
   id: 'plugin.marketplace.api-ref',

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
@@ -36,7 +36,7 @@ export const MarketplaceCatalogContent = () => {
         >
           <Typography variant="h5">
             All plugins
-            {plugins.data ? ` (${plugins.data.length})` : null}
+            {plugins.data ? ` (${plugins.data?.length})` : null}
           </Typography>
           <SearchTextField variant="filter" />
         </Stack>

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
@@ -19,7 +19,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { marketplaceApiRef } from '../api';
 
-export const usePlugins = () => {
+export const usePluginList = () => {
   const marketplaceApi = useApi(marketplaceApiRef);
 
   return useQuery({

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
@@ -19,7 +19,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { marketplaceApiRef } from '../api';
 
-export const usePluginList = () => {
+export const usePlugins = () => {
   const marketplaceApi = useApi(marketplaceApiRef);
 
   return useQuery({

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePlugins.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePlugins.ts
@@ -16,14 +16,10 @@
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useQuery } from '@tanstack/react-query';
-
 import { marketplaceApiRef } from '../api';
 
 export const usePlugins = () => {
   const marketplaceApi = useApi(marketplaceApiRef);
-
-  //   const [search, setSearch] = useQueryParamState<string | undefined>('q');
-
   return useQuery({
     queryKey: ['plugins'],
     queryFn: () => marketplaceApi.getPlugins(),

--- a/workspaces/marketplace/plugins/marketplace/src/plugin.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/plugin.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 import {
-  createApiFactory,
   createPlugin,
   createRoutableExtension,
   createComponentExtension,
+  type IconComponent,
+  createApiFactory,
   discoveryApiRef,
   fetchApiRef,
-  type IconComponent,
 } from '@backstage/core-plugin-api';
 
 import MUIMarketplaceIcon from '@mui/icons-material/ShoppingBasketOutlined';
 
 import { rootRouteRef } from './routes';
-import { marketplaceApiRef, MarketplaceClient } from './api';
+import { marketplaceApiRef, MarketplaceBackendClient } from './api';
 
 /**
  * Marketplace Plugin
@@ -45,7 +45,7 @@ export const marketplacePlugin = createPlugin({
         fetchApi: fetchApiRef,
       },
       factory: ({ discoveryApi, fetchApi }) =>
-        new MarketplaceClient({
+        new MarketplaceBackendClient({
           discoveryApi,
           fetchApi,
         }),

--- a/workspaces/marketplace/yarn.lock
+++ b/workspaces/marketplace/yarn.lock
@@ -10082,6 +10082,7 @@ __metadata:
     "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
     "@backstage/dev-utils": ^1.1.2
+    "@backstage/plugin-catalog-react": ^1.14.0
     "@backstage/test-utils": ^1.7.0
     "@backstage/theme": ^0.6.0
     "@mui/icons-material": ^5.16.7


### PR DESCRIPTION
## Fixes

https://issues.redhat.com/browse/RHIDP-5321

## Hey, I just made a Pull Request!


Changes:

- used catalog API to fetch all the plugins and pluginLists.
-  introduced both the catalog and marketplace backend APIs to easily switch implementations.
- removed redundant type declarations infavor of `Entity`from `@backstage/types`


## How to test:

- `yarn dev` in marketplace workspace, by default it uses MarketplaceBackendClient.

 #### To switch to MarketplaceCatalogClient API implementation:
 
 Change `factory` method to use MarketplaceCatalogClient `plugin.ts` 
 
```
export const marketplacePlugin = createPlugin({
  id: 'marketplace',
  routes: {
    root: rootRouteRef,
  },
  apis: [
    createApiFactory({
      api: marketplaceApiRef,
      deps: {
        catalogApi: catalogApiRef,
      },
      factory: ({ catalogApi }) =>
        new MarketplaceCatalogClient({
          catalogApi,
        }),
    }),
  ],
});
```
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

     

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
