### PR TITLE
chore(version-bump): add temporary 1.36.1 option

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,6 +10,7 @@ on:
         options:
           - next
           - main
+          - '1.36.1'
       workspace_input:
         description: 'Workspace (this must be a JSON array)'
         required: true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a temporary solution to update plugins easily to Backstage 1.36.1 while Backstage 1.37.0 is already released...

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
