### PR TITLE
feat(global-header): add new notificationbanner component

### DIFF
--- a/workspaces/global-header/.changeset/heavy-bulldogs-mate.md
+++ b/workspaces/global-header/.changeset/heavy-bulldogs-mate.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+add new notificationbanner component

--- a/workspaces/global-header/plugins/global-header/dev/index.tsx
+++ b/workspaces/global-header/plugins/global-header/dev/index.tsx
@@ -16,10 +16,13 @@
 
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { globalHeaderPlugin } from '../src/plugin';
-import { ExampleComponent } from '../src/components/ExampleComponent';
 import { TestApiProvider } from '@backstage/test-utils';
 import { MockSearchApi, searchApiRef } from '@backstage/plugin-search-react';
+
+import Button from '@mui/material/Button';
+
+import { globalHeaderPlugin, NotificationBanner } from '../src/plugin';
+import { ExampleComponent } from '../src/components/ExampleComponent';
 
 const mockSearchApi = new MockSearchApi({
   results: [
@@ -44,5 +47,48 @@ createDevApp()
     ),
     title: 'Global Header',
     path: '/global-header',
+  })
+  .addPage({
+    element: (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <NotificationBanner
+          title={`🥳 Happy ${new Date().getFullYear()}! 🥳`}
+        />
+        <NotificationBanner title="## This is Markdown!" markdown />
+        <NotificationBanner title="This is also **Markdown**!" markdown />
+        <NotificationBanner title="This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information! This is a super long notification that contains a lot of information!" />
+
+        {/* <NotificationBanner title="This is a warning!" icon="info" />
+        <NotificationBanner title="This is a warning!" icon="success" />
+        <NotificationBanner title="This is a warning!" icon="warning" />
+        <NotificationBanner title="This is a warning!" icon="error" /> */}
+
+        <NotificationBanner
+          title="A colorized notification: ⚠️ Maintainance planned for this week! ⚠️"
+          textColor="blue"
+          backgroundColor="yellow"
+          border="2px solid blue"
+        />
+        <NotificationBanner
+          title="And a dismissable notification! Will appear after reload!"
+          dismiss="session"
+        />
+        <NotificationBanner
+          title="And a dismissable notification! Dismiss option is saved in local storage!"
+          dismiss="localstorage"
+        />
+
+        <Button
+          onClick={() => {
+            localStorage.removeItem('global-header/NotificationBanner');
+            window.location.reload();
+          }}
+        >
+          Cleanup localStorage
+        </Button>
+      </div>
+    ),
+    title: 'Notifications',
+    path: '/notifications',
   })
   .render();

--- a/workspaces/global-header/plugins/global-header/report.api.md
+++ b/workspaces/global-header/plugins/global-header/report.api.md
@@ -14,5 +14,33 @@ export const GlobalHeader: () => JSX_2.Element;
 // @public
 export const globalHeaderPlugin: BackstagePlugin<{}, {}, {}>;
 
+// @public
+export const NotificationBanner: (
+  props: NotificationBannerProps,
+) => JSX_2.Element | null;
+
+// @public (undocumented)
+export type NotificationBannerDismiss = 'none' | 'session' | 'localstorage';
+
+// @public (undocumented)
+export interface NotificationBannerProps {
+  // (undocumented)
+  backgroundColor?: string;
+  // (undocumented)
+  border?: string;
+  // (undocumented)
+  borderRadius?: string;
+  // (undocumented)
+  dismiss?: NotificationBannerDismiss;
+  // (undocumented)
+  id?: string;
+  // (undocumented)
+  markdown?: boolean;
+  // (undocumented)
+  textColor?: string;
+  // (undocumented)
+  title: string;
+}
+
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/global-header/plugins/global-header/src/components/NotificationBanner.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/NotificationBanner.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import { MarkdownContent } from '@backstage/core-components';
+
+// export type NotificationBannerColor = 'success' | 'info' | 'warning' | 'error';
+// export type NotificationBannerIcon = 'success' | 'info' | 'warning' | 'error';
+// export type NotificationBannerVariant = 'standard' | 'filled' | 'outlined';
+
+/**
+ * @public
+ */
+export type NotificationBannerDismiss = 'none' | 'session' | 'localstorage';
+
+/**
+ * @public
+ */
+export interface NotificationBannerProps {
+  id?: string;
+  title: string;
+  markdown?: boolean;
+
+  textColor?: string;
+  backgroundColor?: string;
+  border?: string;
+  borderRadius?: string;
+
+  // color?: NotificationBannerColor;
+  // icon?: NotificationBannerIcon;
+  // variant?: NotificationBannerVariant;
+
+  dismiss?: NotificationBannerDismiss;
+}
+
+export const NotificationBanner = (props: NotificationBannerProps) => {
+  const [dismissed, setDismissed] = React.useState<boolean>(() => {
+    if (props.dismiss === 'localstorage') {
+      try {
+        const dismissedString =
+          localStorage.getItem('global-header/NotificationBanner') ?? '{}';
+        const dismissedObject = JSON.parse(dismissedString);
+        return dismissedObject[props.id ?? props.title] === 'dismissed';
+      } catch (error) {
+        // nothing
+        return false;
+      }
+    } else {
+      return false;
+    }
+  });
+
+  const onClose = React.useMemo<(() => void) | undefined>(() => {
+    if (!props.dismiss || props.dismiss === 'none') {
+      return undefined;
+    } else if (props.dismiss === 'session') {
+      return () => setDismissed(true);
+    } else if (props.dismiss === 'localstorage') {
+      return () => {
+        try {
+          const dismissedString =
+            localStorage.getItem('global-header/NotificationBanner') ?? '{}';
+          const dismissedObject = JSON.parse(dismissedString);
+          dismissedObject[props.id ?? props.title] = 'dismissed';
+          localStorage.setItem(
+            'global-header/NotificationBanner',
+            JSON.stringify(dismissedObject),
+          );
+        } catch (error) {
+          // nothing
+        }
+        setDismissed(true);
+      };
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Unsupported dismiss option "${props.dismiss}", currently supported "none", "session" or "localstorage"!`,
+    );
+    return undefined;
+  }, [props.id, props.title, props.dismiss]);
+
+  if (dismissed || !props.title) {
+    return null;
+  }
+
+  return (
+    <Alert
+      // color={props.color}
+      // severity={props.icon}
+      icon={false}
+      // variant={props.variant}
+      onClose={onClose}
+      sx={{
+        color: props.textColor ?? 'text.primary',
+        backgroundColor: props.backgroundColor ?? 'background.paper',
+        border: props.border,
+        borderRadius: props.borderRadius,
+        justifyContent: 'center',
+        textAlign: 'center',
+      }}
+    >
+      {props.markdown ? (
+        <MarkdownContent content={props.title} dialect="gfm" />
+      ) : (
+        props.title
+      )}
+    </Alert>
+  );
+};

--- a/workspaces/global-header/plugins/global-header/src/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/index.ts
@@ -21,4 +21,4 @@ ClassNameGenerator.configure(componentName => {
     : `v5-${componentName}`;
 });
 
-export { globalHeaderPlugin, GlobalHeader } from './plugin';
+export * from './plugin';

--- a/workspaces/global-header/plugins/global-header/src/plugin.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.ts
@@ -19,6 +19,11 @@ import {
   createComponentExtension,
 } from '@backstage/core-plugin-api';
 
+export type {
+  NotificationBannerProps,
+  NotificationBannerDismiss,
+} from './components/NotificationBanner';
+
 /**
  * Global Header Plugin
  *
@@ -38,6 +43,23 @@ export const GlobalHeader = globalHeaderPlugin.provide(
     name: 'GlobalHeader',
     component: {
       lazy: () => import('./components/GlobalHeader').then(m => m.GlobalHeader),
+    },
+  }),
+);
+
+/**
+ * NotificationBanner
+ *
+ * @public
+ */
+export const NotificationBanner = globalHeaderPlugin.provide(
+  createComponentExtension({
+    name: 'NotificationBanner',
+    component: {
+      lazy: () =>
+        import('./components/NotificationBanner').then(
+          m => m.NotificationBanner,
+        ),
     },
   }),
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a new `NotificationBanner` component that could used also as a "header".

It supports some initial styling options:

![Screenshot From 2025-01-15 00-48-23](https://github.com/user-attachments/assets/ba7c6d52-c31f-4d35-af63-5ad965daf197)

I like to add more options later.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
