### PR TITLE
fix(theme): fix release after fix-style-inject-imports.sh was removed in @202

### DIFF
--- a/workspaces/theme/.changeset/nine-taxis-beam.md
+++ b/workspaces/theme/.changeset/nine-taxis-beam.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+fix font loading after migrating theme

--- a/workspaces/theme/plugins/theme/CHANGELOG.md
+++ b/workspaces/theme/plugins/theme/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @red-hat-developer-hub/backstage-plugin-theme
 
-## 0.4.9
-
-### Patch Changes
-
-- 1134fb2: fix font loading after migrating theme
-
 ## 0.4.8
 
 ### Patch Changes

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -26,8 +26,7 @@
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack",
-    "prepublish": "./fix-style-inject-imports.sh"
+    "postpack": "backstage-cli package postpack"
   },
   "peerDependencies": {
     "@backstage/core-plugin-api": "^1.10.0",

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-hat-developer-hub/backstage-plugin-theme",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "description": "Red Hat Developer Hub Theme",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Release of #208 failed. From build https://github.com/redhat-developer/rhdh-plugins/actions/runs/12408641051/job/34640814865:

```
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-theme]: ➤ YN0036: Calling the "prepublish" lifecycle script
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-theme]: ➤ YN0000: @red-hat-developer-hub/backstage-plugin-theme@workspace:plugins/theme STDERR command not found: ./fix-style-inject-imports.sh
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-theme]: ➤ YN0036: Prepublish script failed (exit code 127, logs can be found here: /tmp/xfs-bd698101/prepublish.log); run yarn prepublish to investigate
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-theme]: ➤ YN0000: Failed with errors in 0s 979ms
```

This reverts #208 so that we can have a new version PR with the old change and it also removes the reference to fix-style-inject-imports.sh. The script was removed in #202.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
