### PR TITLE
fix(adoption-insights): fix name column in the techdocs chart

### DIFF
--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/controllers/EventApiController.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/controllers/EventApiController.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { QUERY_TYPES, QueryParams } from '../types/event-request';
 import { toEndOfDayUTC, toStartOfDayUTC } from '../utils/date';
+import { TechDocsCount } from '../types/event';
 
 let controller: EventApiController;
 let req: Partial<Request>;
@@ -40,6 +41,7 @@ const mockEventDb = {
   getTopTechDocsViews: jest.fn(),
   getTopTemplateViews: jest.fn(),
   getTopCatalogEntitiesViews: jest.fn(),
+  getTechdocsMetadata: jest.fn(),
 } as unknown as jest.Mocked<EventDatabase>;
 
 const mockProcessor = {
@@ -207,11 +209,20 @@ describe('trackEvents', () => {
 });
 
 describe('GetInsights', () => {
+  let mockTechdocsMetadata: jest.SpyInstance;
+
   beforeEach(() => {
     controller = new EventApiController(
       mockEventDb,
       mockProcessor,
       mockServices.rootConfig.mock(),
+    );
+
+    global.fetch = jest.fn().mockResolvedValue({} as any);
+
+    mockTechdocsMetadata = jest.spyOn(
+      controller,
+      'getTechdocsMetadata' as keyof EventApiController,
     );
 
     req = {
@@ -286,6 +297,134 @@ describe('GetInsights', () => {
     expect(mockEventDb.getTopTemplateViews).toHaveBeenCalled();
     expect(mockEventDb.getTopTechDocsViews).toHaveBeenCalled();
     expect(mockEventDb.getTopCatalogEntitiesViews).toHaveBeenCalled();
+  });
+
+  it('should call getTechdocsMetadata method', async () => {
+    req.query = {
+      ...req.query,
+      type: 'top_techdocs',
+    };
+
+    const getTechdocsMetadata = jest.fn();
+
+    controller.getTechdocsMetadata = getTechdocsMetadata;
+    await controller.getInsights(
+      req as unknown as Request<{}, {}, {}, QueryParams>,
+      res as Response,
+    );
+
+    expect(mockEventDb.getTopTechDocsViews).toHaveBeenCalled();
+    expect(getTechdocsMetadata).toHaveBeenCalled();
+  });
+
+  const setupTechdocsTest = (site_name: string | undefined) => {
+    req.query = {
+      ...req.query,
+      type: 'top_techdocs',
+    };
+    req.headers = {
+      authorization: 'Bearer test-token',
+    };
+
+    (fetch as jest.Mock).mockResolvedValue(
+      new global.Response(JSON.stringify({ site_name }), {
+        status: 200,
+      }),
+    );
+  };
+
+  it('should append site_name metadata for a valid document', async () => {
+    setupTechdocsTest('app-docs');
+    const result = {
+      data: [
+        {
+          count: 1,
+          last_used: new Date().toISOString(),
+          name: 'test-component',
+          kind: 'component',
+          namespace: 'default',
+        } as TechDocsCount,
+      ],
+    };
+
+    await controller.getTechdocsMetadata(
+      req as unknown as Request<{}, {}, {}, QueryParams>,
+      result,
+    );
+
+    expect(result.data[0].site_name).toBe('app-docs');
+  });
+
+  it('should return empty site_name for document root page', async () => {
+    setupTechdocsTest('app-docs');
+
+    const result = {
+      data: [
+        {
+          count: 1,
+          last_used: new Date().toISOString(),
+          name: '',
+          kind: '',
+          namespace: '',
+        } as TechDocsCount,
+      ],
+    };
+
+    await controller.getTechdocsMetadata(
+      req as unknown as Request<{}, {}, {}, QueryParams>,
+      result,
+    );
+
+    expect(result.data[0].site_name).toBe('');
+  });
+
+  it('should return component name as site_name for non-existing or deleted document', async () => {
+    setupTechdocsTest(undefined);
+    const result = {
+      data: [
+        {
+          count: 1,
+          last_used: new Date().toISOString(),
+          name: 'deleted-document',
+          kind: 'component',
+          namespace: 'default',
+        } as TechDocsCount,
+      ],
+    };
+
+    await controller.getTechdocsMetadata(
+      req as unknown as Request<{}, {}, {}, QueryParams>,
+      result,
+    );
+
+    expect(result.data[0].site_name).toBe('deleted-document');
+  });
+
+  it('should handle techdocs metadata API gracefully', async () => {
+    setupTechdocsTest('deleted-document');
+
+    (fetch as jest.Mock).mockRejectedValue(
+      new Error('Failed to fetch techdocs metadata'),
+    );
+
+    const result = {
+      data: [
+        {
+          count: 1,
+          last_used: new Date().toISOString(),
+          name: 'app-docs',
+          kind: 'component',
+          namespace: 'default',
+        } as TechDocsCount,
+      ],
+    };
+
+    await controller.getTechdocsMetadata(
+      req as unknown as Request<{}, {}, {}, QueryParams>,
+      result,
+    );
+
+    expect(result.data[0].site_name).toBe('app-docs');
   });
 
   it('should return the csv file with correct filename', async () => {

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/BaseAdapter.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/BaseAdapter.ts
@@ -219,6 +219,7 @@ export abstract class BaseDatabaseAdapter implements EventDatabase {
       })
       .whereBetween('created_at', [start_date, end_date])
       .groupByRaw(`name, kind, namespace`)
+      .orderBy('count', 'desc')
       .limit(Number(limit) || 3);
 
     return query.then(data => this.getResponseData(data, 'last_used'));

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/SqliteAdapter.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/SqliteAdapter.ts
@@ -30,7 +30,7 @@ export class SqliteAdapter extends BaseDatabaseAdapter {
   }
 
   getLastUsedDate(): string {
-    return `strftime('%Y-%m-%dT%H:%M:%SZ', MAX(created_at), 'localtime') AS last_used`;
+    return `strftime('%Y-%m-%dT%H:%M:%SZ', MAX(created_at)) AS last_used`;
   }
 
   getFormatedDate(column: string): string {

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/types/event.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/types/event.ts
@@ -15,7 +15,7 @@
  */
 interface DateCount {
   date: string; // YYYY-MM-DD format
-  count: string;
+  count: number;
 }
 export interface DailyUser {
   date: string;
@@ -31,21 +31,22 @@ interface TotalUser {
 
 export interface PluginCount {
   plugin_id: string;
-  visit_count: string;
+  visit_count: number;
   trend: DateCount[];
   trend_percentage: string;
 }
 
 interface EntityRefCount {
   entityref: string;
-  count: string;
+  count: number;
   last_used: string;
 }
-interface TechDocsCount {
+export interface TechDocsCount {
+  site_name: string;
   kind: string;
   name: string;
   namespace: string;
-  count: string;
+  count: number;
   last_used: string;
 }
 
@@ -55,7 +56,7 @@ interface CatalogEntityCount {
   name: string;
   namespace: string;
   last_used: string; // ISO 8601 format (e.g., 2025-03-02T16:25:32.819Z);
-  count: string;
+  count: number;
 }
 
 export type ResponseData<T> = {

--- a/workspaces/adoption-insights/plugins/adoption-insights/dev/__data__/techdocs.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/dev/__data__/techdocs.ts
@@ -22,6 +22,7 @@ export default {
       kind: '',
       name: '',
       namespace: '',
+      site_name: '',
     },
     {
       entityref: 'techdocs:catalog-reader-view',
@@ -30,6 +31,7 @@ export default {
       kind: 'component',
       name: 'nationalparks-py',
       namespace: 'default',
+      site_name: 'nationalparks-doc',
     },
   ],
 };

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Techdocs/Techdocs.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Techdocs/Techdocs.tsx
@@ -129,7 +129,9 @@ const Techdocs = () => {
                         },
                       }}
                     >
-                      {!techdoc?.name ? 'index-page' : techdoc?.name || '--'}
+                      {!techdoc?.site_name
+                        ? 'docs'
+                        : techdoc?.site_name || '--'}
                     </Link>
                   </TableCell>
                   <TableCell>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/types/index.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/types/index.ts
@@ -91,6 +91,7 @@ export type TemplatesResponse = {
  * Techdocs
  */
 export type Techdocs = {
+  site_name: string;
   count: number;
   last_used: string;
   kind: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Fixes:

https://issues.redhat.com/browse/RHDHPAI-677

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->


## Screenshots

**Before:**

![image](https://github.com/user-attachments/assets/4c2b8694-c519-40b4-aa59-4bba067813e2)

**After:**

Name column now uses `site_name` from techdocs metadata.


![Techdocs](https://github.com/user-attachments/assets/c24718d3-db76-4ad4-949e-357e42cc022a)




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
