### PR TITLE
fix(adoption-insights): process events when the user identity is ready

### DIFF
--- a/workspaces/adoption-insights/plugins/analytics-module-adoption-insights/report.api.md
+++ b/workspaces/adoption-insights/plugins/analytics-module-adoption-insights/report.api.md
@@ -16,7 +16,7 @@ export class AdoptionInsightsAnalyticsApi implements AnalyticsApi {
   static fromConfig(
     config: ConfigApi,
     options: {
-      identityApi?: IdentityApi;
+      identityApi: IdentityApi;
     },
   ): AdoptionInsightsAnalyticsApi;
 }


### PR DESCRIPTION
## Fixes

https://issues.redhat.com/browse/RHDHPAI-678

Add pending queue to park the events without user information, wait till user identity to resolvde and re-queue the events to track them with user information. 


## How to test


- navigate to Adoption insights page and notice the count on the techdocs chart
- Click on a link from techdocs charts which opens a page in a new tab.
- Now go back to the adoption-insights tab, refresh the page after few seconds to see the count is increased.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
