### PR TITLE
feat(application-provider-test): add CrashProvider and exports now two seperate context providers and cards

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/angry-eggs-agree.md
+++ b/workspaces/global-floating-action-button/.changeset/angry-eggs-agree.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-application-provider-test': patch
+---
+
+Add a new CrashProvider and exports now two seperate context providers and cards

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/README.md
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/README.md
@@ -1,13 +1,23 @@
-# application-provider-test
+# @red-hat-developer-hub/backstage-plugin-application-provider-test
 
-Welcome to the application-provider-test plugin!
+A test-plugin allows you to test the [dynamic plugin mount point `application/provider`](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/frontend-plugin-wiring.md#adding-application-providers).
 
-_This plugin was created through the Backstage CLI_
+These providers allows dynamic plugins to add a `React.Context` on an application level around all routes. Using this feature should be an exception.
 
-## Getting started
+This plugin exports two providers, two components that depends on the context of these providers and a page that renders these cards two times to see that a shared provider context is used correctly.
 
-Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/application-provider-test](http://localhost:3000/application-provider-test).
-
-You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
-This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
-It is only meant for local development, and the setup for it can be found inside the [/dev](./dev) directory.
+```yaml
+dynamicPlugins:
+  frontend:
+    red-hat-developer-hub.backstage-plugin-application-provider-test:
+      dynamicRoutes:
+        - path: /application-provider-test-page
+          importName: TestPage
+      mountPoints:
+        - mountPoint: application/provider
+          importName: CrashProvider
+        - mountPoint: application/provider
+          importName: TestProviderOne
+        - mountPoint: application/provider
+          importName: TestProviderTwo
+```

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/app-config.dynamic.yaml
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/app-config.dynamic.yaml
@@ -1,10 +1,13 @@
-# test global-header components. this isn't implemented yet!
 dynamicPlugins:
   frontend:
     red-hat-developer-hub.backstage-plugin-application-provider-test:
       dynamicRoutes:
-        - path: /countpage
-          importName: CountPage
+        - path: /application-provider-test-page
+          importName: TestPage
       mountPoints:
         - mountPoint: application/provider
-          importName: CountProvider
+          importName: CrashProvider
+        - mountPoint: application/provider
+          importName: TestProviderOne
+        - mountPoint: application/provider
+          importName: TestProviderTwo

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/dev/index.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/dev/index.tsx
@@ -22,41 +22,53 @@ import Grid from '@mui/material/Grid';
 
 import {
   applicationProviderTestPlugin,
-  CountPage,
-  CountProvider,
-  CountCard,
+  TestPage,
+  TestProviderOne,
+  TestProviderTwo,
+  TestCardOne,
+  TestCardTwo,
 } from '../src/plugin';
 
 createDevApp()
   .registerPlugin(applicationProviderTestPlugin)
   .addPage({
     element: (
-      <CountProvider>
-        <CountPage />
-      </CountProvider>
+      <TestProviderOne>
+        <TestProviderTwo>
+          <TestPage />
+        </TestProviderTwo>
+      </TestProviderOne>
     ),
-    title: 'CountPage',
-    path: '/count-page',
+    title: 'TestPage',
+    path: '/test-page',
   })
   .addPage({
     element: (
-      <CountProvider>
-        <Page themeId="home">
-          <Header title="CountProvider" />
-          <Content>
-            <Grid container spacing={2}>
-              <Grid item>
-                <CountCard />
+      <TestProviderOne>
+        <TestProviderTwo>
+          <Page themeId="test">
+            <Header title="Test cards" />
+            <Content>
+              <Grid container spacing={2}>
+                <Grid item sm={6}>
+                  <TestCardOne />
+                </Grid>
+                <Grid item sm={6}>
+                  <TestCardOne />
+                </Grid>
+                <Grid item sm={6}>
+                  <TestCardTwo />
+                </Grid>
+                <Grid item sm={6}>
+                  <TestCardTwo />
+                </Grid>
               </Grid>
-              <Grid item>
-                <CountCard />
-              </Grid>
-            </Grid>
-          </Content>
-        </Page>
-      </CountProvider>
+            </Content>
+          </Page>
+        </TestProviderTwo>
+      </TestProviderOne>
     ),
-    title: 'CountProvider',
-    path: '/count-provider',
+    title: 'TestCards',
+    path: '/test-cards',
   })
   .render();

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/report.api.md
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/report.api.md
@@ -12,14 +12,40 @@ import { ReactNode } from 'react';
 // @public (undocumented)
 export const applicationProviderTestPlugin: BackstagePlugin<{}, {}, {}>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const CountCard: () => JSX_2.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const CountPage: () => JSX_2.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const CountProvider: ({
+  children,
+}: {
+  children?: ReactNode;
+}) => JSX_2.Element;
+
+// @public (undocumented)
+export const CrashProvider: () => never;
+
+// @public (undocumented)
+export const TestCardOne: () => JSX_2.Element;
+
+// @public (undocumented)
+export const TestCardTwo: () => JSX_2.Element;
+
+// @public (undocumented)
+export const TestPage: () => JSX_2.Element;
+
+// @public (undocumented)
+export const TestProviderOne: ({
+  children,
+}: {
+  children?: ReactNode;
+}) => JSX_2.Element;
+
+// @public (undocumented)
+export const TestProviderTwo: ({
   children,
 }: {
   children?: ReactNode;

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/CrashProvider.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/CrashProvider.tsx
@@ -14,25 +14,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
-import {
-  Page,
-  Header,
-  Content,
-  MarkdownContent,
-} from '@backstage/core-components';
-
-import { CountCard } from './CountCard';
-
-export const CountPage = () => {
-  return (
-    <Page themeId="test">
-      <Header title="CountPage" subtitle="A application-provider-test page" />
-      <Content>
-        <MarkdownContent content="This card will work only if you register the `CountProvider` correctly." />
-        <CountCard />
-      </Content>
-    </Page>
-  );
+export const CrashProvider = () => {
+  throw new Error('CrashProvider failed to render (intentional crash)');
 };

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestCardOne.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestCardOne.tsx
@@ -20,12 +20,12 @@ import { InfoCard } from '@backstage/core-components';
 
 import Button from '@mui/material/Button';
 
-import { CountContext } from './CountProvider';
+import { TestContextOne } from './TestProviderOne';
 
-export const CountCard = () => {
-  const value = React.useContext(CountContext);
+export const TestCardOne = () => {
+  const value = React.useContext(TestContextOne);
   return (
-    <InfoCard>
+    <InfoCard title="Context one">
       <div
         style={{
           display: 'flex',

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestCardTwo.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestCardTwo.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { InfoCard } from '@backstage/core-components';
+
+import Button from '@mui/material/Button';
+
+import { TestContextTwo } from './TestProviderTwo';
+
+export const TestCardTwo = () => {
+  const value = React.useContext(TestContextTwo);
+  return (
+    <InfoCard title="Context two">
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Button onClick={value.decrement} style={{ fontSize: '2rem' }}>
+          -
+        </Button>
+        <h2>{value.count}</h2>
+        <Button onClick={value.increment} style={{ fontSize: '2rem' }}>
+          +
+        </Button>
+      </div>
+    </InfoCard>
+  );
+};

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestPage.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestPage.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {
+  Page,
+  Header,
+  Content,
+  MarkdownContent,
+} from '@backstage/core-components';
+
+import Grid from '@mui/material/Grid';
+
+import { TestCardOne } from './TestCardOne';
+import { TestCardTwo } from './TestCardTwo';
+
+export const TestPage = () => {
+  return (
+    <Page themeId="test">
+      <Header title="application/provider TestPage" />
+      <Content>
+        <MarkdownContent content="This card will work only if you register the `TestProviderOne` and `TestProviderTwo` correctly." />
+        <Grid container spacing={2}>
+          <Grid item sm={6}>
+            <TestCardOne />
+          </Grid>
+          <Grid item sm={6}>
+            <TestCardOne />
+          </Grid>
+          <Grid item sm={6}>
+            <TestCardTwo />
+          </Grid>
+          <Grid item sm={6}>
+            <TestCardTwo />
+          </Grid>
+        </Grid>
+      </Content>
+    </Page>
+  );
+};

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestProviderOne.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestProviderOne.tsx
@@ -18,11 +18,11 @@ import React from 'react';
 
 import { CountContextValue } from '../types';
 
-export const CountContext = React.createContext<CountContextValue>(
+export const TestContextOne = React.createContext<CountContextValue>(
   {} as CountContextValue,
 );
 
-export const CountProvider = ({ children }: React.PropsWithChildren<{}>) => {
+export const TestProviderOne = ({ children }: React.PropsWithChildren<{}>) => {
   const [count, setCount] = React.useState(0);
   const increment = React.useCallback(() => setCount(c => c + 1), []);
   const decrement = React.useCallback(() => setCount(c => c - 1), []);
@@ -35,6 +35,6 @@ export const CountProvider = ({ children }: React.PropsWithChildren<{}>) => {
     [count, increment, decrement],
   );
   return (
-    <CountContext.Provider value={value}>{children}</CountContext.Provider>
+    <TestContextOne.Provider value={value}>{children}</TestContextOne.Provider>
   );
 };

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestProviderTwo.tsx
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/components/TestProviderTwo.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { CountContextValue } from '../types';
+
+export const TestContextTwo = React.createContext<CountContextValue>(
+  {} as CountContextValue,
+);
+
+export const TestProviderTwo = ({ children }: React.PropsWithChildren<{}>) => {
+  const [count, setCount] = React.useState(0);
+  const increment = React.useCallback(() => setCount(c => c + 1), []);
+  const decrement = React.useCallback(() => setCount(c => c - 1), []);
+  const value = React.useMemo<CountContextValue>(
+    () => ({
+      count,
+      increment,
+      decrement,
+    }),
+    [count, increment, decrement],
+  );
+  return (
+    <TestContextTwo.Provider value={value}>{children}</TestContextTwo.Provider>
+  );
+};

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/plugin.ts
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/plugin.ts
@@ -32,12 +32,12 @@ export const applicationProviderTestPlugin = createPlugin({
 /**
  * @public
  */
-export const CountProvider = applicationProviderTestPlugin.provide(
+export const CrashProvider = applicationProviderTestPlugin.provide(
   createComponentExtension({
-    name: 'CountProvider',
+    name: 'CrashProvider',
     component: {
       lazy: () =>
-        import('./components/CountProvider').then(m => m.CountProvider),
+        import('./components/CrashProvider').then(m => m.CrashProvider),
     },
   }),
 );
@@ -45,11 +45,12 @@ export const CountProvider = applicationProviderTestPlugin.provide(
 /**
  * @public
  */
-export const CountCard = applicationProviderTestPlugin.provide(
+export const TestProviderOne = applicationProviderTestPlugin.provide(
   createComponentExtension({
-    name: 'CountCard',
+    name: 'TestProviderOne',
     component: {
-      lazy: () => import('./components/CountCard').then(m => m.CountCard),
+      lazy: () =>
+        import('./components/TestProviderOne').then(m => m.TestProviderOne),
     },
   }),
 );
@@ -57,10 +58,65 @@ export const CountCard = applicationProviderTestPlugin.provide(
 /**
  * @public
  */
-export const CountPage = applicationProviderTestPlugin.provide(
+export const TestProviderTwo = applicationProviderTestPlugin.provide(
+  createComponentExtension({
+    name: 'TestProviderTwo',
+    component: {
+      lazy: () =>
+        import('./components/TestProviderTwo').then(m => m.TestProviderTwo),
+    },
+  }),
+);
+
+/**
+ * @public
+ */
+export const TestCardOne = applicationProviderTestPlugin.provide(
+  createComponentExtension({
+    name: 'TestCardOne',
+    component: {
+      lazy: () => import('./components/TestCardOne').then(m => m.TestCardOne),
+    },
+  }),
+);
+
+/**
+ * @public
+ */
+export const TestCardTwo = applicationProviderTestPlugin.provide(
+  createComponentExtension({
+    name: 'TestCardTwo',
+    component: {
+      lazy: () => import('./components/TestCardTwo').then(m => m.TestCardTwo),
+    },
+  }),
+);
+
+/**
+ * @public
+ */
+export const TestPage = applicationProviderTestPlugin.provide(
   createRoutableExtension({
-    name: 'CountPage',
-    component: () => import('./components/CountPage').then(m => m.CountPage),
+    name: 'TestPage',
+    component: () => import('./components/TestPage').then(m => m.TestPage),
     mountPoint: rootRouteRef,
   }),
 );
+
+/**
+ * @public
+ * @deprecated please use `TestProviderOne` and `TestProviderTwo` instead
+ */
+export const CountProvider = TestProviderOne;
+
+/**
+ * @public
+ * @deprecated please use `TestCardOne` and `TestCardTwo` instead
+ */
+export const CountCard = TestCardOne;
+
+/**
+ * @public
+ * @deprecated please use `TestPage` instead
+ */
+export const CountPage = TestPage;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improved test plugin two test the RHDH change with two providers. /cc @debsmita1 :)

I now also added a CrashProvider. It's not needed that this is handled in rhdh yet, but it's good to have a test component for that.

The link in the README depends on https://github.com/redhat-developer/rhdh/pull/2199 and should work soon. :)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation (just the README)
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
