### PR TITLE
fix(global-header): Add keyboard support to global-header to improve a11y

### DIFF
--- a/workspaces/global-header/.changeset/calm-cherries-wonder.md
+++ b/workspaces/global-header/.changeset/calm-cherries-wonder.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': minor
+---
+
+Add keyboard navigation support to global header menu items

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
@@ -19,7 +19,7 @@ import Menu from '@mui/material/Menu';
 import Button from '@mui/material/Button';
 import { Theme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
-import IconButton from '@mui/material/IconButton';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { MenuItemConfig, MenuSectionConfig } from './MenuSection';
 
@@ -34,6 +34,7 @@ interface HeaderDropdownProps {
   anchorEl: HTMLElement | null;
   isIconButton?: boolean;
   tooltip?: string;
+  size?: IconButtonProps['size'];
 }
 
 const menuListStyle = (theme: Theme) => ({
@@ -69,6 +70,7 @@ export const HeaderDropdownComponent: React.FC<HeaderDropdownProps> = ({
   onClose,
   anchorEl,
   isIconButton = false,
+  size = 'small',
   tooltip,
 }) => {
   const id = useId();
@@ -95,7 +97,7 @@ export const HeaderDropdownComponent: React.FC<HeaderDropdownProps> = ({
     <Box>
       <Tooltip title={tooltip}>
         {isIconButton ? (
-          <IconButton {...commonButtonProps} color="inherit">
+          <IconButton {...commonButtonProps} color="inherit" size={size}>
             {buttonContent}
           </IconButton>
         ) : (

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useId } from 'react';
 import Menu from '@mui/material/Menu';
 import Button from '@mui/material/Button';
-import { styled } from '@mui/material/styles';
+import { Theme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
@@ -36,32 +36,30 @@ interface HeaderDropdownProps {
   tooltip?: string;
 }
 
-const Listbox = styled('ul')(
-  ({ theme }) => `
-  font-size: 0.875rem;
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-  min-width: 160px;
-  border-radius: 4px;
-  text-decoration: none;
-  list-style: none;
-  overflow: auto;
-  outline: 1;
-  background: ${theme.palette.background.paper};
-  border: 1px solid ${theme.palette.divider};
-  color: ${
+const menuListStyle = (theme: Theme) => ({
+  fontSize: '0.875rem',
+  boxSizing: 'border-box',
+  padding: 0,
+  margin: 0,
+  minWidth: '160px',
+  borderRadius: '4px',
+  textDecoration: 'none',
+  listStyle: 'none',
+  overflow: 'auto',
+  outline: '1px solid transparent',
+  background: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.divider}`,
+  color:
     theme.palette.mode === 'dark'
       ? theme.palette.text.disabled
-      : theme.palette.text.primary
-  };
-  boxShadow: theme.palette.mode === 'dark'
-    ? '0 2px 6px 2px rgba(0,0,0,0.50), 0 1px 2px 0 rgba(0,0,0,0.50)'
-    : '0 2px 6px 2px rgba(0,0,0,0.15), 0 1px 2px 0 rgba(0,0,0,0.30)',
-  max-height: 60vh;
-  z-index: 1;
-  `,
-);
+      : theme.palette.text.primary,
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 2px 6px 2px rgba(0,0,0,0.50), 0 1px 2px 0 rgba(0,0,0,0.50)'
+      : '0 2px 6px 2px rgba(0,0,0,0.15), 0 1px 2px 0 rgba(0,0,0,0.30)',
+  maxHeight: '60vh',
+  zIndex: 1,
+});
 
 export const HeaderDropdownComponent: React.FC<HeaderDropdownProps> = ({
   buttonContent,
@@ -73,26 +71,41 @@ export const HeaderDropdownComponent: React.FC<HeaderDropdownProps> = ({
   isIconButton = false,
   tooltip,
 }) => {
+  const id = useId();
+
+  const commonButtonProps = {
+    ...buttonProps,
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      onOpen(event);
+      // focus the menu when opened
+      // TODO: investigate why MUI isn't doing this for us
+      setTimeout(() => {
+        document
+          .getElementById(`${id}-menu`)
+          ?.getElementsByTagName('a')[0]
+          ?.focus();
+      }, 0);
+    },
+    'aria-haspopup': true,
+    'aria-controls': id,
+    'aria-expanded': anchorEl ? true : undefined,
+  };
+
   return (
     <Box>
       <Tooltip title={tooltip}>
         {isIconButton ? (
-          <IconButton {...buttonProps} color="inherit" onClick={onOpen}>
+          <IconButton {...commonButtonProps} color="inherit">
             {buttonContent}
           </IconButton>
         ) : (
-          <Button
-            disableRipple
-            disableTouchRipple
-            {...buttonProps}
-            onClick={onOpen}
-          >
+          <Button disableRipple disableTouchRipple {...commonButtonProps}>
             {buttonContent}
           </Button>
         )}
       </Tooltip>
       <Menu
-        id="menu-appbar"
+        id={`${id}-menu`}
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}
@@ -110,8 +123,12 @@ export const HeaderDropdownComponent: React.FC<HeaderDropdownProps> = ({
             py: 0,
           },
         }}
+        MenuListProps={{
+          'aria-labelledby': id,
+          sx: theme => menuListStyle(theme),
+        }}
       >
-        <Listbox role="menu">{children}</Listbox>
+        {children}
       </Menu>
     </Box>
   );

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import Divider from '@mui/material/Divider';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import MenuItem from '@mui/material/MenuItem';
 import { Link } from '@backstage/core-components';
 import { MenuItemLinkProps } from '../MenuItemLink/MenuItemLink';
+import ListSubheader from '@mui/material/ListSubheader';
 
 /**
  * Menu item configuration
@@ -51,55 +51,66 @@ export const MenuSection: React.FC<MenuSectionConfig> = ({
   items,
   hideDivider = false,
   handleClose,
-}) => (
-  <Box>
-    {sectionLabel && (
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          mx: 0,
-          mt: '0.5rem',
-          '&:hover': { background: 'transparent' },
-        }}
-      >
-        <Typography variant="body2" sx={{ pl: 2, color: 'text.disabled' }}>
-          {sectionLabel}
-        </Typography>
+}) => {
+  const hasClickableSubheader =
+    optionalLink && optionalLinkLabel && items.length > 0;
+
+  return (
+    <>
+      {sectionLabel && (
         <MenuItem
           sx={{
-            '&:hover': { background: 'transparent' },
+            p: 0,
           }}
           disableRipple
           disableTouchRipple
+          component={hasClickableSubheader ? Link : Fragment}
+          to={optionalLink}
           onClick={handleClose}
         >
-          {optionalLink && optionalLinkLabel && items.length > 0 && (
-            <Link
-              to={optionalLink}
-              underline="none"
-              style={{ fontSize: '0.875em' }}
+          <ListSubheader
+            sx={{
+              backgroundColor: 'transparent',
+              m: 0,
+              color: 'text.disabled',
+              lineHeight: 2,
+              mt: '0.5rem',
+              fontWeight: 400,
+            }}
+          >
+            {sectionLabel}
+          </ListSubheader>
+
+          {optionalLinkLabel && (
+            <Box
+              sx={{
+                fontSize: '0.875em',
+                mr: 2,
+                flexGrow: 1,
+                textAlign: 'right',
+                mt: '0.5rem',
+              }}
             >
               {optionalLinkLabel}
-            </Link>
+            </Box>
           )}
         </MenuItem>
-      </Box>
-    )}
-    <ul style={{ padding: 0, listStyle: 'none' }}>
+      )}
+
       {items.map(({ icon, label, subLabel, link, Component }, index) => (
         <MenuItem
           key={`menu-item-${index.toString()}`}
           disableRipple
           disableTouchRipple
           onClick={handleClose}
-          sx={{ py: 0.5, '&:hover': { background: 'transparent' } }}
+          sx={{ py: 0.5 }}
+          component={link ? Link : Fragment}
+          to={link}
         >
           <Component icon={icon} to={link!} title={label} subTitle={subLabel} />
         </MenuItem>
       ))}
-    </ul>
-    {!hideDivider && <Divider sx={{ my: 0.5 }} />}
-  </Box>
-);
+      {!hideDivider && <Divider sx={{ my: 0.5 }} />}
+    </>
+  );
+};

--- a/workspaces/global-header/plugins/global-header/src/components/LogoutButton/LogoutButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/LogoutButton/LogoutButton.tsx
@@ -22,7 +22,7 @@ import {
   useApi,
 } from '@backstage/core-plugin-api';
 
-import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
 
 import { MenuItemLinkContent } from '../MenuItemLink/MenuItemLinkContent';
 
@@ -34,13 +34,12 @@ export const LogoutButton = () => {
     identityApi.signOut().catch(error => errorApi.post(error));
   };
 
-  // TODO switch to Button
   return (
-    <Box
+    <MenuItem
       onClick={handleLogout}
       sx={{ cursor: 'pointer', width: '100%', color: 'inherit' }}
     >
       <MenuItemLinkContent icon="logout" label="Sign out" />
-    </Box>
+    </MenuItem>
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/components/MenuItemLink/MenuItemLink.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/MenuItemLink/MenuItemLink.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import Tooltip from '@mui/material/Tooltip';
-import { Link } from '@backstage/core-components';
 import { MenuItemLinkContent } from './MenuItemLinkContent';
 
 /**
@@ -41,22 +40,14 @@ export const MenuItemLink = ({
   const isExternalLink = to.startsWith('http://') || to.startsWith('https://');
 
   const headerLinkContent = () => (
-    <Link
-      to={to}
-      style={{
-        color: 'inherit',
-        textDecoration: 'none',
-        width: '100%',
-      }}
-    >
-      <MenuItemLinkContent
-        icon={icon}
-        label={title}
-        subLabel={subTitle}
-        isExternalLink={isExternalLink}
-      />
-    </Link>
+    <MenuItemLinkContent
+      icon={icon}
+      label={title}
+      subLabel={subTitle}
+      isExternalLink={isExternalLink}
+    />
   );
+
   return (
     <>
       {tooltip && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes https://issues.redhat.com/browse/RHIDP-6537

<!-- Please describe what you added, and add a screenshot if possible.
     That ma

kes it easier to understand the change so we can :shipit: faster. -->

- use more "semantic" MUI components (e.g., `ListSubHeader`)
- remove the MenuList hover style override (a hover style is also in PatternFly)
- make sure `MenuItem`s are always the direct children of the `Menu` for MUI to pick them up for keyboard support

https://github.com/user-attachments/assets/40e63685-cd42-4e13-a42e-40afc8ccc3fd


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
