### PR TITLE
fix(marketplace): remove core-plugin-api dependency from common

### DIFF
--- a/workspaces/marketplace/.changeset/fifty-geckos-smell.md
+++ b/workspaces/marketplace/.changeset/fifty-geckos-smell.md
@@ -1,0 +1,9 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace-common': patch
+'@red-hat-developer-hub/marketplace-cli': patch
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace': patch
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+'@red-hat-developer-hub/backstage-plugin-marketplace-backend': patch
+---
+
+remove core-plugin-api dependency from common

--- a/workspaces/marketplace/plugins/marketplace-common/package.json
+++ b/workspaces/marketplace/plugins/marketplace-common/package.json
@@ -38,7 +38,6 @@
     "@backstage/backend-plugin-api": "^1.1.1",
     "@backstage/catalog-client": "^1.9.1",
     "@backstage/catalog-model": "^1.7.3",
-    "@backstage/core-plugin-api": "^1.10.3",
     "@backstage/errors": "^1.2.7"
   },
   "devDependencies": {

--- a/workspaces/marketplace/plugins/marketplace-common/report.api.md
+++ b/workspaces/marketplace/plugins/marketplace-common/report.api.md
@@ -6,9 +6,7 @@
 
 import type { AuthService } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
-import type { DiscoveryApi } from '@backstage/core-plugin-api';
 import type { Entity } from '@backstage/catalog-model';
-import type { FetchApi } from '@backstage/core-plugin-api';
 import { GetEntityFacetsRequest } from '@backstage/catalog-client';
 import { GetEntityFacetsResponse } from '@backstage/catalog-client';
 import { JsonObject } from '@backstage/types';
@@ -41,6 +39,11 @@ export const decodeGetEntitiesRequest: (searchParams: URLSearchParams) => GetEnt
 export const decodeGetEntityFacetsRequest: (searchParams: URLSearchParams) => GetEntityFacetsRequest;
 
 // @public (undocumented)
+export type DiscoveryApi = {
+    getBaseUrl(pluginId: string): Promise<string>;
+};
+
+// @public (undocumented)
 export interface Documentation extends JsonObject {
     // (undocumented)
     markdown: string;
@@ -69,6 +72,11 @@ export const encodeGetEntitiesRequest: (request: GetEntitiesRequest) => URLSearc
 
 // @public (undocumented)
 export const encodeGetEntityFacetsRequest: (request: GetEntityFacetsRequest) => URLSearchParams;
+
+// @public (undocumented)
+export type FetchApi = {
+    fetch: typeof fetch;
+};
 
 // @public (undocumented)
 export type GetEntitiesRequest = QueryEntitiesInitialRequest;

--- a/workspaces/marketplace/plugins/marketplace-common/src/api/MarketplaceBackendClient.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/api/MarketplaceBackendClient.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import {
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
@@ -35,6 +34,20 @@ import type {
   GetEntitiesRequest,
   GetEntitiesResponse,
 } from './MarketplaceApi';
+
+/**
+ * @public
+ */
+export type DiscoveryApi = {
+  getBaseUrl(pluginId: string): Promise<string>;
+};
+
+/**
+ * @public
+ */
+export type FetchApi = {
+  fetch: typeof fetch;
+};
 
 /**
  * @public

--- a/workspaces/marketplace/yarn.lock
+++ b/workspaces/marketplace/yarn.lock
@@ -10445,7 +10445,6 @@ __metadata:
     "@backstage/catalog-client": ^1.9.1
     "@backstage/catalog-model": ^1.7.3
     "@backstage/cli": ^0.29.5
-    "@backstage/core-plugin-api": ^1.10.3
     "@backstage/errors": ^1.2.7
   peerDependencies:
     "@backstage/backend-plugin-api": ^1.1.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Try to solve:

```
➤ YN0002: │ @red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.1.1 [ea14c] doesn't provide react (pdd725), requested by @backstage/core-plugin-api
➤ YN0002: │ @red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.1.1 [ea14c] doesn't provide react-dom (pa2514), requested by @backstage/core-plugin-api
➤ YN0002: │ @red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.1.1 [ea14c] doesn't provide react-router-dom (paa342), requested by @backstage/core-plugin-api
```

when running `yarn export-dynamic` on the rhdh backend wrapper.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
