### PR TITLE
feat(global-header): add starred entities dropdown to header

### DIFF
--- a/workspaces/global-header/.changeset/mean-weeks-tie.md
+++ b/workspaces/global-header/.changeset/mean-weeks-tie.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': minor
+---
+
+Added a new starred dropdown to global header which shows all the starred entities.

--- a/workspaces/global-header/docs/index.md
+++ b/workspaces/global-header/docs/index.md
@@ -2,7 +2,8 @@
 
 Red Hat Developer Hub includes a new configable and highly extendable global header plugin starting with RHDH 1.5.
 
-By default it includes a Search input field, Create, Support[^1] and Notifications[^2] icon buttons and a user profile dropdown.
+By default it includes a Search input field, Create, Starred[^1], Support[^2] and Notifications[^3] icon buttons and a user profile dropdown.
 
-[^1]: Only when the Support URL is configured in the `app-config.yaml`.
-[^2]: Only when the notification plugin is installed.
+[^1]: Only when an enitity is starred.
+[^2]: Only when the Support URL is configured in the `app-config.yaml`.
+[^3]: Only when the notifications plugin is installed.

--- a/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
+++ b/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
@@ -30,6 +30,11 @@ dynamicPlugins:
               to: create
 
         - mountPoint: global.header/component
+          importName: StarredDropdown
+          config:
+            priority: 85
+
+        - mountPoint: global.header/component
           importName: SupportButton
           config:
             priority: 80

--- a/workspaces/global-header/plugins/global-header/dev/index.tsx
+++ b/workspaces/global-header/plugins/global-header/dev/index.tsx
@@ -19,7 +19,11 @@ import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { mockApis, MockFetchApi, TestApiProvider } from '@backstage/test-utils';
 import { MockSearchApi, searchApiRef } from '@backstage/plugin-search-react';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  MockStarredEntitiesApi,
+  starredEntitiesApiRef,
+} from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { configApiRef } from '@backstage/core-plugin-api';
 import {
@@ -116,6 +120,8 @@ const entities = [
 
 const catalogApi = catalogApiMock({ entities });
 
+const starredEntitiesApi = new MockStarredEntitiesApi();
+
 const mockBaseUrl = 'https://backstage/api/notifications';
 const discoveryApi = { getBaseUrl: async () => mockBaseUrl };
 const fetchApi = new MockFetchApi();
@@ -137,11 +143,13 @@ const Providers = ({
     }),
     [mountPoints],
   );
+  starredEntitiesApi.toggleStarred('template:default/mock-starred-template');
 
   return (
     <TestApiProvider
       apis={[
         [catalogApiRef, catalogApi],
+        [starredEntitiesApiRef, starredEntitiesApi],
         [searchApiRef, mockSearchApi],
         [configApiRef, mockConfigApi],
         [notificationsApiRef, client],

--- a/workspaces/global-header/plugins/global-header/report.api.md
+++ b/workspaces/global-header/plugins/global-header/report.api.md
@@ -308,6 +308,9 @@ export interface SpacerProps {
   minWidth?: number | string;
 }
 
+// @public
+export const StarredDropdown: () => React_2.JSX.Element;
+
 // @public (undocumented)
 export const SupportButton: ({
   title,

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import { HeaderDropdownComponent } from './HeaderDropdownComponent';
+import { renderInTestApp } from '@backstage/test-utils';
+
+describe('HeaderDropdownComponent', () => {
+  const mockOnOpen = jest.fn();
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(console, 'warn').mockImplementation(message => {
+      if (message.includes('⚠️ React Router Future Flag Warning')) {
+        return; // Suppress React Router warning
+      }
+      // eslint-disable-next-line no-console
+      console.warn(message); // Log other warnings
+    });
+
+    jest.spyOn(console, 'error').mockImplementation(message => {
+      if (
+        typeof message === 'string' &&
+        message.includes('findDOMNode is deprecated')
+      ) {
+        return; // Suppress findDOMNode warning in tests
+      }
+      // eslint-disable-next-line no-console
+      console.error(message); // Allow other errors to be logged
+    });
+  });
+
+  it('renders button with provided content', async () => {
+    await renderInTestApp(
+      <HeaderDropdownComponent
+        buttonContent={<span>Click Me</span>}
+        onOpen={mockOnOpen}
+        onClose={mockOnClose}
+        anchorEl={null}
+      >
+        <div>Dropdown Content</div>
+      </HeaderDropdownComponent>,
+    );
+
+    expect(screen.getByText('Click Me')).toBeInTheDocument();
+  });
+
+  it('opens dropdown when button is clicked', async () => {
+    await renderInTestApp(
+      <HeaderDropdownComponent
+        buttonContent={<span>Click Me</span>}
+        onOpen={mockOnOpen}
+        onClose={mockOnClose}
+        anchorEl={null}
+      >
+        <div>Dropdown Content</div>
+      </HeaderDropdownComponent>,
+    );
+
+    fireEvent.click(screen.getByText('Click Me'));
+    expect(mockOnOpen).toHaveBeenCalled();
+  });
+
+  it('renders as an icon button if isIconButton is true', async () => {
+    await renderInTestApp(
+      <HeaderDropdownComponent
+        buttonContent={<span>Icon</span>}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+        anchorEl={null}
+        isIconButton // Explicitly set to true
+      >
+        <div>Dropdown Content</div>
+      </HeaderDropdownComponent>,
+    );
+
+    // Check that an IconButton is rendered
+    const iconButton = screen.getByRole('button');
+    expect(iconButton).toBeInTheDocument();
+    expect(iconButton).toHaveClass('v5-MuiIconButton-root'); // Ensures it's an IconButton
+  });
+
+  it('displays tooltip when hovered', async () => {
+    await renderInTestApp(
+      <HeaderDropdownComponent
+        buttonContent={<span>Click Me</span>}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+        anchorEl={null}
+        tooltip="Test Tooltip"
+      >
+        <div>Dropdown Content</div>
+      </HeaderDropdownComponent>,
+    );
+
+    // Ensure the tooltip is not visible initially
+    expect(screen.queryByText('Test Tooltip')).not.toBeInTheDocument();
+
+    // Hover over the button to trigger the tooltip
+    fireEvent.mouseOver(screen.getByRole('button'));
+
+    // The tooltip should now be visible
+    expect(await screen.findByText('Test Tooltip')).toBeInTheDocument();
+  });
+});

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
@@ -19,6 +19,8 @@ import Menu from '@mui/material/Menu';
 import Button from '@mui/material/Button';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import { MenuItemConfig, MenuSectionConfig } from './MenuSection';
 
 interface HeaderDropdownProps {
@@ -30,6 +32,8 @@ interface HeaderDropdownProps {
   onOpen: (event: React.MouseEvent<HTMLElement>) => void;
   onClose: () => void;
   anchorEl: HTMLElement | null;
+  isIconButton?: boolean;
+  tooltip?: string;
 }
 
 const Listbox = styled('ul')(
@@ -66,17 +70,27 @@ export const HeaderDropdownComponent: React.FC<HeaderDropdownProps> = ({
   onOpen,
   onClose,
   anchorEl,
+  isIconButton = false,
+  tooltip,
 }) => {
   return (
     <Box>
-      <Button
-        disableRipple
-        disableTouchRipple
-        {...buttonProps}
-        onClick={onOpen}
-      >
-        {buttonContent}
-      </Button>
+      <Tooltip title={tooltip}>
+        {isIconButton ? (
+          <IconButton {...buttonProps} color="inherit" onClick={onOpen}>
+            {buttonContent}
+          </IconButton>
+        ) : (
+          <Button
+            disableRipple
+            disableTouchRipple
+            {...buttonProps}
+            onClick={onOpen}
+          >
+            {buttonContent}
+          </Button>
+        )}
+      </Tooltip>
       <Menu
         id="menu-appbar"
         anchorEl={anchorEl}

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import {
+  useStarredEntities,
+  useEntityPresentation,
+} from '@backstage/plugin-catalog-react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { StarredDropdown } from './StarredDropdown';
+import { useDropdownManager } from '../../hooks';
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useStarredEntities: jest.fn(),
+  useEntityPresentation: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+  useDropdownManager: jest.fn(),
+}));
+
+describe('StarredDropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useStarredEntities as jest.Mock).mockReturnValue({
+      starredEntities: new Set(),
+      toggleStarredEntity: jest.fn(),
+      isStarredEntity: jest.fn(),
+    });
+
+    (useEntityPresentation as jest.Mock).mockReturnValue({
+      Icon: () => <svg />, // Mock an icon component
+      primaryTitle: 'Mock Entity',
+      secondaryTitle: 'Mock Kind',
+    });
+
+    (useDropdownManager as jest.Mock).mockReturnValue({
+      anchorEl: null,
+      handleOpen: jest.fn(),
+      handleClose: jest.fn(),
+    });
+
+    jest.spyOn(console, 'warn').mockImplementation(message => {
+      if (message.includes('⚠️ React Router Future Flag Warning')) {
+        return; // Suppress React Router warning
+      }
+      // eslint-disable-next-line no-console
+      console.warn(message); // Log other warnings
+    });
+
+    jest.spyOn(console, 'error').mockImplementation(message => {
+      if (
+        typeof message === 'string' &&
+        message.includes('findDOMNode is deprecated')
+      ) {
+        return; // Suppress findDOMNode warning in tests
+      }
+      // eslint-disable-next-line no-console
+      console.error(message); // Allow other errors to be logged
+    });
+  });
+
+  it('renders an empty state when there are no starred entities', async () => {
+    await renderInTestApp(<StarredDropdown />);
+
+    // Replace this with the actual empty state message in your component
+    expect(screen.getByText(/No starred items yet/i)).toBeInTheDocument();
+  });
+
+  it('renders starred items when entities exist', async () => {
+    (useStarredEntities as jest.Mock).mockReturnValue({
+      starredEntities: new Set(['component:default/my-entity']),
+      toggleStarredEntity: jest.fn(),
+      isStarredEntity: jest.fn(),
+    });
+
+    await renderInTestApp(<StarredDropdown />);
+    expect(screen.getByText(/Your starred items/i)).toBeInTheDocument();
+  });
+
+  it('calls handleOpen when dropdown button is clicked', async () => {
+    const handleOpen = jest.fn();
+    (useStarredEntities as jest.Mock).mockReturnValue({
+      starredEntities: new Set(['component:default/my-entity']),
+      toggleStarredEntity: jest.fn(),
+      isStarredEntity: jest.fn(),
+    });
+
+    (useDropdownManager as jest.Mock).mockReturnValue({
+      anchorEl: null,
+      handleOpen,
+      handleClose: jest.fn(),
+    });
+
+    await renderInTestApp(<StarredDropdown />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleOpen).toHaveBeenCalled();
+  });
+});

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {
+  useEntityPresentation,
+  useStarredEntities,
+} from '@backstage/plugin-catalog-react';
+import { InfoCard, Link } from '@backstage/core-components';
+
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import Star from '@mui/icons-material/Star';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+
+import { useDropdownManager } from '../../hooks';
+import { HeaderDropdownComponent } from './HeaderDropdownComponent';
+import {
+  CompoundEntityRef,
+  Entity,
+  parseEntityRef,
+} from '@backstage/catalog-model';
+import { useTheme } from '@mui/material/styles';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Box from '@mui/material/Box';
+
+/**
+ * @public
+ * Props for each starred entitify item
+ */
+interface SectionComponentProps {
+  entityRef: string | CompoundEntityRef | Entity;
+  toggleStarredEntity: (
+    entityOrRef: Entity | CompoundEntityRef | string,
+  ) => void;
+  handleClose: () => void;
+}
+
+const StarredItem: React.FC<SectionComponentProps> = ({
+  entityRef,
+  toggleStarredEntity,
+  handleClose,
+}) => {
+  const { Icon, primaryTitle, secondaryTitle } =
+    useEntityPresentation(entityRef);
+  const { name, kind, namespace } = parseEntityRef(entityRef as string);
+  const theme = useTheme();
+
+  return (
+    <MenuItem
+      component={Link}
+      to={`/catalog/${namespace || 'default'}/${kind}/${name}`}
+      onClick={handleClose}
+      disableRipple
+      disableTouchRipple
+    >
+      {Icon && (
+        <ListItemIcon sx={{ minWidth: 36 }}>
+          <Icon />
+        </ListItemIcon>
+      )}
+      <ListItemText
+        primary={
+          <Typography sx={{ color: theme.palette.text.primary }}>
+            {primaryTitle || secondaryTitle}
+          </Typography>
+        }
+        secondary={kind.toLocaleUpperCase()}
+        // inset={!Icon}
+        sx={{ ml: 1, mr: 1 }}
+      />
+      <Tooltip title="Remove from list">
+        <IconButton
+          onClick={e => {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleStarredEntity(entityRef);
+          }}
+        >
+          <Star color="warning" />
+        </IconButton>
+      </Tooltip>
+    </MenuItem>
+  );
+};
+
+const NoStarredItems = () => {
+  return (
+    <InfoCard>
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        textAlign="center"
+        py={4}
+        px={2} // Added padding to control width
+        maxWidth={300} // Set max width to constrain text expansion
+        mx="auto"
+      >
+        <AutoAwesomeIcon sx={{ fontSize: 64 }} color="disabled" />
+        <Typography variant="h6" sx={{ mt: 2, color: 'text.primary' }}>
+          No starred items yet
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{ mt: 1, color: 'text.secondary', maxWidth: 250 }}
+        >
+          Click the star icon next to an entity's name to save it here for quick
+          access.
+        </Typography>
+      </Box>
+    </InfoCard>
+  );
+};
+
+export const StarredDropdown = () => {
+  const { anchorEl, handleOpen, handleClose } = useDropdownManager();
+  const { starredEntities, toggleStarredEntity } = useStarredEntities();
+
+  const entitiesArray = Array.from(starredEntities);
+
+  return (
+    <HeaderDropdownComponent
+      buttonContent={<StarBorderIcon />}
+      onOpen={handleOpen}
+      onClose={handleClose}
+      anchorEl={anchorEl}
+      tooltip="Your starred items"
+      isIconButton
+    >
+      {entitiesArray.length > 0 ? (
+        <>
+          <ListItemText
+            primary="Your starred items"
+            sx={{ pl: 2, mt: 1, fontWeight: 'bold', color: 'text.secondary' }}
+          />
+          {entitiesArray.map(enitityRef => (
+            <StarredItem
+              key={enitityRef}
+              entityRef={enitityRef}
+              toggleStarredEntity={toggleStarredEntity}
+              handleClose={handleClose}
+            />
+          ))}
+        </>
+      ) : (
+        <NoStarredItems />
+      )}
+    </HeaderDropdownComponent>
+  );
+};

--- a/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
+++ b/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
@@ -29,6 +29,7 @@ import { NotificationButton } from '../components/NotificationButton/Notificatio
 import { Divider } from '../components/Divider/Divider';
 import { MenuItemLink } from '../components/MenuItemLink/MenuItemLink';
 import { Spacer } from '../components/Spacer/Spacer';
+import { StarredDropdown } from '../components/HeaderDropdownComponent/StarredDropdown';
 
 /**
  * default Global Header Components mount points
@@ -64,6 +65,12 @@ export const defaultGlobalHeaderComponentsMountPoints: GlobalHeaderComponentMoun
           },
           mr: 1.5,
         } as any as React.CSSProperties, // I don't used MUI v5 specific `sx` types here to allow us changing the implementation later
+      },
+    },
+    {
+      Component: StarredDropdown,
+      config: {
+        priority: 85,
       },
     },
     {

--- a/workspaces/global-header/plugins/global-header/src/plugin.ts
+++ b/workspaces/global-header/plugins/global-header/src/plugin.ts
@@ -339,3 +339,20 @@ export const NotificationBanner = globalHeaderPlugin.provide(
     },
   }),
 );
+
+/**
+ * Starred Dropdown
+ *
+ * @public
+ */
+export const StarredDropdown = globalHeaderPlugin.provide(
+  createComponentExtension({
+    name: 'StarredDropdown',
+    component: {
+      lazy: () =>
+        import('./components/HeaderDropdownComponent/StarredDropdown').then(
+          m => m.StarredDropdown,
+        ),
+    },
+  }),
+);


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Fixes - [RHDHPAI-664](https://issues.redhat.com/browse/RHDHPAI-664)

This PR adds a new starred entities dropdown to the global header.

### Screenshots


https://github.com/user-attachments/assets/d5e79058-1484-4173-af3e-f7db6b5917dc


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)


