### PR TITLE
fix(orchestrator): improved devMode, added podman and macos support

### DIFF
--- a/workspaces/orchestrator/.changeset/wicked-hats-give.md
+++ b/workspaces/orchestrator/.changeset/wicked-hats-give.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+improved devMode, added podman and macos support

--- a/workspaces/orchestrator/.gitignore
+++ b/workspaces/orchestrator/.gitignore
@@ -54,3 +54,6 @@ site
 
 # E2E test reports
 e2e-test-report/
+
+# Sonataflow Dev Container Temp files
+packages/backend/.devModeTemp

--- a/workspaces/orchestrator/app-config.yaml
+++ b/workspaces/orchestrator/app-config.yaml
@@ -124,14 +124,26 @@ dynamicPlugins:
   frontend: {}
 orchestrator:
   sonataFlowService:
+    # uncomment the next line to use podman instead of docker
+    # runtime: podman
     baseUrl: http://localhost
     port: 8899
     autoStart: true
+    # If you're using a MacBook with M-series chips, uncomment the line below to use ARM images.
+    # To pull the image, you'll first need to authenticate with the registry.
+    # For more information, visit: https://red.ht/410mMNU.
+    # container:  registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.35.0
     # notsecret
     notificationsBearerToken: bXljdXJscGFzc3dkCg==
     notificationsUrl: http://host.docker.internal:7007
+    # uncomment the next line if you are using podman:
+    # notificationsUrl: http://host.containers.internal:7007
+    # By default the Dev Mode workflows are Ephemeral. If you want to persist the data across restarts,
+    # uncomment the next two lines, read more: https://www.rhdhorchestrator.io/blog/devmode-vs-prodmode/
+    # persistence:
+    #  path: ./.devModeTemp/db_persistence # this will be under packages/backend
     workflowsSource:
       gitRepositoryUrl: https://github.com/parodos-dev/backstage-orchestrator-workflows
-      localPath: /tmp/orchestrator/repository
+      localPath: ./.devModeTemp/repository # this will be under packages/backend
   dataIndexService:
     url: http://localhost:8899


### PR DESCRIPTION
improved devMode to make multi platform development easier

- Added Podman support (opinionated, people can use Podman. Docker is still kept as default) 
- Added M1 (ARM) Mac support
- Added DB persistence in sonata flow dev mode image (optional). This will improve the startup time of the dev mode container. 
- Moved temp directory to `.devModeTemp` folder under the `backend` plugin directory to maintain podman support. Podman does not have access to `/tmp` by default.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
