### PR TITLE
feat(ai-integrations): Initial code drop of model catalog backend module

### DIFF
--- a/workspaces/ai-integrations/.changeset/crazy-clouds-shake.md
+++ b/workspaces/ai-integrations/.changeset/crazy-clouds-shake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog': patch
+---
+
+Initial code drop of prototype model catalog plugin originally from redhat-ai-dev fork

--- a/workspaces/ai-integrations/app-config.yaml
+++ b/workspaces/ai-integrations/app-config.yaml
@@ -92,5 +92,7 @@ catalog:
     - allow: [Component, System, API, Resource, Location]
   providers:
     modelCatalog:
-      ollama:
+      # The field underneath here can be any value that you feel represents your model catalog bridge instance
+      development:
+        # If testing locally, this value should be set to `localhost:9090`
         baseUrl: '${RHDH_AI_BRIDGE_SERVER}'

--- a/workspaces/ai-integrations/app-config.yaml
+++ b/workspaces/ai-integrations/app-config.yaml
@@ -43,6 +43,7 @@ backend:
       - host: '*.mozilla.org'
       - host: '*.openshift.com'
       - host: '*.openshiftapps.com'
+      - host: '${RHDH_BRIDGE_HOST}'
 
 integrations:
   github:

--- a/workspaces/ai-integrations/babel.config.js
+++ b/workspaces/ai-integrations/babel.config.js
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/workspaces/ai-integrations/packages/backend/src/index.ts
+++ b/workspaces/ai-integrations/packages/backend/src/index.ts
@@ -15,6 +15,11 @@
  */
 
 import { createBackend } from '@backstage/backend-defaults';
+import {
+  catalogModuleRHDHRHOAIReaderProcessor,
+  catalogModuleRHDHRHOAILocationsExtensionPoint,
+  catalogModuleRHDHRHOAIEntityProvider,
+} from '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog';
 
 const backend = createBackend();
 
@@ -64,4 +69,7 @@ backend.add(
     '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog'
   ),
 );
+backend.add(catalogModuleRHDHRHOAILocationsExtensionPoint);
+backend.add(catalogModuleRHDHRHOAIReaderProcessor);
+backend.add(catalogModuleRHDHRHOAIEntityProvider);
 backend.start();

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/config.d.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/config.d.ts
@@ -13,18 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { SchedulerServiceTaskScheduleDefinitionConfig } from '@backstage/backend-plugin-api';
 
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+export interface Config {
+  catalog?: {
+    providers?: {
+      modelCatalog?: {
+        [key: string]: {
+          /**
+           * ModelCatalogConfig
+           */
+          baseUrl: string;
+          name?: string;
+          system?: string;
+          owner?: string;
+          schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
+        };
+      };
+    };
+  };
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/package.json
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/package.json
@@ -19,7 +19,10 @@
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "catalog",
-    "pluginPackage": "@backstage/plugin-catalog-backend"
+    "pluginPackage": "@backstage/plugin-catalog-backend",
+    "pluginPackages": [
+      "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog"
+    ]
   },
   "scripts": {
     "start": "backstage-cli package start",
@@ -31,7 +34,16 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "^1.2.1"
+    "@backstage/backend-plugin-api": "^1.1.1",
+    "@backstage/catalog-client": "^1.9.1",
+    "@backstage/catalog-model": "^1.7.2",
+    "@backstage/errors": "^1.2.7",
+    "@backstage/plugin-catalog-backend": "^1.30.0",
+    "@backstage/plugin-catalog-common": "^1.1.3",
+    "@backstage/plugin-catalog-node": "^1.15.1",
+    "@redhat-ai-dev/model-catalog-types": "^1.0.1",
+    "stream": "^0.0.3",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.3.1",

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/report.api.md
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/report.api.md
@@ -4,8 +4,70 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
+import { CatalogProcessorParser } from '@backstage/plugin-catalog-node';
+import type { Config } from '@backstage/config';
+import { Entity } from '@backstage/catalog-model';
+import { EntityProvider } from '@backstage/plugin-catalog-node';
+import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
+import type { SchedulerService } from '@backstage/backend-plugin-api';
+import type { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public
-const catalogModuleModelCatalog: BackendFeature;
-export default catalogModuleModelCatalog;
+const catalogModuleModelCatalogResourceEntityProvider: BackendFeature;
+export default catalogModuleModelCatalogResourceEntityProvider;
+
+// @public
+export const catalogModuleRHDHRHOAIEntityProvider: BackendFeature;
+
+// @public
+export const catalogModuleRHDHRHOAILocationsExtensionPoint: BackendFeature;
+
+// @public
+export const catalogModuleRHDHRHOAIReaderProcessor: BackendFeature;
+
+// @public
+export function fetchCatalogEntities(baseUrl: string): Promise<Entity[]>;
+
+// @public
+export class ModelCatalogResourceEntityProvider implements EntityProvider {
+  connect(connection: EntityProviderConnection): Promise<void>;
+  createScheduleFn(taskRunner: SchedulerServiceTaskRunner): () => Promise<void>;
+  static fromConfig(
+    deps: {
+      config: Config;
+      logger: LoggerService;
+    },
+    options:
+      | {
+          schedule: SchedulerServiceTaskRunner;
+        }
+      | {
+          scheduler: SchedulerService;
+        },
+  ): ModelCatalogResourceEntityProvider[];
+  getProviderName(): string;
+  run(): Promise<void>;
+}
+
+// @public
+export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
+  constructor(
+    reader: UrlReaderService,
+    config: RootConfigService,
+    logger: LoggerService,
+  );
+  getProcessorName(): string;
+  readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: CatalogProcessorEmit,
+    parser: CatalogProcessorParser,
+  ): Promise<boolean>;
+}
 ```

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import YAML from 'yaml';
+import { Entity, ResourceEntity } from '@backstage/catalog-model';
+import { Stream } from 'stream';
+
+const fakeEntity: ResourceEntity = {
+  apiVersion: 'backstage.io/v1beta1',
+  kind: 'Resource',
+  metadata: {
+    name: 'ibm-granite',
+    description: 'IBM Granite code model',
+    tags: [],
+    links: [],
+  },
+  spec: {
+    dependencyOf: [],
+    owner: 'example-user',
+    type: 'ai-model',
+  },
+};
+const blob = new Blob([YAML.stringify(fakeEntity)], {
+  type: 'application/json',
+});
+
+// Mock different fetch results based on the url passed in, to trigger success vs. error scenarios
+global.fetch = jest.fn(url => {
+  if (url === 'errorTest') {
+    return Promise.resolve({
+      ok: false,
+      status: 401,
+      json: () => 'error',
+    });
+  }
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    blob: () => Promise.resolve(blob),
+  });
+}) as jest.Mock;
+
+import { fetchCatalogEntities } from './BridgeResourceConnector';
+
+const httpsMock = require('https');
+
+describe('Bridge Resource Connector', () => {
+  it('should fetch catallog entities successfully', async () => {
+    const streamStream = new Stream();
+    httpsMock.get = jest.fn().mockImplementation(cb => {
+      cb(streamStream);
+      streamStream.emit('data', 'test');
+      streamStream.emit('end');
+    });
+    const entities: Entity[] = await fetchCatalogEntities('fake-url');
+    expect(entities.length).toEqual(1);
+    expect(entities[0].metadata.name).toEqual('ibm-granite');
+  });
+  it('should error out if error encountered', async () => {
+    const streamStream = new Stream();
+    httpsMock.get = jest.fn().mockImplementation(cb => {
+      cb(streamStream);
+      streamStream.emit('data', 'test');
+      streamStream.emit('end');
+    });
+    await expect(
+      async () => await fetchCatalogEntities('errorTest'),
+    ).rejects.toThrow();
+  });
+});

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+
+import YAML from 'yaml';
+
+// listModels will list the models from an OpenAI compatible endpoint
+/*
+export async function listModels(
+  baseUrl: string,
+  access_token: string,
+): Promise<ModelList> {
+  const res = await fetch(`${baseUrl}/v1/models`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    method: 'GET',
+  });
+
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+
+  const data = await res.json();
+  return data;
+}*/
+
+/**
+ * fetchCatalogEntities retrieves model catalog entities from the Model Catalog Bridge services
+ * @public
+ */
+export async function fetchCatalogEntities(baseUrl: string): Promise<Entity[]> {
+  // ToDo: Discover catalog-info endpoint?
+  const res = await fetch(`${baseUrl}`, {
+    method: 'GET',
+  });
+
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+
+  // ToDo: Look at seeing if we can use the parser provided by the CatalogProcessorProvider package
+  const data = await res
+    .blob()
+    .then(blob => blob.text())
+    .then(yamlStr => YAML.parseAllDocuments(yamlStr))
+    .then(yamlData => yamlData.map(item => item.toJS()));
+  return data;
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GenerateCatalogEntities } from './ModelCatalogGenerator';
+import { Entity, ComponentEntity, ApiEntity } from '@backstage/catalog-model';
+import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
+
+// ts-jest throws a module import error when pulling in enums defined in *.d.ts files
+// https://github.com/kulshekhar/ts-jest/issues/1229 - but our generator throws the enum in there, so we don't have the option to move it
+// Mocking the Type enum should be sufficient for these test cases
+enum Type {
+  Asyncapi = 'asyncapi',
+  Graphql = 'graphql',
+  Grpc = 'grpc',
+  Openapi = 'openapi',
+}
+
+describe('Model Catalog Generator', () => {
+  it('should generate catalog entities from a single model with defaults', () => {
+    const modelCatalog: ModelCatalog = {
+      models: [
+        {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          lifecycle: 'production',
+          owner: 'example-user',
+        },
+      ],
+    };
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+    expect(modelCatalogEntities.length).toEqual(1);
+
+    const expectedModelEntities: Entity[] = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          tags: [],
+          links: [],
+        },
+        spec: {
+          dependencyOf: [],
+          owner: 'example-user',
+          type: 'ai-model',
+        },
+      },
+    ];
+    expect(modelCatalogEntities).toEqual(expectedModelEntities);
+  });
+  it('should generate catalog entities for multiple models and a model server with API', () => {
+    const modelCatalog: ModelCatalog = {
+      modelServer: {
+        name: 'developer-model-service',
+        owner: 'example-user',
+        description: 'Developer model service running on vLLM',
+        homepageURL: 'https://example.com',
+        tags: ['vLLM', 'granite', 'ibm'],
+        API: {
+          url: 'https://api.example.com',
+          type: Type.Openapi,
+          spec: 'https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json',
+          tags: ['openapi', 'openai', '3scale'],
+        },
+        lifecycle: 'production',
+      },
+      models: [
+        {
+          name: 'ibm-granite-20b',
+          description: 'IBM Granite 20b model running on vLLM',
+          artifactLocationURL:
+            'https://huggingface.co/ibm-granite/granite-20b-code-instruct',
+          tags: ['IBM', 'granite', 'vllm', '20b'],
+          owner: 'example-user',
+          lifecycle: 'production',
+        },
+        {
+          name: 'mistral-7b',
+          description: 'Mistral 7b model running on vLLM',
+          artifactLocationURL:
+            'https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2',
+          tags: ['mistralai', 'mistral', 'vllm', '7b'],
+          owner: 'example-user',
+          lifecycle: 'production',
+        },
+        {
+          name: 'gemma-2-2b',
+          description: 'Google Gemma 2 2b model running on vLLM',
+          artifactLocationURL: 'https://huggingface.co/google/gemma-2-2b',
+          howToUseURL: 'https://example.com/gemma',
+          tags: ['google', 'gemma'],
+          owner: 'example-user',
+          lifecycle: 'production',
+        },
+      ],
+    };
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+    expect(modelCatalog.modelServer !== undefined).toBe(true);
+    expect(modelCatalog.models.length).toBe(3);
+
+    const expectedModelEntities: Entity[] = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'ibm-granite-20b',
+          description: 'IBM Granite 20b model running on vLLM',
+          tags: ['IBM', 'granite', 'vllm', '20b'],
+          links: [
+            {
+              url: 'https://huggingface.co/ibm-granite/granite-20b-code-instruct',
+              title: 'Artifact Location',
+            },
+          ],
+        },
+        spec: {
+          owner: 'example-user',
+          type: 'ai-model',
+          dependencyOf: ['component:developer-model-service'],
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'mistral-7b',
+          description: 'Mistral 7b model running on vLLM',
+          tags: ['mistralai', 'mistral', 'vllm', '7b'],
+          links: [
+            {
+              url: 'https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2',
+              title: 'Artifact Location',
+            },
+          ],
+        },
+        spec: {
+          owner: 'example-user',
+          type: 'ai-model',
+          dependencyOf: ['component:developer-model-service'],
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'gemma-2-2b',
+          description: 'Google Gemma 2 2b model running on vLLM',
+          tags: ['google', 'gemma'],
+          links: [
+            {
+              url: 'https://huggingface.co/google/gemma-2-2b',
+              title: 'Artifact Location',
+            },
+            {
+              url: 'https://example.com/gemma',
+              title: 'How to use',
+            },
+          ],
+        },
+        spec: {
+          owner: 'example-user',
+          type: 'ai-model',
+          dependencyOf: ['component:developer-model-service'],
+        },
+      },
+    ];
+    const expectedModelServerEntity: ComponentEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'Component',
+      metadata: {
+        name: 'developer-model-service',
+        description: 'Developer model service running on vLLM',
+        tags: ['vLLM', 'granite', 'ibm'],
+        links: [
+          {
+            url: 'https://api.example.com',
+            title: 'API',
+          },
+          {
+            url: 'https://example.com',
+            title: 'Homepage',
+          },
+        ],
+      },
+      spec: {
+        type: 'model-server',
+        lifecycle: 'production',
+        owner: 'example-user',
+        dependsOn: [
+          'resource:ibm-granite-20b',
+          'resource:mistral-7b',
+          'resource:gemma-2-2b',
+        ],
+        providesApis: ['developer-model-service'],
+      },
+    };
+
+    const expectedModelServerAPIEntity: ApiEntity = {
+      apiVersion: `backstage.io/v1beta1`,
+      kind: `API`,
+      metadata: {
+        name: 'developer-model-service',
+        tags: ['openapi', 'openai', '3scale'],
+        links: [
+          {
+            url: `https://api.example.com`,
+            title: `API`,
+          },
+        ],
+      },
+      spec: {
+        type: 'openapi',
+        owner: 'example-user',
+        lifecycle: 'production',
+        definition:
+          'https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json',
+      },
+    };
+    const expectedEntities: Entity[] = expectedModelEntities;
+    expectedEntities.push(expectedModelServerEntity);
+    expectedEntities.push(expectedModelServerAPIEntity);
+    expect(modelCatalogEntities).toEqual(expectedModelEntities);
+  });
+});

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ModelCatalog,
+  Model,
+  ModelServer,
+  API,
+} from '@redhat-ai-dev/model-catalog-types';
+import {
+  Entity,
+  ComponentEntity,
+  ApiEntity,
+  ResourceEntity,
+} from '@backstage/catalog-model';
+
+function isModelCatalog(o: any): o is ModelCatalog {
+  return 'model' in o && 'modelServer' in o;
+}
+
+export function ParseCatalogJSON(jsonStr: string): ModelCatalog {
+  const modelCatalog: ModelCatalog = JSON.parse(jsonStr);
+  if (isModelCatalog(modelCatalog)) {
+    // do something with now correctly typed object
+    return modelCatalog;
+  }
+  throw new Error(`model catalog JSON in unexpected format: ${jsonStr}`);
+}
+
+// Generate the Backstage catalog entities that correspond to the given model catalog json object
+// Note: These entities will need to have their location and origin location annotations set before ingestion into the catalog
+export function GenerateCatalogEntities(modelCatalog: ModelCatalog): Entity[] {
+  // Generate the Resource entities for the Model(s)
+  let modelCatalogEntities: Entity[] = [];
+  const models: Model[] = modelCatalog.models;
+  modelCatalogEntities = modelCatalogEntities.concat(
+    GenerateModelResourceEntities(models, modelCatalog.modelServer),
+  );
+
+  // Generate the Model Server and Model Server APi entity, if present
+  if (modelCatalog.modelServer !== undefined) {
+    const modelServer = modelCatalog.modelServer;
+    modelCatalogEntities.push(
+      GenerateModelServerComponentEntity(modelServer, modelCatalog.models),
+    );
+
+    // If there's an exposed API present, generate that entity as well, and update the model server entity accordingly
+    if (modelServer.API !== undefined) {
+      const api: API = modelServer.API;
+      modelCatalogEntities.push(GenerateModelServerAPI(api, modelServer));
+    }
+  }
+
+  return modelCatalogEntities;
+}
+
+export function GenerateModelResourceEntities(
+  models: Model[],
+  modelServer?: ModelServer,
+): ResourceEntity[] {
+  const modelResourceEntities: ResourceEntity[] = [];
+  models.forEach(model => {
+    const modelResourceEntity: ResourceEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'Resource',
+      metadata: {
+        name: `${model.name}`,
+        description: `${model.description}`,
+        tags: [],
+        links: [],
+      },
+      spec: {
+        owner: `${model.owner}`,
+        type: 'ai-model',
+      },
+    };
+
+    // Set optional parameters, if present
+    if (model.tags !== undefined) {
+      modelResourceEntity.metadata.tags = model.tags;
+    }
+    if (model.artifactLocationURL !== undefined) {
+      modelResourceEntity.metadata.links?.push({
+        title: 'Artifact Location',
+        url: `${model.artifactLocationURL}`,
+      });
+    }
+    if (model.howToUseURL !== undefined) {
+      modelResourceEntity.metadata.links?.push({
+        title: 'How to use',
+        url: `${model.howToUseURL}`,
+      });
+    }
+    modelResourceEntity.spec.dependencyOf = [];
+    if (modelServer !== undefined) {
+      modelResourceEntity.spec.dependencyOf?.push(
+        `component:${modelServer.name}`,
+      );
+    }
+    modelResourceEntities.push(modelResourceEntity);
+  });
+
+  return modelResourceEntities;
+}
+
+export function GenerateModelServerComponentEntity(
+  modelServer: ModelServer,
+  models: Model[],
+): ComponentEntity {
+  const modelServerComponent: ComponentEntity = {
+    apiVersion: 'backstage.io/v1beta1',
+    kind: 'Component',
+    metadata: {
+      name: `${modelServer.name}`,
+      description: `${modelServer.description}`,
+      tags: [],
+      links: [],
+    },
+    spec: {
+      type: 'model-server',
+      lifecycle: `${modelServer.lifecycle}`,
+      owner: `${modelServer.owner}`,
+    },
+  };
+
+  // Add the models to the model server as dependants
+  modelServerComponent.spec.dependsOn = [];
+  models.forEach(model => {
+    modelServerComponent.spec.dependsOn?.push(`resource:${model.name}`);
+  });
+
+  // Configure optional parameters
+  // Set optional parameters, if present
+  if (modelServer.tags !== undefined) {
+    modelServerComponent.metadata.tags = modelServer.tags;
+  }
+  modelServerComponent.metadata.links = [];
+  if (modelServer.API !== undefined) {
+    modelServerComponent.metadata.links.push({
+      title: `API`,
+      url: `${modelServer.API.url}`,
+    });
+    modelServerComponent.spec.providesApis = [modelServer.name];
+  }
+  if (modelServer.homepageURL !== undefined) {
+    modelServerComponent.metadata.links.push({
+      title: 'Homepage',
+      url: `${modelServer.homepageURL}`,
+    });
+  }
+  return modelServerComponent;
+}
+
+export function GenerateModelServerAPI(
+  api: API,
+  modelServer: ModelServer,
+): ApiEntity {
+  const modelServerAPIEntity: ApiEntity = {
+    apiVersion: `backstage.io/v1beta1`,
+    kind: `API`,
+    metadata: {
+      name: `${modelServer.name}`,
+      tags: [],
+      links: [
+        {
+          url: `${api.url}`,
+          title: `API`,
+        },
+      ],
+    },
+    spec: {
+      type: `${api.type}`,
+      owner: `${modelServer.owner}`,
+      lifecycle: `${modelServer.lifecycle}`,
+      definition: `${api.spec}`,
+    },
+  };
+
+  if (api.tags !== undefined) {
+    modelServerAPIEntity.metadata.tags = api.tags;
+  }
+  return modelServerAPIEntity;
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/index.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/index.ts
@@ -13,18 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+export * from './BridgeResourceConnector';

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/types.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/types.ts
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type ModelList = {
+  object: string;
+  data: Model[];
+};
 
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+export type Model = {
+  id: string;
+  object: string;
+  created: number;
+  owned_by: string;
+};

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.test.ts
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
+import {
+  catalogModuleModelCatalogResourceEntityProvider,
+  catalogModuleRHDHRHOAIReaderProcessor,
+  catalogModuleRHDHRHOAILocationsExtensionPoint,
+  catalogModuleRHDHRHOAIEntityProvider,
+} from './module';
 
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+describe('model-catalog', () => {
+  it('should export entity providers and processor', () => {
+    expect(catalogModuleModelCatalogResourceEntityProvider).toBeDefined();
+    expect(catalogModuleRHDHRHOAIReaderProcessor).toBeDefined();
+    expect(catalogModuleRHDHRHOAILocationsExtensionPoint).toBeDefined();
+    expect(catalogModuleRHDHRHOAIEntityProvider).toBeDefined();
+  });
+});

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.ts
@@ -17,19 +17,134 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
+import {
+  catalogProcessingExtensionPoint,
+  catalogLocationsExtensionPoint,
+} from '@backstage/plugin-catalog-node/alpha';
+
+import { ModelCatalogResourceEntityProvider } from './providers';
+import { RHDHRHOAIReaderProcessor } from './processors';
+import { RHDHRHOAIEntityProvider } from './providers/RHDHRHOAIEntityProvider';
 
 /**
- * The model catalog backend module that extends the catalog plugin
+ * catalogModuleModelCatalogResourceEntityProvider defines the model catalog entity provider which runs on startup
+ *
  * @public
  */
-export const catalogModuleModelCatalog = createBackendModule({
+export const catalogModuleModelCatalogResourceEntityProvider =
+  createBackendModule({
+    moduleId: 'catalog-backend-module-model-catalog',
+    pluginId: 'catalog',
+    register(env) {
+      env.registerInit({
+        deps: {
+          catalog: catalogProcessingExtensionPoint,
+          config: coreServices.rootConfig,
+          logger: coreServices.logger,
+          scheduler: coreServices.scheduler,
+        },
+        async init({ catalog, config, logger, scheduler }) {
+          catalog.addEntityProvider(
+            ModelCatalogResourceEntityProvider.fromConfig(
+              { config, logger },
+              {
+                schedule: scheduler.createScheduledTaskRunner({
+                  frequency: { seconds: 30 },
+                  timeout: { minutes: 3 },
+                }),
+                scheduler: scheduler,
+              },
+            ),
+          );
+        },
+      });
+    },
+  });
+
+/**
+ * catalogModuleRHDHRHOAIReaderProcessor defines the custom processor used to ingest updated/newly
+ * discovered model catalog entities
+ *
+ * @public
+ */
+export const catalogModuleRHDHRHOAIReaderProcessor = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'model-catalog',
-  register(reg) {
-    reg.registerInit({
-      deps: { logger: coreServices.logger },
-      async init({ logger }) {
-        logger.info('Hello World!');
+  moduleId: 'rhdh-rhoai-bridge-reader-processor',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogProcessingExtensionPoint,
+        reader: coreServices.urlReader,
+        config: coreServices.rootConfig,
+        logger: coreServices.logger,
+      },
+      async init({ catalog, reader, config, logger }) {
+        catalog.addProcessor(
+          new RHDHRHOAIReaderProcessor(reader, config, logger),
+        );
+      },
+    });
+  },
+});
+
+/** so a `CatalogProcessor` does not need to also provide a `CatalogLocationsExtensionPoint` if it only supports imports of locations
+ * from the app-config.yaml on startup, but if you want to dynamically add Locations via the catalog's REST API (like what the UI does for import
+ * of catalog-info.yaml from git repos) then you need to also provide a `CatalogLocationsExtension` point to add your type to the default list of 'url' and 'file';
+ * fwiw in examining the core Backstage code, none of the default `CatalogProcessors` bother to also provide a `CatalogLocationsExtension`; however,
+ * we want to allow our RHDH bridge to import new locations dynamically
+ *
+ * @public
+ */
+export const catalogModuleRHDHRHOAILocationsExtensionPoint =
+  createBackendModule({
+    pluginId: 'catalog',
+    moduleId: 'rhdh-rhoai-bridge-location-extension-point',
+    register(env) {
+      env.registerInit({
+        deps: {
+          catalog: catalogLocationsExtensionPoint,
+        },
+        async init({ catalog }) {
+          // setAllowedLocationTypes does not add to the list but replaces it, so we preserve the default options of 'file' and 'url'
+          const allowedLocationTypes = ['file', 'url', 'rhdh-rhoai-bridge'];
+          catalog.setAllowedLocationTypes(allowedLocationTypes);
+        },
+      });
+    },
+  });
+
+/**
+ * catalogModuleRHDHRHOAIEntityProvider defines the entity provider used to handle ingestion/cleanup of locations in the model catalog
+ *
+ * @public
+ */
+export const catalogModuleRHDHRHOAIEntityProvider = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'rhdh-rhoai-bridge-entiry-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogProcessingExtensionPoint,
+        config: coreServices.rootConfig,
+        discovery: coreServices.discovery,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
+        reader: coreServices.urlReader,
+      },
+      async init({ catalog, config, logger, scheduler, discovery, reader }) {
+        const runner = scheduler.createScheduledTaskRunner({
+          frequency: { seconds: 30 },
+          timeout: { minutes: 3 },
+        });
+        catalog.addEntityProvider(
+          new RHDHRHOAIEntityProvider(
+            discovery,
+            config,
+            logger,
+            runner,
+            reader,
+          ),
+        );
       },
     });
   },

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  processingResult,
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  CatalogProcessorParser,
+  CatalogProcessorResult,
+} from '@backstage/plugin-catalog-node';
+import {
+  LoggerService,
+  RootConfigService,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
+
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+
+import { ModelCatalogConfig } from '../providers/types';
+import { readModelCatalogApiEntityConfigs } from '../providers/config';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+} from '@backstage/catalog-model';
+
+/**
+ * A processor that reads from the RHDH RHOAI Bridge
+ *
+ * @public
+ * */
+export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
+  private readonly reader: UrlReaderService;
+  private readonly modelCatalogConfigs: ModelCatalogConfig[];
+  private readonly logger: LoggerService;
+  constructor(
+    reader: UrlReaderService,
+    config: RootConfigService,
+    logger: LoggerService,
+  ) {
+    this.reader = reader;
+    this.modelCatalogConfigs = readModelCatalogApiEntityConfigs(config);
+    this.logger = logger;
+  }
+
+  /**
+   * Retrieves the name of the catalog custom processor
+   * @public
+   */
+  getProcessorName(): string {
+    return 'RHDHRHOAIReaderProcessor';
+  }
+
+  /**
+   * Retrieves the list of model catalog locations from the model catalog bridge
+   * @public
+   */
+  async readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: CatalogProcessorEmit,
+    parser: CatalogProcessorParser,
+  ): Promise<boolean> {
+    // Pick a custom location type string. A location will be
+    // registered later with this type.
+    if (location.type !== 'rhdh-rhoai-bridge') {
+      this.logger.info(
+        `skipping non bridge location ${location.type}:${location.target}`,
+      );
+      return false;
+    }
+
+    try {
+      // as part of the life cycles of entities we will get called
+      // when ModelCatalogResourceEntityProvider gets call on startup; leveraging
+      // the config to bypass processing this location to avoid detection of conflicting
+      // entity refs by the core catalog code
+      for (const config of this.modelCatalogConfigs) {
+        if (config.baseUrl === location.target) {
+          this.logger.info(
+            `RHDHRHOAIReaderProcessor skipping bridge location ${location.type}:${location.target} because it is registered for startup processing`,
+          );
+          // still return true to avoid warning from catalog about no processor being able to handle; we are just deferring to ModelCatalog entity provider
+          return true;
+        }
+      }
+
+      // Use the builtin reader facility to grab data from the
+      // API. If you prefer, you can just use plain fetch here
+      // (from the node-fetch package), or any other method of
+      // your choosing.
+      // TODO eventually we will want to take the k8s credentials provided to
+      // backstage and its k8s plugin and supply them to the bridge
+      // for potential auth and access control checks (i.e. SARs) with the kubeflow MR
+      const data = await this.reader.readUrl(location.target);
+      const response = [{ url: location.target, data: await data.buffer() }];
+      // Repeatedly call emit(processingResult.entity(location, <entity>))
+      const parseResults: CatalogProcessorResult[] = [];
+      for (const item of response) {
+        for await (const parseResult of parser({
+          data: item.data,
+          location: { type: location.type, target: item.url },
+        })) {
+          if (parseResult.type === 'entity') {
+            const locKey = `${location.type}:${location.target}`;
+            if (parseResult.entity.metadata.annotations === undefined) {
+              parseResult.entity.metadata.annotations = {
+                [ANNOTATION_LOCATION]: locKey,
+                [ANNOTATION_ORIGIN_LOCATION]: locKey,
+              };
+            } else {
+              parseResult.entity.metadata.annotations[ANNOTATION_LOCATION] =
+                locKey;
+              parseResult.entity.metadata.annotations[
+                ANNOTATION_ORIGIN_LOCATION
+              ] = locKey;
+            }
+          }
+          parseResults.push(parseResult);
+          emit(parseResult);
+        }
+      }
+      emit(processingResult.refresh(`${location.type}:${location.target}`));
+    } catch (error) {
+      const message = `Unable to read ${location.type}, ${error}`.substring(
+        0,
+        5000,
+      );
+      // TODO when we enable cache this is how UrlReaderPRocessor.ts in core backstage handles errors
+      // if (error.name === 'NotModifiedError' && cacheItem) {
+      //   for (const parseResult of cacheItem.value) {
+      //     emit(parseResult);
+      //   }
+      //   emit(processingResult.refresh(`${location.type}:${location.target}`));
+      //   await cache.set(CACHE_KEY, cacheItem);
+      // } else if (error.name === 'NotFoundError') {
+      //   if (!optional) {
+      //     emit(processingResult.notFoundError(location, message));
+      //   }
+      // } else {
+      //   emit(processingResult.generalError(location, message));
+      // }
+      emit(processingResult.generalError(location, message));
+    }
+
+    return true;
+  }
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/index.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/index.ts
@@ -13,18 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+export { RHDHRHOAIReaderProcessor } from './RHDHRHOAIReaderProcessor';

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {
+  LoggerService,
+  SchedulerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+} from '@backstage/catalog-model';
+
+import { fetchCatalogEntities } from '../clients/BridgeResourceConnector';
+import { ModelCatalogConfig } from './types';
+import { readModelCatalogApiEntityConfigs } from './config';
+import type { Config } from '@backstage/config';
+import { InputError, isError } from '@backstage/errors';
+/**
+ * Provides entities from the model catalog service, allowing models and model servers to be imported into RHDH
+ *
+ * @public
+ */
+export class ModelCatalogResourceEntityProvider implements EntityProvider {
+  private readonly env: string;
+  private readonly baseUrl: string;
+  private readonly logger: LoggerService;
+  private readonly scheduleFn: () => Promise<void>;
+  private connection?: EntityProviderConnection;
+
+  /**
+   * Fetches the configuration values specified for the entity provider in the app-config.yaml
+   * @public
+   */
+  static fromConfig(
+    deps: {
+      config: Config;
+      logger: LoggerService;
+    },
+    options:
+      | { schedule: SchedulerServiceTaskRunner }
+      | { scheduler: SchedulerService },
+  ): ModelCatalogResourceEntityProvider[] {
+    const { config, logger } = deps;
+
+    const providerConfigs = readModelCatalogApiEntityConfigs(config);
+
+    return providerConfigs.map(providerConfig => {
+      let taskRunner;
+      if ('scheduler' in options && providerConfig.schedule) {
+        taskRunner = options.scheduler.createScheduledTaskRunner(
+          providerConfig.schedule,
+        );
+      } else if ('schedule' in options) {
+        taskRunner = options.schedule;
+      } else {
+        throw new InputError(
+          `No schedule provided via config for ModelCatalogResourceEntityProvider:${providerConfig.id}.`,
+        );
+      }
+
+      return new ModelCatalogResourceEntityProvider(
+        providerConfig,
+        logger,
+        taskRunner,
+      );
+    });
+  }
+  /** [1]: Set configuration values passed into the entity provider. Fields are defined in types.ts */
+  private constructor(
+    config: ModelCatalogConfig,
+    logger: LoggerService,
+    taskRunner: SchedulerServiceTaskRunner,
+  ) {
+    this.env = config.id;
+    this.baseUrl = config.baseUrl;
+    this.logger = logger.child({
+      target: this.getProviderName(),
+    });
+    this.scheduleFn = this.createScheduleFn(taskRunner);
+  }
+
+  /** Configure the schedule function and its logger */
+  createScheduleFn(
+    taskRunner: SchedulerServiceTaskRunner,
+  ): () => Promise<void> {
+    return async () => {
+      const taskId = `${this.getProviderName()}:run`;
+      return taskRunner.run({
+        id: taskId,
+        fn: async () => {
+          try {
+            await this.run();
+          } catch (error) {
+            if (isError(error)) {
+              // Ensure that we don't log any sensitive internal data:
+              this.logger.error(
+                `Error while syncing resources from Model Catalog ${this.baseUrl}`,
+                {
+                  // Default Error properties:
+                  name: error.name,
+                  message: error.message,
+                  stack: error.stack,
+                  // Additional status code if available:
+                  status: (error.response as { status?: string })?.status,
+                },
+              );
+            }
+          }
+        },
+      });
+    };
+  }
+
+  /** [2]: Model Catalog entity provider must have a unique name */
+  getProviderName(): string {
+    return `ModelCatalogResourceEntityProvider:${this.env}`;
+  }
+
+  /** [3]: Connect Backstage catalog engine to ModelCatalogEntityProvider */
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+    await this.scheduleFn();
+  }
+
+  /** [4]: Define the function that the entity provider will execute on a set schedule */
+  async run(): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+    this.logger.info(
+      `Discovering ResourceEntities from Model Server ${this.baseUrl}`,
+    );
+
+    /** [5]: Convert the fetched model and model server data into RHDH catalog entities */
+    const entityList = await fetchCatalogEntities(this.baseUrl);
+    entityList.forEach(entity => {
+      if (entity.metadata.annotations === undefined) {
+        entity.metadata.annotations = {
+          [ANNOTATION_LOCATION]: this.getProviderName(),
+          [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
+        };
+      } else {
+        entity.metadata.annotations[ANNOTATION_LOCATION] =
+          this.getProviderName();
+        entity.metadata.annotations[ANNOTATION_ORIGIN_LOCATION] =
+          this.getProviderName();
+      }
+    });
+
+    // ATTEMPT ONE
+    // create a location with the URL set to this.baseUrl and the type of 'rhdh-rhoai-bridge'
+    // to correspond to the location annotations of the entities created; this may help reconciling with the bridge later on pushing updates via
+    // the catalog rest API.
+    // const thisLocation: LocationEntity = {
+    //   apiVersion: 'backstage.io/v1beta1',
+    //   kind: 'Location',
+    //   metadata: {
+    //     name: `ModelCatalogResourceEntityProvider_${this.env}`,
+    //     annotations: {
+    //       [ANNOTATION_LOCATION]: this.getProviderName(),
+    //       [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
+    //     },
+    //   },
+    //   spec: {
+    //     type: 'rhdh-rhoai-bridge',
+    //     target: this.baseUrl,
+    //   },
+    // };
+    // entityList.push(thisLocation);
+
+    // ATTEMPT TWO at creating a location
+    // const entities = this.getLocationEntity(this.baseUrl)
+    // await this.connection.applyMutation({
+    //   type: 'full',
+    //   entities,
+    // });
+
+    /* const modelServerName: string = this.convertModeServerName(this.name);
+    let entities: Entity[] = [];
+    const modelServerEntity: ComponentEntity =
+      this.buildComponentEntityFromModelEndpoint(modelServerName);
+    const modelResourceEntities: ResourceEntity[] =
+      this.buildResourceEntityFromModelEndpoint(modelList, modelServerName);
+    entities = entities.concat(modelServerEntity, modelResourceEntities);
+
+    /** [6]: Add/update the catalog entities that correspond to the models */
+    await this.connection.applyMutation({
+      type: 'full',
+      entities: entityList.map(entity => ({
+        entity,
+        locationKey: this.getProviderName(),
+      })),
+    });
+  }
+
+  /* private getEntityLocationRef(entity: LocationEntityV1alpha1): string {
+    const ref = entity.metadata.annotations?.[ANNOTATION_LOCATION];
+    if (!ref) {
+      throw new InputError(
+        `Entity '${entity.metadata.name}' does not have the annotation ${ANNOTATION_LOCATION}`,
+      );
+    }
+    return ref;
+  }
+
+  private getLocationEntity(
+    urlStr: string,
+  ): { entity: LocationEntityV1alpha1; locationKey: string }[] {
+    const entity = locationSpecToLocationEntity({
+      location: {
+        type: 'rhdh-rhoai-bridge',
+        target: urlStr,
+      },
+    });
+    const locationKey = this.getEntityLocationRef(entity);
+    return [{ entity, locationKey }];
+  }*/
+
+  /* private convertModelNameToEntityName(modelName: string): string {
+    return modelName.replaceAll(/\:/g, '-');
+  }
+
+  private convertModeServerName(modelName: string): string {
+    return modelName.replaceAll(/\s/g, '-').toLowerCase();
+  }
+
+  private buildResourceEntityFromModelEndpoint(
+    models: ModelList,
+    modelServerName: string,
+  ): ResourceEntity[] {
+    const modelResources: ResourceEntity[] = [];
+    models.data.forEach(model => {
+      const modelResourceEntity: ResourceEntity = {
+        kind: 'Resource',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          annotations: {
+            [ANNOTATION_LOCATION]: this.getProviderName(),
+            [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
+          },
+          name: `${this.convertModelNameToEntityName(model.id)}`,
+          description: `STUB description`,
+          links: [
+            {
+              url: `${this.baseUrl}`,
+              title: 'Model API',
+            },
+          ],
+        },
+        spec: {
+          type: `ai-model`,
+          owner: `${this.owner}`,
+          dependencyOf: [`component:${modelServerName}`],
+          ...(this.system && { system: `${this.system}` }),
+        },
+      };
+      modelResources.push(modelResourceEntity);
+    });
+    return modelResources;
+  }
+
+  private buildComponentEntityFromModelEndpoint(
+    modelServerName: string,
+  ): ComponentEntity {
+    const modelServerComponent: ComponentEntity = {
+      kind: 'Component',
+      apiVersion: 'backstage.io/v1alpha1',
+      metadata: {
+        annotations: {
+          [ANNOTATION_LOCATION]: this.getProviderName(),
+          [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
+        },
+        name: `${this.convertModeServerName(modelServerName)}`,
+        description: `${this.name}`,
+        links: [
+          {
+            url: `${this.baseUrl}`,
+            title: 'Model Server API',
+          },
+        ],
+      },
+      spec: {
+        type: `model-server`,
+        lifecycle: 'production',
+        owner: `${this.owner}`,
+        ...(this.system && { system: `${this.system}` }),
+      },
+    };
+
+    return modelServerComponent;
+  }*/
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/RHDHRHOAIEntityProvider.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/RHDHRHOAIEntityProvider.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  DiscoveryService,
+  LoggerService,
+  RootConfigService,
+  SchedulerServiceTaskRunner,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+  LocationEntity,
+} from '@backstage/catalog-model';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+  CatalogProcessorParser,
+  CatalogProcessorEntityResult,
+} from '@backstage/plugin-catalog-node';
+import {
+  CatalogApi,
+  CatalogClient,
+  CatalogRequestOptions,
+} from '@backstage/catalog-client';
+import { isError } from '@backstage/errors';
+import { parseEntityYaml } from '@backstage/plugin-catalog-backend';
+import { ModelCatalogConfig } from './types';
+import { readModelCatalogApiEntityConfigs } from './config';
+/**
+ * Provides entities from the model catalog service, allowing models and model servers to be imported into RHDH
+ */
+export class RHDHRHOAIEntityProvider implements EntityProvider {
+  private readonly catalogClient: CatalogApi;
+  private readonly logger: LoggerService;
+  private readonly scheduleFn: () => Promise<void>;
+  private connection?: EntityProviderConnection;
+  private readonly reader: UrlReaderService;
+  private readonly token: string;
+  private readonly modelCatalogConfigs: ModelCatalogConfig[];
+
+  /** [1]: Set configuration values passed into the entity provider. Fields are defined in types.ts */
+  constructor(
+    discovery: DiscoveryService,
+    config: RootConfigService,
+    logger: LoggerService,
+    taskRunner: SchedulerServiceTaskRunner,
+    reader: UrlReaderService,
+  ) {
+    this.reader = reader;
+    this.catalogClient = new CatalogClient({ discoveryApi: discovery });
+    this.logger = logger.child({
+      target: this.getProviderName(),
+    });
+    this.scheduleFn = this.createScheduleFn(taskRunner);
+    const authConfigs =
+      config.getOptionalConfigArray('backend.auth.externalAccess') ?? [];
+    this.token = '';
+    for (const authConfig of authConfigs) {
+      const type = authConfig.getString('type');
+      const subject = authConfig.getString('options.subject');
+      // TODO make this name something RHDH bridge specific
+      if (type === 'static' && subject === 'admin-curl-access') {
+        this.token = authConfig.getString('options.token');
+        break;
+      }
+    }
+    this.modelCatalogConfigs = readModelCatalogApiEntityConfigs(config);
+  }
+
+  /** Configure the schedule function and its logger */
+  createScheduleFn(
+    taskRunner: SchedulerServiceTaskRunner,
+  ): () => Promise<void> {
+    return async () => {
+      const taskId = `${this.getProviderName()}:run`;
+      return taskRunner.run({
+        id: taskId,
+        fn: async () => {
+          try {
+            await this.run();
+          } catch (error) {
+            if (isError(error)) {
+              // Ensure that we don't log any sensitive internal data:
+              this.logger.error(
+                `Error while syncing resources from RHDH RHOAI bridge}`,
+                {
+                  // Default Error properties:
+                  name: error.name,
+                  message: error.message,
+                  stack: error.stack,
+                  // Additional status code if available:
+                  status: (error.response as { status?: string })?.status,
+                },
+              );
+            }
+          }
+        },
+      });
+    };
+  }
+
+  /** [2]: Model Catalog entity provider must have a unique name */
+  getProviderName(): string {
+    return `RHDHRHOAIEntityProvider`;
+  }
+
+  /** [3]: Connect Backstage catalog engine to ModelCatalogEntityProvider */
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+    await this.scheduleFn();
+  }
+
+  // the defaultEntityDataParser from backstage's catalog-backend module is not exported (though the parseEntityYaml from the same file is)
+  // so we are replicating the small function they have there
+  defaultEntityDataParser: CatalogProcessorParser =
+    async function* defaultEntityDataParser({ data, location }) {
+      for (const e of parseEntityYaml(data, location)) {
+        yield e;
+      }
+    };
+
+  /** [4]: Define the function that the entity provider will execute on a set schedule */
+  async run(): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+    this.logger.info(`Checking RHDH/RHOAI Locations`);
+
+    const filter: Record<string, string> = {
+      kind: 'location',
+    };
+    const options: CatalogRequestOptions = {
+      token: this.token,
+    };
+
+    const { items } = await this.catalogClient.getEntities({ filter }, options);
+    if (items.length === 0) {
+      return;
+    }
+    for (const item of items) {
+      const loc = item as LocationEntity;
+      let startUpLocation = false;
+      if (loc.spec.type === 'rhdh-rhoai-bridge') {
+        for (const config of this.modelCatalogConfigs) {
+          if (config.baseUrl === loc.spec.target) {
+            startUpLocation = true;
+            break;
+          }
+        }
+        if (startUpLocation) {
+          this.logger.info(
+            `RHDHRHOAIEntityProvider skipping ${loc.spec.target} because if is handled by ModelCatalogEntityProvider`,
+          );
+          continue;
+        }
+        try {
+          const locationURL = loc.spec.target as string;
+          const data = await this.reader.readUrl(locationURL);
+          const response = [
+            { url: loc.spec.target, data: await data.buffer() },
+          ];
+          for (const resp of response) {
+            if (resp.url !== undefined) {
+              for await (const parseResult of this.defaultEntityDataParser({
+                data: resp.data,
+                location: { type: loc.spec.type, target: resp.url },
+              })) {
+                const resultEntity =
+                  parseResult as CatalogProcessorEntityResult;
+                const locType = loc.spec.type;
+                const locTarget = loc.spec.target;
+                const locKey = `${locType}:${locTarget}`;
+                if (resultEntity.entity.metadata.annotations === undefined) {
+                  resultEntity.entity.metadata.annotations = {
+                    [ANNOTATION_LOCATION]: locKey,
+                    [ANNOTATION_ORIGIN_LOCATION]: locKey,
+                  };
+                } else {
+                  resultEntity.entity.metadata.annotations[
+                    ANNOTATION_LOCATION
+                  ] = locKey;
+                  resultEntity.entity.metadata.annotations[
+                    ANNOTATION_ORIGIN_LOCATION
+                  ] = locKey;
+                }
+                const deferredEntity = {
+                  entity: resultEntity.entity,
+                  locationKey: locKey,
+                };
+                await this.connection.applyMutation({
+                  type: 'delta',
+                  added: [deferredEntity],
+                  removed: [],
+                });
+              }
+            }
+          }
+        } catch (error) {
+          const deferredEntity = { entity: item };
+          await this.connection.applyMutation({
+            type: 'delta',
+            added: [],
+            removed: [deferredEntity],
+          });
+        }
+      }
+    }
+  }
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/config.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/config.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { readSchedulerServiceTaskScheduleDefinitionFromConfig } from '@backstage/backend-plugin-api';
+import type { Config } from '@backstage/config';
+
+import type { ModelCatalogConfig } from './types';
+
+export function readModelCatalogApiEntityConfigs(
+  config: Config,
+): ModelCatalogConfig[] {
+  const providerConfigs = config.getOptionalConfig(
+    'catalog.providers.modelCatalog',
+  );
+  if (!providerConfigs) {
+    return [];
+  }
+  return providerConfigs
+    .keys()
+    .map(id =>
+      readModelCatalogApiEntityConfig(id, providerConfigs.getConfig(id)),
+    );
+}
+
+function readModelCatalogApiEntityConfig(
+  id: string,
+  config: Config,
+): ModelCatalogConfig {
+  const baseUrl = config.getString('baseUrl');
+
+  const schedule = config.has('schedule')
+    ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
+        config.getConfig('schedule'),
+      )
+    : undefined;
+
+  return {
+    id,
+    baseUrl,
+    schedule,
+  };
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/index.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/index.ts
@@ -13,18 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+export { ModelCatalogResourceEntityProvider } from './ModelCatalogResourceEntityProvider';

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/types.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/types.ts
@@ -13,18 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-plugin-api';
 
-/**
- * The model-catalog backend module for the catalog plugin.
- *
- * @packageDocumentation
- */
-
-// export * from './clients';
-export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
-export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
-export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
-export { catalogModuleRHDHRHOAIEntityProvider } from './module';
-export * from './providers';
-export * from './processors';
-export * from './clients';
+export type ModelCatalogConfig = {
+  id: string;
+  baseUrl: string;
+  schedule?: SchedulerServiceTaskScheduleDefinition;
+};

--- a/workspaces/ai-integrations/yarn.lock
+++ b/workspaces/ai-integrations/yarn.lock
@@ -3055,7 +3055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.7.3":
+"@backstage/catalog-model@npm:^1.7.2, @backstage/catalog-model@npm:^1.7.3":
   version: 1.7.3
   resolution: "@backstage/catalog-model@npm:1.7.3"
   dependencies:
@@ -4098,7 +4098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:^1.32.0":
+"@backstage/plugin-catalog-backend@npm:^1.30.0, @backstage/plugin-catalog-backend@npm:^1.32.0":
   version: 1.32.0
   resolution: "@backstage/plugin-catalog-backend@npm:1.32.0"
   dependencies:
@@ -4222,7 +4222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.16.1":
+"@backstage/plugin-catalog-node@npm:^1.15.1, @backstage/plugin-catalog-node@npm:^1.16.1":
   version: 1.16.1
   resolution: "@backstage/plugin-catalog-node@npm:1.16.1"
   dependencies:
@@ -10377,11 +10377,27 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog@workspace:plugins/catalog-backend-module-model-catalog"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.2.1
+    "@backstage/backend-plugin-api": ^1.1.1
     "@backstage/backend-test-utils": ^1.3.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.2
     "@backstage/cli": ^0.31.0
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-catalog-backend": ^1.30.0
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@redhat-ai-dev/model-catalog-types": ^1.0.1
+    stream: ^0.0.3
+    yaml: ^2.7.0
   languageName: unknown
   linkType: soft
+
+"@redhat-ai-dev/model-catalog-types@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@redhat-ai-dev/model-catalog-types@npm:1.0.1"
+  checksum: 6b85d92c85f34d675168ad1bebf1b48f015c5fe59f235f06a0d8e7271f5415e25e40cbe1d5eecf03ada85be8214f09353f1987a316f97b9d681e4ef6d32102de
+  languageName: node
+  linkType: hard
 
 "@redis/bloom@npm:1.2.0":
   version: 1.2.0
@@ -16843,6 +16859,13 @@ __metadata:
   version: 4.1.4
   resolution: "compare-versions@npm:4.1.4"
   checksum: c1617544b79c2f36a1d543c50efd0da1a994040294c8923218080bc0df46da83ca414e3378282e93cab073744995124946417d130d8987e8efb5d1a73c0c4ba6
+  languageName: node
+  linkType: hard
+
+"component-emitter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "component-emitter@npm:2.0.0"
+  checksum: 017715272fcf82203932237260451df4c7c27e32a51a4a291faf6f503d6ef9e8583add993850cb5b98cc0c1b0846ff0c68938ad3ef1d544f9b480a290e74fb4f
   languageName: node
   linkType: hard
 
@@ -31454,6 +31477,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "stream@npm:0.0.3"
+  dependencies:
+    component-emitter: ^2.0.0
+  checksum: d59f108098c6bb40cec13dc0d4a9c435498b1f451d0f825e0e7145e83c8579bcf45f1bde0f621b89c925546bfff85ce09d591279e937bb87b1d0a88594fbe7dd
+  languageName: node
+  linkType: hard
+
 "streamroller@npm:^3.1.5":
   version: 3.1.5
   resolution: "streamroller@npm:3.1.5"
@@ -34494,7 +34526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.2.1, yaml@npm:^2.2.2":
+"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.2.1, yaml@npm:^2.2.2, yaml@npm:^2.7.0":
   version: 2.7.0
   resolution: "yaml@npm:2.7.0"
   bin:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Initial code drop of the model catalog plugin originally under development in the [redhat-ai-dev/rhdh-plugins fork](https://github.com/redhat-ai-dev/rhdh-plugins/tree/main/workspaces/rhdh-ai). 

It's largely a straightforward copy/paste, with a couple (small) test additions and handling renames from rhdh-ai -> ai-integration.

Verified by configuring a [model-catalog-bridge](https://github.com/redhat-ai-dev/model-catalog-bridge/) instance on my laptop, and setting the environment variables in [README.md of the workspace](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/ai-integrations/README.md), then running:

1) `yarn install`
2) `yarn dev`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
