### PR TITLE
Update copyright header

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage and RHDH Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,7 @@ module.exports = {
     'notice/notice': [
       'error',
       {
-        mustMatch:
-          /Copyright \d{4} (The Backstage and RHDH Authors|The RHDH Authors)/,
+        mustMatch: /Copyright \d{4} (The Backstage Authors|The RHDH Authors)/,
         templateFile: path.resolve(
           // eslint-disable-next-line no-restricted-syntax
           __dirname,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2024 The Backstage and RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ module.exports = {
     'notice/notice': [
       'error',
       {
+        mustMatch:
+          /Copyright \d{4} (The Backstage and RHDH Authors|The RHDH Authors)/,
         templateFile: path.resolve(
           // eslint-disable-next-line no-restricted-syntax
           __dirname,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ module.exports = {
     'notice/notice': [
       'error',
       {
-        mustMatch: /Copyright \d{4} (The Backstage Authors|The RHDH Authors)/,
+        mustMatch: /Copyright (The Backstage Authors|Red Hat, Inc.)/,
         templateFile: path.resolve(
           // eslint-disable-next-line no-restricted-syntax
           __dirname,

--- a/scripts/ci/check-if-release.js
+++ b/scripts/ci/check-if-release.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable @backstage/no-undeclared-imports */
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/create-tag.js
+++ b/scripts/ci/create-tag.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/generate-bump-changesets.js
+++ b/scripts/ci/generate-bump-changesets.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/generate-knip-report.js
+++ b/scripts/ci/generate-knip-report.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/generate-version-bump-changeset.js
+++ b/scripts/ci/generate-version-bump-changeset.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable @backstage/no-undeclared-imports */
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/list-workspaces-with-changes.js
+++ b/scripts/ci/list-workspaces-with-changes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/set-release-name.js
+++ b/scripts/ci/set-release-name.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable @backstage/no-undeclared-imports */
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/ci/verify-changesets.js
+++ b/scripts/ci/verify-changesets.js
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-import { join } from 'path';
-import fs from 'fs/promises';
-import { default as parseChangeset } from '@changesets/parse';
+import { join } from "path";
+import fs from "fs/promises";
+import { default as parseChangeset } from "@changesets/parse";
 
 const privatePackages = new Set([
-  'app',
-  'backend',
-  'e2e-test',
-  'storybook',
-  'techdocs-cli-embedded-app',
+  "app",
+  "backend",
+  "e2e-test",
+  "storybook",
+  "techdocs-cli-embedded-app",
 ]);
 
 /**
@@ -34,42 +34,42 @@ const privatePackages = new Set([
  */
 async function main() {
   if (process.argv.length < 3) {
-    throw new Error('Usage: node verify-changesets.js name-of-the-workspace');
+    throw new Error("Usage: node verify-changesets.js name-of-the-workspace");
   }
   const workspace = process.argv[2];
 
   const changesetsFolderPath = join(
     import.meta.dirname,
-    '..',
-    '..',
-    'workspaces',
+    "..",
+    "..",
+    "workspaces",
     workspace,
-    '.changeset',
+    ".changeset"
   );
   const fileNames = await fs.readdir(changesetsFolderPath);
   const changesetNames = fileNames.filter(
-    name => name.endsWith('.md') && name !== 'README.md',
+    (name) => name.endsWith(".md") && name !== "README.md"
   );
 
   const changesets = await Promise.all(
-    changesetNames.map(async name => {
+    changesetNames.map(async (name) => {
       const content = await fs.readFile(
         join(changesetsFolderPath, name),
-        'utf8',
+        "utf8"
       );
       return { name, ...parseChangeset(content) };
-    }),
+    })
   );
 
   const errors = [];
   for (const changeset of changesets) {
-    const privateReleases = changeset.releases.filter(release =>
-      privatePackages.has(release.name),
+    const privateReleases = changeset.releases.filter((release) =>
+      privatePackages.has(release.name)
     );
     if (privateReleases.length > 0) {
       const names = privateReleases
-        .map(release => `'${release.name}'`)
-        .join(', ');
+        .map((release) => `'${release.name}'`)
+        .join(", ");
       errors.push({
         name: changeset.name,
         messages: [
@@ -81,9 +81,9 @@ async function main() {
 
   if (errors.length) {
     console.log();
-    console.log('***********************************************************');
-    console.log('*             Changeset verification failed!              *');
-    console.log('***********************************************************');
+    console.log("***********************************************************");
+    console.log("*             Changeset verification failed!              *");
+    console.log("***********************************************************");
     console.log();
     for (const error of errors) {
       console.error(`Changeset '${error.name}' is invalid:`);
@@ -93,13 +93,13 @@ async function main() {
       }
     }
     console.log();
-    console.log('***********************************************************');
+    console.log("***********************************************************");
     console.log();
     process.exit(1);
   }
 }
 
-main().catch(error => {
+main().catch((error) => {
   console.error(error.stack);
   process.exit(1);
 });

--- a/scripts/ci/verify-changesets.js
+++ b/scripts/ci/verify-changesets.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-import { join } from "path";
-import fs from "fs/promises";
-import { default as parseChangeset } from "@changesets/parse";
+import { join } from 'path';
+import fs from 'fs/promises';
+import { default as parseChangeset } from '@changesets/parse';
 
 const privatePackages = new Set([
-  "app",
-  "backend",
-  "e2e-test",
-  "storybook",
-  "techdocs-cli-embedded-app",
+  'app',
+  'backend',
+  'e2e-test',
+  'storybook',
+  'techdocs-cli-embedded-app',
 ]);
 
 /**
@@ -34,42 +34,42 @@ const privatePackages = new Set([
  */
 async function main() {
   if (process.argv.length < 3) {
-    throw new Error("Usage: node verify-changesets.js name-of-the-workspace");
+    throw new Error('Usage: node verify-changesets.js name-of-the-workspace');
   }
   const workspace = process.argv[2];
 
   const changesetsFolderPath = join(
     import.meta.dirname,
-    "..",
-    "..",
-    "workspaces",
+    '..',
+    '..',
+    'workspaces',
     workspace,
-    ".changeset"
+    '.changeset',
   );
   const fileNames = await fs.readdir(changesetsFolderPath);
   const changesetNames = fileNames.filter(
-    (name) => name.endsWith(".md") && name !== "README.md"
+    name => name.endsWith('.md') && name !== 'README.md',
   );
 
   const changesets = await Promise.all(
-    changesetNames.map(async (name) => {
+    changesetNames.map(async name => {
       const content = await fs.readFile(
         join(changesetsFolderPath, name),
-        "utf8"
+        'utf8',
       );
       return { name, ...parseChangeset(content) };
-    })
+    }),
   );
 
   const errors = [];
   for (const changeset of changesets) {
-    const privateReleases = changeset.releases.filter((release) =>
-      privatePackages.has(release.name)
+    const privateReleases = changeset.releases.filter(release =>
+      privatePackages.has(release.name),
     );
     if (privateReleases.length > 0) {
       const names = privateReleases
-        .map((release) => `'${release.name}'`)
-        .join(", ");
+        .map(release => `'${release.name}'`)
+        .join(', ');
       errors.push({
         name: changeset.name,
         messages: [
@@ -81,9 +81,9 @@ async function main() {
 
   if (errors.length) {
     console.log();
-    console.log("***********************************************************");
-    console.log("*             Changeset verification failed!              *");
-    console.log("***********************************************************");
+    console.log('***********************************************************');
+    console.log('*             Changeset verification failed!              *');
+    console.log('***********************************************************');
     console.log();
     for (const error of errors) {
       console.error(`Changeset '${error.name}' is invalid:`);
@@ -93,13 +93,13 @@ async function main() {
       }
     }
     console.log();
-    console.log("***********************************************************");
+    console.log('***********************************************************');
     console.log();
     process.exit(1);
   }
 }
 
-main().catch((error) => {
+main().catch(error => {
   console.error(error.stack);
   process.exit(1);
 });

--- a/scripts/ci/verify-lockfile-duplicates.js
+++ b/scripts/ci/verify-lockfile-duplicates.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,17 @@
 
 /* eslint-disable @backstage/no-undeclared-imports */
 
-import { execFile as execFileCb } from "child_process";
-import { resolve as resolvePath, dirname as dirnamePath } from "path";
-import { promisify } from "util";
+import { execFile as execFileCb } from 'child_process';
+import { resolve as resolvePath, dirname as dirnamePath } from 'path';
+import { promisify } from 'util';
 
 const execFile = promisify(execFileCb);
 
 async function findLockFiles() {
   //  Not using relative paths as this should be run inside a workspace folder
-  const projectRoot = resolvePath(".");
+  const projectRoot = resolvePath('.');
 
-  let files = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
+  let files = process.argv.slice(2).filter(arg => !arg.startsWith('--'));
 
   for (const argumentFile of files) {
     if (!argumentFile.match(/(?:^|[\/\\])yarn.lock$/)) {
@@ -37,10 +37,10 @@ async function findLockFiles() {
 
   if (!files.length) {
     // List all lock files that are in the root or in an immediate subdirectory
-    files = ["yarn.lock"];
+    files = ['yarn.lock'];
   }
 
-  return files.map((file) => ({
+  return files.map(file => ({
     fileRelativeToProjectRoot: file,
     directoryRelativeToProjectRoot: dirnamePath(file),
     directoryAbsolute: resolvePath(projectRoot, dirnamePath(file)),
@@ -52,8 +52,8 @@ async function main() {
 
   let fix = false;
   for (const arg of process.argv) {
-    if (arg.startsWith("--")) {
-      if (arg === "--fix") {
+    if (arg.startsWith('--')) {
+      if (arg === '--fix') {
         fix = true;
       } else {
         throw new Error(`Unknown argument ${arg}`);
@@ -62,7 +62,7 @@ async function main() {
   }
 
   for (const lockFile of lockFiles) {
-    console.log("Checking lock file", lockFile.fileRelativeToProjectRoot);
+    console.log('Checking lock file', lockFile.fileRelativeToProjectRoot);
 
     let stdout;
     let stderr;
@@ -70,12 +70,12 @@ async function main() {
 
     try {
       const result = await execFile(
-        "yarn",
-        ["dedupe", ...(fix ? [] : ["--check"])],
+        'yarn',
+        ['dedupe', ...(fix ? [] : ['--check'])],
         {
           shell: true,
           cwd: lockFile.directoryAbsolute,
-        }
+        },
       );
       stdout = result.stdout?.trim();
       stderr = result.stderr?.trim();
@@ -97,32 +97,32 @@ async function main() {
     if (failed) {
       if (!fix) {
         const command = `yarn${
-          lockFile.directoryRelativeToProjectRoot === "."
-            ? ""
+          lockFile.directoryRelativeToProjectRoot === '.'
+            ? ''
             : ` --cwd ${lockFile.directoryRelativeToProjectRoot}`
         } dedupe`;
-        const padding = " ".repeat(Math.max(0, 85 - 6 - command.length));
-        console.error("");
+        const padding = ' '.repeat(Math.max(0, 85 - 6 - command.length));
+        console.error('');
         console.error(
-          "*************************************************************************************"
+          '*************************************************************************************',
         );
         console.error(
-          "* You have duplicate versions of some packages in a yarn.lock file.                 *"
+          '* You have duplicate versions of some packages in a yarn.lock file.                 *',
         );
         console.error(
-          "* To solve this, run the following command from the project root and commit all     *"
+          '* To solve this, run the following command from the project root and commit all     *',
         );
         console.log(
-          "* yarn.lock changes.                                                                *"
+          '* yarn.lock changes.                                                                *',
         );
         console.log(
-          "*                                                                                   *"
+          '*                                                                                   *',
         );
         console.log(`*   ${command}${padding} *`);
         console.error(
-          "*************************************************************************************"
+          '*************************************************************************************',
         );
-        console.error("");
+        console.error('');
       }
 
       process.exit(1);
@@ -130,7 +130,7 @@ async function main() {
   }
 }
 
-main().catch((error) => {
+main().catch(error => {
   console.error(error.stack);
   process.exit(1);
 });

--- a/scripts/ci/verify-lockfile-duplicates.js
+++ b/scripts/ci/verify-lockfile-duplicates.js
@@ -17,17 +17,17 @@
 
 /* eslint-disable @backstage/no-undeclared-imports */
 
-import { execFile as execFileCb } from 'child_process';
-import { resolve as resolvePath, dirname as dirnamePath } from 'path';
-import { promisify } from 'util';
+import { execFile as execFileCb } from "child_process";
+import { resolve as resolvePath, dirname as dirnamePath } from "path";
+import { promisify } from "util";
 
 const execFile = promisify(execFileCb);
 
 async function findLockFiles() {
   //  Not using relative paths as this should be run inside a workspace folder
-  const projectRoot = resolvePath('.');
+  const projectRoot = resolvePath(".");
 
-  let files = process.argv.slice(2).filter(arg => !arg.startsWith('--'));
+  let files = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
 
   for (const argumentFile of files) {
     if (!argumentFile.match(/(?:^|[\/\\])yarn.lock$/)) {
@@ -37,10 +37,10 @@ async function findLockFiles() {
 
   if (!files.length) {
     // List all lock files that are in the root or in an immediate subdirectory
-    files = ['yarn.lock'];
+    files = ["yarn.lock"];
   }
 
-  return files.map(file => ({
+  return files.map((file) => ({
     fileRelativeToProjectRoot: file,
     directoryRelativeToProjectRoot: dirnamePath(file),
     directoryAbsolute: resolvePath(projectRoot, dirnamePath(file)),
@@ -52,8 +52,8 @@ async function main() {
 
   let fix = false;
   for (const arg of process.argv) {
-    if (arg.startsWith('--')) {
-      if (arg === '--fix') {
+    if (arg.startsWith("--")) {
+      if (arg === "--fix") {
         fix = true;
       } else {
         throw new Error(`Unknown argument ${arg}`);
@@ -62,7 +62,7 @@ async function main() {
   }
 
   for (const lockFile of lockFiles) {
-    console.log('Checking lock file', lockFile.fileRelativeToProjectRoot);
+    console.log("Checking lock file", lockFile.fileRelativeToProjectRoot);
 
     let stdout;
     let stderr;
@@ -70,12 +70,12 @@ async function main() {
 
     try {
       const result = await execFile(
-        'yarn',
-        ['dedupe', ...(fix ? [] : ['--check'])],
+        "yarn",
+        ["dedupe", ...(fix ? [] : ["--check"])],
         {
           shell: true,
           cwd: lockFile.directoryAbsolute,
-        },
+        }
       );
       stdout = result.stdout?.trim();
       stderr = result.stderr?.trim();
@@ -97,32 +97,32 @@ async function main() {
     if (failed) {
       if (!fix) {
         const command = `yarn${
-          lockFile.directoryRelativeToProjectRoot === '.'
-            ? ''
+          lockFile.directoryRelativeToProjectRoot === "."
+            ? ""
             : ` --cwd ${lockFile.directoryRelativeToProjectRoot}`
         } dedupe`;
-        const padding = ' '.repeat(Math.max(0, 85 - 6 - command.length));
-        console.error('');
+        const padding = " ".repeat(Math.max(0, 85 - 6 - command.length));
+        console.error("");
         console.error(
-          '*************************************************************************************',
+          "*************************************************************************************"
         );
         console.error(
-          '* You have duplicate versions of some packages in a yarn.lock file.                 *',
+          "* You have duplicate versions of some packages in a yarn.lock file.                 *"
         );
         console.error(
-          '* To solve this, run the following command from the project root and commit all     *',
+          "* To solve this, run the following command from the project root and commit all     *"
         );
         console.log(
-          '* yarn.lock changes.                                                                *',
+          "* yarn.lock changes.                                                                *"
         );
         console.log(
-          '*                                                                                   *',
+          "*                                                                                   *"
         );
         console.log(`*   ${command}${padding} *`);
         console.error(
-          '*************************************************************************************',
+          "*************************************************************************************"
         );
-        console.error('');
+        console.error("");
       }
 
       process.exit(1);
@@ -130,7 +130,7 @@ async function main() {
   }
 }
 
-main().catch(error => {
+main().catch((error) => {
   console.error(error.stack);
   process.exit(1);
 });

--- a/scripts/list-backend-feature.js
+++ b/scripts/list-backend-feature.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/list-compatibility.js
+++ b/scripts/list-compatibility.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/list-frontend-feature.js
+++ b/scripts/list-frontend-feature.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/list-workspaces-for-docs.js
+++ b/scripts/list-workspaces-for-docs.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/templates/copyright-header.txt
+++ b/scripts/templates/copyright-header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright <%= YEAR %> The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/templates/copyright-header.txt
+++ b/scripts/templates/copyright-header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright <%= YEAR %> The Backstage Authors
+ * Copyright <%= YEAR %> The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/examples/template/content/index.js
+++ b/workspaces/bulk-import/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 console.log('Hello from ${{ values.name }}!');

--- a/workspaces/bulk-import/examples/template/content/index.js
+++ b/workspaces/bulk-import/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/App.test.tsx
+++ b/workspaces/bulk-import/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/App.test.tsx
+++ b/workspaces/bulk-import/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import App from './App';

--- a/workspaces/bulk-import/packages/app/src/App.tsx
+++ b/workspaces/bulk-import/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import {

--- a/workspaces/bulk-import/packages/app/src/App.tsx
+++ b/workspaces/bulk-import/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/apis.ts
+++ b/workspaces/bulk-import/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   AnyApiFactory,
   configApiRef,

--- a/workspaces/bulk-import/packages/app/src/apis.ts
+++ b/workspaces/bulk-import/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 

--- a/workspaces/bulk-import/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 

--- a/workspaces/bulk-import/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   Link,
   Sidebar,

--- a/workspaces/bulk-import/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/components/Root/index.ts
+++ b/workspaces/bulk-import/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/components/Root/index.ts
+++ b/workspaces/bulk-import/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/bulk-import/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   RELATION_API_CONSUMED_BY,
   RELATION_API_PROVIDED_BY,

--- a/workspaces/bulk-import/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   CatalogIcon,
   Content,

--- a/workspaces/bulk-import/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/bulk-import/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/index.tsx
+++ b/workspaces/bulk-import/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/index.tsx
+++ b/workspaces/bulk-import/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/bulk-import/packages/app/src/setupTests.ts
+++ b/workspaces/bulk-import/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/packages/app/src/setupTests.ts
+++ b/workspaces/bulk-import/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/bulk-import/packages/backend/src/index.ts
+++ b/workspaces/bulk-import/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createBackend } from '@backstage/backend-defaults';
 
 const backend = createBackend();

--- a/workspaces/bulk-import/packages/backend/src/index.ts
+++ b/workspaces/bulk-import/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/.eslintrc.js
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/.prettierrc.js
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/handlers.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/handlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { rest } from 'msw';
 
 const localHostAndPort = 'localhost:8765';

--- a/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/handlers.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/handlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/testUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/testUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/testUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/__fixtures__/testUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/config.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/config.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/dev/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/dev/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/dev/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/dev/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogHttpClient.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogHttpClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogHttpClient.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogHttpClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type { LoggerService } from '@backstage/backend-plugin-api';
 
 import gitUrlParse from 'git-url-parse';

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogInfoGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/catalogUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/catalog/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapi.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapi.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapi.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapi.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapidocument.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapidocument.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapidocument.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/generated/openapidocument.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/GithubAppManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/githubApiService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/ghUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/ghUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/ghUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/ghUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/orgUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/orgUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/orgUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/orgUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/prUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/prUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/prUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/prUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/repoUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/repoUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/repoUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/repoUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/utils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/utils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/github/utils/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auditLogUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auditLogUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auditLogUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auditLogUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auth.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auth.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auth.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/auth.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/loggingUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/loggingUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/loggingUtils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/loggingUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/pagination.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/plugin.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/plugin.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/handlers.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/handlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/handlers.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/handlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/importStatus.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/importStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/importStatus.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/importStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/imports.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/imports.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/imports.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/imports.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/organization/organizations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/ping/ping.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/repository/repositories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/setupTests.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/setupTests.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/bulk-import/plugins/bulk-import-common/.eslintrc.js
+++ b/workspaces/bulk-import/plugins/bulk-import-common/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/.prettierrc.js
+++ b/workspaces/bulk-import/plugins/bulk-import-common/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/permissions.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/permissions.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/setupTests.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/setupTests.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import-common/src/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-common/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/bulk-import/plugins/bulk-import/.eslintrc.js
+++ b/workspaces/bulk-import/plugins/bulk-import/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/.prettierrc.js
+++ b/workspaces/bulk-import/plugins/bulk-import/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/config.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,4 +12,5 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ export interface Config {}
+ */
+export interface Config {}

--- a/workspaces/bulk-import/plugins/bulk-import/config.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export interface Config {}

--- a/workspaces/bulk-import/plugins/bulk-import/dev/index.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/dev/index.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { configApiRef } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/playwright.config.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/playwright.config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { IdentityApi } from '@backstage/core-plugin-api';
 
 import { rest } from 'msw';

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ConfigApi,
   createApiRef,

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositories.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositories.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useDrawer } from '@janus-idp/shared-react';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositories.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositories.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesDrawer.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesDrawer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useState } from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesDrawer.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesDrawer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesFormFooter.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesFormFooter.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesFormFooter.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesFormFooter.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { Content, Header, Page, Progress } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { useAsync } from 'react-use';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import Box from '@mui/material/Box';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTableToolbar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTableToolbar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import ToggleButton from '@mui/material/ToggleButton';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTableToolbar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTableToolbar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/CatalogInfoStatus.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/CatalogInfoStatus.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { StatusRunning } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/CatalogInfoStatus.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/CatalogInfoStatus.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/Illustrations.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/Illustrations.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { makeStyles } from '@mui/styles';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/Illustrations.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/Illustrations.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationTableRow.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationTableRow.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationsColumnHeader.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationsColumnHeader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { TableColumn } from '@backstage/core-components';
 
 export const OrganizationsColumnHeader: TableColumn[] = [

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationsColumnHeader.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/OrganizationsColumnHeader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/ReposSelectDrawerColumnHeader.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/ReposSelectDrawerColumnHeader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { TableColumn } from '@backstage/core-components';
 
 export const ReposSelectDrawerColumnHeader: TableColumn[] = [

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/ReposSelectDrawerColumnHeader.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/ReposSelectDrawerColumnHeader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesColumnHeader.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesColumnHeader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { TableColumn } from '@backstage/core-components';
 
 export const RepositoriesColumnHeader: TableColumn[] = [

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesColumnHeader.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesColumnHeader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesHeader.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesHeader.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import Checkbox from '@mui/material/Checkbox';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesSearchBar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesSearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import Clear from '@mui/icons-material/Clear';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesSearchBar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesSearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import Alert from '@mui/material/Alert';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import Box from '@mui/material/Box';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoryTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoryTableRow.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 import { useAsync } from 'react-use';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoryTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoryTableRow.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { useAsync } from 'react-use';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import {

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { Content, Header, Page, Progress } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { SidebarItem } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { SidebarItem } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/GitAltIcon.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/GitAltIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 const GitAltIcon: React.FC<React.HTMLProps<SVGElement>> = ({

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/GitAltIcon.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/GitAltIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/KeyValueTextField.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/KeyValueTextField.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import FormHelperText from '@mui/material/FormHelperText';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/KeyValueTextField.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/KeyValueTextField.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import {

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useState } from 'react';
 
 import { configApiRef } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequest.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { configApiRef } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 import { useAsync } from 'react-use';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequestForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useState } from 'react';
 
 import { configApiRef } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import ErrorOutline from '@mui/icons-material/ErrorOutline';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewPullRequests.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoriesTableBody.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoriesTableBody.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoriesTableBody.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoriesTableBody.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import Alert from '@mui/material/Alert';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoryTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoryTableRow.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoryTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/AddedRepositoryTableRow.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { useAsync } from 'react-use';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAsync } from 'react-use';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepository.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepository.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { useDeleteDialog } from '@janus-idp/shared-react';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepository.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepository.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/DeleteRepositoryDialog.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/EditCatalogInfo.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/EditCatalogInfo.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { Entity } from '@backstage/catalog-model';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/EditCatalogInfo.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/EditCatalogInfo.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesAddLink.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesAddLink.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesAddLink.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesAddLink.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { LinkButton } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesListColumns.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesListColumns.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { TableColumn } from '@backstage/core-components';
 
 import { AddRepositoryData } from '../../types';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesListColumns.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/RepositoriesListColumns.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/SyncRepository.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/SyncRepository.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/SyncRepository.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/SyncRepository.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Router.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Router.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Router.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Router.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/WaitingForPR.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/WaitingForPR.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/WaitingForPR.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/WaitingForPR.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Link, StatusPending } from '@backstage/core-components';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { BulkImportPage } from './BulkImportPage';
 export { BulkImportSidebarItem } from './BulkImportSidebarItem';
 export { Router } from './Router';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/globals.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/globals.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 declare module '*.svg' {
   const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;

--- a/workspaces/bulk-import/plugins/bulk-import/src/globals.d.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/globals.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ declare module '*.svg' {
+ */
+declare module '*.svg' {
   const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;
 }

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,5 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ export { useAddedRepositories } from './useAddedRepositories';
+ */
+export { useAddedRepositories } from './useAddedRepositories';
 export { useRepositories } from './useRepositories';

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { useAddedRepositories } from './useAddedRepositories';
 export { useRepositories } from './useRepositories';

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { mockGetImportJobs, mockGetRepositories } from '../mocks/mockData';

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useAsync } from 'react-use';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useQuery } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useAsync } from 'react-use';
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {
   bulkImportPlugin,
   BulkImportPage,

--- a/workspaces/bulk-import/plugins/bulk-import/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockData.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { AddedRepositories, ApprovalTool, ImportJobs } from '../types';
 
 export const mockGetOrganizations = {

--- a/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockData.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockEntities.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockEntities.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export const mockEntities = [
   {
     apiVersion: '1',

--- a/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockEntities.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/mocks/mockEntities.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ export const mockEntities = [
+ */
+export const mockEntities = [
   {
     apiVersion: '1',
     kind: 'User',

--- a/workspaces/bulk-import/plugins/bulk-import/src/plugin.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { bulkImportPlugin } from './plugin';
 
 describe('bulk-import', () => {

--- a/workspaces/bulk-import/plugins/bulk-import/src/plugin.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/plugin.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/plugin.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   configApiRef,
   createApiFactory,

--- a/workspaces/bulk-import/plugins/bulk-import/src/routes.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef, createSubRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/bulk-import/plugins/bulk-import/src/routes.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/setupTests.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/setupTests.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/bulk-import/plugins/bulk-import/src/types/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/types/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export * from './types';
 export * from './response-types';

--- a/workspaces/bulk-import/plugins/bulk-import/src/types/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/types/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,5 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ export * from './types';
+ */
+export * from './types';
 export * from './response-types';

--- a/workspaces/bulk-import/plugins/bulk-import/src/types/response-types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/types/response-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { RepositoryStatus } from './types';
 
 export type Repository = {

--- a/workspaces/bulk-import/plugins/bulk-import/src/types/response-types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/types/response-types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/types/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/types/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Entity } from '@backstage/catalog-model';
 
 import { Repository as RepositoryResponse } from './response-types';

--- a/workspaces/bulk-import/plugins/bulk-import/src/types/types.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/types/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/icons.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/icons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import approvalToolBlackImg from '../images/ApprovalTool_Black.svg';
 import approvalToolWhiteImg from '../images/ApprovalTool_White.svg';
 import bulkImportWhiteImg from '../images/BulkImportIcon-White.svg';

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/icons.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/icons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   mockGetRepositories,
   mockSelectedRepositories,

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import { Entity } from '@backstage/catalog-model';

--- a/workspaces/bulk-import/plugins/bulk-import/tests/bulkImport.spec.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/tests/bulkImport.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { expect, Page, test } from '@playwright/test';
 
 import { Common } from './bulkImportHelper';

--- a/workspaces/bulk-import/plugins/bulk-import/tests/bulkImport.spec.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/tests/bulkImport.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/tests/bulkImportHelper.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/tests/bulkImportHelper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/bulk-import/plugins/bulk-import/tests/bulkImportHelper.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/tests/bulkImportHelper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { expect, type Locator, type Page } from '@playwright/test';
 
 export class Common {

--- a/workspaces/global-header/examples/template/content/index.js
+++ b/workspaces/global-header/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 console.log('Hello from ${{ values.name }}!');

--- a/workspaces/global-header/examples/template/content/index.js
+++ b/workspaces/global-header/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/global-header/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/global-header/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/App.test.tsx
+++ b/workspaces/global-header/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/App.test.tsx
+++ b/workspaces/global-header/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import App from './App';

--- a/workspaces/global-header/packages/app/src/App.tsx
+++ b/workspaces/global-header/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Navigate, Route } from 'react-router-dom';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';

--- a/workspaces/global-header/packages/app/src/App.tsx
+++ b/workspaces/global-header/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/apis.ts
+++ b/workspaces/global-header/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,

--- a/workspaces/global-header/packages/app/src/apis.ts
+++ b/workspaces/global-header/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/global-header/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/global-header/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/global-header/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/global-header/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/global-header/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/global-header/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/global-header/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';

--- a/workspaces/global-header/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/global-header/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/Root/index.ts
+++ b/workspaces/global-header/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/Root/index.ts
+++ b/workspaces/global-header/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/global-header/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/global-header/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/global-header/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Button, Grid } from '@material-ui/core';
 import {

--- a/workspaces/global-header/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/global-header/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/global-header/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
 

--- a/workspaces/global-header/packages/app/src/index.tsx
+++ b/workspaces/global-header/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/index.tsx
+++ b/workspaces/global-header/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/global-header/packages/app/src/setupTests.ts
+++ b/workspaces/global-header/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/app/src/setupTests.ts
+++ b/workspaces/global-header/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/global-header/packages/backend/src/index.ts
+++ b/workspaces/global-header/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/packages/backend/src/index.ts
+++ b/workspaces/global-header/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/playwright.config.ts
+++ b/workspaces/global-header/playwright.config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/dev/index.tsx
+++ b/workspaces/global-header/plugins/global-header/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/dev/index.tsx
+++ b/workspaces/global-header/plugins/global-header/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { globalHeaderPlugin } from '../src/plugin';

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { ExampleComponent } from './ExampleComponent';
 import { rest } from 'msw';

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/ExampleComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleComponent/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { ExampleComponent } from './ExampleComponent';

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ExampleFetchComponent } from './ExampleFetchComponent';

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import {
   Table,

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { ExampleFetchComponent } from './ExampleFetchComponent';

--- a/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/ExampleFetchComponent/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuItemContent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuItemContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuItemContent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuItemContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/HeaderIconButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/HeaderIconButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/HeaderIconButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/HeaderIconButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/SmallIconWrapper.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/SmallIconWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/SmallIconWrapper.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/SmallIconWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchComponent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/components/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { GlobalHeader } from './GlobalHeader';

--- a/workspaces/global-header/plugins/global-header/src/components/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/hooks/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { useDropdownManager } from './useDropdownManager';

--- a/workspaces/global-header/plugins/global-header/src/hooks/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/hooks/useDropdownManager.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useDropdownManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/hooks/useDropdownManager.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useDropdownManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { globalHeaderPlugin, GlobalHeader } from './plugin';

--- a/workspaces/global-header/plugins/global-header/src/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/plugin.test.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/plugin.test.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { globalHeaderPlugin } from './plugin';
 
 describe('global-header', () => {

--- a/workspaces/global-header/plugins/global-header/src/plugin.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createPlugin,
   createComponentExtension,

--- a/workspaces/global-header/plugins/global-header/src/plugin.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/setupTests.ts
+++ b/workspaces/global-header/plugins/global-header/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/global-header/plugins/global-header/src/setupTests.ts
+++ b/workspaces/global-header/plugins/global-header/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/homepage/examples/template/content/index.js
+++ b/workspaces/homepage/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 console.log('Hello from ${{ values.name }}!');

--- a/workspaces/homepage/examples/template/content/index.js
+++ b/workspaces/homepage/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/homepage/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/homepage/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/App.test.tsx
+++ b/workspaces/homepage/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/App.test.tsx
+++ b/workspaces/homepage/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import App from './App';

--- a/workspaces/homepage/packages/app/src/App.tsx
+++ b/workspaces/homepage/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';

--- a/workspaces/homepage/packages/app/src/App.tsx
+++ b/workspaces/homepage/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/apis.ts
+++ b/workspaces/homepage/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,

--- a/workspaces/homepage/packages/app/src/apis.ts
+++ b/workspaces/homepage/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/homepage/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/homepage/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/homepage/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/homepage/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/homepage/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/homepage/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/homepage/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/homepage/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { PropsWithChildren } from 'react';
 import { CatalogIcon } from '@backstage/core-components';
 import { makeStyles } from '@material-ui/core';

--- a/workspaces/homepage/packages/app/src/components/Root/index.ts
+++ b/workspaces/homepage/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/Root/index.ts
+++ b/workspaces/homepage/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/homepage/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/homepage/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/homepage/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Button, Grid } from '@material-ui/core';
 import {

--- a/workspaces/homepage/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/homepage/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/homepage/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
 

--- a/workspaces/homepage/packages/app/src/index.tsx
+++ b/workspaces/homepage/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/index.tsx
+++ b/workspaces/homepage/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/homepage/packages/app/src/setupTests.ts
+++ b/workspaces/homepage/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/packages/app/src/setupTests.ts
+++ b/workspaces/homepage/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/homepage/packages/backend/src/index.ts
+++ b/workspaces/homepage/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createBackend } from '@backstage/backend-defaults';
 
 const backend = createBackend();

--- a/workspaces/homepage/packages/backend/src/index.ts
+++ b/workspaces/homepage/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/playwright.config.ts
+++ b/workspaces/homepage/playwright.config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/dev/index.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { createDevApp, DevAppPageOptions } from '@backstage/dev-utils';

--- a/workspaces/homepage/plugins/dynamic-home-page/dev/index.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/api/QuickAccessApiClient.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/api/QuickAccessApiClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ConfigApi,
   createApiRef,

--- a/workspaces/homepage/plugins/dynamic-home-page/src/api/QuickAccessApiClient.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/api/QuickAccessApiClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/api/index.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export * from './QuickAccessApiClient';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/api/index.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/DynamicHomePage.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/DynamicHomePage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useMemo } from 'react';
 
 import { Content, EmptyState, Header, Page } from '@backstage/core-components';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/DynamicHomePage.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/DynamicHomePage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/FeaturedDocsCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/FeaturedDocsCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import {

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/FeaturedDocsCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/FeaturedDocsCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/Headline.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/Headline.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 /**

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/Headline.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/Headline.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/Markdown.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/Markdown.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { MarkdownContent } from '@backstage/core-components';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/Markdown.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/Markdown.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/MarkdownCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/MarkdownCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { InfoCard, MarkdownContent } from '@backstage/core-components';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/MarkdownCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/MarkdownCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/Placeholder.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/Placeholder.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/Placeholder.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/Placeholder.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { makeStyles } from 'tss-react/mui';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import {

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/ReadOnlyGrid.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/ReadOnlyGrid.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/ReadOnlyGrid.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/ReadOnlyGrid.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/SearchBar.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/SearchBar.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/VisitListener.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/VisitListener.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { VisitListener as VisitListenerComponent } from '@backstage/plugin-home';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/VisitListener.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/VisitListener.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/defaults.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/defaults.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export type Breakpoints = 'xl' | 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
 
 // prettier-ignore

--- a/workspaces/homepage/plugins/dynamic-home-page/src/defaults.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/defaults.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useHomePageMountPoints.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useHomePageMountPoints.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useHomePageMountPoints.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useHomePageMountPoints.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useScalprum } from '@scalprum/react-core';
 
 import { HomePageCardMountPoint } from '../types';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.test.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.test.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { renderHook, waitFor } from '@testing-library/react';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useCallback, useEffect, useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 

--- a/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/hooks/useQuickAccessLinks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/index.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/index.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/plugin.test.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { dynamicHomePagePlugin } from './plugin';
 
 describe('dynamic-home-page', () => {

--- a/workspaces/homepage/plugins/dynamic-home-page/src/plugin.test.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/plugin.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import {

--- a/workspaces/homepage/plugins/dynamic-home-page/src/plugin.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/routes.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/homepage/plugins/dynamic-home-page/src/routes.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/setupTests.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/setupTests.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/types.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import type { Tool } from '@backstage/plugin-home';

--- a/workspaces/homepage/plugins/dynamic-home-page/src/types.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/.eslintrc.js
+++ b/workspaces/lightspeed/.eslintrc.js
@@ -1,1 +1,16 @@
+/*
+ * Copyright 2025 The RHDH Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module.exports = require('../../.eslintrc.cjs');

--- a/workspaces/lightspeed/.eslintrc.js
+++ b/workspaces/lightspeed/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = require('../../.eslintrc.cjs');

--- a/workspaces/lightspeed/package.json
+++ b/workspaces/lightspeed/package.json
@@ -44,7 +44,7 @@
     "@backstage/e2e-test-utils": "^0.1.1",
     "@backstage/repo-tools": "^0.10.0",
     "@changesets/cli": "^2.27.1",
-    "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.4.0",
     "@spotify/prettier-config": "^12.0.0",
     "knip": "^5.27.4",
     "node-gyp": "^9.0.0",

--- a/workspaces/lightspeed/packages/app/.eslintrc.js
+++ b/workspaces/lightspeed/packages/app/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/packages/app/.eslintrc.js
+++ b/workspaces/lightspeed/packages/app/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/App.test.tsx
+++ b/workspaces/lightspeed/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/App.test.tsx
+++ b/workspaces/lightspeed/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import App from './App';

--- a/workspaces/lightspeed/packages/app/src/App.tsx
+++ b/workspaces/lightspeed/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Navigate, Route } from 'react-router-dom';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';

--- a/workspaces/lightspeed/packages/app/src/App.tsx
+++ b/workspaces/lightspeed/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/apis.ts
+++ b/workspaces/lightspeed/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,

--- a/workspaces/lightspeed/packages/app/src/apis.ts
+++ b/workspaces/lightspeed/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/lightspeed/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/lightspeed/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';

--- a/workspaces/lightspeed/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/Root/index.ts
+++ b/workspaces/lightspeed/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/Root/index.ts
+++ b/workspaces/lightspeed/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/lightspeed/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Button, Grid } from '@material-ui/core';
 import {

--- a/workspaces/lightspeed/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/lightspeed/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
 

--- a/workspaces/lightspeed/packages/app/src/index.tsx
+++ b/workspaces/lightspeed/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/index.tsx
+++ b/workspaces/lightspeed/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/lightspeed/packages/app/src/setupTests.ts
+++ b/workspaces/lightspeed/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/app/src/setupTests.ts
+++ b/workspaces/lightspeed/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/lightspeed/packages/backend/.eslintrc.js
+++ b/workspaces/lightspeed/packages/backend/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/packages/backend/.eslintrc.js
+++ b/workspaces/lightspeed/packages/backend/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/packages/backend/src/index.ts
+++ b/workspaces/lightspeed/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/packages/backend/src/index.ts
+++ b/workspaces/lightspeed/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/.eslintrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/.eslintrc.js
@@ -1,1 +1,16 @@
+/*
+ * Copyright 2025 The RHDH Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/.eslintrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/.prettierrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/.prettierrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/__fixtures__/handlers.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/__fixtures__/handlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { http, HttpResponse } from 'msw';
 
 const localHostAndPort = 'localhost:443';

--- a/workspaces/lightspeed/plugins/lightspeed-backend/__fixtures__/handlers.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/__fixtures__/handlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/config.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export interface Config {
   /**
    * Configuration required for using lightspeed

--- a/workspaces/lightspeed/plugins/lightspeed-backend/config.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/dev/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/dev/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createBackend } from '@backstage/backend-defaults';
 
 import lightspeedPlugin from '../src';

--- a/workspaces/lightspeed/plugins/lightspeed-backend/dev/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/dev/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 
 import { Roles } from '../service/types';

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   AIMessage,
   HumanMessage,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/chatHistory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   generateConversationId,
   getUserId,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { randomBytes } from 'crypto';
 
 const SESSION_ID_LENGTH = 16;

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/handlers/conversationId.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   coreServices,
   createBackendPlugin,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { mockCredentials } from '@backstage/backend-test-utils';
 import {
   AuthorizeResult,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/permission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   BackstageCredentials,
   PermissionsService,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { type BackendFeature } from '@backstage/backend-plugin-api';
 import {
   mockCredentials,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { NotAllowedError } from '@backstage/errors';
 import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type {
   HttpAuthService,
   LoggerService,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type { NextFunction, Request, Response } from 'express';
 
 import { QueryRequestBody } from './types';

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/setupTests.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/setupTests.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/lightspeed/plugins/lightspeed-common/.eslintrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-common/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/.eslintrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-common/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/plugins/lightspeed-common/.prettierrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-common/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/.prettierrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed-common/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createPermission } from '@backstage/plugin-permission-common';
 
 /** This permission is used to access the lightspeed read conversations endpoint

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/setupTests.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/setupTests.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/lightspeed/plugins/lightspeed/.eslintrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed/.eslintrc.js
@@ -1,1 +1,16 @@
+/*
+ * Copyright 2025 The RHDH Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/plugins/lightspeed/.eslintrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/workspaces/lightspeed/plugins/lightspeed/.prettierrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/.prettierrc.js
+++ b/workspaces/lightspeed/plugins/lightspeed/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/config.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export interface Config {
   /**
    * Configuration required for using lightspeed

--- a/workspaces/lightspeed/plugins/lightspeed/config.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/dev/index.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/dev/index.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { createDevApp } from '@backstage/dev-utils';

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ConfigApi, FetchApi } from '@backstage/core-plugin-api';
 
 import { LightspeedAPI } from './api';

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/api.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createApiRef } from '@backstage/core-plugin-api';
 
 import OpenAI from 'openai';

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/api.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { ErrorPanel } from '@backstage/core-components';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { makeStyles } from '@material-ui/core';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedIcon.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedIcon.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import logo from '../images/logo-white.svg';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useAsync } from 'react-use';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredIcon.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as React from 'react';
 
 import permissionRequired from '../images/permission-required.svg';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredIcon.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { EmptyState } from '@backstage/core-components';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { IdentityApi, identityApiRef } from '@backstage/core-plugin-api';

--- a/workspaces/lightspeed/plugins/lightspeed/src/globals.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/globals.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 declare module '*.svg' {
   const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;

--- a/workspaces/lightspeed/plugins/lightspeed/src/globals.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/globals.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useBackstageUserIdentity.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useBackstageUserIdentity.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useBackstageUserIdentity.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useBackstageUserIdentity.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { renderHook, waitFor } from '@testing-library/react';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useConversationMessages.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useConversationMessages.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useConversationMessages.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useConversationMessages.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useDeleteConversation.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useDeleteConversation.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useDeleteConversation.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useDeleteConversation.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useAllModels.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useAllModels.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useQuery } from '@tanstack/react-query';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useAllModels.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useAllModels.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useBackstageUserIdentity.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useBackstageUserIdentity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useAsync } from 'react-use';
 
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useBackstageUserIdentity.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useBackstageUserIdentity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversations.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useQuery } from '@tanstack/react-query';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversations.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateConversation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateConversation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateConversation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateConversation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateCoversationMessage.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateCoversationMessage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateCoversationMessage.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useCreateCoversationMessage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useMutation } from '@tanstack/react-query';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useDeleteConversation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useDeleteConversation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useDeleteConversation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useDeleteConversation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedDeletePermission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedDeletePermission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedDeletePermission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedDeletePermission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { lightspeedConversationsDeletePermission } from '@red-hat-developer-hub/backstage-plugin-lightspeed-common';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedViewPermission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedViewPermission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import {

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedViewPermission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedViewPermission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { lightspeedPlugin, LightspeedPage } from './plugin';
 export { LightspeedIcon } from './components/LightspeedIcon';

--- a/workspaces/lightspeed/plugins/lightspeed/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/plugin.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { lightspeedPlugin } from './plugin';
 
 describe('lightspeed', () => {

--- a/workspaces/lightspeed/plugins/lightspeed/src/plugin.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/virtual-assistant/dist/css/main.css';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/routes.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/lightspeed/plugins/lightspeed/src/routes.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/setupTests.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';
 
 // eslint-disable-next-line no-restricted-imports

--- a/workspaces/lightspeed/plugins/lightspeed/src/setupTests.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export type Conversations = {
   [key: string]: {
     user: string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/lightspeed-chatbot-utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/lightspeed-chatbot-utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ConversationList, ConversationSummary } from '../../types';
 import {
   createBotMessage,

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/lightspeed-chatbot-utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/lightspeed-chatbot-utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Conversation } from '@patternfly/virtual-assistant';
 
 import { BaseMessage, ConversationList, ConversationSummary } from '../types';

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/queryClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/queryClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { QueryClient } from '@tanstack/react-query';
 
 const queryClient = new QueryClient();

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/queryClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/queryClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -7468,7 +7468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ianvs/prettier-plugin-sort-imports@npm:^4.3.1, @ianvs/prettier-plugin-sort-imports@npm:^4.4.0":
+"@ianvs/prettier-plugin-sort-imports@npm:^4.4.0":
   version: 4.4.0
   resolution: "@ianvs/prettier-plugin-sort-imports@npm:4.4.0"
   dependencies:
@@ -7540,7 +7540,7 @@ __metadata:
     "@backstage/e2e-test-utils": ^0.1.1
     "@backstage/repo-tools": ^0.10.0
     "@changesets/cli": ^2.27.1
-    "@ianvs/prettier-plugin-sort-imports": ^4.3.1
+    "@ianvs/prettier-plugin-sort-imports": ^4.4.0
     "@spotify/prettier-config": ^12.0.0
     knip: ^5.27.4
     node-gyp: ^9.0.0

--- a/workspaces/marketplace/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/marketplace/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/marketplace/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/App.test.tsx
+++ b/workspaces/marketplace/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/App.test.tsx
+++ b/workspaces/marketplace/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import App from './App';

--- a/workspaces/marketplace/packages/app/src/App.tsx
+++ b/workspaces/marketplace/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Navigate, Route } from 'react-router-dom';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';

--- a/workspaces/marketplace/packages/app/src/App.tsx
+++ b/workspaces/marketplace/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/apis.ts
+++ b/workspaces/marketplace/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,

--- a/workspaces/marketplace/packages/app/src/apis.ts
+++ b/workspaces/marketplace/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/marketplace/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/marketplace/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/marketplace/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/marketplace/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/marketplace/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/marketplace/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/marketplace/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';

--- a/workspaces/marketplace/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/marketplace/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/Root/index.ts
+++ b/workspaces/marketplace/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/Root/index.ts
+++ b/workspaces/marketplace/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/marketplace/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/marketplace/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/marketplace/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Button, Grid } from '@material-ui/core';
 import {

--- a/workspaces/marketplace/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/marketplace/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/marketplace/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
 

--- a/workspaces/marketplace/packages/app/src/index.tsx
+++ b/workspaces/marketplace/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/index.tsx
+++ b/workspaces/marketplace/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/marketplace/packages/app/src/setupTests.ts
+++ b/workspaces/marketplace/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/app/src/setupTests.ts
+++ b/workspaces/marketplace/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/marketplace/packages/backend/src/index.ts
+++ b/workspaces/marketplace/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/packages/backend/src/index.ts
+++ b/workspaces/marketplace/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginListProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginListProcessor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginListProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginListProcessor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   CatalogProcessor,
   CatalogProcessorEmit,

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginProcessor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/MarketplacePluginProcessor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   CatalogProcessor,
   CatalogProcessorEmit,

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/index.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/index.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   coreServices,
   createBackendModule,

--- a/workspaces/marketplace/plugins/marketplace-backend/dev/index.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/dev/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/dev/index.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/dev/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createBackend } from '@backstage/backend-defaults';
 import { mockServices } from '@backstage/backend-test-utils';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';

--- a/workspaces/marketplace/plugins/marketplace-backend/src/index.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { marketplacePlugin as default } from './plugin';

--- a/workspaces/marketplace/plugins/marketplace-backend/src/index.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/plugin.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { startTestBackend } from '@backstage/backend-test-utils';
 import request from 'supertest';
 

--- a/workspaces/marketplace/plugins/marketplace-backend/src/plugin.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/plugin.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/plugin.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   coreServices,
   createBackendPlugin,

--- a/workspaces/marketplace/plugins/marketplace-backend/src/router.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/router.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/router.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/router.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
 import express from 'express';
 import request from 'supertest';

--- a/workspaces/marketplace/plugins/marketplace-backend/src/router.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { HttpAuthService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import Router from 'express-promise-router';

--- a/workspaces/marketplace/plugins/marketplace-backend/src/router.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceCatalogService.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceCatalogService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceCatalogService.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceCatalogService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   AuthService,
   LoggerService,

--- a/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceService.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   MarketplacePluginEntry,
   MarketplacePluginList,

--- a/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceService.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/services/MarketplaceService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/setupTests.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-backend/src/setupTests.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/marketplace/plugins/marketplace-common/src/index.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-common/src/index.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-common/src/setupTests.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-common/src/setupTests.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {};

--- a/workspaces/marketplace/plugins/marketplace-common/src/types.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace-common/src/types.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Entity } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/types';
 

--- a/workspaces/marketplace/plugins/marketplace/dev/index.tsx
+++ b/workspaces/marketplace/plugins/marketplace/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/dev/index.tsx
+++ b/workspaces/marketplace/plugins/marketplace/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceApi.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceApi.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   MarketplacePluginEntry,
   MarketplacePluginList,

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceApi.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceApi.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceBackendClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceBackendClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 
 import {

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceBackendClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceBackendClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/api/MarketplaceCatalogClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/api/index.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createApiRef } from '@backstage/core-plugin-api';
 
 import { MarketplaceApi } from './MarketplaceApi';

--- a/workspaces/marketplace/plugins/marketplace/src/api/index.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import Card from '@mui/material/Card';

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogGrid.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogGrid.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogGrid.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogGrid.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryAboutDrawer.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryAboutDrawer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryAboutDrawer.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryAboutDrawer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryInstallDrawer.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryInstallDrawer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryInstallDrawer.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceEntryInstallDrawer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Page, Header, TabbedLayout } from '@backstage/core-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/workspaces/marketplace/plugins/marketplace/src/components/SearchTextField.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/SearchTextField.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/components/SearchTextField.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/SearchTextField.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { useQueryParamState } from '@backstage/core-components';

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useQuery } from '@tanstack/react-query';

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePluginList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePlugins.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePlugins.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useApi } from '@backstage/core-plugin-api';
 
 import { useQuery } from '@tanstack/react-query';

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/usePlugins.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/usePlugins.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/index.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/index.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
 
 ClassNameGenerator.configure(componentName => {

--- a/workspaces/marketplace/plugins/marketplace/src/plugin.test.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/plugin.test.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { marketplacePlugin } from './plugin';
 
 describe('marketplace', () => {

--- a/workspaces/marketplace/plugins/marketplace/src/plugin.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createPlugin,
   createRoutableExtension,

--- a/workspaces/marketplace/plugins/marketplace/src/plugin.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/routes.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef, createSubRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/marketplace/plugins/marketplace/src/routes.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/setupTests.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/marketplace/plugins/marketplace/src/setupTests.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/openshift-image-registry/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/openshift-image-registry/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/openshift-image-registry/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/App.test.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/App.test.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import App from './App';

--- a/workspaces/openshift-image-registry/packages/app/src/App.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import {

--- a/workspaces/openshift-image-registry/packages/app/src/App.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/apis.ts
+++ b/workspaces/openshift-image-registry/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   AnyApiFactory,
   configApiRef,

--- a/workspaces/openshift-image-registry/packages/app/src/apis.ts
+++ b/workspaces/openshift-image-registry/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   Link,
   Sidebar,

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/index.ts
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/components/Root/index.ts
+++ b/workspaces/openshift-image-registry/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/openshift-image-registry/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   RELATION_API_CONSUMED_BY,
   RELATION_API_PROVIDED_BY,

--- a/workspaces/openshift-image-registry/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   CatalogIcon,
   Content,

--- a/workspaces/openshift-image-registry/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/index.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/index.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/openshift-image-registry/packages/app/src/setupTests.ts
+++ b/workspaces/openshift-image-registry/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/packages/app/src/setupTests.ts
+++ b/workspaces/openshift-image-registry/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/openshift-image-registry/packages/backend/src/index.ts
+++ b/workspaces/openshift-image-registry/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createBackend } from '@backstage/backend-defaults';
 
 const backend = createBackend();

--- a/workspaces/openshift-image-registry/packages/backend/src/index.ts
+++ b/workspaces/openshift-image-registry/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/.eslintrc.js
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/.prettierrc.js
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/.prettierrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/config.d.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/config.d.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/dev/index.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/dev/index.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import { createDevApp } from '@backstage/dev-utils';

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/api/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/api/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSearchBar.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSearchBar.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSidebar.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSidebar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSidebar.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImageSidebar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCard.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCard.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCards.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCards.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCards.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesCards.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesView.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesView.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesView.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/OcirImagesView.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirImages/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/OcirPage.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/OcirPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/OcirPage.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/OcirPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/components/OcirPage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useAllNsImageStreams.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useAllNsImageStreams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useAllNsImageStreams.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useAllNsImageStreams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useImageStreamsMetadataFromTag.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useImageStreamsMetadataFromTag.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useImageStreamsMetadataFromTag.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useImageStreamsMetadataFromTag.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/index.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.test.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.test.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/routes.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/routes.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/setupTests.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/setupTests.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/types.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/types.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/commands/index.ts
+++ b/workspaces/repo-tools/packages/cli/src/commands/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/commands/lint/lint-legacy-backend-exports.ts
+++ b/workspaces/repo-tools/packages/cli/src/commands/lint/lint-legacy-backend-exports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/commands/plugin/janus-migration.ts
+++ b/workspaces/repo-tools/packages/cli/src/commands/plugin/janus-migration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/commands/workspace/create.ts
+++ b/workspaces/repo-tools/packages/cli/src/commands/workspace/create.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/index.ts
+++ b/workspaces/repo-tools/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/lib/errors.ts
+++ b/workspaces/repo-tools/packages/cli/src/lib/errors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/createWorkspace.ts
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/createWorkspace.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/examples/template/content/index.js
+++ b/workspaces/theme/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 console.log('Hello from ${{ values.name }}!');

--- a/workspaces/theme/examples/template/content/index.js
+++ b/workspaces/theme/examples/template/content/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,4 +12,5 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ console.log('Hello from ${{ values.name }}!');
+ */
+console.log('Hello from ${{ values.name }}!');

--- a/workspaces/theme/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/theme/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/theme/packages/app/e2e-tests/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/App.test.tsx
+++ b/workspaces/theme/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/App.test.tsx
+++ b/workspaces/theme/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import App from './App';

--- a/workspaces/theme/packages/app/src/App.tsx
+++ b/workspaces/theme/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Navigate, Route } from 'react-router-dom';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';

--- a/workspaces/theme/packages/app/src/App.tsx
+++ b/workspaces/theme/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/apis.ts
+++ b/workspaces/theme/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,

--- a/workspaces/theme/packages/app/src/apis.ts
+++ b/workspaces/theme/packages/app/src/apis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/theme/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/theme/packages/app/src/components/Root/LogoFull.tsx
+++ b/workspaces/theme/packages/app/src/components/Root/LogoFull.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/theme/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 

--- a/workspaces/theme/packages/app/src/components/Root/LogoIcon.tsx
+++ b/workspaces/theme/packages/app/src/components/Root/LogoIcon.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/theme/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';

--- a/workspaces/theme/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/theme/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/Root/index.ts
+++ b/workspaces/theme/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/Root/index.ts
+++ b/workspaces/theme/packages/app/src/components/Root/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { Root } from './Root';

--- a/workspaces/theme/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/theme/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/theme/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Button, Grid } from '@material-ui/core';
 import {

--- a/workspaces/theme/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/theme/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/theme/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
 

--- a/workspaces/theme/packages/app/src/index.tsx
+++ b/workspaces/theme/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/index.tsx
+++ b/workspaces/theme/packages/app/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@backstage/cli/asset-types';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/workspaces/theme/packages/app/src/setupTests.ts
+++ b/workspaces/theme/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/app/src/setupTests.ts
+++ b/workspaces/theme/packages/app/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/theme/packages/backend/src/index.ts
+++ b/workspaces/theme/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/packages/backend/src/index.ts
+++ b/workspaces/theme/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/dev/index.tsx
+++ b/workspaces/theme/plugins/bc-test/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { bcTestPlugin, BCTestPage } from '../src/plugin';

--- a/workspaces/theme/plugins/bc-test/dev/index.tsx
+++ b/workspaces/theme/plugins/bc-test/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/components/BCTestPage.tsx
+++ b/workspaces/theme/plugins/bc-test/src/components/BCTestPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/components/BCTestPage.tsx
+++ b/workspaces/theme/plugins/bc-test/src/components/BCTestPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Page, Header, TabbedLayout } from '@backstage/core-components';
 import { UserSettingsThemeToggle } from '@backstage/plugin-user-settings';

--- a/workspaces/theme/plugins/bc-test/src/components/CardExample.tsx
+++ b/workspaces/theme/plugins/bc-test/src/components/CardExample.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { InfoCard } from '@backstage/core-components';
 

--- a/workspaces/theme/plugins/bc-test/src/components/CardExample.tsx
+++ b/workspaces/theme/plugins/bc-test/src/components/CardExample.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/components/TableExample.tsx
+++ b/workspaces/theme/plugins/bc-test/src/components/TableExample.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Table, TableColumn, Avatar } from '@backstage/core-components';
 

--- a/workspaces/theme/plugins/bc-test/src/components/TableExample.tsx
+++ b/workspaces/theme/plugins/bc-test/src/components/TableExample.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/index.ts
+++ b/workspaces/theme/plugins/bc-test/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/index.ts
+++ b/workspaces/theme/plugins/bc-test/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/plugin.test.ts
+++ b/workspaces/theme/plugins/bc-test/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { bcTestPlugin } from './plugin';
 
 describe('bc-test', () => {

--- a/workspaces/theme/plugins/bc-test/src/plugin.test.ts
+++ b/workspaces/theme/plugins/bc-test/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/plugin.ts
+++ b/workspaces/theme/plugins/bc-test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createPlugin,
   createRoutableExtension,

--- a/workspaces/theme/plugins/bc-test/src/plugin.ts
+++ b/workspaces/theme/plugins/bc-test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/routes.ts
+++ b/workspaces/theme/plugins/bc-test/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/theme/plugins/bc-test/src/routes.ts
+++ b/workspaces/theme/plugins/bc-test/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/setupTests.ts
+++ b/workspaces/theme/plugins/bc-test/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/bc-test/src/setupTests.ts
+++ b/workspaces/theme/plugins/bc-test/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/theme/plugins/mui4-test/dev/index.tsx
+++ b/workspaces/theme/plugins/mui4-test/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/dev/index.tsx
+++ b/workspaces/theme/plugins/mui4-test/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { mui4TestPlugin, MUI4TestPage } from '../src/plugin';

--- a/workspaces/theme/plugins/mui4-test/src/components/FormComponents.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/FormComponents.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { InfoCard } from '@backstage/core-components';
 import Button, { ButtonProps } from '@material-ui/core/Button';

--- a/workspaces/theme/plugins/mui4-test/src/components/FormComponents.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/FormComponents.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/components/InlineStyles.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/InlineStyles.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { InfoCard } from '@backstage/core-components';
 import Button from '@material-ui/core/Button';

--- a/workspaces/theme/plugins/mui4-test/src/components/InlineStyles.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/InlineStyles.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/components/MUI4TestPage.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/MUI4TestPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/components/MUI4TestPage.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/MUI4TestPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Page, Header, TabbedLayout } from '@backstage/core-components';
 import { UserSettingsThemeToggle } from '@backstage/plugin-user-settings';

--- a/workspaces/theme/plugins/mui4-test/src/components/PaperExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/PaperExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import Paper from '@material-ui/core/Paper';
 

--- a/workspaces/theme/plugins/mui4-test/src/components/PaperExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/PaperExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import Tabs, { TabsProps } from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';

--- a/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui4-test/src/components/TabExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/index.ts
+++ b/workspaces/theme/plugins/mui4-test/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/index.ts
+++ b/workspaces/theme/plugins/mui4-test/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/plugin.test.ts
+++ b/workspaces/theme/plugins/mui4-test/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/plugin.test.ts
+++ b/workspaces/theme/plugins/mui4-test/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { mui4TestPlugin } from './plugin';
 
 describe('mui4-test', () => {

--- a/workspaces/theme/plugins/mui4-test/src/plugin.ts
+++ b/workspaces/theme/plugins/mui4-test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createPlugin,
   createRoutableExtension,

--- a/workspaces/theme/plugins/mui4-test/src/plugin.ts
+++ b/workspaces/theme/plugins/mui4-test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/routes.ts
+++ b/workspaces/theme/plugins/mui4-test/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/theme/plugins/mui4-test/src/routes.ts
+++ b/workspaces/theme/plugins/mui4-test/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/setupTests.ts
+++ b/workspaces/theme/plugins/mui4-test/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui4-test/src/setupTests.ts
+++ b/workspaces/theme/plugins/mui4-test/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/theme/plugins/mui5-test/dev/index.tsx
+++ b/workspaces/theme/plugins/mui5-test/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/dev/index.tsx
+++ b/workspaces/theme/plugins/mui5-test/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { mui5TestPlugin, MUI5TestPage } from '../src/plugin';

--- a/workspaces/theme/plugins/mui5-test/src/components/FormComponents.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/FormComponents.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/components/FormComponents.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/FormComponents.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { InfoCard } from '@backstage/core-components';
 import Button, { ButtonProps } from '@mui/material/Button';

--- a/workspaces/theme/plugins/mui5-test/src/components/InlineStyles.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/InlineStyles.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { InfoCard } from '@backstage/core-components';
 import Button from '@mui/material/Button';

--- a/workspaces/theme/plugins/mui5-test/src/components/InlineStyles.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/InlineStyles.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/components/MUI5TestPage.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/MUI5TestPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/components/MUI5TestPage.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/MUI5TestPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { Page, Header, TabbedLayout } from '@backstage/core-components';
 import { UserSettingsThemeToggle } from '@backstage/plugin-user-settings';

--- a/workspaces/theme/plugins/mui5-test/src/components/PaperExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/PaperExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/components/PaperExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/PaperExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import Paper from '@mui/material/Paper';
 

--- a/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import Tabs, { TabsProps } from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';

--- a/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
+++ b/workspaces/theme/plugins/mui5-test/src/components/TabExamples.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/index.ts
+++ b/workspaces/theme/plugins/mui5-test/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/index.ts
+++ b/workspaces/theme/plugins/mui5-test/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/plugin.test.ts
+++ b/workspaces/theme/plugins/mui5-test/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { mui5TestPlugin } from './plugin';
 
 describe('mui5-test', () => {

--- a/workspaces/theme/plugins/mui5-test/src/plugin.test.ts
+++ b/workspaces/theme/plugins/mui5-test/src/plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/plugin.ts
+++ b/workspaces/theme/plugins/mui5-test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createPlugin,
   createRoutableExtension,

--- a/workspaces/theme/plugins/mui5-test/src/plugin.ts
+++ b/workspaces/theme/plugins/mui5-test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/routes.ts
+++ b/workspaces/theme/plugins/mui5-test/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/workspaces/theme/plugins/mui5-test/src/routes.ts
+++ b/workspaces/theme/plugins/mui5-test/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/setupTests.ts
+++ b/workspaces/theme/plugins/mui5-test/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/mui5-test/src/setupTests.ts
+++ b/workspaces/theme/plugins/mui5-test/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/theme/plugins/theme/config.d.ts
+++ b/workspaces/theme/plugins/theme/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ThemeConfig } from './src';
 
 export interface Config {

--- a/workspaces/theme/plugins/theme/config.d.ts
+++ b/workspaces/theme/plugins/theme/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/dev/index.tsx
+++ b/workspaces/theme/plugins/theme/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { getAllThemes } from '../src';

--- a/workspaces/theme/plugins/theme/dev/index.tsx
+++ b/workspaces/theme/plugins/theme/dev/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/backstage.test.ts
+++ b/workspaces/theme/plugins/theme/src/backstage.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { getDefaultThemeConfig } from './backstage';
 
 // This test will fail when backstage theme is updated.

--- a/workspaces/theme/plugins/theme/src/backstage.test.ts
+++ b/workspaces/theme/plugins/theme/src/backstage.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/backstage.ts
+++ b/workspaces/theme/plugins/theme/src/backstage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/backstage.ts
+++ b/workspaces/theme/plugins/theme/src/backstage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { palettes } from '@backstage/theme';
 
 import { ThemeConfig } from './types';

--- a/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
+++ b/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { AppTheme } from '@backstage/core-plugin-api';
 import { UnifiedTheme, UnifiedThemeProvider } from '@backstage/theme';

--- a/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
+++ b/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/darkTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { customDarkTheme } from './darkTheme';
 
 describe('customDarkTheme', () => {

--- a/workspaces/theme/plugins/theme/src/darkTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { palettes } from '@backstage/theme';
 import { type PaletteOptions } from '@mui/material/styles';
 

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/fonts.tsx
+++ b/workspaces/theme/plugins/theme/src/fonts.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/fonts.tsx
+++ b/workspaces/theme/plugins/theme/src/fonts.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import RedHatDisplay from './assets/fonts/RedHatDisplay/RedHatDisplayVF.woff2';
 import RedHatDisplayItalic from './assets/fonts/RedHatDisplay/RedHatDisplayVF-Italic.woff2';
 import RedHatText from './assets/fonts/RedHatText/RedHatTextVF.woff2';

--- a/workspaces/theme/plugins/theme/src/hooks/index.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export * from './useBranding';
 export * from './useThemeConfig';
 export * from './useThemeOptions';

--- a/workspaces/theme/plugins/theme/src/hooks/index.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useBranding.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useBranding.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { renderHook } from '@testing-library/react-hooks';
 import { useApi } from '@backstage/core-plugin-api';
 import { MockConfigApi } from '@backstage/test-utils';

--- a/workspaces/theme/plugins/theme/src/hooks/useBranding.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useBranding.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useBranding.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useBranding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { ConfigApi, configApiRef, useApi } from '@backstage/core-plugin-api';
 import { Branding } from '../types';

--- a/workspaces/theme/plugins/theme/src/hooks/useBranding.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useBranding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { renderHook } from '@testing-library/react-hooks';
 import { useTheme } from './useTheme';
 

--- a/workspaces/theme/plugins/theme/src/hooks/useTheme.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useTheme.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { createUnifiedTheme, type UnifiedTheme } from '@backstage/theme';
 import type { ThemeConfig } from '../types';

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { renderHook } from '@testing-library/react-hooks';
 import { useApi } from '@backstage/core-plugin-api';
 import { MockConfigApi } from '@backstage/test-utils';

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { ConfigApi, configApiRef, useApi } from '@backstage/core-plugin-api';
 import { ThemeConfig } from '../types';

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { renderHook } from '@testing-library/react-hooks';
 import { useThemeOptions } from './useThemeOptions';
 

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.test.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { type UnifiedThemeOptions } from '@backstage/theme';
 import type { ThemeConfig } from '../types';

--- a/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.ts
+++ b/workspaces/theme/plugins/theme/src/hooks/useThemeOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/index.ts
+++ b/workspaces/theme/plugins/theme/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export * from './hooks';
 export * from './themes';
 export type {

--- a/workspaces/theme/plugins/theme/src/index.ts
+++ b/workspaces/theme/plugins/theme/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/lightTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/lightTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { customLightTheme } from './lightTheme';
 
 describe('customLightTheme', () => {

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { palettes } from '@backstage/theme';
 import { type PaletteOptions } from '@mui/material/styles';
 

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/rhdh.ts
+++ b/workspaces/theme/plugins/theme/src/rhdh.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ThemeConfig } from './types';
 import { customDarkTheme } from './darkTheme';
 import { customLightTheme } from './lightTheme';

--- a/workspaces/theme/plugins/theme/src/rhdh.ts
+++ b/workspaces/theme/plugins/theme/src/rhdh.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/setupTests.ts
+++ b/workspaces/theme/plugins/theme/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/setupTests.ts
+++ b/workspaces/theme/plugins/theme/src/setupTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';

--- a/workspaces/theme/plugins/theme/src/themes.tsx
+++ b/workspaces/theme/plugins/theme/src/themes.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { AppTheme } from '@backstage/core-plugin-api';
 import { themes } from '@backstage/theme';

--- a/workspaces/theme/plugins/theme/src/themes.tsx
+++ b/workspaces/theme/plugins/theme/src/themes.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/types.ts
+++ b/workspaces/theme/plugins/theme/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { type UnifiedThemeOptions } from '@backstage/theme';
 
 export type BackstageThemePalette = UnifiedThemeOptions['palette'];

--- a/workspaces/theme/plugins/theme/src/types.ts
+++ b/workspaces/theme/plugins/theme/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/typography.ts
+++ b/workspaces/theme/plugins/theme/src/typography.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/typography.ts
+++ b/workspaces/theme/plugins/theme/src/typography.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { BackstageTypography } from '@backstage/theme';
 
 import { redHatFonts } from './fonts';

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type { ThemeConfig } from '../types';
 import { createComponents, type Components } from './createComponents';
 

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   type UnifiedThemeOptions,
   defaultComponentThemes as backstageComponents,

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/createPageTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/createPageTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { PageTheme, shapes } from '@backstage/theme';
 import { ThemeConfigPageTheme } from '../types';
 import { createPageTheme } from './createPageTheme';

--- a/workspaces/theme/plugins/theme/src/utils/createPageTheme.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/createPageTheme.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { PageTheme, genPageTheme, shapes } from '@backstage/theme';
 import { ThemeConfigPageTheme } from '../types';
 

--- a/workspaces/theme/plugins/theme/src/utils/createPageThemes.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageThemes.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { PageTheme, shapes } from '@backstage/theme';
 import { ThemeConfig } from '../types';
 import { createPageThemes } from './createPageThemes';

--- a/workspaces/theme/plugins/theme/src/utils/createPageThemes.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageThemes.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/createPageThemes.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageThemes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { PageTheme } from '@backstage/theme';
 import { ThemeConfig } from '../types';
 import { createPageTheme } from './createPageTheme';

--- a/workspaces/theme/plugins/theme/src/utils/createPageThemes.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createPageThemes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/mergeTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/mergeTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { UnifiedThemeOptions } from '@backstage/theme';
 import { mergeUnifiedThemeOptions } from './mergeTheme';
 

--- a/workspaces/theme/plugins/theme/src/utils/mergeTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/mergeTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/mergeTheme.ts
+++ b/workspaces/theme/plugins/theme/src/utils/mergeTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ThemeConfig } from '../types';
 
 function isObject(

--- a/workspaces/theme/plugins/theme/src/utils/mergeTheme.ts
+++ b/workspaces/theme/plugins/theme/src/utils/mergeTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/migrateTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/migrateTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { BackstagePaletteAdditions } from '@backstage/theme';
 import { ThemeConfig } from '../types';
 import {

--- a/workspaces/theme/plugins/theme/src/utils/migrateTheme.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/migrateTheme.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/theme/plugins/theme/src/utils/migrateTheme.ts
+++ b/workspaces/theme/plugins/theme/src/utils/migrateTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The RHDH Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type { BackstagePaletteAdditions } from '@backstage/theme';
 import type { SimplePaletteColorOptions } from '@mui/material/styles';
 import type { ThemeConfig } from '../types';

--- a/workspaces/theme/plugins/theme/src/utils/migrateTheme.ts
+++ b/workspaces/theme/plugins/theme/src/utils/migrateTheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The RHDH Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the copyright header template to accept copyright headers with either "The RHDH Authors" or "The Backstage" (since a lot of the workflows used in this repository are from backstage/community-plugins) as valid options.

The header files for the following workspaces are also updated in the PR: bulk-import, global-header, homepage, lightspeed, marketplace, openshift-image-registry, theme.

I will update the orchestrator workplace files in a separate PR as it has few eslint errors. 

Fixes: https://issues.redhat.com/browse/RHIDP-5401

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
