### PR TITLE
fix(theme): move the mui v5 package to a peer dependency to ensure that we don't load it twice

### DIFF
--- a/workspaces/theme/.changeset/brave-sloths-cross.md
+++ b/workspaces/theme/.changeset/brave-sloths-cross.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+move the mui v5 package to a peer dependency to ensure that we don't load it twice

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -31,20 +31,16 @@
     "postpack": "backstage-cli package postpack",
     "prepublish": "./fix-style-inject-imports.sh"
   },
-  "dependencies": {
-    "@mui/material": "^5.0.0"
-  },
   "peerDependencies": {
-    "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",
     "@backstage/theme": "^0.6.0",
     "@material-ui/icons": "^4.11.3",
+    "@mui/material": "^5.0.0",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.28.0",
     "@backstage/core-app-api": "^1.15.1",
-    "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",
     "@backstage/dev-utils": "^1.1.2",
     "@backstage/test-utils": "^1.7.0",

--- a/workspaces/theme/yarn.lock
+++ b/workspaces/theme/yarn.lock
@@ -8353,7 +8353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^5, @mui/material@npm:^5.0.0, @mui/material@npm:^5.12.2":
+"@mui/material@npm:^5, @mui/material@npm:^5.12.2":
   version: 5.16.8
   resolution: "@mui/material@npm:5.16.8"
   dependencies:
@@ -10130,14 +10130,12 @@ __metadata:
   dependencies:
     "@backstage/cli": ^0.28.0
     "@backstage/core-app-api": ^1.15.1
-    "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
     "@backstage/dev-utils": ^1.1.2
     "@backstage/test-utils": ^1.7.0
     "@backstage/theme": ^0.6.0
     "@backstage/types": ^1.2.0
     "@material-ui/icons": ^4.11.3
-    "@mui/material": ^5.0.0
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0
     "@testing-library/react-hooks": ^8.0.1
@@ -10145,10 +10143,10 @@ __metadata:
     msw: ^1.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
   peerDependencies:
-    "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
     "@backstage/theme": ^0.6.0
     "@material-ui/icons": ^4.11.3
+    "@mui/material": ^5.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To be honest, this is more like an experiment. Maybe we can give it a try to check this with a new theme release (which isn't used yet) and rhdh-showcase?

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
