### PR TITLE
feat(marketplace): add monaco editor

### DIFF
--- a/workspaces/marketplace/.changeset/small-fireants-care.md
+++ b/workspaces/marketplace/.changeset/small-fireants-care.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': minor
+---
+
+add manaco editor for the upcoming installation page

--- a/workspaces/marketplace/packages/cli/src/commands/generate/index.ts
+++ b/workspaces/marketplace/packages/cli/src/commands/generate/index.ts
@@ -17,7 +17,7 @@
 import fs from 'fs-extra';
 import { OptionValues } from 'commander';
 import path from 'path';
-import YAML from 'yaml';
+import yaml from 'yaml';
 import {
   EXTENSIONS_API_VERSION,
   MarketplaceKind,
@@ -51,7 +51,7 @@ export default async (opts: OptionValues) => {
       defaultDynamicPluginsPath,
       'utf8',
     );
-    const defaultPluginsConfig = YAML.parse(
+    const defaultPluginsConfig = yaml.parse(
       defaultDynamicPluginsContent,
     ) as DynamicPluginsConfig;
 
@@ -207,16 +207,16 @@ export default async (opts: OptionValues) => {
     for (const entity of entities) {
       const filename = `${entity.metadata.name}.yaml`;
       const entityPath = path.join(outputDirPath, filename);
-      await fs.writeFile(entityPath, YAML.stringify(entity));
+      await fs.writeFile(entityPath, yaml.stringify(entity));
       location.spec.targets?.push(`./${filename}`);
     }
     await fs.writeFile(
       path.join(outputDirPath, 'all.yaml'),
-      YAML.stringify(location),
+      yaml.stringify(location),
     );
   } else {
     for (const entity of entities) {
-      console.log(YAML.stringify(entity));
+      console.log(yaml.stringify(entity));
       console.log('---');
     }
   }

--- a/workspaces/marketplace/plugins/marketplace/package.json
+++ b/workspaces/marketplace/plugins/marketplace/package.json
@@ -39,11 +39,15 @@
     "@backstage/core-plugin-api": "^1.10.3",
     "@backstage/plugin-catalog-react": "^1.15.1",
     "@backstage/theme": "^0.6.3",
+    "@monaco-editor/react": "^4.7.0",
     "@mui/icons-material": "^5.16.7",
     "@mui/material": "^5.12.2",
     "@red-hat-developer-hub/backstage-plugin-marketplace-common": "workspace:^",
     "@scalprum/react-core": "0.9.3",
-    "@tanstack/react-query": "^5.60.5"
+    "@tanstack/react-query": "^5.60.5",
+    "monaco-editor": "^0.52.2",
+    "react-use": "^17.6.0",
+    "yaml": "^2.7.0"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",

--- a/workspaces/marketplace/plugins/marketplace/src/components/CodeEditor.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/CodeEditor.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { Progress } from '@backstage/core-components';
+
+import { useTheme } from '@mui/material/styles';
+import Editor, { loader, OnChange, OnMount } from '@monaco-editor/react';
+import * as monacoEditor from 'monaco-editor';
+import type MonacoEditor from 'monaco-editor';
+
+loader.config({ monaco: monacoEditor });
+
+const defaultOptions: MonacoEditor.editor.IEditorConstructionOptions = {
+  minimap: { enabled: false },
+};
+
+interface CodeEditorContextValue {
+  getEditor: () => MonacoEditor.editor.ICodeEditor | null;
+  setEditor: (editor: MonacoEditor.editor.ICodeEditor) => void;
+  /** short for getEditor()?.getValue() */
+  getValue: () => string | undefined;
+  /** short for getEditor()?.setValue() and getEditor()?.focus() */
+  setValue: (value: string, autoFocus?: boolean) => void;
+}
+
+const CodeEditorContext = React.createContext<CodeEditorContextValue>(
+  undefined as any as CodeEditorContextValue,
+);
+
+export const CodeEditorContextProvider = (props: {
+  children: React.ReactNode;
+}) => {
+  const editorRef = React.useRef<MonacoEditor.editor.ICodeEditor | null>(null);
+  const contextValue = React.useMemo<CodeEditorContextValue>(
+    () => ({
+      getEditor: () => editorRef.current,
+      setEditor: (editor: MonacoEditor.editor.ICodeEditor) => {
+        editorRef.current = editor;
+      },
+      getValue: () => editorRef.current?.getValue(),
+      setValue: (value: string, autoFocus = true) => {
+        editorRef.current?.setValue(value);
+        if (autoFocus) {
+          editorRef.current?.focus();
+        }
+      },
+    }),
+    [],
+  );
+
+  return (
+    <CodeEditorContext.Provider value={contextValue}>
+      {props.children}
+    </CodeEditorContext.Provider>
+  );
+};
+
+export const useCodeEditor = () => {
+  const contextValue = React.useContext(CodeEditorContext);
+  if (!contextValue) {
+    throw new Error(
+      'useCodeEditor must be used within a CodeEditorContextProvider',
+    );
+  }
+  return contextValue;
+};
+
+export interface CodeEditorProps {
+  defaultLanguage: 'yaml'; // We enforce YAML for now
+  defaultValue?: string;
+  onChange?: OnChange;
+  onLoaded?: () => void;
+}
+
+/**
+ * Wrapper around Editor from @monaco-editor/react.
+ * It automaticallty sets the editor into the current
+ * CodeEditorContext so that it can be accessed via useCodeEditor
+ * and we can have a uncontrolled input component.
+ */
+export const CodeEditor = ({
+  defaultLanguage,
+  onChange,
+  onLoaded,
+  ...otherProps
+}: CodeEditorProps) => {
+  const theme = useTheme().palette.mode === 'dark' ? 'vs-dark' : 'vs-light';
+
+  const codeEditor = useCodeEditor();
+
+  const onMount = React.useCallback<OnMount>(
+    (editor, _monaco) => {
+      codeEditor.setEditor(editor);
+      onLoaded?.();
+    },
+    [codeEditor, onLoaded],
+  );
+
+  return (
+    <Editor
+      theme={theme}
+      defaultLanguage={defaultLanguage}
+      onChange={onChange}
+      onMount={onMount}
+      loading={<Progress />}
+      options={defaultOptions}
+      {...otherProps}
+    />
+  );
+};

--- a/workspaces/marketplace/yarn.lock
+++ b/workspaces/marketplace/yarn.lock
@@ -8600,6 +8600,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@monaco-editor/loader@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@monaco-editor/loader@npm:1.5.0"
+  dependencies:
+    state-local: ^1.0.6
+  checksum: 45e5f56ea9b1e5c16e3d40b05f8c365af830627d2aa8215c86cfac57384419c1b896927408c1261a12dc182a08419d4f20a0d0949d3e76ca42ccc68f4ffec508
+  languageName: node
+  linkType: hard
+
+"@monaco-editor/react@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@monaco-editor/react@npm:4.7.0"
+  dependencies:
+    "@monaco-editor/loader": ^1.5.0
+  peerDependencies:
+    monaco-editor: ">= 0.25.0 < 1"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 8b3bd8adfcd6af70dc5f965e986932269e1e2c2a0f6beb5a3c632c8c7942c1341f6086d9664f9a949983bdf4a04a706e529a93bfec3b5884642915dfcc0354c3
+  languageName: node
+  linkType: hard
+
 "@motionone/animation@npm:^10.12.0":
   version: 10.18.0
   resolution: "@motionone/animation@npm:10.18.0"
@@ -10468,6 +10490,7 @@ __metadata:
     "@backstage/plugin-catalog-react": ^1.15.1
     "@backstage/test-utils": ^1.7.4
     "@backstage/theme": ^0.6.3
+    "@monaco-editor/react": ^4.7.0
     "@mui/icons-material": ^5.16.7
     "@mui/material": ^5.12.2
     "@red-hat-developer-hub/backstage-plugin-marketplace-common": "workspace:^"
@@ -10477,9 +10500,12 @@ __metadata:
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
+    monaco-editor: ^0.52.2
     msw: ^1.0.0
     react: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
+    react-use: ^17.6.0
+    yaml: ^2.7.0
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -26352,6 +26378,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor@npm:^0.52.2":
+  version: 0.52.2
+  resolution: "monaco-editor@npm:0.52.2"
+  checksum: d5ff7b7a469afee25ac708d9ace0dcc5ef24ed328dfc526a52944a497f0d826cfb0685a778ff4b7becc0a8f7843f260c17ea6de3f6719481d53501d79ebb1260
+  languageName: node
+  linkType: hard
+
 "moo@npm:^0.5.0":
   version: 0.5.2
   resolution: "moo@npm:0.5.2"
@@ -29779,9 +29812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0":
-  version: 17.5.1
-  resolution: "react-use@npm:17.5.1"
+"react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.6.0":
+  version: 17.6.0
+  resolution: "react-use@npm:17.6.0"
   dependencies:
     "@types/js-cookie": ^2.2.6
     "@xobotyi/scrollbar-width": ^1.9.5
@@ -29800,7 +29833,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 68f4333d986161038308a844d4ab99103484b69a0599a03c345eeb7cb5a0eabd0c55994fefc471ef11d4d2799a8e063d7f11fe0c48d56b54516333025fc7d726
+  checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
   languageName: node
   linkType: hard
 
@@ -31680,6 +31713,13 @@ __metadata:
   version: 2.1.0
   resolution: "standard-as-callback@npm:2.1.0"
   checksum: 88bec83ee220687c72d94fd86a98d5272c91d37ec64b66d830dbc0d79b62bfa6e47f53b71646011835fc9ce7fae62739545d13124262b53be4fbb3e2ebad551c
+  languageName: node
+  linkType: hard
+
+"state-local@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "state-local@npm:1.0.7"
+  checksum: d1afcf1429e7e6eb08685b3a94be8797db847369316d4776fd51f3962b15b984dacc7f8e401ad20968e5798c9565b4b377afedf4e4c4d60fe7495e1cbe14a251
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a new `CodeEditor` component and show initial YAML from the packages.

Hopefully resolves https://issues.redhat.com/browse/RHIDP-6278 without unit tests yet. But I like to release this to see if its working fine on RHDH / on a cluster.

The unreachable /install page looks now like this:

![image](https://github.com/user-attachments/assets/7b75ddee-85ca-444f-8108-3240c8077130)

I implemented this with a React context so that we don't need to "control" and rerender this form on any change.

The Buttons can get and set the latest editor value. The copy button works already but should have a alert/tooltip "copied" later.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
