### PR TITLE
chore(openshift-image-registry): add missing CORS configuration to test plugin with the bundled backstage app

### DIFF
--- a/workspaces/openshift-image-registry/app-config.yaml
+++ b/workspaces/openshift-image-registry/app-config.yaml
@@ -15,7 +15,25 @@ backend:
   baseUrl: http://localhost:7007
   listen:
     port: 7007
+    # Uncomment the following host directive to bind to specific interfaces
+    # host: 127.0.0.1
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+  cors:
+    origin: http://localhost:3000
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  # This is for local development only, it is not recommended to use this in production
+  # The production database configuration is stored in app-config.production.yaml
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+  # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
 
+# You can also copy this section into a file called app-config.local.yaml
+# and fill in the values.
 proxy:
   endpoints:
     '/openshift-image-registry/api':
@@ -26,3 +44,10 @@ proxy:
       changeOrigin: true
       # Change to "false" in case of using self hosted OpenShift cluster with a self-signed certificate
       secure: true
+      # credentials: dangerously-allow-unauthenticated
+
+auth:
+  # see https://backstage.io/docs/auth/ to learn about auth providers
+  providers:
+    # See https://backstage.io/docs/auth/guest/provider
+    guest: {}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I got CORS issues when the OpenShift Image registry plugin fetches information from a included backstage app.

This additional, default backstage configuration solves that problem.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
