### PR TITLE
fix(marketplace): emit pluginlist relationships bidirectionally to establish complete connections

### DIFF
--- a/workspaces/marketplace/.changeset/slimy-paws-dance.md
+++ b/workspaces/marketplace/.changeset/slimy-paws-dance.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace': patch
+---
+
+Emit pluginlist relationship bidirectionlly to establish complete connections

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePluginListProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePluginListProcessor.test.ts
@@ -69,7 +69,7 @@ describe('MarketplacePluginListProcessor', () => {
 
     const emit = jest.fn();
     await processor.postProcessEntity(pluginListEntity, null as any, emit);
-    expect(emit).toHaveBeenCalledTimes(4);
+    expect(emit).toHaveBeenCalledTimes(7);
     expect(emit).toHaveBeenCalledWith({
       type: 'relation',
       relation: {
@@ -81,6 +81,27 @@ describe('MarketplacePluginListProcessor', () => {
         type: 'ownedBy',
         target: { kind: 'Group', namespace: 'default', name: 'test-group' },
       },
+    });
+    const getPluginHasPartOfPluginListRelation = (pluginName: string) => ({
+      source: {
+        kind: 'Plugin',
+        namespace: 'default',
+        name: pluginName,
+      },
+      type: 'hasPart',
+      target: {
+        kind: 'PluginList',
+        namespace: 'default',
+        name: 'testplugin',
+      },
+    });
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: getPluginHasPartOfPluginListRelation('plugin-a'),
+    });
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: getPluginHasPartOfPluginListRelation('plugin-b'),
     });
   });
 });

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePluginListProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePluginListProcessor.ts
@@ -25,6 +25,7 @@ import {
   entityKindSchemaValidator,
   getCompoundEntityRef,
   parseEntityRef,
+  RELATION_HAS_PART,
   RELATION_OWNED_BY,
   RELATION_PART_OF,
 } from '@backstage/catalog-model';
@@ -195,6 +196,14 @@ export class MarketplacePluginListProcessor implements CatalogProcessor {
                 type: RELATION_PART_OF,
                 target: pluginRef,
                 source: thisEntityRef,
+              }),
+            );
+
+            emit(
+              processingResult.relation({
+                type: RELATION_HAS_PART,
+                target: thisEntityRef,
+                source: pluginRef,
               }),
             );
           }


### PR DESCRIPTION


## Fixes

https://issues.redhat.com/browse/RHIDP-5564

This PR fixes the `Plugin` relationship graph to show its relation with `PluginList` entity.

## Screenshots


| Before  |  After |
| ------------- | ------------- |
| ![plugin_relations_missing_pluginlist](https://github.com/user-attachments/assets/1d52efbf-1e19-4b6c-ad95-81b1cfa3574b) | ![plugins_relationship_with_pluginlist](https://github.com/user-attachments/assets/36baa6c8-e409-40a3-bee5-789f745b4691)|

---

![image](https://github.com/user-attachments/assets/05734c04-e110-4750-9c77-63b5b6e517f1)


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
