### PR TITLE
chore(orchestrator): update devmode image

### DIFF
--- a/workspaces/orchestrator/.changeset/wild-owls-invite.md
+++ b/workspaces/orchestrator/.changeset/wild-owls-invite.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+update sonataflow devmode image

--- a/workspaces/orchestrator/plugins/orchestrator-common/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-common/report.api.md
@@ -146,7 +146,7 @@ export const DEFAULT_SONATAFLOW_BASE_URL = "http://localhost";
 // Warning: (ae-missing-release-tag) "DEFAULT_SONATAFLOW_CONTAINER_IMAGE" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const DEFAULT_SONATAFLOW_CONTAINER_IMAGE = "docker.io/apache/incubator-kie-sonataflow-devmode:latest";
+export const DEFAULT_SONATAFLOW_CONTAINER_IMAGE = "quay.io/kubesmarts/incubator-kie-sonataflow-devmode:main";
 
 // Warning: (ae-missing-release-tag) "DEFAULT_SONATAFLOW_PERSISTENCE_PATH" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/constants.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/constants.ts
@@ -15,7 +15,7 @@
  */
 
 export const DEFAULT_SONATAFLOW_CONTAINER_IMAGE =
-  'docker.io/apache/incubator-kie-sonataflow-devmode:latest';
+  'quay.io/kubesmarts/incubator-kie-sonataflow-devmode:main';
 export const DEFAULT_SONATAFLOW_PERSISTENCE_PATH = '/home/kogito/persistence';
 export const DEFAULT_SONATAFLOW_BASE_URL = 'http://localhost';
 


### PR DESCRIPTION
resolves broken developer environment, following sonataflow images moving from docker hub to quay