### PR TITLE
fix(orchestrator): multiple bug fixes following pagination PR

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePageContent.tsx
@@ -36,19 +36,17 @@ import { WorkflowVariablesViewer } from './WorkflowVariablesViewer';
 export const mapProcessInstanceToDetails = (
   instance: ProcessInstanceDTO,
 ): WorkflowRunDetail => {
-  const name = instance.processName || instance.processId;
   const start = instance.start ? moment(instance.start) : undefined;
   let duration: string = VALUE_UNAVAILABLE;
   if (start && instance.end) {
     const end = moment(instance.end);
     duration = moment.duration(start.diff(end)).humanize();
   }
-
   const started = start?.toDate().toLocaleString() ?? VALUE_UNAVAILABLE;
 
   return {
     id: instance.id,
-    name,
+    processName: instance.processName || VALUE_UNAVAILABLE,
     workflowId: instance.processId,
     start: started,
     duration,

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowRunDetail.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowRunDetail.ts
@@ -20,7 +20,7 @@ export interface WorkflowSuggestion {
 
 export type WorkflowRunDetail = {
   id: string;
-  name: string;
+  processName: string;
   workflowId: string;
   state?: string;
   start: string;

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/usePolling.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/usePolling.ts
@@ -52,6 +52,7 @@ const usePolling = <T>(
     onSuccess: () => {
       isInitalLoad.current = false;
     },
+    revalidateOnFocus: false, // click on sort will result in two calls to backend if not disabled
   });
 
   const restart = React.useCallback(


### PR DESCRIPTION
Multiple bug fixes in instances table following https://github.com/redhat-developer/rhdh-plugins/pull/211

1. Each click on sort resulted in two calls to backend, one with previous sort direction and one with new one, resulting in inconsistent results. Fix is by disabling useSwr revalidateOnFocus.
2. Sorting didn't display results in correct order, since material-table overrides the order from backend with simple sort by string. The only way to resolve this was to force the additional sorting to use the same order received from backend.
3. Sort by workflow name failed because it sent to backend the field 'name' instead of 'processName'
4. Sorting was enabled for fields that aren't supported by backend: category and duration
