### PR TITLE
fix(adoption-insights): Add adoption insights plugin icon

### DIFF
--- a/workspaces/adoption-insights/package.json
+++ b/workspaces/adoption-insights/package.json
@@ -14,7 +14,7 @@
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build:api-reports": "yarn build:api-reports:only",
-    "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type --validate-release-tags",
+    "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type,ae-undocumented --validate-release-tags",
     "build-image": "yarn workspace backend build-image",
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/package.json
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/package.json
@@ -58,7 +58,8 @@
   },
   "files": [
     "dist",
-    "config.d.ts"
+    "config.d.ts",
+    "migrations"
   ],
   "configSchema": "config.d.ts"
 }

--- a/workspaces/adoption-insights/plugins/adoption-insights/app-config.dynamic.yaml
+++ b/workspaces/adoption-insights/plugins/adoption-insights/app-config.dynamic.yaml
@@ -1,0 +1,16 @@
+dynamicPlugins:
+  frontend:
+    red-hat-developer-hub.backstage-plugin-adoption-insights:
+      appIcons:
+        - name: adoptionInsightsIcon
+          importName: AdoptionInsightsIcon
+      dynamicRoutes:
+        - path: /adoption-insights
+          importName: AdoptionInsightsPage
+          menuItem:
+            icon: adoptionInsightsIcon
+            text: Adoption Insights
+      menuItems:
+        adoption-insights:
+          parent: admin
+          icon: adoptionInsightsIcon

--- a/workspaces/adoption-insights/plugins/adoption-insights/package.json
+++ b/workspaces/adoption-insights/plugins/adoption-insights/package.json
@@ -70,6 +70,7 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "files": [
+    "app-config.dynamic.yaml",
     "dist"
   ]
 }

--- a/workspaces/adoption-insights/plugins/adoption-insights/report.api.md
+++ b/workspaces/adoption-insights/plugins/adoption-insights/report.api.md
@@ -6,8 +6,12 @@
 /// <reference types="react" />
 
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { IconComponent } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
+
+// @public (undocumented)
+export const AdoptionInsightsIcon: IconComponent;
 
 // @public
 export const AdoptionInsightsPage: () => JSX_2.Element | null;

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/index.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/index.ts
@@ -13,4 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from './plugin';

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/index.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { adoptionInsightsPlugin, AdoptionInsightsPage } from './plugin';
+export * from './plugin';

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/plugin.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/plugin.ts
@@ -19,7 +19,7 @@ import {
   createPlugin,
   createRoutableExtension,
   fetchApiRef,
-  IconComponent,
+  type IconComponent,
 } from '@backstage/core-plugin-api';
 
 import MUIAdoptionInsightsIcon from '@mui/icons-material/QueryStatsOutlined';
@@ -62,14 +62,6 @@ export const AdoptionInsightsPage = adoptionInsightsPlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
-
-import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
-
-ClassNameGenerator.configure(componentName => {
-  return componentName.startsWith('v5-')
-    ? componentName
-    : `v5-${componentName}`;
-});
 
 /**
  * @public

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/plugin.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/plugin.ts
@@ -19,8 +19,10 @@ import {
   createPlugin,
   createRoutableExtension,
   fetchApiRef,
+  IconComponent,
 } from '@backstage/core-plugin-api';
 
+import MUIAdoptionInsightsIcon from '@mui/icons-material/QueryStatsOutlined';
 import { rootRouteRef } from './routes';
 import { AdoptionInsightsApiClient, adoptionInsightsApiRef } from './api';
 
@@ -60,3 +62,16 @@ export const AdoptionInsightsPage = adoptionInsightsPlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
+
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
+/**
+ * @public
+ */
+export const AdoptionInsightsIcon: IconComponent = MUIAdoptionInsightsIcon;


### PR DESCRIPTION
## Add Insights Icon

This PR contains the following changes:

1. Add and export Insights plugin Icon
2. Fix MUI v5 classname prefix
3. Update the header to "Adoption Insights"

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
## Screenshots


![AdoptionInsights](https://github.com/user-attachments/assets/e5a2cded-ea61-47ec-8668-c8b4d192230d)



#### :heavy_check_mark: Checklist


<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
