### PR TITLE
fix(global-header): Emit search analytics data from global header searchbar

### DIFF
--- a/workspaces/global-header/.changeset/tall-zoos-pump.md
+++ b/workspaces/global-header/.changeset/tall-zoos-pump.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Emit search analytics events for search and discover events

--- a/workspaces/global-header/packages/app/src/apis.ts
+++ b/workspaces/global-header/packages/app/src/apis.ts
@@ -20,6 +20,8 @@ import {
   ScmAuth,
 } from '@backstage/integration-react';
 import {
+  analyticsApiRef,
+  AnalyticsEvent,
   AnyApiFactory,
   configApiRef,
   createApiFactory,
@@ -43,5 +45,12 @@ export const apis: AnyApiFactory[] = [
     deps: { fetchApi: fetchApiRef, discoveryApi: discoveryApiRef },
     factory: ({ fetchApi, discoveryApi }) =>
       new NotificationsClient({ fetchApi, discoveryApi }),
+  }),
+
+  createApiFactory(analyticsApiRef, {
+    captureEvent: (event: AnalyticsEvent) => {
+      // eslint-disable-next-line no-console
+      console.log('Captured event:', event);
+    },
   }),
 ];

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.test.tsx
@@ -25,6 +25,10 @@ import { mockApis, TestApiProvider } from '@backstage/test-utils';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { configApiRef } from '@backstage/core-plugin-api';
 
+jest.mock('../../hooks/useDebouncedCallback', () => ({
+  useDebouncedCallback: (fn: (...args: any[]) => void) => fn,
+}));
+
 const createInitialState = ({
   term = 'term',
   filters = {},

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
@@ -18,6 +18,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   SearchResultState,
   SearchResultProps,
+  useSearch,
 } from '@backstage/plugin-search-react';
 import Autocomplete from '@mui/material/Autocomplete';
 import { createSearchLink } from '../../utils/stringUtils';
@@ -25,17 +26,25 @@ import { useNavigate } from 'react-router-dom';
 import { SearchInput } from './SearchInput';
 import { SearchOption } from './SearchOption';
 import { useTheme } from '@mui/material/styles';
+import { useDebouncedCallback } from '../../hooks/useDebouncedCallback';
 
 interface SearchBarProps {
   query: SearchResultProps['query'];
   setSearchTerm: (term: string) => void;
 }
+
 export const SearchBar = (props: SearchBarProps) => {
   const { query, setSearchTerm } = props;
   const navigate = useNavigate();
   const theme = useTheme();
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const highlightedIndexRef = useRef(highlightedIndex);
+  const { setTerm } = useSearch();
+
+  const onInputChange = useDebouncedCallback((_, inputValue) => {
+    setSearchTerm(inputValue);
+    setTerm(inputValue);
+  }, 300);
 
   useEffect(() => {
     highlightedIndexRef.current = highlightedIndex;
@@ -64,7 +73,7 @@ export const SearchBar = (props: SearchBarProps) => {
             loading={loading}
             value={query?.term ?? ''}
             getOptionLabel={option => option ?? ''}
-            onInputChange={(_, inputValue) => setSearchTerm(inputValue)}
+            onInputChange={onInputChange}
             onHighlightChange={(_, option) =>
               setHighlightedIndex(options.indexOf(option ?? ''))
             }

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
@@ -32,7 +32,6 @@ interface SearchBarProps {
   query: SearchResultProps['query'];
   setSearchTerm: (term: string) => void;
 }
-
 export const SearchBar = (props: SearchBarProps) => {
   const { query, setSearchTerm } = props;
   const navigate = useNavigate();

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
@@ -50,11 +50,12 @@ export const SearchResultItem = ({
       <ListItem
         {...renderProps}
         sx={{ py: 1 }}
-        onClick={() => {
+        onClick={e => {
           analytics.captureEvent('discover', result?.document.title ?? '', {
             attributes: { to: result?.document.location ?? '#' },
             value: result?.rank,
           });
+          renderProps?.onClick?.(e);
         }}
       >
         <Typography sx={{ color: 'text.primary', flexGrow: 1 }}>

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
@@ -22,6 +22,7 @@ import Typography from '@mui/material/Typography';
 import { highlightMatch } from '../../utils/stringUtils';
 import { SearchResultProps } from '@backstage/plugin-search-react';
 import { Result, SearchDocument } from '@backstage/plugin-search-common';
+import { useAnalytics } from '@backstage/core-plugin-api';
 
 interface SearchResultItemProps {
   option: string;
@@ -37,6 +38,8 @@ export const SearchResultItem = ({
   renderProps,
 }: SearchResultItemProps) => {
   const isNoResultsFound = option === 'No results found';
+  const analytics = useAnalytics();
+
   return (
     <Box
       component={isNoResultsFound ? 'div' : Link}
@@ -44,7 +47,16 @@ export const SearchResultItem = ({
       underline="none"
       sx={{ width: '100%', ...(isNoResultsFound ? {} : { cursor: 'pointer' }) }}
     >
-      <ListItem {...renderProps} sx={{ py: 1 }}>
+      <ListItem
+        {...renderProps}
+        sx={{ py: 1 }}
+        onClick={() => {
+          analytics.captureEvent('discover', result?.document.title ?? '', {
+            attributes: { to: result?.document.location ?? '#' },
+            value: result?.rank,
+          });
+        }}
+      >
         <Typography sx={{ color: 'text.primary', flexGrow: 1 }}>
           {isNoResultsFound
             ? option

--- a/workspaces/global-header/plugins/global-header/src/hooks/useDebouncedCallback.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useDebouncedCallback.ts
@@ -21,6 +21,14 @@ export const useDebouncedCallback = <T extends (...args: any[]) => void>(
 ) => {
   const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
   return React.useCallback(
     (...args: Parameters<T>) => {
       if (timeoutRef.current) {

--- a/workspaces/global-header/plugins/global-header/src/hooks/useDebouncedCallback.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+export const useDebouncedCallback = <T extends (...args: any[]) => void>(
+  callback: T,
+  delay: number,
+) => {
+  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  return React.useCallback(
+    (...args: Parameters<T>) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        callback(...args);
+      }, delay);
+    },
+    [callback, delay],
+  );
+};


### PR DESCRIPTION


## Fixes
https://issues.redhat.com/browse/RHIDP-6480

## Description
Backstage search component emits the Search analytics data such as `search`, `discover` events with additional metadata but the custom search component in global header does not emit the search analytics data.

This PR fixes by emitting `search` and `discover` events and adds debounce on InputChange to avoid frequent execution of callbacks.

## How to test

Setup analytics in the application in `/packages/app/src/apis.ts`.
```
createApiFactory(analyticsApiRef, {
 captureEvent: (event:AnalyticsEvent) => {
   console.log('Captured event:', event);
  },
}), 
```
## Screenshots


**Before:**

`search` event is missing
![image](https://github.com/user-attachments/assets/65bdc4d8-6982-4a81-8279-1aa74b0504a7)

---
on clicking any search results it is missing `discover` event.

![image](https://github.com/user-attachments/assets/a772f28d-ea2d-4979-873c-d6d5184385a5)


**After:**

onSearch:

![image](https://github.com/user-attachments/assets/3620d661-d5f3-4f5c-9f6a-601c17f074d4)
---
on clicking any search results:
![image](https://github.com/user-attachments/assets/b810dba0-125f-4556-934d-d82ec277d695)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
