### PR TITLE
fix(theme): add mui v4 and v5 grid examples

### DIFF
--- a/workspaces/theme/plugins/bc-test/package.json
+++ b/workspaces/theme/plugins/bc-test/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",
-    "@backstage/plugin-user-settings": "^0.8.16"
+    "@backstage/plugin-user-settings": "^0.8.16",
+    "@mui/material": "^5"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"

--- a/workspaces/theme/plugins/bc-test/src/index.ts
+++ b/workspaces/theme/plugins/bc-test/src/index.ts
@@ -13,4 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from './plugin';

--- a/workspaces/theme/plugins/mui4-test/package.json
+++ b/workspaces/theme/plugins/mui4-test/package.json
@@ -38,7 +38,8 @@
     "@backstage/plugin-user-settings": "^0.8.16",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.61"
+    "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/material": "^5"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"

--- a/workspaces/theme/plugins/mui4-test/src/components/FormComponents.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/FormComponents.tsx
@@ -37,7 +37,7 @@ const Buttons = () => {
       </tr>
       {colors.map(color => (
         <tr key={color}>
-          <td>{color ?? 'undefined'}</td>
+          <td>{color ?? 'no color'}</td>
           {variants.map(variant => (
             <td key={variant}>
               <Button color={color} variant={variant}>
@@ -74,7 +74,7 @@ const Checkboxes = () => {
       </tr>
       {colors.map(color => (
         <tr key={color}>
-          <td>{color ?? 'undefined'}</td>
+          <td>{color ?? 'no color'}</td>
           <td>
             <FormControlLabel
               control={<Checkbox defaultChecked color={color} />}

--- a/workspaces/theme/plugins/mui4-test/src/components/GridExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/GridExamples.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Card from '@material-ui/core/Card';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Grid, { GridProps } from '@material-ui/core/Grid';
+
+const GridContainer = (props: GridProps) => <Grid container {...props} />;
+
+const GridItem = (props: GridProps) => (
+  <Grid
+    item
+    xs={12} // show 1 item  per row on extra small screens
+    sm={6} // show 2 items per row on small screens
+    md={4} // show 3 items per row on medium screens
+    lg={3} // show 4 items per row on large screens
+    xl={2} // show 6 items per row on extra large screens
+    {...props}
+  />
+);
+
+export const CommonGridExamples = () => {
+  const cards = Array.from({ length: 8 }, (_, i) => i + 1);
+  return (
+    <>
+      <h1>
+        Default: Grid container without spacing, an unstyled Grid item and an
+        unstyled Card
+      </h1>
+      <GridContainer>
+        {cards.map(cardContent => (
+          <GridItem key={cardContent}>
+            <Card>{cardContent}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=2, an unstyled Grid item and an unstyled
+        Card
+      </h1>
+      <GridContainer spacing={2}>
+        {cards.map(cardContent => (
+          <GridItem key={cardContent}>
+            <Card>{cardContent}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4, an unstyled Grid item and a Card with
+        padding=2
+      </h1>
+      <GridContainer spacing={4}>
+        {cards.map(cardContent => (
+          <GridItem key={cardContent}>
+            <Card style={{ padding: 16 }}>{cardContent}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+    </>
+  );
+};
+
+const DebugGridExamples = () => {
+  const backgroundColors = [
+    '#600',
+    '#060',
+    '#800',
+    '#080',
+    '#a00',
+    '#0a0',
+    '#d00',
+    '#0d0',
+  ];
+  return (
+    <>
+      <h1>
+        Grid container without spacing, an unstyled Grid item and colorized Card
+      </h1>
+      <GridContainer>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem key={backgroundColor}>
+            <Card style={{ color: '#ffffff', backgroundColor }}>
+              {index + 1}
+            </Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with colorized Grid item to show all-sided padding, Card
+        position is fine
+      </h1>
+      <GridContainer>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            style={{ color: '#ffffff', backgroundColor }}
+          >
+            <Card>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4, an unstyled Grid item and a colorized
+        Card with padding=16
+      </h1>
+      <GridContainer spacing={4}>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem key={backgroundColor}>
+            <Card style={{ color: '#ffffff', backgroundColor, padding: 16 }}>
+              {index + 1}
+            </Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4, an colorized Grid item to show all-sided
+        padding, Card position is fine
+      </h1>
+      <GridContainer spacing={4}>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            style={{ color: '#ffffff', backgroundColor }}
+          >
+            <Card style={{ padding: 16 }}>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container without spacing and Grid item with padding=32 result in
+        aligned Cards! (Not in MUI v5!)
+      </h1>
+      <GridContainer>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            style={{ color: '#ffffff', backgroundColor, padding: 32 }}
+          >
+            <Card>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4 and Grid item with padding=32 result also
+        in aligned Cards! (Not in MUI v5!)
+      </h1>
+      <GridContainer spacing={4}>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            style={{ color: '#ffffff', backgroundColor, padding: 32 }}
+          >
+            <Card>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+    </>
+  );
+};
+
+export const GridExamples = () => {
+  const [showDebugExamples, setShowDebugExamples] = React.useState(false);
+  return (
+    <>
+      <CommonGridExamples />
+      <Box sx={{ pt: 4, pb: 4 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              onChange={(_, checked) => setShowDebugExamples(checked)}
+            />
+          }
+          label="Show debug examples"
+        />
+      </Box>
+      {showDebugExamples && <DebugGridExamples />}
+    </>
+  );
+};

--- a/workspaces/theme/plugins/mui4-test/src/components/MUI4TestPage.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/MUI4TestPage.tsx
@@ -19,36 +19,32 @@ import { UserSettingsThemeToggle } from '@backstage/plugin-user-settings';
 
 import { FormComponents } from './FormComponents';
 import { PaperExamples } from './PaperExamples';
-import { InlineStyles } from './InlineStyles';
 import { TabExamples } from './TabExamples';
+import { GridExamples } from './GridExamples';
+import { InlineStyles } from './InlineStyles';
 
 export const MUI4TestPage = () => {
   return (
     <Page themeId="tool">
-      <Header title="MUI v4 / Material UI Test Page">
+      <Header title="MUI v4 Test Page">
         <UserSettingsThemeToggle />
       </Header>
       <TabbedLayout>
-        <TabbedLayout.Route
-          path="/"
-          title="Form components"
-          children={<FormComponents />}
-        />
-        <TabbedLayout.Route
-          path="/paper-examples"
-          title="Paper examples"
-          children={<PaperExamples />}
-        />
-        <TabbedLayout.Route
-          path="/inline-styles"
-          title="Inline styles"
-          children={<InlineStyles />}
-        />
-        <TabbedLayout.Route
-          path="/tabs"
-          title="Tabs"
-          children={<TabExamples />}
-        />
+        <TabbedLayout.Route path="/" title="Form components">
+          <FormComponents />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/papers" title="Papers">
+          <PaperExamples />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/tabs" title="Tabs">
+          <TabExamples />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/grids" title="Grids">
+          <GridExamples />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/inline-styles" title="Inline styles">
+          <InlineStyles />
+        </TabbedLayout.Route>
       </TabbedLayout>
     </Page>
   );

--- a/workspaces/theme/plugins/mui4-test/src/index.ts
+++ b/workspaces/theme/plugins/mui4-test/src/index.ts
@@ -13,4 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from './plugin';

--- a/workspaces/theme/plugins/mui5-test/src/components/FormComponents.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/FormComponents.tsx
@@ -87,7 +87,7 @@ const Checkboxes = () => {
       </tr>
       {colors.map(color => (
         <tr key={color}>
-          <td>{color ?? 'undefined'}</td>
+          <td>{color ?? 'no color'}</td>
           <td>
             <FormControlLabel
               control={<Checkbox defaultChecked color={color} />}

--- a/workspaces/theme/plugins/mui5-test/src/components/GridExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/GridExamples.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid, { GridProps } from '@mui/material/Grid';
+
+const GridContainer = (props: GridProps) => <Grid container {...props} />;
+
+const GridItem = (props: GridProps) => (
+  <Grid
+    item
+    xs={12} // show 1 item  per row on extra small screens
+    sm={6} // show 2 items per row on small screens
+    md={4} // show 3 items per row on medium screens
+    lg={3} // show 4 items per row on large screens
+    xl={2} // show 6 items per row on extra large screens
+    {...props}
+  />
+);
+
+export const CommonGridExamples = () => {
+  const cards = Array.from({ length: 8 }, (_, i) => i + 1);
+  return (
+    <>
+      <h1>
+        Default: Grid container without spacing, an unstyled Grid item and an
+        unstyled Card
+      </h1>
+      <GridContainer>
+        {cards.map(cardContent => (
+          <GridItem key={cardContent}>
+            <Card>{cardContent}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=2, an unstyled Grid item and an unstyled
+        Card
+      </h1>
+      <GridContainer spacing={2}>
+        {cards.map(cardContent => (
+          <GridItem key={cardContent}>
+            <Card>{cardContent}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4, an unstyled Grid item and a Card with
+        padding=2
+      </h1>
+      <GridContainer spacing={4}>
+        {cards.map(cardContent => (
+          <GridItem key={cardContent}>
+            <Card sx={{ p: 2 }}>{cardContent}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+    </>
+  );
+};
+
+const DebugGridExamples = () => {
+  const backgroundColors = [
+    '#600',
+    '#060',
+    '#800',
+    '#080',
+    '#a00',
+    '#0a0',
+    '#d00',
+    '#0d0',
+  ];
+  return (
+    <>
+      <h1>
+        Grid container without spacing, an unstyled Grid item and colorized Card
+      </h1>
+      <GridContainer>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem key={backgroundColor}>
+            <Card sx={{ color: '#ffffff', backgroundColor }}>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with colorized Grid item to show one-sided padding, Card
+        position is fine
+      </h1>
+      <GridContainer>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            sx={{ color: '#ffffff', backgroundColor }}
+          >
+            <Card>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4, an unstyled Grid item and a colorized
+        Card with p=2
+      </h1>
+      <GridContainer spacing={4}>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem key={backgroundColor}>
+            <Card sx={{ color: '#ffffff', backgroundColor, p: 2 }}>
+              {index + 1}
+            </Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4, an colorized Grid item to show one-sided
+        padding, Card position is fine
+      </h1>
+      <GridContainer spacing={4}>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            sx={{ color: '#ffffff', backgroundColor }}
+          >
+            <Card sx={{ p: 2 }}>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container without spacing and Grid item with p=4 result in
+        unaligned Cards! (Too much padding on the right side!)
+      </h1>
+      <GridContainer>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            sx={{ color: '#ffffff', backgroundColor, p: 4 }}
+          >
+            <Card>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+
+      <h1>
+        Grid container with spacing=4 and Grid item with p=4 result also in
+        unaligned Cards! (Too much padding on the right side!)
+      </h1>
+      <GridContainer spacing={4}>
+        {backgroundColors.map((backgroundColor, index) => (
+          <GridItem
+            key={backgroundColor}
+            sx={{ color: '#ffffff', backgroundColor, p: 4 }}
+          >
+            <Card>{index + 1}</Card>
+          </GridItem>
+        ))}
+      </GridContainer>
+    </>
+  );
+};
+
+export const GridExamples = () => {
+  const [showDebugExamples, setShowDebugExamples] = React.useState(false);
+  return (
+    <>
+      <CommonGridExamples />
+      <Box sx={{ pt: 4, pb: 4 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              onChange={(_, checked) => setShowDebugExamples(checked)}
+            />
+          }
+          label="Show debug examples"
+        />
+      </Box>
+      {showDebugExamples && <DebugGridExamples />}
+    </>
+  );
+};

--- a/workspaces/theme/plugins/mui5-test/src/components/MUI5TestPage.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/MUI5TestPage.tsx
@@ -19,8 +19,9 @@ import { UserSettingsThemeToggle } from '@backstage/plugin-user-settings';
 
 import { FormComponents } from './FormComponents';
 import { PaperExamples } from './PaperExamples';
-import { InlineStyles } from './InlineStyles';
 import { TabExamples } from './TabExamples';
+import { GridExamples } from './GridExamples';
+import { InlineStyles } from './InlineStyles';
 
 export const MUI5TestPage = () => {
   return (
@@ -29,26 +30,21 @@ export const MUI5TestPage = () => {
         <UserSettingsThemeToggle />
       </Header>
       <TabbedLayout>
-        <TabbedLayout.Route
-          path="/form-components"
-          title="Form components"
-          children={<FormComponents />}
-        />
-        <TabbedLayout.Route
-          path="/paper-examples"
-          title="Paper examples"
-          children={<PaperExamples />}
-        />
-        <TabbedLayout.Route
-          path="/inline-styles"
-          title="Inline styles"
-          children={<InlineStyles />}
-        />
-        <TabbedLayout.Route
-          path="/tabs"
-          title="Tabs"
-          children={<TabExamples />}
-        />
+        <TabbedLayout.Route path="/form-components" title="Form components">
+          <FormComponents />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/papers" title="Papers">
+          <PaperExamples />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/tabs" title="Tabs">
+          <TabExamples />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/grids" title="Grids">
+          <GridExamples />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/inline-styles" title="Inline styles">
+          <InlineStyles />
+        </TabbedLayout.Route>
       </TabbedLayout>
     </Page>
   );

--- a/workspaces/theme/plugins/mui5-test/src/index.ts
+++ b/workspaces/theme/plugins/mui5-test/src/index.ts
@@ -13,4 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from './plugin';

--- a/workspaces/theme/yarn.lock
+++ b/workspaces/theme/yarn.lock
@@ -10066,6 +10066,7 @@ __metadata:
     "@backstage/dev-utils": ^1.1.2
     "@backstage/plugin-user-settings": ^0.8.16
     "@backstage/test-utils": ^1.7.0
+    "@mui/material": ^5
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
@@ -10090,6 +10091,7 @@ __metadata:
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.61
+    "@mui/material": ^5
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds

1. some new Grid examples to **test plugins** to see and understand the difference between Backstage and RHDH. But there is none; both look except different colors and borders really similar!
2. add workaround to load mui v5 theme correctly when package test plugins

Backstage defines a default spacing for all Grids, see:

https://github.com/backstage/backstage/blob/3d2e95f71c2be9a63530697cf01e482e4f50f98d/packages/theme/src/v5/defaultComponentThemes.ts#L67-L71

The RHDH theme doesn't change the padding or default spacing. But in MUI 5 it's required to add additional padding via spacing to the `Grid container` or to the content (in the `Grid item`). 

The UI will looks unaligned when a padding is added to the `Grid item`.

### MUI v4 and v5 looks similar if no padding is added to the `Grid item`

![image](https://github.com/user-attachments/assets/ec44f5f9-4502-4163-a36e-f18acab1036a)

![image](https://github.com/user-attachments/assets/ef7c69f1-421b-4943-8a6a-ac4514e5d14f)

### But it's not okay to add padding to `Grid item` in MUI v5:

MUI v4

![image](https://github.com/user-attachments/assets/a4ead321-3d2d-4965-b396-7c26613fccc6)

MUI v5

![image](https://github.com/user-attachments/assets/495db45d-359c-4691-9728-bd58503f8279)

#### :heavy_check_mark: Checklist


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
