### PR TITLE
feat(global-header): changing create to self-service

### DIFF
--- a/workspaces/global-header/.changeset/quiet-bulldogs-battle.md
+++ b/workspaces/global-header/.changeset/quiet-bulldogs-battle.md
@@ -1,5 +1,5 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-global-header': patch
+'@red-hat-developer-hub/backstage-plugin-global-header': minor
 ---
 
 Renaming the 'Create' to 'Self-service'

--- a/workspaces/global-header/.changeset/quiet-bulldogs-battle.md
+++ b/workspaces/global-header/.changeset/quiet-bulldogs-battle.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Renaming the 'Create' to 'Self-service'

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
@@ -64,7 +64,7 @@ export const CreateDropdown = ({ layout }: CreateDropdownProps) => {
     <HeaderDropdownComponent
       buttonContent={
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          Create <ArrowDropDownOutlinedIcon sx={{ ml: 1 }} />
+          Self-service <ArrowDropDownOutlinedIcon sx={{ ml: 1 }} />
         </Box>
       }
       buttonProps={{


### PR DESCRIPTION
Fixing : [Rename the 'Create' that appears on the Global header ](https://issues.redhat.com/browse/RHIDP-6164)

Screenshot from RHDH-Plugin
![Screenshot 2025-03-13 at 6 54 02 PM (2)](https://github.com/user-attachments/assets/99d13df2-fdc8-4727-859b-68fa5ea6aec2)

ScreenShot from RHDH
<img width="1710" alt="Screenshot 2025-03-13 at 8 35 14 PM" src="https://github.com/user-attachments/assets/104412ba-de86-4928-b502-c191e205fab6" />


