### PR TITLE
fix(marketplace): add missing grid spacing when loaded as dynamic plugin

### DIFF
--- a/workspaces/marketplace/.changeset/funny-donkeys-occur.md
+++ b/workspaces/marketplace/.changeset/funny-donkeys-occur.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+add missing grid spacing when loaded as dynamic plugin

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePackageContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePackageContent.tsx
@@ -75,7 +75,7 @@ const MarketplacePackageContentSkeleton = () => {
       </Stack>
       <br />
       <br />
-      <Grid container>
+      <Grid container spacing={2}>
         <Grid item md={2}>
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
             Highlights
@@ -114,7 +114,7 @@ const MarketplacePackageContent = ({ pkg }: { pkg: MarketplacePackage }) => {
           </Stack>
         </Stack>
 
-        <Grid container>
+        <Grid container spacing={2}>
           <Grid item md={3}>
             <LinkButton
               to={getInstallPath({

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginContent.tsx
@@ -73,7 +73,7 @@ export const MarketplacePluginContentSkeleton = () => {
       </Stack>
       <br />
       <br />
-      <Grid container>
+      <Grid container spacing={2}>
         <Grid item md={2}>
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
             Highlights
@@ -224,7 +224,7 @@ export const MarketplacePluginContent = ({
           </Stack>
         </Stack>
 
-        <Grid container>
+        <Grid container spacing={2}>
           <Grid item md={3}>
             {highlights.length > 0 ? (
               <>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the default Grid spacing that isn't applied when the plugin is loaded as dynamic plugin.

Before:

![image](https://github.com/user-attachments/assets/2d6a7b16-8f2d-461d-9a5e-85f653fcae18)

With this PR:

![image](https://github.com/user-attachments/assets/c64ef0ca-c226-483f-969e-163781ed76e0)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
