### PR TITLE
feat(marketplace): Add marketplace providers to add entities into the catalog

### DIFF
--- a/workspaces/marketplace/.changeset/shaggy-zoos-fetch.md
+++ b/workspaces/marketplace/.changeset/shaggy-zoos-fetch.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace': patch
+---
+
+Add marketplace providers to add entities into catalog

--- a/workspaces/marketplace/package.json
+++ b/workspaces/marketplace/package.json
@@ -11,7 +11,7 @@
     "start-backend": "yarn workspace backend start",
     "build:backend": "yarn workspace backend build",
     "tsc": "tsc",
-    "tsc:full": "tsc --skipLibCheck false --incremental false",
+    "tsc:full": "tsc --skipLibCheck true --incremental false",
     "build:all": "backstage-cli repo build --all",
     "build:api-reports": "yarn build:api-reports:only --tsc",
     "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type,ae-undocumented --validate-release-tags",

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/package.json
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/package.json
@@ -39,11 +39,15 @@
     "@backstage/plugin-catalog-node": "^1.15.1",
     "@backstage/types": "^1.2.1",
     "@red-hat-developer-hub/backstage-plugin-marketplace-common": "workspace:^",
+    "find-root": "^1.1.0",
+    "glob": "^8.1.0",
+    "js-yaml": "^4.1.0",
     "semver": "^7.6.3"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.2.1",
-    "@backstage/cli": "^0.29.5"
+    "@backstage/cli": "^0.29.5",
+    "@types/glob": "^8.1.0"
   },
   "files": [
     "dist"

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/report.api.md
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/report.api.md
@@ -11,9 +11,28 @@ import { CatalogProcessorCache } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { EntityProvider } from '@backstage/plugin-catalog-node';
+import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { MarketplaceCollection } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 import { MarketplacePackage } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 import { MarketplacePlugin } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+
+// @public (undocumented)
+export abstract class BaseEntityProvider<T extends Entity> implements EntityProvider {
+    constructor(taskRunner: SchedulerServiceTaskRunner);
+    // (undocumented)
+    connect(connection: EntityProviderConnection): Promise<void>;
+    // (undocumented)
+    getEntities(allEntities: JsonFileData<T>[]): T[];
+    // (undocumented)
+    abstract getKind(): string;
+    // (undocumented)
+    abstract getProviderName(): string;
+    // (undocumented)
+    run(): Promise<void>;
+}
 
 // @public (undocumented)
 export type CachedData = {
@@ -40,6 +59,12 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
 }
 
 // @public (undocumented)
+export type JsonFileData<T> = {
+    filePath: string;
+    content: T;
+};
+
+// @public (undocumented)
 export class LocalPackageInstallStatusProcessor implements CatalogProcessor {
     constructor(paths?: string[]);
     // (undocumented)
@@ -61,6 +86,14 @@ export class MarketplaceCollectionProcessor implements CatalogProcessor {
 }
 
 // @public (undocumented)
+export class MarketplaceCollectionProvider extends BaseEntityProvider<MarketplaceCollection> {
+    // (undocumented)
+    getKind(): string;
+    // (undocumented)
+    getProviderName(): string;
+}
+
+// @public (undocumented)
 export class MarketplacePackageProcessor implements CatalogProcessor {
     // (undocumented)
     getProcessorName(): string;
@@ -71,6 +104,14 @@ export class MarketplacePackageProcessor implements CatalogProcessor {
 }
 
 // @public (undocumented)
+export class MarketplacePackageProvider extends BaseEntityProvider<MarketplacePackage> {
+    // (undocumented)
+    getKind(): string;
+    // (undocumented)
+    getProviderName(): string;
+}
+
+// @public (undocumented)
 export class MarketplacePluginProcessor implements CatalogProcessor {
     // (undocumented)
     getProcessorName(): string;
@@ -78,6 +119,14 @@ export class MarketplacePluginProcessor implements CatalogProcessor {
     postProcessEntity(entity: MarketplacePlugin, _location: LocationSpec, emit: CatalogProcessorEmit): Promise<Entity>;
     // (undocumented)
     validateEntityKind(entity: Entity): Promise<boolean>;
+}
+
+// @public (undocumented)
+export class MarketplacePluginProvider extends BaseEntityProvider<MarketplacePlugin> {
+    // (undocumented)
+    getKind(): string;
+    // (undocumented)
+    getProviderName(): string;
 }
 
 ```

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.test.ts
@@ -20,7 +20,10 @@ import { startTestBackend } from '@backstage/backend-test-utils';
 
 describe('catalogModuleMarketplace', () => {
   it('should register the extension point', async () => {
-    const extensionPoint = { addProcessor: jest.fn() };
+    const extensionPoint = {
+      addProcessor: jest.fn(),
+      addEntityProvider: jest.fn(),
+    };
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       features: [catalogModuleMarketplace],

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/module.ts
@@ -26,7 +26,6 @@ import { DynamicPackageInstallStatusProcessor } from './processors/DynamicPackag
 import { LocalPackageInstallStatusProcessor } from './processors/LocalPackageInstallStatusProcessor';
 import { MarketplacePackageProcessor } from './processors/MarketplacePackageProcessor';
 import { MarketplacePluginProvider } from './providers/MarketplacePluginProvider';
-import { MarketplaceCollectionProvider } from './providers/MarketplaceCollectionProvider';
 import { MarketplacePackageProvider } from './providers/MarketplacePackageProvider';
 
 /**
@@ -55,9 +54,10 @@ export const catalogModuleMarketplace = createBackendModule({
 
         catalog.addEntityProvider(new MarketplacePackageProvider(taskRunner));
         catalog.addEntityProvider(new MarketplacePluginProvider(taskRunner));
-        catalog.addEntityProvider(
-          new MarketplaceCollectionProvider(taskRunner),
-        );
+        // Disabling the collection provider as collections/all.yaml is already commented in RHDH 1.5 image.
+        // catalog.addEntityProvider(
+        //   new MarketplaceCollectionProvider(taskRunner),
+        // );
         catalog.addProcessor(new MarketplacePluginProcessor());
         catalog.addProcessor(new MarketplaceCollectionProcessor());
         catalog.addProcessor(new LocalPackageInstallStatusProcessor());

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/BaseEntityProvider.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/BaseEntityProvider.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+  Entity,
+} from '@backstage/catalog-model';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+
+import { findTopmostFolder, readYamlFiles } from '../utils/file-utils';
+import { JsonFileData } from '../types';
+
+/**
+ * @public
+ */
+export abstract class BaseEntityProvider<T extends Entity>
+  implements EntityProvider
+{
+  private connection?: EntityProviderConnection;
+  private taskRunner: SchedulerServiceTaskRunner;
+
+  constructor(taskRunner: SchedulerServiceTaskRunner) {
+    this.taskRunner = taskRunner;
+  }
+
+  abstract getProviderName(): string;
+  abstract getKind(): string;
+
+  getEntities(allEntities: JsonFileData<T>[]): T[] {
+    if (allEntities.length === 0) {
+      return [];
+    }
+    return allEntities
+      .filter(d => d.content.kind === this.getKind())
+      .map(file => ({
+        ...file.content,
+        metadata: {
+          ...file.content.metadata,
+          annotations: {
+            [ANNOTATION_LOCATION]: `file:${this.getProviderName()}`,
+            [ANNOTATION_ORIGIN_LOCATION]: `file:${this.getProviderName()}`,
+          },
+        },
+      }));
+  }
+
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+    await this.taskRunner.run({
+      id: this.getProviderName(),
+      fn: async () => {
+        await this.run();
+      },
+    });
+  }
+
+  async run(): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+
+    const marketplaceFilePath = findTopmostFolder('marketplace');
+
+    let yamlData: JsonFileData<T>[] = [];
+    if (marketplaceFilePath) {
+      try {
+        yamlData = readYamlFiles(marketplaceFilePath);
+      } catch (error) {
+        console.error(error.message);
+      }
+    }
+
+    const entities: T[] = this.getEntities(yamlData);
+
+    await this.connection.applyMutation({
+      type: 'full',
+      entities: entities.map(entity => ({
+        entity,
+        locationKey: `file:${this.getProviderName()}`,
+      })),
+    });
+  }
+}

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/MarketplaceCollectionProvider.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/MarketplaceCollectionProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  MarketplaceCollection,
+  MarketplaceKind,
+} from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import { BaseEntityProvider } from './BaseEntityProvider';
 
 /**
- * The marketplace backend module for the catalog plugin.
- *
- * @packageDocumentation
+ * @public
  */
+export class MarketplaceCollectionProvider extends BaseEntityProvider<MarketplaceCollection> {
+  getKind(): string {
+    return MarketplaceKind.Collection;
+  }
 
-export { catalogModuleMarketplace as default } from './module';
-
-export * from './processors';
-export * from './providers';
-export * from './types';
+  getProviderName(): string {
+    return 'marketplace-collection-provider';
+  }
+}

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/MarketplacePackageProvider.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/MarketplacePackageProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  MarketplaceKind,
+  MarketplacePackage,
+} from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import { BaseEntityProvider } from './BaseEntityProvider';
 
 /**
- * The marketplace backend module for the catalog plugin.
- *
- * @packageDocumentation
+ * @public
  */
+export class MarketplacePackageProvider extends BaseEntityProvider<MarketplacePackage> {
+  getKind(): string {
+    return MarketplaceKind.Package;
+  }
 
-export { catalogModuleMarketplace as default } from './module';
-
-export * from './processors';
-export * from './providers';
-export * from './types';
+  getProviderName(): string {
+    return 'marketplace-package-provider';
+  }
+}

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/MarketplacePluginProvider.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/MarketplacePluginProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  MarketplaceKind,
+  MarketplacePlugin,
+} from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import { BaseEntityProvider } from './BaseEntityProvider';
 
 /**
- * The marketplace backend module for the catalog plugin.
- *
- * @packageDocumentation
+ * @public
  */
+export class MarketplacePluginProvider extends BaseEntityProvider<MarketplacePlugin> {
+  getKind(): string {
+    return MarketplaceKind.Plugin;
+  }
 
-export { catalogModuleMarketplace as default } from './module';
-
-export * from './processors';
-export * from './providers';
-export * from './types';
+  getProviderName(): string {
+    return 'marketplace-plugin-provider';
+  }
+}

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/index.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/providers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The marketplace backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-export { catalogModuleMarketplace as default } from './module';
-
-export * from './processors';
-export * from './providers';
-export * from './types';
+export * from './BaseEntityProvider';
+export * from './MarketplacePluginProvider';
+export * from './MarketplaceCollectionProvider';
+export * from './MarketplacePackageProvider';

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/types.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,6 @@
  */
 
 /**
- * The marketplace backend module for the catalog plugin.
- *
- * @packageDocumentation
+ * @public
  */
-
-export { catalogModuleMarketplace as default } from './module';
-
-export * from './processors';
-export * from './providers';
-export * from './types';
+export type JsonFileData<T> = { filePath: string; content: T };

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/utils/file-utils.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/utils/file-utils.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import glob from 'glob';
+import yaml from 'js-yaml';
+import { findTopmostFolder, readYamlFiles } from './file-utils';
+
+jest.mock('fs');
+jest.mock('glob');
+jest.mock('js-yaml');
+
+describe('findTopmostFolder', () => {
+  const mockExistsSync = fs.existsSync as jest.Mock;
+  const mockStatSync = fs.statSync as jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return the topmost occurrence of the folder', () => {
+    const folderName = 'targetFolder';
+    const startPath = '/Users/test/dynamic-plugins/dist/src';
+
+    mockExistsSync.mockImplementation(folderPath => {
+      return [
+        '/Users/test/targetFolder',
+        '/Users/test/dynamic-plugins/dist/targetFolder',
+      ].includes(folderPath);
+    });
+
+    mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
+
+    const result = findTopmostFolder(folderName, startPath);
+    expect(result).toBe('/Users/test/targetFolder');
+  });
+
+  it('should return the folder if it exists at only one level', () => {
+    const folderName = 'targetFolder';
+    const startPath = '/Users/test/dynamic-plugins/dist/src';
+
+    mockExistsSync.mockImplementation(
+      folderPath =>
+        folderPath === '/Users/test/dynamic-plugins/dist/targetFolder',
+    );
+    mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
+
+    const result = findTopmostFolder(folderName, startPath);
+    expect(result).toBe('/Users/test/dynamic-plugins/dist/targetFolder');
+  });
+
+  it('should return null if the folder does not exist', () => {
+    const folderName = 'missingFolder';
+    const startPath =
+      '/Users/test/dynamic-plugins/dist/catalog-backend-module-test';
+
+    mockExistsSync.mockReturnValue(false);
+
+    const result = findTopmostFolder(folderName, startPath);
+    expect(result).toBeNull();
+  });
+
+  it('should return root if the folder is at the root level', () => {
+    const folderName = 'rootFolder';
+    const startPath =
+      '/Users/test/dynamic-plugins/dist/catalog-backend-module-test';
+
+    mockExistsSync.mockImplementation(
+      folderPath => folderPath === '/rootFolder',
+    );
+    mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
+
+    const result = findTopmostFolder(folderName, startPath);
+    expect(result).toBe('/rootFolder');
+  });
+
+  it('should warn when the folder is not found', () => {
+    console.warn = jest.fn();
+    const folderName = 'notFoundFolder';
+    const startPath = '/Users/test/project/src';
+
+    mockExistsSync.mockReturnValue(false);
+
+    const result = findTopmostFolder(folderName, startPath);
+    expect(result).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      `Folder "notFoundFolder" not found in any parent directory`,
+    );
+  });
+});
+
+describe('readYamlFiles', () => {
+  const mockGlobSync = glob.sync as unknown as jest.Mock;
+  const mockReadFileSync = fs.readFileSync as jest.Mock;
+  const mockYamlLoad = yaml.load as jest.Mock;
+  const folderPath = '/path/to/yaml';
+
+  beforeEach(() => jest.resetAllMocks());
+
+  it('shouldparses YAML files correctly', () => {
+    mockGlobSync.mockReturnValue(['file1.yaml', 'file2.yml']);
+    mockReadFileSync
+      .mockReturnValueOnce(
+        `
+kind: Plugin
+name: test-plugin
+`,
+      )
+      .mockReturnValueOnce(
+        `
+kind: Package
+name: test-package`,
+      );
+
+    mockYamlLoad
+      .mockReturnValueOnce({ kind: 'Plugin', name: 'test-plugin' })
+      .mockReturnValueOnce({ kind: 'Package', name: 'test-package' });
+
+    expect(readYamlFiles(folderPath)).toEqual([
+      {
+        filePath: 'file1.yaml',
+        content: { kind: 'Plugin', name: 'test-plugin' },
+      },
+      {
+        filePath: 'file2.yml',
+        content: { kind: 'Package', name: 'test-package' },
+      },
+    ]);
+  });
+
+  it('handles YAML parsing errors', () => {
+    mockGlobSync.mockReturnValue(['file1.yaml']);
+    mockReadFileSync.mockReturnValue('invalid yaml');
+    mockYamlLoad.mockImplementation(() => {
+      throw new Error('YAML Error');
+    });
+
+    console.error = jest.fn();
+    expect(readYamlFiles(folderPath)).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error parsing YAML file'),
+      expect.any(Error),
+    );
+  });
+
+  it('returns an empty array when no files are found', () => {
+    mockGlobSync.mockReturnValue([]);
+    expect(readYamlFiles(folderPath)).toEqual([]);
+  });
+});

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/utils/file-utils.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/utils/file-utils.ts
@@ -57,10 +57,6 @@ export const readYamlFiles = <T extends Entity>(
   folderPath: string,
 ): JsonFileData<T>[] => {
   const yamlFiles = glob.sync(path.join(folderPath, '**/*.@(yaml|yml)'));
-  // const yamlFiles = globbySync(path.join(folderPath, '**/*.@(yaml|yml)'), {
-  //   ignore: ['node_modules/**'],
-  //   absolute: true,
-  // });
   const jsonFiles: JsonFileData<T>[] = [];
 
   yamlFiles.forEach(filePath => {

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/utils/file-utils.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/utils/file-utils.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import path from 'path';
+import { glob } from 'glob';
+import yaml from 'js-yaml';
+import { Entity } from '@backstage/catalog-model';
+import { JsonFileData } from '../types';
+
+export const findTopmostFolder = (
+  folderName: string,
+  startPath = process.cwd(),
+): string | null => {
+  let currentPath = path.resolve(startPath);
+  let topmostFoundPath: string | null = null;
+
+  while (currentPath !== path.parse(currentPath).root) {
+    const targetFolderPath = path.join(currentPath, folderName);
+    if (
+      fs.existsSync(targetFolderPath) &&
+      fs.statSync(targetFolderPath).isDirectory()
+    ) {
+      topmostFoundPath = targetFolderPath;
+    }
+    currentPath = path.dirname(currentPath);
+  }
+  const targetFolderPath = path.join(currentPath, folderName);
+
+  if (
+    fs.existsSync(targetFolderPath) &&
+    fs.statSync(targetFolderPath).isDirectory()
+  ) {
+    topmostFoundPath = targetFolderPath;
+  }
+
+  if (!topmostFoundPath) {
+    console.warn(`Folder "${folderName}" not found in any parent directory`);
+  }
+
+  return topmostFoundPath;
+};
+
+export const readYamlFiles = <T extends Entity>(
+  folderPath: string,
+): JsonFileData<T>[] => {
+  const yamlFiles = glob.sync(path.join(folderPath, '**/*.@(yaml|yml)'));
+  // const yamlFiles = globbySync(path.join(folderPath, '**/*.@(yaml|yml)'), {
+  //   ignore: ['node_modules/**'],
+  //   absolute: true,
+  // });
+  const jsonFiles: JsonFileData<T>[] = [];
+
+  yamlFiles.forEach(filePath => {
+    try {
+      const fileContent = fs.readFileSync(filePath, 'utf8');
+      const jsonData = yaml.load(fileContent);
+      jsonFiles.push({ filePath, content: jsonData as unknown as T });
+    } catch (error) {
+      console.error(`Error parsing YAML file: ${filePath}`, error);
+    }
+  });
+
+  return jsonFiles;
+};

--- a/workspaces/marketplace/yarn.lock
+++ b/workspaces/marketplace/yarn.lock
@@ -10411,6 +10411,10 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.15.1
     "@backstage/types": ^1.2.1
     "@red-hat-developer-hub/backstage-plugin-marketplace-common": "workspace:^"
+    "@types/glob": ^8.1.0
+    find-root: ^1.1.0
+    glob: ^8.1.0
+    js-yaml: ^4.1.0
     semver: ^7.6.3
   languageName: unknown
   linkType: soft
@@ -13284,6 +13288,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/glob@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@types/glob@npm:8.1.0"
+  dependencies:
+    "@types/minimatch": ^5.1.2
+    "@types/node": "*"
+  checksum: 9101f3a9061e40137190f70626aa0e202369b5ec4012c3fabe6f5d229cce04772db9a94fa5a0eb39655e2e4ad105c38afbb4af56a56c0996a8c7d4fc72350e3d
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.9
   resolution: "@types/graceful-fs@npm:4.1.9"
@@ -13507,6 +13521,13 @@ __metadata:
   version: 1.3.5
   resolution: "@types/mime@npm:1.3.5"
   checksum: e29a5f9c4776f5229d84e525b7cd7dd960b51c30a0fb9a028c0821790b82fca9f672dab56561e2acd9e8eed51d431bde52eafdfef30f643586c4162f1aecfc78
+  languageName: node
+  linkType: hard
+
+"@types/minimatch@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@types/minimatch@npm:5.1.2"
+  checksum: 0391a282860c7cb6fe262c12b99564732401bdaa5e395bee9ca323c312c1a0f45efbf34dce974682036e857db59a5c9b1da522f3d6055aeead7097264c8705a8
   languageName: node
   linkType: hard
 
@@ -20209,15 +20230,15 @@ __metadata:
   linkType: hard
 
 "fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "fast-glob@npm:3.3.2"
+  version: 3.3.3
+  resolution: "fast-glob@npm:3.3.3"
   dependencies:
     "@nodelib/fs.stat": ^2.0.2
     "@nodelib/fs.walk": ^1.2.3
     glob-parent: ^5.1.2
     merge2: ^1.3.0
-    micromatch: ^4.0.4
-  checksum: 900e4979f4dbc3313840078419245621259f349950411ca2fa445a2f9a1a6d98c3b5e7e0660c5ccd563aa61abe133a21765c6c0dec8e57da1ba71d8000b05ec1
+    micromatch: ^4.0.8
+  checksum: 0704d7b85c0305fd2cef37777337dfa26230fdd072dce9fb5c82a4b03156f3ffb8ed3e636033e65d45d2a5805a4e475825369a27404c0307f2db0c8eb3366fbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR adds three new marketplace providers to add entities into the catalog.  The providers reads the plugins, package and collection entity metadata from RHDH image and adds to the catalog.

```
        catalog.addEntityProvider(new MarketplacePackageProvider(taskRunner));
        catalog.addEntityProvider(new MarketplacePluginProvider(taskRunner));
        // catalog.addEntityProvider(new MarketplaceCollectionProvider(taskRunner)); // not registered for 1.5 
```



## Screenshots:

![image](https://github.com/user-attachments/assets/f1434969-cd3e-4b8e-9446-1e67c422193a)


## Unit tests

![image](https://github.com/user-attachments/assets/7613a37b-7596-4cf5-8407-cc0963e11697)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
