### PR TITLE
fix(orchestrator): list orchestrator.workflow.use in the RBAC UI

### DIFF
--- a/workspaces/orchestrator/.changeset/strange-fishes-wait.md
+++ b/workspaces/orchestrator/.changeset/strange-fishes-wait.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+add orchestrator.workflow.use among permissions in the RBAC UI

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/permissions.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createPermission } from '@backstage/plugin-permission-common';
 
 export const orchestratorWorkflowPermission = createPermission({
@@ -41,4 +42,7 @@ export const orchestratorWorkflowUseSpecificPermission = (workflowId: string) =>
     attributes: {},
   });
 
-export const orchestratorPermissions = [orchestratorWorkflowPermission];
+export const orchestratorPermissions = [
+  orchestratorWorkflowPermission,
+  orchestratorWorkflowUsePermission,
+];


### PR DESCRIPTION
With this change, the RBAC UI can list both `orchestrator.workflow` and `orchestrator.workflow.use` permissions.

Fixes: FLPATH-2032
