### PR TITLE
chore: add renovate config validator to CI

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -1,0 +1,20 @@
+name: PR Renovate Config Validator
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json'
+    # Renovate always uses the config from the repository default branch
+    # https://docs.renovatebot.com/configuration-options/
+    branches: [ 'main' ]
+
+jobs:
+  renovate-config-validator:
+    runs-on: ubuntu-latest
+    name: Renovate Config Validator
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Validate config
+        # See https://docs.renovatebot.com/config-validation/
+        run: |
+          npx --yes --package renovate -- renovate-config-validator --strict .github/renovate.json


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
- Add Renovate Config Validator to this repo to ensure bad configs are not merged.
- [Copy](https://github.com/redhat-developer/rhdh-operator/blob/main/.github/workflows/renovate-checks.yaml) of the config @rm3l introduced in rhdh-operator repo

Fixes: https://issues.redhat.com/browse/RHIDP-4068

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
