### PR TITLE
fix(marketplace): restore dynamic plugin export and improve no plugins screen

### DIFF
--- a/workspaces/marketplace/.changeset/six-emus-grab.md
+++ b/workspaces/marketplace/.changeset/six-emus-grab.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+restore dynamic plugin export

--- a/workspaces/marketplace/app-config.dynamic.yaml
+++ b/workspaces/marketplace/app-config.dynamic.yaml
@@ -21,11 +21,11 @@ dynamicPlugins:
         - name: marketplace
           importName: MarketplaceIcon
       dynamicRoutes:
-        - path: /marketplace
-          importName: MarketplacePage
-          menuItem:
-            icon: marketplace
-            text: Marketplace
+        - path: /plugins/marketplace
+          importName: DynamicMarketplacePluginRouter
       mountPoints:
-        - mountPoint: admin.page.plugins/cards
-          importName: MarketplaceCatalogContent
+        - mountPoint: internal.plugins/tab
+          importName: DynamicMarketplacePluginContent
+          config:
+            path: marketplace
+            title: Marketplace

--- a/workspaces/marketplace/plugins/marketplace/report.api.md
+++ b/workspaces/marketplace/plugins/marketplace/report.api.md
@@ -14,6 +14,9 @@ import { RouteRef } from '@backstage/core-plugin-api';
 import { SubRouteRef } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
+export const DynamicMarketplacePluginContent: () => JSX_2.Element;
+
+// @public (undocumented)
 export const DynamicMarketplacePluginRouter: () => JSX_2.Element;
 
 // @public

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
@@ -100,6 +100,10 @@ export const MarketplaceCatalogContent = () => {
     title += ` (${filteredPlugins.data.filteredItems})`;
   }
 
+  if (filteredPlugins.data?.totalItems === 0) {
+    return <NoPluginsFound />;
+  }
+
   return (
     <CatalogFilterLayout>
       <CatalogFilterLayout.Filters>
@@ -114,24 +118,20 @@ export const MarketplaceCatalogContent = () => {
             />
           ))}
 
-          {filteredPlugins.data && filteredPlugins.data.totalItems === 0 ? (
-            <NoPluginsFound />
-          ) : (
-            <Card>
-              <Stack gap={3} sx={{ p: 2 }}>
-                <Stack
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="center"
-                >
-                  <Typography variant="h4">{title}</Typography>
-                  <SearchTextField variant="search" />
-                </Stack>
-
-                <MarketplaceCatalogGrid />
+          <Card>
+            <Stack gap={3} sx={{ p: 2 }}>
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Typography variant="h4">{title}</Typography>
+                <SearchTextField variant="search" />
               </Stack>
-            </Card>
-          )}
+
+              <MarketplaceCatalogGrid />
+            </Stack>
+          </Card>
         </Stack>
       </CatalogFilterLayout.Content>
     </CatalogFilterLayout>

--- a/workspaces/marketplace/plugins/marketplace/src/pages/DynamicMarketplacePluginRouter.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/DynamicMarketplacePluginRouter.tsx
@@ -151,3 +151,9 @@ export const DynamicMarketplacePluginRouter = () => (
     </Routes>
   </ReactQueryProvider>
 );
+
+export const DynamicMarketplacePluginContent = () => (
+  <ReactQueryProvider>
+    <MarketplaceCatalogContent />
+  </ReactQueryProvider>
+);

--- a/workspaces/marketplace/plugins/marketplace/src/plugin.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createApiFactory,
   discoveryApiRef,
   fetchApiRef,
+  createComponentExtension,
 } from '@backstage/core-plugin-api';
 
 import MUIMarketplaceIcon from '@mui/icons-material/ShoppingBasketOutlined';
@@ -94,6 +95,21 @@ export const DynamicMarketplacePluginRouter = marketplacePlugin.provide(
         m => m.DynamicMarketplacePluginRouter,
       ),
     mountPoint: allRoutes.rootRouteRef,
+  }),
+);
+
+/**
+ * @public
+ */
+export const DynamicMarketplacePluginContent = marketplacePlugin.provide(
+  createComponentExtension({
+    name: 'DynamicMarketplacePluginContent',
+    component: {
+      lazy: () =>
+        import('./pages/DynamicMarketplacePluginRouter').then(
+          m => m.DynamicMarketplacePluginContent,
+        ),
+    },
   }),
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On local RHDH with

```yaml
dynamicPlugins:
  frontend:

    red-hat-developer-hub.backstage-plugin-marketplace:
      appIcons:
        - name: marketplace
          importName: MarketplaceIcon
      dynamicRoutes:
        - path: /plugins/marketplace
          importName: DynamicMarketplacePluginRouter
      mountPoints:
        - mountPoint: internal.plugins/tab
          importName: DynamicMarketplacePluginContent
          config:
            path: marketplace
            title: Marketplace
```

![image](https://github.com/user-attachments/assets/3d15ef89-add9-45dd-b4c9-bbdee527e988)

With catalog changes:

```yaml
catalog:
  locations:
    # Examples from https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/marketplace/examples
    - type: url
      target: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/marketplace/examples/all-orgs.yaml
      rules:
        - allow: [Group]
    - type: url
      target: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/marketplace/examples/all-plugins.yaml
      rules:
        - allow: [Plugin]
    - type: url
      target: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/marketplace/examples/all-collections.yaml
      rules:
        - allow: [PluginCollection]
```

![image](https://github.com/user-attachments/assets/c24603ce-78fe-4328-b627-4d4682cd3eed)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
