### PR TITLE
fix(adoption-insights): add last 28 days and catalog filter

### DIFF
--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/CatalogEntities/CatalogEntities.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/CatalogEntities/CatalogEntities.tsx
@@ -97,7 +97,10 @@ const CatalogEntities = () => {
       .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
   }, [catalogEntities, page, rowsPerPage, selectedOption]);
 
-  if (!visibleCatalogEntities || visibleCatalogEntities?.length === 0) {
+  if (
+    (!visibleCatalogEntities || visibleCatalogEntities?.length === 0) &&
+    !loading
+  ) {
     return (
       <CardWrapper title={CATALOG_ENTITIES_TITLE}>
         <Box
@@ -132,6 +135,7 @@ const CatalogEntities = () => {
                 align="left"
                 sx={{
                   borderBottom: theme => `1px solid ${theme.palette.grey[300]}`,
+                  width: '25%',
                 }}
               >
                 {header.title}
@@ -152,13 +156,13 @@ const CatalogEntities = () => {
           ) : (
             visibleCatalogEntities?.map(entity => (
               <TableRow
-                key={entity.name}
+                key={`${entity.kind}-${entity.name}`}
                 sx={{
                   '&:nth-of-type(odd)': { backgroundColor: 'inherit' },
                   borderBottom: theme => `1px solid ${theme.palette.grey[300]}`,
                 }}
               >
-                <TableCell>
+                <TableCell sx={{ width: '25%' }}>
                   <Link
                     component="a"
                     href={entityLink({
@@ -178,14 +182,14 @@ const CatalogEntities = () => {
                     {entity.name ?? '--'}
                   </Link>
                 </TableCell>
-                <TableCell>
+                <TableCell sx={{ width: '25%' }}>
                   {entity.kind?.charAt(0).toLocaleUpperCase('en-US') +
                     entity.kind?.slice(1) || '--'}
                 </TableCell>
-                <TableCell>
+                <TableCell sx={{ width: '25%' }}>
                   {getLastUsedDay(entity.last_used) ?? '--'}
                 </TableCell>
-                <TableCell>
+                <TableCell sx={{ width: '25%' }}>
                   {Number(entity.count).toLocaleString() ?? '--'}
                 </TableCell>
               </TableRow>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
@@ -35,7 +35,8 @@ interface InsightsHeaderProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 const InsightsHeader: React.FC<InsightsHeaderProps> = ({ title }) => {
-  const [selectedOption, setSelectedOption] = React.useState<string>('');
+  const [selectedOption, setSelectedOption] =
+    React.useState<string>('last-28-days');
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [startDate, setStartDate] = React.useState<Date | null>(null);
   const [endDate, setEndDate] = React.useState<Date | null>(null);
@@ -58,7 +59,7 @@ const InsightsHeader: React.FC<InsightsHeaderProps> = ({ title }) => {
   const handleChange = React.useCallback(
     (event: SelectChangeEvent<string>) => {
       const value = event.target.value;
-      if (value === 'all-time' || !value) return;
+      if (!value) return;
 
       const { startDate: newStartDate, endDate: newEndDate } =
         getDateRange(value);

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/__tests__/Header.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/__tests__/Header.test.tsx
@@ -112,6 +112,7 @@ describe('InsightsHeader', () => {
     expect(screen.getByText('Today')).toBeInTheDocument();
     expect(screen.getByText('Last week')).toBeInTheDocument();
     expect(screen.getByText('Last month')).toBeInTheDocument();
+    expect(screen.getByText('Last 28 days')).toBeInTheDocument();
     expect(screen.getByText('Last year')).toBeInTheDocument();
   });
 

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/hooks/useCatalogEntities.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/hooks/useCatalogEntities.tsx
@@ -63,6 +63,8 @@ export const useCatalogEntities = ({
     let mounted = true;
     if (!loading && mounted) {
       setLoadingData(false);
+    } else {
+      setLoadingData(true);
     }
     return () => {
       mounted = false;

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/__tests__/constants.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/__tests__/constants.test.tsx
@@ -28,6 +28,7 @@ describe('Constants', () => {
       { value: 'today', label: 'Today' },
       { value: 'last-week', label: 'Last week' },
       { value: 'last-month', label: 'Last month' },
+      { value: 'last-28-days', label: 'Last 28 days' },
       { value: 'last-year', label: 'Last year' },
     ]);
   });

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/constants.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/constants.ts
@@ -17,6 +17,7 @@ export const DATE_RANGE_OPTIONS = [
   { value: 'today', label: 'Today' },
   { value: 'last-week', label: 'Last week' },
   { value: 'last-month', label: 'Last month' },
+  { value: 'last-28-days', label: 'Last 28 days' },
   { value: 'last-year', label: 'Last year' },
 ];
 

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
@@ -21,6 +21,7 @@ import {
   isYesterday,
   startOfMonth,
   startOfWeek,
+  subDays,
 } from 'date-fns';
 import { APIsViewOptions } from '../types';
 
@@ -45,6 +46,12 @@ export const getDateRange = (value: string) => {
     case 'last-month':
       return {
         startDate: format(startOfMonth(today), 'yyyy-MM-dd'),
+        endDate: format(today, 'yyyy-MM-dd'),
+      };
+
+    case 'last-28-days':
+      return {
+        startDate: format(subDays(today, 27), 'yyyy-MM-dd'),
         endDate: format(today, 'yyyy-MM-dd'),
       };
 


### PR DESCRIPTION
## Fixes
https://issues.redhat.com/browse/RHDHPAI-715
https://issues.redhat.com/browse/RHDHPAI-706

Add Last 28 days to date range dropdown. And catalog entities filter issue.

Before
![Screenshot 2025-03-26 at 11 58 35 AM](https://github.com/user-attachments/assets/5329f811-8640-4ba9-94d7-5d4f4ef726df)




After
![Screenshot 2025-03-26 at 11 57 49 AM](https://github.com/user-attachments/assets/09df189c-0614-47df-88a8-1608aa254fa6)

![Screenshot 2025-03-26 at 12 31 05 PM](https://github.com/user-attachments/assets/ca85057d-616f-4045-af2d-587e1ab3dda9)


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
