### PR TITLE
chore: add explicit yarn install before creating plugin in new workspace to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,7 @@ Once you have a workspace setup, the creation of new plugins and packages is jus
 
 ```bash
 cd workspaces/openshift-image-registry
+yarn install
 yarn new
 ```
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the CONTRIBUTING.md doc to include a `yarn install` in a new workspace before generating plugins. Without the `yarn install`, I was given this error:
```
Internal Error: @internal/test-workspace@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile
    at z0.getCandidates (/Users/jcollier/git/rhdh-plugins/.yarn/releases/yarn-3.8.7.cjs:436:5149)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
