### PR TITLE
fix(bulk-import): fixing extra apis call on added repo list page

### DIFF
--- a/workspaces/bulk-import/.changeset/gorgeous-ants-hear.md
+++ b/workspaces/bulk-import/.changeset/gorgeous-ants-hear.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+fixing extra apis call on added repository list

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
@@ -95,7 +95,7 @@ export const useAddedRepositories = (
         sortColumn,
         sortOrder,
       ),
-    { refetchInterval: pollInterval || 60000 },
+    { refetchInterval: pollInterval || 60000, refetchOnWindowFocus: false },
   );
 
   const prepareData = React.useMemo(() => {


### PR DESCRIPTION
**Fixing** : [RHIDP-5626](https://issues.redhat.com/browse/RHIDP-5626)

**Description of Issue** : 
When changing `sort column`, `sort order`, `Page Number`, or `Page Size`, the Imports API is being called twice:
**1. First call**: with the current parameter values.
**2. Second call**: with the updated (new) parameter values.

Below is the screen Recording demonstrating the above issue 

https://github.com/user-attachments/assets/b153825b-1860-4528-b8bc-dc2bd9cd4f44

**Root Cause** 
React Query’s `useQuery` automatically refetches when the window regains focus. Clicking on the UI to change the sort column, page number, page size, or sort order causes the window to regain focus, triggering an additional refetch. Additionally, since these interactions also update state, another API call is made, leading to duplicate requests.

**Solution**
Since the data is already being refetched every 60 seconds, we can safely disable refetching on window focus to prevent unnecessary API calls.

**After Fix** 


https://github.com/user-attachments/assets/19d2dd5c-d429-4b5a-b964-0baa2aaa29cc


