### PR TITLE
chore: update multiple catalog-info.yamls

### DIFF
--- a/catalog-info-teams.yaml
+++ b/catalog-info-teams.yaml
@@ -36,14 +36,6 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
-  name: rhtap-team
-spec:
-  type: team
-  children: []
----
-apiVersion: backstage.io/v1alpha1
-kind: Group
-metadata:
   name: orchestrator-team
 spec:
   type: team

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
     github.com/team-slug: redhat-developer/rhdh-plugins-contributers
     #sonarqube.org/project-key: redhat-developer_rhdh-plugins
 spec:
-  type: plugins
+  type: backstage-plugin-repository
   lifecycle: production
   owner: rhdh-team
   system: rhdh

--- a/workspaces/bulk-import/catalog-info.yaml
+++ b/workspaces/bulk-import/catalog-info.yaml
@@ -5,12 +5,14 @@ metadata:
   name: red-hat-developer-hub-bulk-import
   title: RHDH Bulk Import plugin
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/bulk-import/plugins/bulk-import
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/bulk-import/plugins/bulk-import/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/bulk-import/plugins/bulk-import/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: rhdh/maintainers-plugins
     sonarqube.org/project-key: red_hat_developer_hub_plugins
+  tags:
+    - backstage
+    - rhdh
+    - plugin
+    - github
   links:
     - url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/bulk-import/plugins/bulk-import
       title: GitHub Source

--- a/workspaces/bulk-import/plugins/bulk-import-backend/catalog-info.yaml
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend'
   description: Bulk Import Backend Plugin
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/bulk-import/plugins/bulk-import-backend
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/bulk-import/plugins/bulk-import-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/bulk-import/plugins/bulk-import-backend/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: rhdh/maintainers-plugins
     sonarqube.org/project-key: red_hat_developer_hub_plugins
@@ -35,9 +32,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend API'
   description: Bulk Import Backend Plugin
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/bulk-import/plugins/bulk-import-backend
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/bulk-import/plugins/bulk-import-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/bulk-import/plugins/bulk-import-backend/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: rhdh/maintainers-plugins
     sonarqube.org/project-key: red_hat_developer_hub_plugins

--- a/workspaces/bulk-import/plugins/bulk-import-common/catalog-info.yaml
+++ b/workspaces/bulk-import/plugins/bulk-import-common/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-bulk-import-common'
   description: Bulk import for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/bulk-import/plugins/bulk-import-common
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/bulk-import/plugins/bulk-import-common/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/bulk-import/plugins/bulk-import-common/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: rhdh/maintainers-plugins
     sonarqube.org/project-key: red_hat_developer_hub_plugins

--- a/workspaces/bulk-import/plugins/bulk-import/catalog-info.yaml
+++ b/workspaces/bulk-import/plugins/bulk-import/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-bulk-import'
   description: Bulk import frontend plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/bulk-import/plugins/bulk-import
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/bulk-import/plugins/bulk-import/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/bulk-import/plugins/bulk-import/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: rhdh/maintainers-plugins
     sonarqube.org/project-key: red_hat_developer_hub_plugins

--- a/workspaces/global-floating-action-button/catalog-info.yaml
+++ b/workspaces/global-floating-action-button/catalog-info.yaml
@@ -8,9 +8,14 @@ metadata:
     github.com/project-slug: redhat-developer/rhdh-plugins
     github.com/team-slug: redhat-developer/rhdh-plugins-contributers
     #sonarqube.org/project-key: redhat-developer_rhdh-plugins
+  tags:
+    - backstage
+    - rhdh
+    - plugin
+    - ui
 spec:
   type: backstage-plugin
-  lifecycle: production
-  owner: rhdh-team
+  lifecycle: development
+  owner: rhdh-ui-team
   system: rhdh
   subcomponentOf: rhdh-plugins

--- a/workspaces/global-header/catalog-info.yaml
+++ b/workspaces/global-header/catalog-info.yaml
@@ -14,7 +14,7 @@ metadata:
     - plugin
 spec:
   type: backstage-plugin
-  lifecycle: production
-  owner: rhdh-team
+  lifecycle: development
+  owner: rhdh-ui-team
   system: rhdh
   subcomponentOf: rhdh-plugins

--- a/workspaces/homepage/catalog-info.yaml
+++ b/workspaces/homepage/catalog-info.yaml
@@ -14,6 +14,7 @@ metadata:
     - rhdh
     - plugin
     - homepage
+    - ui
   links:
     - url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/homepage
       title: GitHub Source

--- a/workspaces/lightspeed/catalog-info.yaml
+++ b/workspaces/lightspeed/catalog-info.yaml
@@ -3,6 +3,11 @@ kind: Component
 metadata:
   name: red-hat-developer-hub-lightspeed
   title: RHDH Lightspeed plugin
+  tags:
+    - backstage
+    - rhdh
+    - plugin
+    - ai
 spec:
   type: backstage-plugin
   lifecycle: production

--- a/workspaces/marketplace/catalog-info.yaml
+++ b/workspaces/marketplace/catalog-info.yaml
@@ -14,7 +14,7 @@ metadata:
     - plugin
 spec:
   type: backstage-plugin
-  lifecycle: production
-  owner: rhdh-team
+  lifecycle: development
+  owner: rhdh-ui-team
   system: rhdh
   subcomponentOf: rhdh-plugins

--- a/workspaces/openshift-image-registry/catalog-info.yaml
+++ b/workspaces/openshift-image-registry/catalog-info.yaml
@@ -5,9 +5,6 @@ metadata:
   title: RHDH OpenShift Image Registry plugin
   description: OpenShift Image Registry plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/openshift-image-registry/plugins/openshift-image-registry
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/openshift-image-registry/plugins/openshift-image-registry/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/openshift-image-registry/plugins/openshift-image-registry/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/maintainers-plugins
     sonarqube.org/project-key: red-hat-developer-hub_backstage-plugins

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/catalog-info.yaml
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-openshift-image-registry'
   description: OpenShift Image Registry plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/openshift-image-registry/plugins/openshift-image-registry
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/openshift-image-registry/plugins/openshift-image-registry/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/openshift-image-registry/plugins/openshift-image-registry/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/maintainers-plugins
     sonarqube.org/project-key: red-hat-developer-hub_backstage-plugins

--- a/workspaces/orchestrator/catalog-info.yaml
+++ b/workspaces/orchestrator/catalog-info.yaml
@@ -6,12 +6,14 @@ metadata:
   title: RHDH Orchestrator plugin
   description: Orchestrator Plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/orchestrator/plugins/orchestrator/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/orchestrator-codeowners
     sonarqube.org/project-key: red_hat_developer_hub_plugins
+  tags:
+    - backstage
+    - rhdh
+    - plugin
+    - orchestrator
   links:
     - url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator
       title: GitHub Source

--- a/workspaces/orchestrator/plugins/orchestrator-backend/catalog-info.yaml
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend'
   description: Orchestrator Backend Plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator-backend
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/orchestrator/plugins/orchestrator-backend/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/orchestrator-codeowners
     sonarqube.org/project-key: red_hat_developer_hub_plugins

--- a/workspaces/orchestrator/plugins/orchestrator-common/catalog-info.yaml
+++ b/workspaces/orchestrator/plugins/orchestrator-common/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-orchestrator-common'
   description: Orchestrator Common Plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator-common
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator-common/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/orchestrator/plugins/orchestrator-common/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/orchestrator-codeowners
     sonarqube.org/project-key: red_hat_developer_hub_plugins

--- a/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
+++ b/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-orchestrator-swf-editor-envelope'
   description: Serverless workflow editor envelope for the Orchestrator plugin
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/orchestrator/plugins/orchestrator-swf-editor-envelope/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/orchestrator-codeowners
     sonarqube.org/project-key: red_hat_developer_hub_plugins

--- a/workspaces/orchestrator/plugins/orchestrator/catalog-info.yaml
+++ b/workspaces/orchestrator/plugins/orchestrator/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@red-hat-developer-hub/backstage-plugin-orchestrator'
   description: Orchestrator Plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator
-    backstage.io/view-url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/redhat-developer/rhdh-plugins/edit/main/workspaces/orchestrator/plugins/orchestrator/catalog-info.yaml
     github.com/project-slug: red-hat-developer-hub/backstage-plugins
     github.com/team-slug: red-hat-developer-hub/orchestrator-codeowners
     sonarqube.org/project-key: red_hat_developer_hub_plugins


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Part of https://issues.redhat.com/browse/RHIDP-5574

Backstage sets this annotations automatically when the catalog-info.yaml is loaded from GitHub, so it's not needed:

```yaml
    backstage.io/source-location: url:...
    backstage.io/view-url: ...
    backstage.io/edit-url: ....
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
