### PR TITLE
feat(global-header): add support for layout option in app-config and improved responsive layout a bit

### DIFF
--- a/workspaces/global-header/.changeset/clever-forks-double.md
+++ b/workspaces/global-header/.changeset/clever-forks-double.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': minor
+---
+
+Remove ComponmentType to simplify API and add layout prop to the header components to support some responsive design tweaks in dynamic plugin config. Moved some local styles to the incl. app config as well and hide the username on xs and sm screen sizes.

--- a/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
+++ b/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
@@ -20,23 +20,6 @@ dynamicPlugins:
             props:
               growFactor: 0
 
-        # - mountPoint: global.header/component
-        #   importName: CreateDropdown
-        #   config:
-        #     priority: 90
-        #     layout:
-        #       display:
-        #         sm: none
-        #         md: block
-        #       mr: 1.5
-        # - mountPoint: global.header/create
-        #   importName: SoftwareTemplatesSection
-        #   config:
-        #     priority: 100
-        # - mountPoint: global.header/create
-        #   importName: RegisterAComponentSection
-        #   config:
-        #     priority: 50
         - mountPoint: global.header/component
           importName: HeaderIconButton
           config:
@@ -45,11 +28,6 @@ dynamicPlugins:
               title: Create...
               icon: add
               to: create
-            layout:
-              display:
-                xs: none
-                md: block
-              mr: 1.5
 
         - mountPoint: global.header/component
           importName: SupportButton

--- a/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
+++ b/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
@@ -7,56 +7,80 @@ dynamicPlugins:
           importName: GlobalHeader
           config:
             position: above-main-content # above-main-content | below-main-content
+
         - mountPoint: global.header/component
           importName: SearchComponent
           config:
-            type: search
             priority: 100
+
         - mountPoint: global.header/component
-          importName: CreateDropdown
+          importName: Spacer
           config:
-            type: dropdown_button
+            priority: 99
+            props:
+              growFactor: 0
+
+        # - mountPoint: global.header/component
+        #   importName: CreateDropdown
+        #   config:
+        #     priority: 90
+        #     layout:
+        #       display:
+        #         sm: none
+        #         md: block
+        #       mr: 1.5
+        # - mountPoint: global.header/create
+        #   importName: SoftwareTemplatesSection
+        #   config:
+        #     priority: 100
+        # - mountPoint: global.header/create
+        #   importName: RegisterAComponentSection
+        #   config:
+        #     priority: 50
+        - mountPoint: global.header/component
+          importName: HeaderIconButton
+          config:
             priority: 90
-        - mountPoint: global.header/create
-          importName: SoftwareTemplatesSection
-          config:
-            type: list
-            priority: 10
-        - mountPoint: global.header/create
-          importName: RegisterAComponentSection
-          config:
-            type: link
+            props:
+              title: Create...
+              icon: add
+              to: create
+            layout:
+              display:
+                xs: none
+                md: block
+              mr: 1.5
+
         - mountPoint: global.header/component
-          importName: HeaderIconButton
+          importName: SupportButton
           config:
-            type: icon_button
             priority: 80
-            props:
-              icon: support
-              tooltip: 'Support'
+
         - mountPoint: global.header/component
-          importName: HeaderIconButton
+          importName: NotificationButton
           config:
-            type: icon_button
             priority: 70
-            props:
-              icon: notifications
-              tooltip: 'Notifications'
+
+        - mountPoint: global.header/component
+          importName: Divider
+          config:
+            priority: 50
+
         - mountPoint: global.header/component
           importName: ProfileDropdown
           config:
-            type: dropdown_button
-            priority: 0
+            priority: 10
+
         - mountPoint: global.header/profile
           importName: MenuItemLink
           config:
-            type: link
-            priority: 200
+            priority: 100
             props:
               title: Settings
               link: /settings
               icon: manageAccounts
+
         - mountPoint: global.header/profile
           importName: LogoutButton
           config:
-            priority: 100
+            priority: 10

--- a/workspaces/global-header/plugins/global-header/dev/index.tsx
+++ b/workspaces/global-header/plugins/global-header/dev/index.tsx
@@ -48,7 +48,6 @@ import {
 } from '../src/defaultMountPoints/defaultMountPoints';
 
 import { HeaderButton } from '../src/components/HeaderButton/HeaderButton';
-import { ComponentType } from '../src/types';
 
 const mockSearchApi = new MockSearchApi({
   results: [
@@ -179,13 +178,12 @@ createDevApp()
         mountPoints={{
           'global.header/component': [
             ...defaultGlobalHeaderComponentsMountPoints.filter(
-              mp => mp.config?.type !== ComponentType.SEARCH,
+              (_mp, index) => index > 0,
             ),
             {
               Component: Spacer,
               config: {
-                type: ComponentType.SPACER,
-                priority: 10000, // the greater the number, the more to the left it will be
+                priority: 100, // the greater the number, the more to the left it will be
               },
             },
           ],

--- a/workspaces/global-header/plugins/global-header/report.api.md
+++ b/workspaces/global-header/plugins/global-header/report.api.md
@@ -9,7 +9,13 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 
 // @public
-export const CreateDropdown: () => React_2.JSX.Element | null;
+export const CreateDropdown: React_2.ComponentType<CreateDropdownProps>;
+
+// @public
+export interface CreateDropdownProps {
+  // (undocumented)
+  layout?: React_2.CSSProperties;
+}
 
 // @public
 export const defaultGlobalHeaderComponentsMountPoints: GlobalHeaderComponentMountPoint[];
@@ -254,7 +260,13 @@ export interface NotificationButtonProps {
 }
 
 // @public
-export const ProfileDropdown: () => React_2.JSX.Element | null;
+export const ProfileDropdown: React_2.ComponentType<ProfileDropdownProps>;
+
+// @public
+export interface ProfileDropdownProps {
+  // (undocumented)
+  layout?: React_2.CSSProperties;
+}
 
 // @public
 export const RegisterAComponentSection: React_2.ComponentType<RegisterAComponentSectionProps>;

--- a/workspaces/global-header/plugins/global-header/report.api.md
+++ b/workspaces/global-header/plugins/global-header/report.api.md
@@ -9,25 +9,19 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 
 // @public
-export enum ComponentType {
-  DROPDOWN_BUTTON = 'dropdown_button',
-  ICON_BUTTON = 'icon_button',
-  LINK = 'link',
-  LIST = 'list',
-  LOGOUT = 'logout',
-  SEARCH = 'search',
-  SPACER = 'spacer',
-  SUPPORT_BUTTON = 'support_button',
-}
-
-// @public
 export const CreateDropdown: () => React_2.JSX.Element | null;
 
 // @public
 export const defaultGlobalHeaderComponentsMountPoints: GlobalHeaderComponentMountPoint[];
 
 // @public (undocumented)
-export const Divider: () => React_2.JSX.Element;
+export const Divider: ({ layout }: DividerProps) => React_2.JSX.Element;
+
+// @public (undocumented)
+export interface DividerProps {
+  // (undocumented)
+  layout?: React_2.CSSProperties;
+}
 
 // @public
 export const GlobalHeader: () => React_2.JSX.Element;
@@ -38,11 +32,13 @@ export const GlobalHeaderComponent: React_2.ComponentType<GlobalHeaderComponentP
 // @public
 export interface GlobalHeaderComponentMountPoint {
   // (undocumented)
-  Component: React.ComponentType<{}>;
+  Component: React.ComponentType<{
+    layout?: React.CSSProperties;
+  }>;
   // (undocumented)
   config?: GlobalHeaderComponentMountPointConfig & {
-    layout?: Record<string, any>;
     props?: Record<string, any>;
+    layout?: React.CSSProperties;
   };
 }
 
@@ -50,8 +46,6 @@ export interface GlobalHeaderComponentMountPoint {
 export interface GlobalHeaderComponentMountPointConfig {
   // (undocumented)
   priority?: number;
-  // (undocumented)
-  type?: ComponentType;
 }
 
 // @public
@@ -75,7 +69,7 @@ export const HeaderButton: ({
   endIcon,
   externalLinkIcon,
   to,
-  style,
+  layout,
 }: HeaderButtonProps) => React_2.JSX.Element;
 
 // @public (undocumented)
@@ -89,11 +83,11 @@ export interface HeaderButtonProps {
   // (undocumented)
   externalLinkIcon?: boolean;
   // (undocumented)
+  layout?: React_2.CSSProperties;
+  // (undocumented)
   size?: 'small' | 'medium' | 'large';
   // (undocumented)
   startIcon?: string;
-  // (undocumented)
-  style?: React_2.CSSProperties;
   // (undocumented)
   title: string;
   // (undocumented)
@@ -108,7 +102,7 @@ export interface HeaderButtonProps {
 export const HeaderIcon: ({
   icon,
   size,
-  styles,
+  layout,
 }: HeaderIconProps) => React_2.JSX.Element | null;
 
 // @public (undocumented)
@@ -120,7 +114,7 @@ export const HeaderIconButton: ({
   size,
   ariaLabel,
   to,
-  style,
+  layout,
 }: HeaderIconButtonProps) => React_2.JSX.Element;
 
 // @public (undocumented)
@@ -132,9 +126,9 @@ export interface HeaderIconButtonProps {
   // (undocumented)
   icon: string;
   // (undocumented)
-  size?: 'small' | 'medium' | 'large';
+  layout?: React_2.CSSProperties;
   // (undocumented)
-  style?: React_2.CSSProperties;
+  size?: 'small' | 'medium' | 'large';
   // (undocumented)
   title: string;
   // (undocumented)
@@ -148,9 +142,9 @@ export interface HeaderIconProps {
   // (undocumented)
   icon: string;
   // (undocumented)
-  size?: 'small' | 'medium' | 'large';
+  layout?: React_2.CSSProperties;
   // (undocumented)
-  styles?: React_2.CSSProperties;
+  size?: 'small' | 'medium' | 'large';
 }
 
 // @public
@@ -168,8 +162,6 @@ export interface MenuItemConfig {
   link?: string;
   // (undocumented)
   subLabel?: string;
-  // (undocumented)
-  type: string;
 }
 
 // @public
@@ -225,6 +217,7 @@ export const NotificationButton: ({
   size,
   badgeColor,
   to,
+  layout,
 }: NotificationButtonProps) => React_2.JSX.Element | null;
 
 // @public (undocumented)
@@ -248,6 +241,8 @@ export interface NotificationButtonProps {
     | 'info'
     | 'success'
     | 'warning';
+  // (undocumented)
+  layout?: React_2.CSSProperties;
   // (undocumented)
   size?: 'small' | 'medium' | 'large';
   // (undocumented)
@@ -286,12 +281,15 @@ export type SoftwareTemplatesSectionProps = {
 export const Spacer: ({
   growFactor,
   minWidth,
+  layout,
 }: SpacerProps) => React_2.JSX.Element;
 
 // @public (undocumented)
 export interface SpacerProps {
   // (undocumented)
   growFactor?: number;
+  // (undocumented)
+  layout?: React_2.CSSProperties;
   // (undocumented)
   minWidth?: number | string;
 }
@@ -303,6 +301,7 @@ export const SupportButton: ({
   color,
   size,
   to,
+  layout,
 }: SupportButtonProps) => React_2.JSX.Element | null;
 
 // @public (undocumented)
@@ -317,6 +316,8 @@ export interface SupportButtonProps {
     | 'info'
     | 'success'
     | 'warning';
+  // (undocumented)
+  layout?: React_2.CSSProperties;
   // (undocumented)
   size?: 'small' | 'medium' | 'large';
   // (undocumented)

--- a/workspaces/global-header/plugins/global-header/src/components/Divider/Divider.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/Divider/Divider.tsx
@@ -21,12 +21,19 @@ import MUIDivider from '@mui/material/Divider';
 /**
  * @public
  */
-export const Divider = () => {
+export interface DividerProps {
+  layout?: React.CSSProperties;
+}
+
+/**
+ * @public
+ */
+export const Divider = ({ layout }: DividerProps) => {
   return (
     <MUIDivider
       orientation="vertical"
       flexItem
-      sx={{ borderColor: '#383838', marginX: 1 }}
+      sx={{ borderColor: '#383838', marginX: 1, ...layout }}
     />
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/components/GlobalHeaderComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/GlobalHeaderComponent.tsx
@@ -24,8 +24,8 @@ import Toolbar from '@mui/material/Toolbar';
 import { GlobalHeaderComponentMountPoint } from '../types';
 
 /**
- * @public
  * Global Header Component properties
+ * @public
  */
 export interface GlobalHeaderComponentProps {
   globalHeaderMountPoints: GlobalHeaderComponentMountPoint[];
@@ -53,7 +53,7 @@ export const GlobalHeaderComponent = ({
           <ErrorBoundary key={`header-component-${index}`}>
             <mountPoint.Component
               {...mountPoint.config?.props}
-              // sx={mountPoint.config.layout}
+              layout={mountPoint.config?.layout}
             />
           </ErrorBoundary>
         ))}

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderButton/HeaderButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderButton/HeaderButton.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 
 import { LinkButton } from '@backstage/core-components';
 
+import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
 import { HeaderIcon } from '../HeaderIcon/HeaderIcon';
 
@@ -35,7 +36,7 @@ export interface HeaderButtonProps {
   endIcon?: string;
   externalLinkIcon?: boolean;
   to: string;
-  style?: React.CSSProperties;
+  layout?: React.CSSProperties;
 }
 
 /**
@@ -52,7 +53,7 @@ export const HeaderButton = ({
   endIcon,
   externalLinkIcon = true,
   to,
-  style,
+  layout,
 }: HeaderButtonProps) => {
   const button = (
     <LinkButton
@@ -64,7 +65,6 @@ export const HeaderButton = ({
       endIcon={endIcon ? <HeaderIcon icon={endIcon} size={size} /> : null}
       externalLinkIcon={externalLinkIcon}
       to={to}
-      style={style}
     >
       {title}
     </LinkButton>
@@ -72,11 +72,13 @@ export const HeaderButton = ({
 
   if (tooltip) {
     return (
-      <Tooltip title={tooltip}>
-        <div>{button}</div>
-      </Tooltip>
+      <Box sx={layout}>
+        <Tooltip title={tooltip}>
+          <div>{button}</div>
+        </Tooltip>
+      </Box>
     );
   }
 
-  return button;
+  return <Box sx={layout}>{button}</Box>;
 };

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
@@ -22,6 +22,7 @@ import { MenuItemConfig } from './MenuSection';
 import { useCreateDropdownMountPoints } from '../../hooks/useCreateDropdownMountPoints';
 import { useDropdownManager } from '../../hooks';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
+import Box from '@mui/material/Box';
 
 /**
  * @public
@@ -33,7 +34,15 @@ interface SectionComponentProps {
   items?: MenuItemConfig[];
 }
 
-export const CreateDropdown = () => {
+/**
+ * @public
+ * Props for Create Dropdown
+ */
+export interface CreateDropdownProps {
+  layout?: React.CSSProperties;
+}
+
+export const CreateDropdown = ({ layout }: CreateDropdownProps) => {
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
 
   const createDropdownMountPoints = useCreateDropdownMountPoints();
@@ -54,9 +63,9 @@ export const CreateDropdown = () => {
   return (
     <HeaderDropdownComponent
       buttonContent={
-        <>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
           Create <ArrowDropDownOutlinedIcon sx={{ ml: 1 }} />
-        </>
+        </Box>
       }
       buttonProps={{
         variant: 'outlined',
@@ -66,6 +75,7 @@ export const CreateDropdown = () => {
           '&:hover, &.Mui-focusVisible': {
             border: '1px solid #fff',
           },
+          ...layout,
         },
       }}
       onOpen={handleOpen}

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
@@ -18,7 +18,6 @@ import React, { useMemo } from 'react';
 
 import ArrowDropDownOutlinedIcon from '@mui/icons-material/ArrowDropDownOutlined';
 
-import { ComponentType } from '../../types';
 import { MenuItemConfig } from './MenuSection';
 import { useCreateDropdownMountPoints } from '../../hooks/useCreateDropdownMountPoints';
 import { useDropdownManager } from '../../hooks';
@@ -43,7 +42,6 @@ export const CreateDropdown = () => {
     return (createDropdownMountPoints ?? [])
       .map(mp => ({
         Component: mp.Component as React.ComponentType<SectionComponentProps>,
-        type: mp.config?.type ?? ComponentType.LINK,
         priority: mp.config?.priority ?? 0,
       }))
       .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
@@ -68,7 +66,6 @@ export const CreateDropdown = () => {
           '&:hover, &.Mui-focusVisible': {
             border: '1px solid #fff',
           },
-          mr: 1.5,
         },
       }}
       onOpen={handleOpen}

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
@@ -29,7 +29,6 @@ import { MenuItemLinkProps } from '../MenuItemLink/MenuItemLink';
  */
 export interface MenuItemConfig {
   Component: React.ComponentType<MenuItemLinkProps | {}>;
-  type: string;
   label: string;
   icon?: string;
   subLabel?: string;
@@ -89,7 +88,7 @@ export const MenuSection: React.FC<MenuSectionConfig> = ({
       </Box>
     )}
     <ul style={{ padding: 0, listStyle: 'none' }}>
-      {items.map(({ type, icon, label, subLabel, link, Component }, index) => (
+      {items.map(({ icon, label, subLabel, link, Component }, index) => (
         <MenuItem
           key={`menu-item-${index.toString()}`}
           disableRipple
@@ -97,15 +96,7 @@ export const MenuSection: React.FC<MenuSectionConfig> = ({
           onClick={handleClose}
           sx={{ py: 0.5, '&:hover': { background: 'transparent' } }}
         >
-          {link && (
-            <Component
-              icon={icon}
-              to={link}
-              title={label}
-              subTitle={subLabel}
-            />
-          )}
-          {type === 'logout' && <Component />}
+          <Component icon={icon} to={link!} title={label} subTitle={subLabel} />
         </MenuItem>
       ))}
     </ul>

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
@@ -28,8 +28,17 @@ import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import { useProfileDropdownMountPoints } from '../../hooks/useProfileDropdownMountPoints';
 import { MenuSection } from './MenuSection';
 import { useDropdownManager } from '../../hooks';
+import Box from '@mui/material/Box';
 
-export const ProfileDropdown = () => {
+/**
+ * @public
+ * Props for Profile Dropdown
+ */
+export interface ProfileDropdownProps {
+  layout?: React.CSSProperties;
+}
+
+export const ProfileDropdown = ({ layout }: ProfileDropdownProps) => {
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
 
   const identityApi = useApi(identityApiRef);
@@ -84,7 +93,7 @@ export const ProfileDropdown = () => {
   return (
     <HeaderDropdownComponent
       buttonContent={
-        <>
+        <Box sx={{ display: 'flex', alignItems: 'center', ...layout }}>
           <AccountCircleOutlinedIcon fontSize="small" sx={{ mr: 1 }} />
           <Typography
             variant="body2"
@@ -102,7 +111,7 @@ export const ProfileDropdown = () => {
               borderRadius: '25%',
             }}
           />
-        </>
+        </Box>
       }
       buttonProps={{
         color: 'inherit',

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
@@ -26,7 +26,6 @@ import Typography from '@mui/material/Typography';
 import { lighten } from '@mui/material/styles';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import { useProfileDropdownMountPoints } from '../../hooks/useProfileDropdownMountPoints';
-import { ComponentType } from '../../types';
 import { MenuSection } from './MenuSection';
 import { useDropdownManager } from '../../hooks';
 
@@ -70,7 +69,6 @@ export const ProfileDropdown = () => {
     return (profileDropdownMountPoints ?? [])
       .map(mp => ({
         Component: mp.Component,
-        type: mp.config?.type ?? ComponentType.LINK,
         icon: mp.config?.props?.icon ?? '',
         label: mp.config?.props?.title ?? '',
         link: mp.config?.props?.link ?? '',
@@ -87,13 +85,19 @@ export const ProfileDropdown = () => {
     <HeaderDropdownComponent
       buttonContent={
         <>
-          <AccountCircleOutlinedIcon fontSize="small" sx={{ mx: 1 }} />
-          <Typography variant="body2" sx={{ fontWeight: 500, mx: 1 }}>
+          <AccountCircleOutlinedIcon fontSize="small" sx={{ mr: 1 }} />
+          <Typography
+            variant="body2"
+            sx={{
+              display: { xs: 'none', md: 'block' },
+              fontWeight: 500,
+              mr: '1rem',
+            }}
+          >
             {user?.displayName ?? 'Guest'}
           </Typography>
           <KeyboardArrowDownOutlinedIcon
             sx={{
-              marginLeft: '1rem',
               bgcolor: bgColor,
               borderRadius: '25%',
             }}

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/RegisterAComponentSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/RegisterAComponentSection.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import { MenuSection } from './MenuSection';
 import { MenuItemLink } from '../MenuItemLink/MenuItemLink';
-import { ComponentType } from '../../types';
 
 /**
  * Register A Component Section properties
@@ -38,7 +37,6 @@ export const RegisterAComponentSection = ({
       hideDivider={hideDivider}
       items={[
         {
-          type: ComponentType.LINK,
           label: 'Register a component',
           subLabel: 'Import it to the catalog page',
           link: '/catalog-import',

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/SoftwareTemplatesSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/SoftwareTemplatesSection.tsx
@@ -26,7 +26,6 @@ import Typography from '@mui/material/Typography';
 
 import { MenuSection } from './MenuSection';
 import { MenuItemLink } from '../MenuItemLink/MenuItemLink';
-import { ComponentType } from '../../types';
 
 /**
  * Software Templates Section properties
@@ -72,7 +71,6 @@ export const SoftwareTemplatesSection = ({
       .filter(e => e.kind === 'Template')
       .map(m => ({
         Component: MenuItemLink as React.ComponentType,
-        type: ComponentType.LINK,
         label: m.metadata.title ?? m.metadata.name,
         link: `/create/templates/default/${m.metadata.name}`,
       }));

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderIcon/HeaderIcon.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderIcon/HeaderIcon.tsx
@@ -24,7 +24,7 @@ import Box from '@mui/material/Box';
 export interface HeaderIconProps {
   icon: string;
   size?: 'small' | 'medium' | 'large';
-  styles?: React.CSSProperties;
+  layout?: React.CSSProperties;
 }
 
 /**
@@ -33,7 +33,7 @@ export interface HeaderIconProps {
 export const HeaderIcon = ({
   icon,
   size = 'small',
-  styles,
+  layout,
 }: HeaderIconProps) => {
   const app = useApp();
   if (!icon) {
@@ -43,7 +43,7 @@ export const HeaderIcon = ({
   const SystemIcon = app.getSystemIcon(icon);
   if (SystemIcon) {
     return (
-      <Box sx={{ display: 'flex', alignItems: 'center', ...styles }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', ...layout }}>
         <SystemIcon fontSize={size} />
       </Box>
     );
@@ -52,7 +52,7 @@ export const HeaderIcon = ({
   if (icon.startsWith('<svg')) {
     const svgDataUri = `data:image/svg+xml;base64,${btoa(icon)}`;
     return (
-      <MuiIcon fontSize={size} sx={{ ...styles }}>
+      <MuiIcon fontSize={size} sx={layout}>
         <img src={svgDataUri} alt="" />
       </MuiIcon>
     );
@@ -66,8 +66,8 @@ export const HeaderIcon = ({
     return (
       <MuiIcon
         fontSize={size}
-        sx={styles}
         baseClassName="material-icons-outlined"
+        sx={layout}
       >
         <img src={icon} alt="" />
       </MuiIcon>
@@ -75,7 +75,11 @@ export const HeaderIcon = ({
   }
 
   return (
-    <MuiIcon fontSize={size} baseClassName="material-icons-outlined">
+    <MuiIcon
+      fontSize={size}
+      baseClassName="material-icons-outlined"
+      sx={layout}
+    >
       {icon}
     </MuiIcon>
   );

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/HeaderIconButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderIconButton/HeaderIconButton.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 
 import { Link as BackstageLink } from '@backstage/core-components';
 
+import Box from '@mui/material/Box';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
@@ -34,7 +35,7 @@ export interface HeaderIconButtonProps {
   size?: 'small' | 'medium' | 'large';
   ariaLabel?: string;
   to: string;
-  style?: React.CSSProperties;
+  layout?: React.CSSProperties;
 }
 
 // Backstage Link automatically detects external links and emits analytic events.
@@ -50,7 +51,7 @@ export const HeaderIconButton = ({
   size = 'small',
   ariaLabel,
   to,
-  style,
+  layout,
 }: HeaderIconButtonProps) => {
   if (!title) {
     // eslint-disable-next-line no-console
@@ -60,19 +61,20 @@ export const HeaderIconButton = ({
   const linkProps = { to } as IconButtonProps;
 
   return (
-    <Tooltip title={tooltip ?? title}>
-      <div>
-        <IconButton
-          LinkComponent={Link}
-          color={color}
-          size={size}
-          aria-label={ariaLabel ?? title}
-          {...linkProps} // to={to} isn't supported
-          sx={style}
-        >
-          <HeaderIcon icon={icon} size={size} />
-        </IconButton>
-      </div>
-    </Tooltip>
+    <Box sx={layout}>
+      <Tooltip title={tooltip ?? title}>
+        <div>
+          <IconButton
+            LinkComponent={Link}
+            color={color}
+            size={size}
+            aria-label={ariaLabel ?? title}
+            {...linkProps} // to={to} isn't supported
+          >
+            <HeaderIcon icon={icon} size={size} />
+          </IconButton>
+        </div>
+      </Tooltip>
+    </Box>
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/components/MenuItemLink/MenuItemLinkContent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/MenuItemLink/MenuItemLinkContent.tsx
@@ -45,7 +45,7 @@ export const MenuItemLinkContent: React.FC<MenuItemLinkContentProps> = ({
         <HeaderIcon
           icon={icon}
           size="small"
-          styles={
+          layout={
             label
               ? {
                   marginRight: '0.5rem',

--- a/workspaces/global-header/plugins/global-header/src/components/NotificationButton/NotificationButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/NotificationButton/NotificationButton.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { Link as BackstageLink } from '@backstage/core-components';
 
 import Badge from '@mui/material/Badge';
+import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import NotificationIcon from '@mui/icons-material/NotificationsOutlined';
@@ -50,6 +51,7 @@ export interface NotificationButtonProps {
     | 'success'
     | 'warning';
   to?: string;
+  layout?: React.CSSProperties;
 }
 
 // Backstage Link automatically detects external links and emits analytic events.
@@ -67,6 +69,7 @@ export const NotificationButton = ({
   size = 'small',
   badgeColor = 'error',
   to = '/notifications',
+  layout,
 }: NotificationButtonProps) => {
   const { available, unreadCount } = useNotificationCount();
 
@@ -75,24 +78,26 @@ export const NotificationButton = ({
   }
 
   return (
-    <Tooltip title={tooltip ?? title}>
-      <div>
-        <IconButton
-          component={Link}
-          color={color}
-          size={size}
-          to={to}
-          aria-label={title}
-        >
-          {unreadCount > 0 ? (
-            <Badge badgeContent={unreadCount} color={badgeColor} max={999}>
+    <Box sx={layout}>
+      <Tooltip title={tooltip ?? title}>
+        <div>
+          <IconButton
+            component={Link}
+            color={color}
+            size={size}
+            to={to}
+            aria-label={title}
+          >
+            {unreadCount > 0 ? (
+              <Badge badgeContent={unreadCount} color={badgeColor} max={999}>
+                <NotificationIcon fontSize={size} />
+              </Badge>
+            ) : (
               <NotificationIcon fontSize={size} />
-            </Badge>
-          ) : (
-            <NotificationIcon fontSize={size} />
-          )}
-        </IconButton>
-      </div>
-    </Tooltip>
+            )}
+          </IconButton>
+        </div>
+      </Tooltip>
+    </Box>
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchComponent.tsx
@@ -32,7 +32,6 @@ export const SearchComponent = () => {
           flexDirection: 'row',
           justifyContent: 'start',
           direction: 'ltr',
-          mr: 4,
         }}
       >
         <SearchBar query={{ term: searchTerm }} setSearchTerm={setSearchTerm} />

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchInput.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchInput.tsx
@@ -46,7 +46,6 @@ export const SearchInput = ({
       ),
     }}
     sx={{
-      pt: '6px',
       input: { color: '#fff' },
       button: { color: '#fff' },
       '& fieldset': { border: 'none' },

--- a/workspaces/global-header/plugins/global-header/src/components/Spacer/Spacer.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/Spacer/Spacer.tsx
@@ -22,17 +22,23 @@ import React from 'react';
 export interface SpacerProps {
   growFactor?: number;
   minWidth?: number | string;
+  layout?: React.CSSProperties;
 }
 
 /**
  * @public
  */
-export const Spacer = ({ growFactor = 1, minWidth = 1 }: SpacerProps) => {
+export const Spacer = ({
+  growFactor = 1,
+  minWidth = 1,
+  layout,
+}: SpacerProps) => {
   return (
     <div
       style={{
         flexGrow: growFactor,
         minWidth: typeof minWidth === 'number' ? minWidth * 8 : minWidth,
+        ...layout,
       }}
     />
   );

--- a/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.test.tsx
@@ -21,7 +21,7 @@ import {
   renderInTestApp,
   mockApis,
   TestApiProvider,
-} from '@backstage/frontend-test-utils';
+} from '@backstage/test-utils';
 
 import { SupportButton } from './SupportButton';
 

--- a/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
@@ -53,7 +53,7 @@ const Link = (props: any) => (
  * @public
  */
 export const SupportButton = ({
-  title = 'Support (external link)',
+  title = 'Support',
   tooltip,
   color = 'inherit',
   size = 'small',
@@ -68,9 +68,14 @@ export const SupportButton = ({
     return null;
   }
 
+  const isExternalLink =
+    supportUrl.startsWith('http') || supportUrl.startsWith('https');
+
   return (
     <Box sx={layout}>
-      <Tooltip title={tooltip ?? title}>
+      <Tooltip
+        title={tooltip ?? `${title}${isExternalLink ? ' (external link)' : ''}`}
+      >
         <div>
           <IconButton
             component={Link}

--- a/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
@@ -53,7 +53,7 @@ const Link = (props: any) => (
  * @public
  */
 export const SupportButton = ({
-  title = 'Support',
+  title = 'Support (external link)',
   tooltip,
   color = 'inherit',
   size = 'small',

--- a/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { configApiRef, useApiHolder } from '@backstage/core-plugin-api';
 import { Link as BackstageLink } from '@backstage/core-components';
 
+import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import HelpIcon from '@mui/icons-material/HelpOutline';
@@ -40,6 +41,7 @@ export interface SupportButtonProps {
     | 'warning';
   size?: 'small' | 'medium' | 'large';
   to?: string;
+  layout?: React.CSSProperties;
 }
 
 // Backstage Link automatically detects external links and emits analytic events.
@@ -56,6 +58,7 @@ export const SupportButton = ({
   color = 'inherit',
   size = 'small',
   to,
+  layout,
 }: SupportButtonProps) => {
   const apiHolder = useApiHolder();
   const config = apiHolder.get(configApiRef);
@@ -66,18 +69,20 @@ export const SupportButton = ({
   }
 
   return (
-    <Tooltip title={tooltip ?? title}>
-      <div>
-        <IconButton
-          component={Link}
-          color={color}
-          size={size}
-          to={supportUrl}
-          aria-label={title}
-        >
-          <HelpIcon fontSize={size} />
-        </IconButton>
-      </div>
-    </Tooltip>
+    <Box sx={layout}>
+      <Tooltip title={tooltip ?? title}>
+        <div>
+          <IconButton
+            component={Link}
+            color={color}
+            size={size}
+            to={supportUrl}
+            aria-label={title}
+          >
+            <HelpIcon fontSize={size} />
+          </IconButton>
+        </div>
+      </Tooltip>
+    </Box>
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
+++ b/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
@@ -21,7 +21,6 @@ import { SoftwareTemplatesSection } from '../components/HeaderDropdownComponent/
 import { SearchComponent } from '../components/SearchComponent/SearchComponent';
 import { SupportButton } from '../components/SupportButton/SupportButton';
 import {
-  ComponentType,
   CreateDropdownMountPoint,
   GlobalHeaderComponentMountPoint,
   ProfileDropdownMountPoint,
@@ -29,6 +28,7 @@ import {
 import { NotificationButton } from '../components/NotificationButton/NotificationButton';
 import { Divider } from '../components/Divider/Divider';
 import { MenuItemLink } from '../components/MenuItemLink/MenuItemLink';
+import { Spacer } from '../components/Spacer/Spacer';
 
 /**
  * default Global Header Components mount points
@@ -40,38 +40,54 @@ export const defaultGlobalHeaderComponentsMountPoints: GlobalHeaderComponentMoun
     {
       Component: SearchComponent,
       config: {
-        type: ComponentType.SEARCH,
-        priority: 1000, // the greater the number, the more to the left it will be
+        priority: 100, // the greater the number, the more to the left it will be
       },
     },
     {
+      Component: Spacer,
+      config: {
+        priority: 99, // the greater the number, the more to the left it will be
+        props: {
+          growFactor: 0,
+        },
+      },
+    },
+    // Notice: 1.5 ships with a Create link instead of a dropdown!!!
+    {
       Component: CreateDropdown,
       config: {
-        priority: 900,
+        priority: 90,
+        layout: {
+          display: {
+            sm: 'none',
+            md: 'block',
+          },
+          mr: 1.5,
+        } as any as React.CSSProperties, // I don't used MUI v5 specific `sx` types here to allow us changing the implementation later
       },
     },
     {
       Component: SupportButton,
       config: {
-        priority: 800,
+        priority: 80,
       },
     },
     {
       Component: NotificationButton,
       config: {
-        priority: 700,
+        priority: 70,
       },
     },
     {
       Component: Divider,
       config: {
-        priority: 200,
+        priority: 50,
       },
     },
     {
       Component: ProfileDropdown,
       config: {
-        priority: 100, // the greater the number, the more to the left it will be
+        priority: 10, // the greater the number, the more to the left it will be
       },
     },
   ];
@@ -80,14 +96,12 @@ export const defaultCreateDropdownMountPoints: CreateDropdownMountPoint[] = [
   {
     Component: SoftwareTemplatesSection as React.ComponentType,
     config: {
-      type: ComponentType.LIST,
       priority: 200,
     },
   },
   {
     Component: RegisterAComponentSection as React.ComponentType,
     config: {
-      type: ComponentType.LINK,
       priority: 100,
     },
   },
@@ -97,7 +111,6 @@ export const defaultProfileDropdownMountPoints: ProfileDropdownMountPoint[] = [
   {
     Component: MenuItemLink as React.ComponentType,
     config: {
-      type: ComponentType.LINK,
       priority: 200,
       props: {
         title: 'Settings',
@@ -109,7 +122,6 @@ export const defaultProfileDropdownMountPoints: ProfileDropdownMountPoint[] = [
   {
     Component: LogoutButton,
     config: {
-      type: ComponentType.LOGOUT,
       priority: 100,
     },
   },

--- a/workspaces/global-header/plugins/global-header/src/hooks/useNotificationCount.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useNotificationCount.ts
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { configApiRef, useApi, useApiHolder } from '@backstage/core-plugin-api';
+import { useApiHolder } from '@backstage/core-plugin-api';
 import { notificationsApiRef } from '@backstage/plugin-notifications';
 import { useSignal } from '@backstage/plugin-signals-react';
 import { NotificationSignal } from '@backstage/plugin-notifications-common';
@@ -26,24 +26,14 @@ export const useNotificationCount = () => {
   const [available, setAvailable] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
 
-  const config = useApi(configApiRef);
-  const frontendPackages =
-    (config.getOptionalConfig('dynamicPlugins.frontend')?.get() as Record<
-      string,
-      any
-    >) ?? {};
-  const displayNotifications =
-    frontendPackages['backstage.plugin-notifications']?.dynamicRoutes?.some(
-      ({ path }: { path: string }) => path === '/notifications',
-    ) ?? false;
-
   useEffect(() => {
     const notificationsApi = apiHolder.get(notificationsApiRef);
     if (!notificationsApi) {
       return;
     }
-
-    setAvailable(displayNotifications);
+    if (!available) {
+      setAvailable(true);
+    }
 
     const fetchUnreadCount = async () => {
       try {

--- a/workspaces/global-header/plugins/global-header/src/plugin.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.ts
@@ -36,6 +36,7 @@ export type { MenuItemLinkProps } from './components/MenuItemLink/MenuItemLink';
 export type { MenuItemConfig } from './components/HeaderDropdownComponent/MenuSection';
 export type { SoftwareTemplatesSectionProps } from './components/HeaderDropdownComponent/SoftwareTemplatesSection';
 export type { RegisterAComponentSectionProps } from './components/HeaderDropdownComponent/RegisterAComponentSection';
+export type { DividerProps } from './components/Divider/Divider';
 export type { SpacerProps } from './components/Spacer/Spacer';
 export type { SupportButtonProps } from './components/SupportButton/SupportButton';
 export type { NotificationButtonProps } from './components/NotificationButton/NotificationButton';
@@ -46,7 +47,6 @@ export type {
 } from './components/NotificationBanner';
 
 export type {
-  ComponentType,
   GlobalHeaderComponentMountPoint,
   GlobalHeaderComponentMountPointConfig,
 } from './types';

--- a/workspaces/global-header/plugins/global-header/src/plugin.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.ts
@@ -25,12 +25,16 @@ import { GlobalHeaderComponentProps } from './components/GlobalHeaderComponent';
 import { MenuItemLinkProps } from './components/MenuItemLink/MenuItemLink';
 import { SoftwareTemplatesSectionProps } from './components/HeaderDropdownComponent/SoftwareTemplatesSection';
 import { RegisterAComponentSectionProps } from './components/HeaderDropdownComponent/RegisterAComponentSection';
+import { CreateDropdownProps } from './components/HeaderDropdownComponent/CreateDropdown';
+import { ProfileDropdownProps } from './components/HeaderDropdownComponent/ProfileDropdown';
 
 export type { GlobalHeaderComponentProps } from './components/GlobalHeaderComponent';
 
 export type { HeaderButtonProps } from './components/HeaderButton/HeaderButton';
 export type { HeaderIconProps } from './components/HeaderIcon/HeaderIcon';
 export type { HeaderIconButtonProps } from './components/HeaderIconButton/HeaderIconButton';
+export type { CreateDropdownProps } from './components/HeaderDropdownComponent/CreateDropdown';
+export type { ProfileDropdownProps } from './components/HeaderDropdownComponent/ProfileDropdown';
 
 export type { MenuItemLinkProps } from './components/MenuItemLink/MenuItemLink';
 export type { MenuItemConfig } from './components/HeaderDropdownComponent/MenuSection';
@@ -159,34 +163,36 @@ export const SearchComponent: React.ComponentType = globalHeaderPlugin.provide(
  *
  * @public
  */
-export const CreateDropdown = globalHeaderPlugin.provide(
-  createComponentExtension({
-    name: 'CreateDropdown',
-    component: {
-      lazy: () =>
-        import('./components/HeaderDropdownComponent/CreateDropdown').then(
-          m => m.CreateDropdown,
-        ),
-    },
-  }),
-);
+export const CreateDropdown: React.ComponentType<CreateDropdownProps> =
+  globalHeaderPlugin.provide(
+    createComponentExtension({
+      name: 'CreateDropdown',
+      component: {
+        lazy: () =>
+          import('./components/HeaderDropdownComponent/CreateDropdown').then(
+            m => m.CreateDropdown,
+          ),
+      },
+    }),
+  );
 
 /**
  * Profile Dropdown
  *
  * @public
  */
-export const ProfileDropdown = globalHeaderPlugin.provide(
-  createComponentExtension({
-    name: 'ProfileDropdown',
-    component: {
-      lazy: () =>
-        import('./components/HeaderDropdownComponent/ProfileDropdown').then(
-          m => m.ProfileDropdown,
-        ),
-    },
-  }),
-);
+export const ProfileDropdown: React.ComponentType<ProfileDropdownProps> =
+  globalHeaderPlugin.provide(
+    createComponentExtension({
+      name: 'ProfileDropdown',
+      component: {
+        lazy: () =>
+          import('./components/HeaderDropdownComponent/ProfileDropdown').then(
+            m => m.ProfileDropdown,
+          ),
+      },
+    }),
+  );
 
 /**
  * Software Templates List

--- a/workspaces/global-header/plugins/global-header/src/types.ts
+++ b/workspaces/global-header/plugins/global-header/src/types.ts
@@ -15,52 +15,11 @@
  */
 
 /**
- * Component
- *
- * @public
- */
-export enum ComponentType {
-  /**
-   * Global Header spacer
-   */
-  SPACER = 'spacer',
-  /**
-   * Global Header support button
-   */
-  SUPPORT_BUTTON = 'support_button',
-  /**
-   * Global Header Component dropdown button
-   */
-  DROPDOWN_BUTTON = 'dropdown_button',
-  /**
-   * Global Header Component icon button
-   */
-  ICON_BUTTON = 'icon_button',
-  /**
-   * Global Header Component link
-   */
-  LINK = 'link',
-  /**
-   * Global Header Component list
-   */
-  LIST = 'list',
-  /**
-   * Global Header Component search
-   */
-  SEARCH = 'search',
-  /**
-   * Global Header Component logout
-   */
-  LOGOUT = 'logout',
-}
-
-/**
  * Global Header Config
  *
  * @public
  */
 export interface GlobalHeaderComponentMountPointConfig {
-  type?: ComponentType;
   priority?: number;
 }
 
@@ -70,7 +29,6 @@ export interface GlobalHeaderComponentMountPointConfig {
  * @public
  */
 export interface CreateDropdownMountPointConfig {
-  type: ComponentType;
   priority?: number;
   props?: Record<string, any>;
 }
@@ -80,7 +38,6 @@ export interface CreateDropdownMountPointConfig {
  * @public
  */
 export interface ProfileDropdownMountPointConfig {
-  type: ComponentType;
   priority?: number;
   icon?: string;
   title?: string;
@@ -94,10 +51,12 @@ export interface ProfileDropdownMountPointConfig {
  * @public
  */
 export interface GlobalHeaderComponentMountPoint {
-  Component: React.ComponentType<{}>;
+  Component: React.ComponentType<{
+    layout?: React.CSSProperties;
+  }>;
   config?: GlobalHeaderComponentMountPointConfig & {
-    layout?: Record<string, any>;
     props?: Record<string, any>;
+    layout?: React.CSSProperties;
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Revert https://github.com/redhat-developer/rhdh-plugins/commit/aaebac0e1338b65b3cca88a89c781bed25cfa658 because I still believe we don't need this specific code to detect if notification plugin is installed or not.
* Removed ComponmentType to simplify API and
* Added/fixed layout prop to the header components to support some responsive design tweaks in dynamic plugin config. see incl. app-config.
* Moved some local styles to the incl. app config as well
* Hide the username on xs and sm screen sizes to improve responsive layout



#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
