### PR TITLE
fix(marketplace): apply default sorting to filtered plugins api call

### DIFF
--- a/workspaces/marketplace/.changeset/smart-balloons-confess.md
+++ b/workspaces/marketplace/.changeset/smart-balloons-confess.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+apply default sorting to filtered plugins api call

--- a/workspaces/marketplace/app-config.yaml
+++ b/workspaces/marketplace/app-config.yaml
@@ -1,9 +1,9 @@
 app:
-  title: Backstage
+  title: Backstage App
   baseUrl: http://localhost:3000
 
-#organization:
-#  name: My Company
+organization:
+  name: My Company
 
 backend:
   # Used for enabling authentication, secret is shared by all backend plugins

--- a/workspaces/marketplace/plugins/marketplace/src/hooks/useFilteredPlugins.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/hooks/useFilteredPlugins.ts
@@ -18,7 +18,22 @@ import { useSearchParams } from 'react-router-dom';
 
 import { useQuery } from '@tanstack/react-query';
 
+import { GetEntitiesRequest } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+
 import { useMarketplaceApi } from './useMarketplaceApi';
+
+const filteredPluginsRequest: GetEntitiesRequest = {
+  orderFields: [
+    {
+      field: 'metadata.title',
+      order: 'asc',
+    },
+    {
+      field: 'metadata.name',
+      order: 'asc',
+    },
+  ],
+};
 
 export const useFilteredPlugins = () => {
   const [searchParams] = useSearchParams();
@@ -27,8 +42,8 @@ export const useFilteredPlugins = () => {
 
   const marketplaceApi = useMarketplaceApi();
   return useQuery({
-    queryKey: ['marketplaceApi', 'getPlugins', {}],
-    queryFn: () => marketplaceApi.getPlugins({}),
+    queryKey: ['marketplaceApi', 'getPlugins', filteredPluginsRequest],
+    queryFn: () => marketplaceApi.getPlugins(filteredPluginsRequest),
     select: data => {
       let plugins = data.items;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just adds a default sort to the use / get filtered plugins API call

Without this:

![image](https://github.com/user-attachments/assets/8b18be3e-bdd9-4c21-8360-82a9694c6805)

With this change:

![image](https://github.com/user-attachments/assets/5c635c2f-51e6-46de-a674-1f7d6d0bc787)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
