### PR TITLE
chore: update templates used in create-workspace command

### DIFF
--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -35,9 +35,8 @@
   "devDependencies": {
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@backstage/e2e-test-utils": "^{{version '@backstage/e2e-test-utils'}}",
-    "@backstage/repo-tools": "^0.10.0",
+    "@backstage/repo-tools": "^{{version '@backstage/repo-tools'}}",
     "@changesets/cli": "^2.27.1",
-    "@spotify/prettier-config": "^12.0.0",
     "knip": "^5.27.4",
     "node-gyp": "^9.0.0",
     "prettier": "^2.3.2",


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Since this has been merged https://github.com/backstage/backstage/pull/27630, updated @backstage/repo-tools to use version syntax
- Removed Usages of @spotify/prettier-config as we can now use @backstage/cli/config/prettier instead (from backstage version 1.34.0 onwards)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
