### PR TITLE
fix(orchestrator): use 'update' policy for orchestrator.workflow.use

### DIFF
--- a/workspaces/orchestrator/.changeset/tasty-boxes-accept.md
+++ b/workspaces/orchestrator/.changeset/tasty-boxes-accept.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+use 'update' policy for orchestrator.workflow.use

--- a/workspaces/orchestrator/docs/Permissions.md
+++ b/workspaces/orchestrator/docs/Permissions.md
@@ -7,8 +7,8 @@ the RBAC plugin. The result is control over what users can see or execute.
 | ---------------------------------------- | -------------- | ------ | ------------------------------------------------------------------------------------- | ------------ |
 | orchestrator.workflow                    | named resource | read   | Allows the user to list and read _any_ workflow definition and their instances (runs) |              |
 | orchestrator.workflow.[`workflowId`]     | named resource | read   | Allows the user to list and read the details of a _single_ workflow definition        |              |
-| orchestrator.workflow.use                | named resource | read   | Allows the user to run or abort _any_ workflow                                        |              |
-| orchestrator.workflow.use.[`workflowId`] | named resource | read   | Allows the user to run or abort the _single_ workflow                                 |              |
+| orchestrator.workflow.use                | named resource | update | Allows the user to run or abort _any_ workflow                                        |              |
+| orchestrator.workflow.use.[`workflowId`] | named resource | update | Allows the user to run or abort the _single_ workflow                                 |              |
 
 The user is permitted to do an action if either the generic permission or the specific one allows it.
 In other words, it is not possible to grant generic `orchestrator.workflow` and then selectively disable it for a specific workflow via `orchestrator.workflow.use.[workflowId]` with `deny`.
@@ -33,10 +33,10 @@ The users of the `default/workflowAdmin` role have full permissions (can list, r
 p, role:default/workflowUser, orchestrator.workflow.yamlgreet, read, allow
 p, role:default/workflowUser, orchestrator.workflow.wait-or-error, read, allow
 
-p, role:default/workflowUser, orchestrator.workflow.use.yamlgreet, use, allow
+p, role:default/workflowUser, orchestrator.workflow.use.yamlgreet, update, allow
 
 p, role:default/workflowAdmin, orchestrator.workflow, read, allow
-p, role:default/workflowAdmin, orchestrator.workflow.use, use, allow
+p, role:default/workflowAdmin, orchestrator.workflow.use, update, allow
 
 g, user:development/guest, role:default/workflowUser
 g, user:default/mareklibra, role:default/workflowAdmin
@@ -53,5 +53,10 @@ permission:
   enabled: true
   rbac:
     policies-csv-file: <absolute path to the policy file>
+    pluginsWithPermission:
+      - orchestrator
     policyFileReload: true
+    admin:
+      users:
+        - name: user:default/YOUR_USER
 ```

--- a/workspaces/orchestrator/docs/rbac-policy.csv
+++ b/workspaces/orchestrator/docs/rbac-policy.csv
@@ -1,12 +1,12 @@
 p, role:default/workflowUser, orchestrator.workflow.yamlgreet, read, allow
 p, role:default/workflowUser, orchestrator.workflow.wait-or-error, read, allow
 
-##p, role:default/workflowUser, orchestrator.workflow.use, use, allow
-p, role:default/workflowUser, orchestrator.workflow.use.yamlgreet, use, allow
-##p, role:default/workflowUser, orchestrator.workflow.use.wait-or-error, use, allow
+##p, role:default/workflowUser, orchestrator.workflow.use, update, allow
+p, role:default/workflowUser, orchestrator.workflow.use.yamlgreet, update, allow
+##p, role:default/workflowUser, orchestrator.workflow.use.wait-or-error, update, allow
 
 p, role:default/workflowAdmin, orchestrator.workflow, read, allow
-p, role:default/workflowAdmin, orchestrator.workflow.use, use, allow
+p, role:default/workflowAdmin, orchestrator.workflow.use, update, allow
 
 g, user:development/guest, role:default/workflowUser
 g, user:default/rgolangh, role:default/workflowAdmin

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/permissions.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/permissions.ts
@@ -32,13 +32,17 @@ export const orchestratorWorkflowSpecificPermission = (workflowId: string) =>
 
 export const orchestratorWorkflowUsePermission = createPermission({
   name: 'orchestrator.workflow.use',
-  attributes: {},
+  attributes: {
+    action: 'update',
+  },
 });
 
 export const orchestratorWorkflowUseSpecificPermission = (workflowId: string) =>
   createPermission({
     name: `orchestrator.workflow.use.${workflowId}`,
-    attributes: {},
+    attributes: {
+      action: 'update',
+    },
   });
 
 export const orchestratorPermissions = [orchestratorWorkflowPermission];


### PR DESCRIPTION
Changing the `read` policy to `update` of the `orchestrator.workflow.use` permission to closer align with other plugins.
Documentation updated.

Fixes: FLPATH-2033