### PR TITLE
feat(adoption-insights): add grouping configuration in insights endpoints.

### DIFF
--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/README.md
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/README.md
@@ -56,6 +56,7 @@ If you want to run the entire project, including the frontend, run `yarn dev` fr
 | `end_date`   | string (YYYY-MM-DD) | Yes      | Fetch events up to this date.                                                                                                                   |
 | `limit`      | integer             | No       | Limit the number of events returned (default: `3`).                                                                                             |
 | `kind`       | string              | No       | Filter the entities by kind.                                                                                                                    |
+| `grouping`   | string              | No       | Group API endpoint `(active_users,top_plugins and top_searches)` response by `hourly`, `daily`, `weekly`, and `monthly`.                        |
 | `format`     | string              | No       | Response format, either `json` (default) or `csv`.                                                                                              |
 
 ## Example Request

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/SqliteAdapter.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/SqliteAdapter.ts
@@ -30,7 +30,7 @@ export class SqliteAdapter extends BaseDatabaseAdapter {
   }
 
   getLastUsedDate(): string {
-    return 'MAX(created_at) AS last_used';
+    return `strftime('%Y-%m-%dT%H:%M:%SZ', MAX(created_at), 'localtime') AS last_used`;
   }
 
   getFormatedDate(column: string): string {
@@ -54,10 +54,11 @@ export class SqliteAdapter extends BaseDatabaseAdapter {
   }
 
   getDynamicDateGrouping(onlyText: boolean = false): string {
-    const { start_date, end_date } = this.filters!;
+    const { start_date, end_date, grouping: groupingStrategy } = this.filters!;
     const dateDiff = calculateDateRange(start_date, end_date);
 
-    const grouping = getDateGroupingType(dateDiff, start_date, end_date);
+    const grouping =
+      groupingStrategy || getDateGroupingType(dateDiff, start_date, end_date);
 
     if (onlyText) {
       return grouping;
@@ -70,6 +71,8 @@ export class SqliteAdapter extends BaseDatabaseAdapter {
 
   private getDateGroupingQuery(grouping: string): string {
     switch (grouping) {
+      case 'hourly':
+        return `strftime('%Y-%m-%d %H:00:00', created_at, 'localtime')`;
       case 'daily':
         return `strftime('%Y-%m-%d', created_at, 'localtime')`;
       case 'weekly':

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/event-database.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/event-database.ts
@@ -16,6 +16,7 @@
 import { Knex } from 'knex';
 import {
   DailyUsers,
+  Grouping,
   TopCatalogEntitiesCount,
   TopPluginCount,
   TopSearches,
@@ -28,8 +29,9 @@ import { Event } from '../models/Event';
 export interface Filters {
   start_date: string;
   end_date: string;
-  limit?: number;
-  kind?: string;
+  limit?: number | undefined;
+  kind?: string | undefined;
+  grouping?: Grouping | undefined;
 }
 
 export type UserConfig = {

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/plugin.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/plugin.test.ts
@@ -72,6 +72,6 @@ describe('plugin', () => {
       .get(
         '/api/adoption-insights/events?type=active_users&start_date=1990-03-02&end_date=1990-03-04',
       )
-      .expect(200, { data: [] });
+      .expect(200, { grouping: 'daily', data: [] });
   });
 });

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/types/event.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/types/event.ts
@@ -17,7 +17,7 @@ interface DateCount {
   date: string; // YYYY-MM-DD format
   count: string;
 }
-interface DailyUser {
+export interface DailyUser {
   date: string;
   total_users: number;
   new_users: number;
@@ -29,7 +29,7 @@ interface TotalUser {
   licensed_users: number;
 }
 
-interface PluginCount {
+export interface PluginCount {
   plugin_id: string;
   visit_count: string;
   trend: DateCount[];
@@ -51,12 +51,13 @@ interface CatalogEntityCount {
   count: string;
 }
 
-type ResponseData<T> = {
+export type ResponseData<T> = {
   data: T;
 };
 
-type ResponseWithGrouping<T> = {
-  grouping: 'daily' | 'weekly' | 'monthly';
+export type Grouping = 'hourly' | 'daily' | 'weekly' | 'monthly';
+export type ResponseWithGrouping<T> = {
+  grouping: Grouping;
   data: T;
 };
 export type DailyUsers = ResponseWithGrouping<DailyUser[]>;

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.test.ts
@@ -15,6 +15,7 @@
  */
 import {
   calculateDateRange,
+  convertToLocalTimezone,
   getDateGroupingType,
   isSameMonth,
   toEndOfDayUTC,
@@ -64,6 +65,10 @@ describe('isSameMonth', () => {
 });
 
 describe('getDateGroupingType', () => {
+  it('should return "hourly" if dateDiff is 0', () => {
+    expect(getDateGroupingType(0, '2024-03-11', '2024-03-11')).toBe('hourly');
+  });
+
   it('should return "daily" if dateDiff is 7 or less', () => {
     expect(getDateGroupingType(3, '2024-03-01', '2024-03-04')).toBe('daily');
     expect(getDateGroupingType(7, '2024-03-01', '2024-03-08')).toBe('daily');
@@ -77,5 +82,30 @@ describe('getDateGroupingType', () => {
   it('should return "monthly" if dateDiff is greater than 30 or in different months', () => {
     expect(getDateGroupingType(31, '2024-03-01', '2024-04-01')).toBe('monthly');
     expect(getDateGroupingType(10, '2024-03-25', '2024-04-04')).toBe('monthly');
+  });
+});
+
+describe('convertToLocalTimezone', () => {
+  it('should return the date time converted to local timestamp', () => {
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValue({
+        timeZone: 'Asia/Kolkata',
+      } as Intl.ResolvedDateTimeFormatOptions);
+
+    expect(convertToLocalTimezone('2025-03-02 23:30:00')).toBe(
+      '2025-03-02 23:30:00 GMT+5:30',
+    );
+  });
+  it('should return the UTC date converted to local timezone', () => {
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValue({
+        timeZone: 'Asia/Kolkata',
+      } as Intl.ResolvedDateTimeFormatOptions);
+
+    expect(convertToLocalTimezone('2025-03-02T18:00:00.000Z')).toBe(
+      '2025-03-02 23:30:00 GMT+5:30',
+    );
   });
 });

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { DateTime } from 'luxon';
+import { Grouping } from '../types/event';
 
 export const toStartOfDayUTC = (dateString: string, timezone = 'UTC') =>
   DateTime.fromFormat(dateString, 'yyyy-MM-dd', { zone: timezone })
@@ -48,8 +49,30 @@ export const getDateGroupingType = (
   dateDiff: number,
   start_date: string,
   end_date: string,
-): 'daily' | 'weekly' | 'monthly' => {
+): Grouping => {
+  if (dateDiff === 0) return 'hourly';
   if (dateDiff <= 7) return 'daily';
   if (dateDiff <= 30 && isSameMonth(start_date, end_date)) return 'weekly';
   return 'monthly';
+};
+
+export const hasZFormat = (dateStr: string): boolean => {
+  return dateStr.includes('Z') || dateStr.includes('T');
+};
+
+export const convertToLocalTimezone = (date: string) => {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const parsedDate = hasZFormat(date.toString())
+    ? new Date(date).toISOString()
+    : date;
+
+  if (DateTime.fromISO(parsedDate, { zone: timeZone }).isValid) {
+    return DateTime.fromISO(parsedDate, { zone: timeZone }).toFormat(
+      'yyyy-MM-dd HH:mm:ss ZZZZ',
+    );
+  }
+  return DateTime.fromFormat(parsedDate, 'yyyy-MM-dd HH:mm:ss', {
+    zone: timeZone,
+  }).toFormat('yyyy-MM-dd HH:mm:ss ZZZZ');
 };

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/validation/event-request.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/validation/event-request.ts
@@ -24,6 +24,7 @@ const dateRequiredSchema = (fieldName: string) =>
 
 export const EventRequestSchema = z
   .object({
+    grouping: z.enum(['hourly', 'weekly', 'daily', 'monthly']).optional(),
     start_date: dateRequiredSchema('start_date'),
     end_date: dateRequiredSchema('end_date'),
     limit: z.string().regex(/^\d+$/).transform(Number).optional(),


### PR DESCRIPTION


## Fixes
https://issues.redhat.com/browse/RHDHPAI-658

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR contains following changes:

- Add `grouping` query param configuration to provide fine grain control to the consumers. Now users can explicitly fetch the queries based on their need, if not then backend will choose them a better grouping strategy based on the date interval.
- added `hourly` grouping strategy to get data points for every hour in a day.
- Updated the documentation.

Screenshots:

![Grouping_param](https://github.com/user-attachments/assets/1b390908-bd04-475d-b39f-859fd7e34eab)

## unit tests:

![image](https://github.com/user-attachments/assets/3f350e98-0560-4f99-afec-2156d8eec7db)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
