### PR TITLE
feat(marketplace): add package entity relationship with plugin entity

### DIFF
--- a/workspaces/marketplace/.changeset/short-berries-perform.md
+++ b/workspaces/marketplace/.changeset/short-berries-perform.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace': patch
+---
+
+emit package relationships with plugin entity.

--- a/workspaces/marketplace/app-config.yaml
+++ b/workspaces/marketplace/app-config.yaml
@@ -76,7 +76,17 @@ catalog:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration
   rules:
-    - allow: [Component, System, API, Resource, Plugin, PluginList, Location]
+    - allow:
+        [
+          Component,
+          System,
+          API,
+          Resource,
+          Plugin,
+          PluginList,
+          Package,
+          Location,
+        ]
   locations:
     # Local example data, file locations are relative to the backend process, typically `packages/backend`
     - type: file
@@ -91,6 +101,10 @@ catalog:
       target: ../../examples/all-pluginlists.yaml
       rules:
         - allow: [PluginList]
+    - type: file
+      target: ../../examples/all-packages.yaml
+      rules:
+        - allow: [Package]
 
     - type: file
       target: ../../examples/catalog-demo.yaml

--- a/workspaces/marketplace/examples/all-packages.yaml
+++ b/workspaces/marketplace/examples/all-packages.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: all-packages
+  description: A collection of all the marketplace packages
+spec:
+  targets:
+    - ./packages/tekton.yaml

--- a/workspaces/marketplace/examples/packages/tekton.yaml
+++ b/workspaces/marketplace/examples/packages/tekton.yaml
@@ -3,7 +3,6 @@ apiVersion: marketplace.backstage.io/v1alpha1
 metadata:
   name: backstage-community-plugin-tekton
   title: '@backstage-community/plugin-tekton'
-  owner: system/rhdh
   links:
     - url: https://red.ht/rhdh
       title: Homepage

--- a/workspaces/marketplace/examples/packages/tekton.yaml
+++ b/workspaces/marketplace/examples/packages/tekton.yaml
@@ -1,0 +1,44 @@
+kind: Package
+apiVersion: marketplace.backstage.io/v1alpha1
+metadata:
+  name: backstage-community-plugin-tekton
+  title: '@backstage-community/plugin-tekton'
+  owner: system/rhdh
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://issues.redhat.com/browse/RHIDP
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/backstage-community-plugin-tekton
+  annotations:
+    backstage.io/source-location: url
+      https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/backstage-community-plugin-tekton
+  tags: []
+spec:
+  packageName: '@backstage-community/plugin-tekton'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tekton
+  version: 3.17.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.35.0
+  author: Red Hat
+  support: production
+  lifecycle: active
+  partOf:
+    - tekton
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-tekton:
+              mountPoints:
+                - mountPoint: entity.page.ci/cards
+                  importName: TektonCI
+                  config:
+                    layout:
+                      gridColumn: 1 / -1
+                    if:
+                      allOf:
+                        - isTektonCIAvailable

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/report.api.md
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/report.api.md
@@ -12,6 +12,7 @@ import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { MarketplacePackage } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 import { MarketplacePlugin } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 
 // @public (undocumented)
@@ -56,7 +57,7 @@ export class MarketplacePackageProcessor implements CatalogProcessor {
     // (undocumented)
     getProcessorName(): string;
     // (undocumented)
-    postProcessEntity(entity: Entity, _location: LocationSpec, emit: CatalogProcessorEmit): Promise<Entity>;
+    postProcessEntity(entity: MarketplacePackage, _location: LocationSpec, emit: CatalogProcessorEmit): Promise<Entity>;
     // (undocumented)
     validateEntityKind(entity: Entity): Promise<boolean>;
 }

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePackageProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePackageProcessor.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MarketplacePackage } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import { MarketplacePackageProcessor } from './MarketplacePackageProcessor';
+
+describe('MarketplacePackageProcessor', () => {
+  const testPackage: MarketplacePackage = {
+    kind: 'Package',
+    apiVersion: 'marketplace.backstage.io/v1alpha1',
+    metadata: {
+      name: 'backstage-community-plugin-test',
+      title: '@backstage-community/plugin-test',
+      owner: 'system/rhdh',
+      annotations: {
+        'backstage.io/source-location':
+          'url https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/backstage-community-plugin-test',
+      },
+    },
+    spec: {
+      packageName: '@backstage-community/plugin-test',
+      dynamicArtifact: './dynamic-plugins/dist/backstage-community-plugin-test',
+      version: '3.17.0',
+      backstage: {
+        role: 'frontend-plugin',
+        supportedVersions: '1.35.0',
+      },
+      author: 'Red Hat',
+      support: 'production',
+      owner: 'test-group',
+      lifecycle: 'active',
+      partOf: ['plugin-a', 'plugin-b'],
+    },
+  };
+
+  it('should return processor name', () => {
+    const processor = new MarketplacePackageProcessor();
+    expect(processor.getProcessorName()).toBe('MarketplacePackageProcessor');
+  });
+
+  it('should validate Package kind', async () => {
+    const processor = new MarketplacePackageProcessor();
+    expect(
+      await processor.validateEntityKind({
+        ...testPackage,
+        kind: 'invalid-kind',
+      }),
+    ).toBe(false);
+    expect(await processor.validateEntityKind(testPackage)).toBe(true);
+  });
+
+  it('should return package entity with ownedBy relation', async () => {
+    const processor = new MarketplacePackageProcessor();
+
+    const emit = jest.fn();
+    await processor.postProcessEntity(
+      {
+        ...testPackage,
+        spec: { ...testPackage.spec, partOf: null } as any,
+      },
+      null as any,
+      emit,
+    );
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: {
+        source: {
+          kind: 'Package',
+          namespace: 'default',
+          name: 'backstage-community-plugin-test',
+        },
+        type: 'ownedBy',
+        target: { kind: 'Group', namespace: 'default', name: 'test-group' },
+      },
+    });
+  });
+
+  it('should return package entity with partOf relation', async () => {
+    const processor = new MarketplacePackageProcessor();
+
+    const emit = jest.fn();
+    await processor.postProcessEntity(testPackage, null as any, emit);
+    expect(emit).toHaveBeenCalledTimes(5);
+
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: {
+        source: {
+          kind: 'Package',
+          namespace: 'default',
+          name: 'backstage-community-plugin-test',
+        },
+        type: 'ownedBy',
+        target: { kind: 'Group', namespace: 'default', name: 'test-group' },
+      },
+    });
+
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: {
+        source: {
+          kind: 'Package',
+          namespace: 'default',
+          name: 'backstage-community-plugin-test',
+        },
+        type: 'partOf',
+        target: { kind: 'Plugin', namespace: 'default', name: 'plugin-a' },
+      },
+    });
+    const getPluginPartOfPackageRelation = (pluginName: string) => ({
+      source: {
+        kind: 'Package',
+        namespace: 'default',
+        name: 'backstage-community-plugin-test',
+      },
+      type: 'partOf',
+      target: {
+        kind: 'Plugin',
+        namespace: 'default',
+        name: pluginName,
+      },
+    });
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: getPluginPartOfPackageRelation('plugin-a'),
+    });
+    expect(emit).toHaveBeenCalledWith({
+      type: 'relation',
+      relation: getPluginPartOfPackageRelation('plugin-b'),
+    });
+  });
+});

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePackageProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/MarketplacePackageProcessor.test.ts
@@ -23,7 +23,6 @@ describe('MarketplacePackageProcessor', () => {
     metadata: {
       name: 'backstage-community-plugin-test',
       title: '@backstage-community/plugin-test',
-      owner: 'system/rhdh',
       annotations: {
         'backstage.io/source-location':
           'url https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/backstage-community-plugin-test',
@@ -33,14 +32,7 @@ describe('MarketplacePackageProcessor', () => {
       packageName: '@backstage-community/plugin-test',
       dynamicArtifact: './dynamic-plugins/dist/backstage-community-plugin-test',
       version: '3.17.0',
-      backstage: {
-        role: 'frontend-plugin',
-        supportedVersions: '1.35.0',
-      },
-      author: 'Red Hat',
-      support: 'production',
       owner: 'test-group',
-      lifecycle: 'active',
       partOf: ['plugin-a', 'plugin-b'],
     },
   };

--- a/workspaces/marketplace/plugins/marketplace-common/report.api.md
+++ b/workspaces/marketplace/plugins/marketplace-common/report.api.md
@@ -191,7 +191,11 @@ export interface MarketplacePackageSpec extends JsonObject {
     // (undocumented)
     lifecycle?: string;
     // (undocumented)
+    owner?: string;
+    // (undocumented)
     packageName: string;
+    // (undocumented)
+    partOf?: string[];
     // (undocumented)
     support?: string;
 }

--- a/workspaces/marketplace/plugins/marketplace-common/src/types.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/types.ts
@@ -148,6 +148,8 @@ export interface MarketplacePackageSpec extends JsonObject {
   lifecycle?: string;
   backstage?: MarketplacePackageBackstage;
   appConfigExamples?: AppConfigExample[];
+  owner?: string;
+  partOf?: string[];
 }
 
 /**


### PR DESCRIPTION
## Package entity relationship

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Emitting `partOf/HasPart` relationship in `MarketplacePackageProcessor`.


## Screenshots:

## `Package` entity page

### Before

![image](https://github.com/user-attachments/assets/31f12614-30bd-4b17-b251-74042c084762)


### After

![Package relationship](https://github.com/user-attachments/assets/d93b9159-f32b-4089-80dd-64435df0039d)

---

## `Plugin` entity page

### Before
![image](https://github.com/user-attachments/assets/79667729-de04-4dbd-9140-f68c4cf028fe)

### After
![Plugin relationship](https://github.com/user-attachments/assets/50365cd2-e980-473e-adb0-a6e64913432e)



## Unit tests:

![Unit tests](https://github.com/user-attachments/assets/cf9e2ded-6d01-4271-aa91-19aaa577b9a8)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
