### PR TITLE
fix(global-header): enable dynamic plugin support for global-header-test plugin

### DIFF
--- a/workspaces/global-header/.changeset/fuzzy-sheep-doubt.md
+++ b/workspaces/global-header/.changeset/fuzzy-sheep-doubt.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header-test': patch
+---
+
+Enable dynamic plugin support for this plugin.

--- a/workspaces/global-header/.changeset/gorgeous-carrots-tie.md
+++ b/workspaces/global-header/.changeset/gorgeous-carrots-tie.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header-test': patch
+---
+
+Add workaround for the test-plugin for MUI v5 components

--- a/workspaces/global-header/plugins/global-header-test/package.json
+++ b/workspaces/global-header/plugins/global-header-test/package.json
@@ -28,7 +28,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean && rm -rf dist-scalprum",
-    "prepack": "backstage-cli package prepack",
+    "prepack": "backstage-cli package prepack && yarn export-dynamic",
     "postpack": "backstage-cli package postpack",
     "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },

--- a/workspaces/global-header/plugins/global-header-test/src/index.ts
+++ b/workspaces/global-header/plugins/global-header-test/src/index.ts
@@ -13,4 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from './plugin';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Add dist-scalprum folder to enable dynamic plugin support for the npm package. This is an interim solution until we have automated container images for all plugins.
* Add a workaround for the test-plugin for MUI v5 components

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
