### PR TITLE
fix(marketplace): reduce bundle size to run in RHDH and show error when YAML isn't valid

### DIFF
--- a/workspaces/marketplace/.changeset/twenty-beers-talk.md
+++ b/workspaces/marketplace/.changeset/twenty-beers-talk.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+show error message when the YAML example could not be applied

--- a/workspaces/marketplace/.changeset/unlucky-lemons-reply.md
+++ b/workspaces/marketplace/.changeset/unlucky-lemons-reply.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+reduce code editor bundled size (js and js.map)

--- a/workspaces/marketplace/plugins/marketplace/src/components/CodeEditor.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/CodeEditor.tsx
@@ -25,7 +25,12 @@ import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 
 import Editor, { loader, OnChange, OnMount } from '@monaco-editor/react';
-import * as monacoEditor from 'monaco-editor';
+
+// TODO: Load the CodeEditor or the pages that uses the CodeEditor lazy!
+// Currently manaco is loaded when the main extensions page is opened.
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution';
+// @ts-ignore
+import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import type MonacoEditor from 'monaco-editor';
 
 loader.config({ monaco: monacoEditor });
@@ -38,11 +43,11 @@ interface CodeEditorContextValue {
   getEditor: () => MonacoEditor.editor.ICodeEditor | null;
   setEditor: (editor: MonacoEditor.editor.ICodeEditor) => void;
 
-  getSelection: () => monacoEditor.Selection | null;
-  setSelection: (editorSelection: monacoEditor.Selection) => void;
+  getSelection: () => MonacoEditor.Selection | null;
+  setSelection: (editorSelection: MonacoEditor.Selection) => void;
 
-  getPosition: () => monacoEditor.Position | null;
-  setPosition: (cursorPosition: monacoEditor.Position) => void;
+  getPosition: () => MonacoEditor.Position | null;
+  setPosition: (cursorPosition: MonacoEditor.Position) => void;
   /** short for getEditor()?.getValue() */
   getValue: () => string | undefined;
   /** short for getEditor()?.setValue() and getEditor()?.focus() */
@@ -64,11 +69,11 @@ export const CodeEditorContextProvider = (props: {
         editorRef.current = editor;
       },
       getPosition: () => editorRef.current?.getPosition() || null,
-      setPosition: (cursorPosition: monacoEditor.Position) => {
+      setPosition: (cursorPosition: MonacoEditor.Position) => {
         editorRef.current?.setPosition(cursorPosition);
       },
       getSelection: () => editorRef.current?.getSelection() || null,
-      setSelection: (editorSelection: monacoEditor.Selection) => {
+      setSelection: (editorSelection: MonacoEditor.Selection) => {
         editorRef.current?.setSelection(editorSelection);
       },
       getValue: () => editorRef.current?.getValue(),

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePackageInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePackageInstallContent.tsx
@@ -17,7 +17,12 @@
 import React, { useState } from 'react';
 
 import { ErrorPage, Progress } from '@backstage/core-components';
-import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
+import {
+  alertApiRef,
+  useApi,
+  useRouteRef,
+  useRouteRefParams,
+} from '@backstage/core-plugin-api';
 
 import yaml from 'yaml';
 import { useNavigate } from 'react-router-dom';
@@ -69,26 +74,35 @@ interface TabPanelProps {
 }
 
 const TabPanel = ({ markdownContent, index, value, others }: TabPanelProps) => {
+  const alertApi = useApi(alertApiRef);
   const codeEditor = useCodeEditor();
   if (value !== index) return null;
 
   const handleApplyContent = (content: string | JsonObject) => {
-    const codeEditorContent = codeEditor.getValue();
-    const appliedContent = applyContent(
-      codeEditorContent || '',
-      others?.packageName,
-      content,
-    );
-    const selection = codeEditor.getSelection();
-    const position = codeEditor.getPosition();
-    if (appliedContent) {
-      codeEditor.setValue(appliedContent);
-      if (selection) {
-        codeEditor.setSelection(selection);
+    try {
+      const codeEditorContent = codeEditor.getValue();
+      const newContent = applyContent(
+        codeEditorContent || '',
+        others?.packageName,
+        content,
+      );
+      const selection = codeEditor.getSelection();
+      const position = codeEditor.getPosition();
+      if (newContent) {
+        codeEditor.setValue(newContent);
+        if (selection) {
+          codeEditor.setSelection(selection);
+        }
+        if (position) {
+          codeEditor.setPosition(position);
+        }
       }
-      if (position) {
-        codeEditor.setPosition(position);
-      }
+    } catch (error) {
+      alertApi.post({
+        display: 'transient',
+        severity: 'warning',
+        message: `Could not apply YAML: ${error}`,
+      });
     }
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Incl. 2 fixes:

1. add workaround to reduce code editor bundled size (js and js.map)
2. show error message when the YAML example could not be applied

File size before:

```
cd workspaces/marketplace/plugins/marketplace
rm -rf dist-dynamic
npx --yes @janus-idp/cli package export-dynamic-plugin
du -hs dist-dynamic/dist-scalprum/static/* | grep 'M[^a-z]'

4.7M	dist-dynamic/dist-scalprum/static/5804.5bb67286.chunk.js
20M	dist-dynamic/dist-scalprum/static/5804.5bb67286.chunk.js.map
```

With this change:

```
rm -rf dist-dynamic
npx --yes @janus-idp/cli package export-dynamic-plugin
du -hs dist-dynamic/dist-scalprum/static/* | grep 'M[^a-z]'

du -hs dist-dynamic/dist-scalprum/static/* | grep 'M[^a-z]'
3.7M	dist-dynamic/dist-scalprum/static/23.143aaf50.chunk.js
16M	dist-dynamic/dist-scalprum/static/23.143aaf50.chunk.js.map
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
