### PR TITLE
fix(lightspeed): Add resizable drawers and default to closed drawers on smaller screens

### DIFF
--- a/workspaces/lightspeed/.changeset/modern-ways-shave.md
+++ b/workspaces/lightspeed/.changeset/modern-ways-shave.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Make lightspeed conversation drawer resizable and default to closed on smaller screens

--- a/workspaces/lightspeed/plugins/lightspeed/package.json
+++ b/workspaces/lightspeed/plugins/lightspeed/package.json
@@ -44,7 +44,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@mui/icons-material": "^6.1.8",
-    "@patternfly/chatbot": "2.2.0-prerelease.10",
+    "@patternfly/chatbot": "2.2.0-prerelease.12",
     "@patternfly/react-core": "6.1.0-prerelease.14",
     "@red-hat-developer-hub/backstage-plugin-lightspeed-common": "workspace:^",
     "@tanstack/react-query": "^5.59.15",

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -36,13 +36,16 @@ import ChatbotConversationHistoryNav from '@patternfly/chatbot/dist/dynamic/Chat
 import { DropdownItem, Title } from '@patternfly/react-core';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { useBackstageUserIdentity } from '../hooks/useBackstageUserIdentity';
-import { useConversationMessages } from '../hooks/useConversationMessages';
-import { useConversations } from '../hooks/useConversations';
-import { useCreateConversation } from '../hooks/useCreateConversation';
-import { useDeleteConversation } from '../hooks/useDeleteConversation';
-import { useLastOpenedConversation } from '../hooks/useLastOpenedConversation';
-import { useLightspeedDeletePermission } from '../hooks/useLightspeedDeletePermission';
+import {
+  useBackstageUserIdentity,
+  useConversationMessages,
+  useConversations,
+  useCreateConversation,
+  useDeleteConversation,
+  useIsMobile,
+  useLastOpenedConversation,
+  useLightspeedDeletePermission,
+} from '../hooks';
 import { ConversationSummary } from '../types';
 import {
   getCategorizeMessages,
@@ -84,12 +87,13 @@ export const LightspeedChat = ({
   handleSelectedModel,
   models,
 }: LightspeedChatProps) => {
+  const isMobile = useIsMobile();
   const classes = useStyles();
   const user = useBackstageUserIdentity();
   const [filterValue, setFilterValue] = React.useState<string>('');
   const [announcement, setAnnouncement] = React.useState<string>('');
   const [conversationId, setConversationId] = React.useState<string>('');
-  const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(true);
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(!isMobile);
   const [newChatCreated, setNewChatCreated] = React.useState<boolean>(false);
   const [isSendButtonDisabled, setIsSendButtonDisabled] =
     React.useState<boolean>(false);
@@ -338,6 +342,7 @@ export const LightspeedChat = ({
           />
         </ChatbotHeader>
         <ChatbotConversationHistoryNav
+          drawerPanelContentProps={{ isResizable: true, minSize: '200px' }}
           reverseButtonOrder
           displayMode={ChatbotDisplayMode.embedded}
           onDrawerToggle={onDrawerToggle}

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './useAllModels';
+export * from './useBackstageUserIdentity';
+export * from './useConversationMessages';
+export * from './useConversations';
+export * from './useCreateConversation';
+export * from './useCreateCoversationMessage';
+export * from './useDeleteConversation';
+export * from './useIsMobile';
+export * from './useLastOpenedConversation';
+export * from './useLightspeedDeletePermission';
+export * from './useLightspeedViewPermission';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useIsMobile.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useIsMobile.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = React.useState(window.innerWidth <= 768);
+
+  React.useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 768);
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isMobile;
+};

--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -9541,9 +9541,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/chatbot@npm:2.2.0-prerelease.10":
-  version: 2.2.0-prerelease.10
-  resolution: "@patternfly/chatbot@npm:2.2.0-prerelease.10"
+"@patternfly/chatbot@npm:2.2.0-prerelease.12":
+  version: 2.2.0-prerelease.12
+  resolution: "@patternfly/chatbot@npm:2.2.0-prerelease.12"
   dependencies:
     "@patternfly/react-code-editor": ^6.1.0
     "@patternfly/react-core": ^6.1.0
@@ -9557,7 +9557,7 @@ __metadata:
   peerDependencies:
     react: ^17 || ^18
     react-dom: ^17 || ^18
-  checksum: 4552ec4a2378fbaa8783d8e7c27ef211a65b22ff782bfd90791ab122cd7a5372e986dd239cea753c2fe9ddec6d3d837eb2143322babf4f224de69a61b9880eab
+  checksum: 3ba64adf2e60ba0e538d1e83e0ab89bf3982b02b91739e972380dac866e32c8335fc9cef777bc74e5e9adf23803f0625ed6066fa9b83064de871a7f0c553a2ff
   languageName: node
   linkType: hard
 
@@ -10388,7 +10388,7 @@ __metadata:
     "@material-ui/core": ^4.9.13
     "@material-ui/lab": ^4.0.0-alpha.61
     "@mui/icons-material": ^6.1.8
-    "@patternfly/chatbot": 2.2.0-prerelease.10
+    "@patternfly/chatbot": 2.2.0-prerelease.12
     "@patternfly/react-core": 6.1.0-prerelease.14
     "@red-hat-developer-hub/backstage-plugin-lightspeed-common": "workspace:^"
     "@spotify/prettier-config": ^15.0.0


### PR DESCRIPTION

## Fixes

https://issues.redhat.com/browse/RHDHPAI-483

This PR upgrades to the latest PF and includes following changes:

- Add resizable drawers to the conversation history
- close conversation history by default on smaller screens.

---
**Conversation history is closed by default in smaller screens:**

 

![Screenshot 2025-01-21 at 12 20 05 PM](https://github.com/user-attachments/assets/df4a6d98-c973-4666-8b2b-7a557b1562a0)
---
**Resizable drawers:**


https://github.com/user-attachments/assets/86a05cd9-3aa6-4f53-923d-86b58ad7c76b




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
