### PR TITLE
chore(orchestrator): add orchestror among pluginsWithPermission

### DIFF
--- a/workspaces/orchestrator/app-config.yaml
+++ b/workspaces/orchestrator/app-config.yaml
@@ -81,8 +81,10 @@ auth:
 # permission:
 #   enabled: true
 #   rbac:
-#     policies-csv-file: ../../plugins/orchestrator/docs/rbac-policy.csv
+#     policies-csv-file: ../../docs/rbac-policy.csv
 #     policyFileReload: true
+#     pluginsWithPermission:
+#       - orchestrator
 #     admin:
 #       users:
 #         - name: user:default/mareklibra


### PR DESCRIPTION
The only purpose is to simplify dev-env setup when working with RBAC