### PR TITLE
fix(global-floating-action-button): fix crash and design issues when testing locally

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/dirty-crabs-invent.md
+++ b/workspaces/global-floating-action-button/.changeset/dirty-crabs-invent.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-floating-action-button': patch
+---
+
+add MUI v5 workaround to fix local design issues

--- a/workspaces/global-floating-action-button/.changeset/perfect-years-scream.md
+++ b/workspaces/global-floating-action-button/.changeset/perfect-years-scream.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-floating-action-button': patch
+---
+
+fix crash if slot name contains a typo

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/CustomFab.tsx
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/CustomFab.tsx
@@ -23,7 +23,7 @@ import Typography from '@mui/material/Typography';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { FabIcon } from './FabIcon';
 import { FloatingActionButton, Slot } from '../types';
-import { slotOptions } from '../utils';
+import { getSlotOptions } from '../utils';
 
 const useStyles = makeStyles(() => ({
   openInNew: { paddingBottom: '5px', paddingTop: '3px' },
@@ -43,7 +43,7 @@ const FABLabel = ({
   order: { externalIcon?: number; icon?: number };
 }) => {
   const styles = useStyles();
-  const marginStyle = slotOptions[slot].margin;
+  const marginStyle = getSlotOptions(slot).margin;
   return (
     <>
       {showExternalIcon && (
@@ -116,9 +116,7 @@ export const CustomFab = ({
   return (
     <Tooltip
       title={actionButton.toolTip}
-      placement={
-        slotOptions[actionButton.slot || Slot.PAGE_END].tooltipDirection
-      }
+      placement={getSlotOptions(actionButton.slot).tooltipDirection}
     >
       <Fab
         {...(newWindow ? { target: '_blank', rel: 'noopener' } : {})}

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/FABWithSubmenu.tsx
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/FABWithSubmenu.tsx
@@ -27,7 +27,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import MenuIcon from '@mui/icons-material/Menu';
 import Slide from '@mui/material/Slide';
 import { CustomFab } from './CustomFab';
-import { slotOptions } from '../utils';
+import { getSlotOptions } from '../utils';
 import { FloatingActionButton, Slot } from '../types';
 import Typography from '@mui/material/Typography';
 
@@ -91,7 +91,7 @@ export const FABWithSubmenu = ({
       id="floating-button-with-submenu"
       data-testid="floating-button-with-submenu"
     >
-      <Tooltip title="Menu" placement={slotOptions[slot].tooltipDirection}>
+      <Tooltip title="Menu" placement={getSlotOptions(slot).tooltipDirection}>
         <Typography>
           <Box ref={containerRef} sx={{ overflow: 'hidden' }} />
           <Fab

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/index.ts
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/index.ts
@@ -13,5 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from './plugin';
 export * from './types';

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/utils.test.ts
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/utils.test.ts
@@ -135,12 +135,25 @@ describe('Global floating action button utils', () => {
   });
 
   it('should evaluate floating buttons in the record along with their positions and an array of actions for floating buttons', () => {
-    const buttons = evaluateFloatingButtonsWithPositions(floatingButtons);
+    const fabs: FloatingActionButton[] = [
+      ...floatingButtons,
+      {
+        slot: 'bottom-leftt' as Slot,
+        color: 'success',
+        icon: 'GitIcon',
+        label: 'Add2',
+        toolTip: 'Add2',
+        to: 'https://github.com/xyz',
+        priority: 100,
+      },
+    ];
+    const buttons = evaluateFloatingButtonsWithPositions(fabs);
     expect(buttons).toEqual([
       {
         slot: Slot.PAGE_END,
         actions: [
           {
+            slot: Slot.PAGE_END,
             color: 'success',
             icon: 'GitIcon',
             label: 'Git repo',
@@ -148,6 +161,7 @@ describe('Global floating action button utils', () => {
             toolTip: 'Git',
           },
           {
+            slot: Slot.PAGE_END,
             color: 'success',
             icon: 'GitIcon',
             label: 'Menu',
@@ -155,6 +169,15 @@ describe('Global floating action button utils', () => {
             to: 'https://github.com/xyz',
             priority: 200,
             excludeOnPaths: ['/test-pathname'],
+          },
+          {
+            slot: Slot.PAGE_END,
+            color: 'success',
+            icon: 'GitIcon',
+            label: 'Add2',
+            toolTip: 'Add2',
+            to: 'https://github.com/xyz',
+            priority: 100,
           },
         ],
       },

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/utils.ts
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/utils.ts
@@ -74,7 +74,13 @@ export const filterAndSortButtons = (
   return sortedButtons;
 };
 
-export const slotOptions = {
+type SlotOption = {
+  tooltipDirection: 'left' | 'right';
+  textAlign: 'left' | 'right';
+  margin: { ml?: number; mr?: number };
+};
+
+const slotOptions: Record<Slot, SlotOption> = {
   [Slot.BOTTOM_LEFT]: {
     tooltipDirection: 'right',
     textAlign: 'left',
@@ -85,4 +91,8 @@ export const slotOptions = {
     textAlign: 'right',
     margin: { mr: 1 },
   },
-} as const;
+};
+
+/** Get some layout options for a slot. Automatically fallbacks to PAGE_END */
+export const getSlotOptions = (slot: Slot | undefined) =>
+  slotOptions[slot ?? Slot.PAGE_END] ?? slotOptions[Slot.PAGE_END];

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/utils.ts
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/utils.ts
@@ -24,14 +24,17 @@ export const evaluateFloatingButtonsWithPositions = (
 ): FloatingActionButtonWithPositions =>
   floatingButtons.reduce(
     (acc: FloatingActionButtonWithPositions, fb: FloatingActionButton) => {
-      const slot = fb.slot ?? Slot.PAGE_END;
+      const slot =
+        fb.slot && Object.values(Slot).includes(fb.slot)
+          ? fb.slot
+          : Slot.PAGE_END;
       const slotWithActions = acc.find(a => a.slot === slot);
       if (slotWithActions) {
-        slotWithActions.actions.push(fb);
+        slotWithActions.actions.push({ ...fb, slot });
       } else {
         acc.push({
           slot,
-          actions: [fb],
+          actions: [{ ...fb, slot }],
         });
       }
       return acc;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Fixes:** https://issues.redhat.com/browse/RHIDP-6463

I noticed two issues when testing the global-floating-action-button plugin with RHDH and installed it with:

```
npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root ~/git/redhat-developer/rhdh/dynamic-plugins-root --dev --clean
```

I then enabled the plugin with:

```yaml
dynamicPlugins:
  frontend:

    red-hat-developer-hub.backstage-plugin-global-floating-action-button:
      mountPoints:
        - mountPoint: application/listener
          importName: DynamicGlobalFloatingActionButton

    red-hat-developer-hub.backstage-plugin-bulk-import:
      mountPoints:
        - mountPoint: global.floatingactionbutton/config
          importName: BulkImportPage
          config:
            slot: page-end
            icon: bulkImportIcon
            label: 'Bulk import'
            toolTip: 'Register multiple repositories in bulk'
            to: /bulk-import/repositories
      appIcons:
        - name: bulkImportIcon
          importName: BulkImportIcon
      dynamicRoutes:
        - path: /bulk-import/repositories
          importName: BulkImportPage
          menuItem:
            icon: bulkImportIcon
            text: Bulk import 
```

This PR fixes two things:

1. When I used a wrong slot, the CustomFAB component crashes, because the slot layout information from slotOptions returned undefined. I added a small util function that returns PAGE_END layout informations instead.
2. The 2nd issue was also mentioned by @its-mitesh-kumar review https://github.com/redhat-developer/rhdh-plugins/pull/448#pullrequestreview-2643908849. It's related to an issue with MUI v5 components. I've added a workaround that we had already in other plugins and also in all RHDH wrappers. See https://github.com/redhat-developer/rhdh/blob/main/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button/src/index.ts

   Without this PR:

   ![image](https://github.com/user-attachments/assets/213ae4c7-dcdb-4b33-ab5b-735bd4dc8d35)

   With this PR:

   ![image](https://github.com/user-attachments/assets/043e8127-47d8-4e2b-adc5-872e9145d5a1)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
