### PR TITLE
feat(global-fab): add test components without errorboundaries

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/six-camels-bow.md
+++ b/workspaces/global-floating-action-button/.changeset/six-camels-bow.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-application-listener-test': patch
+---
+
+Add CrashListenerWithoutErrorBoundary

--- a/workspaces/global-floating-action-button/.changeset/wet-mayflies-pull.md
+++ b/workspaces/global-floating-action-button/.changeset/wet-mayflies-pull.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-application-provider-test': patch
+---
+
+Add CrashProviderWithoutErrorBoundary

--- a/workspaces/global-floating-action-button/plugins/application-listener-test/report.api.md
+++ b/workspaces/global-floating-action-button/plugins/application-listener-test/report.api.md
@@ -12,6 +12,12 @@ export const applicationListenerTestPlugin: BackstagePlugin<{}, {}, {}>;
 export const CrashListener: () => never;
 
 // @public (undocumented)
+export const CrashListenerWithoutErrorBoundary: {
+  (): never;
+  displayName: string;
+};
+
+// @public (undocumented)
 export const LocationListener: () => null;
 
 // (No @packageDocumentation comment for this package)

--- a/workspaces/global-floating-action-button/plugins/application-listener-test/src/index.ts
+++ b/workspaces/global-floating-action-button/plugins/application-listener-test/src/index.ts
@@ -14,3 +14,15 @@
  * limitations under the License.
  */
 export * from './plugin';
+
+/**
+ * @public
+ */
+export const CrashListenerWithoutErrorBoundary = () => {
+  throw new Error(
+    'CrashListenerWithoutErrorBoundary failed to render (intentional crash)',
+  );
+};
+
+CrashListenerWithoutErrorBoundary.displayName =
+  'CrashListenerWithoutErrorBoundary';

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/report.api.md
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/report.api.md
@@ -29,6 +29,12 @@ export const CountProvider: ({
 export const CrashProvider: () => never;
 
 // @public (undocumented)
+export const CrashProviderWithoutErrorBoundary: {
+  (): never;
+  displayName: string;
+};
+
+// @public (undocumented)
 export const TestCardOne: () => JSX_2.Element;
 
 // @public (undocumented)

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/src/index.ts
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/src/index.ts
@@ -22,3 +22,15 @@ ClassNameGenerator.configure(componentName => {
 });
 
 export * from './plugin';
+
+/**
+ * @public
+ */
+export const CrashProviderWithoutErrorBoundary = () => {
+  throw new Error(
+    'CrashProviderWithoutErrorBoundary failed to render (intentional crash)',
+  );
+};
+
+CrashProviderWithoutErrorBoundary.displayName =
+  'CrashProviderWithoutErrorBoundary';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Manually installed both plugins into rhdh:

```
cd rhdh-plugins/workspaces/global-floating-action-button/plugins/application-listener-test

npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root ~/git/redhat-developer/rhdh/dynamic-plugins-root --dev --clean

cd rhdh-plugins/workspaces/global-floating-action-button/plugins/application-provider-test

npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root ~/git/redhat-developer/rhdh/dynamic-plugins-root --dev --clean
```

Configured rhdh like this:

```yaml

dynamicPlugins:
  frontend:

    red-hat-developer-hub.backstage-plugin-application-provider-test:
      dynamicRoutes:
        - path: /application-provider-test-page
          importName: TestPage
      mountPoints:
        - mountPoint: application/provider
          importName: CrashProvider
        - mountPoint: application/provider
          importName: TestProviderOne
        - mountPoint: application/provider
          importName: TestProviderTwo

    red-hat-developer-hub.backstage-plugin-application-listener-test:
      dynamicRoutes:
        - path: /application-provider-test-page
          importName: TestPage
      mountPoints:
        - mountPoint: application/listener
          importName: CrashListener
        - mountPoint: application/listener
          importName: LocationListener
```

![image](https://github.com/user-attachments/assets/c02bf23e-7db8-4d12-92fc-61dc7f4cf6a4)

With https://github.com/redhat-developer/rhdh/pull/2327 and configured components that doesn't have error boundaries:

```yaml

dynamicPlugins:
  frontend:

    red-hat-developer-hub.backstage-plugin-application-provider-test:
      dynamicRoutes:
        - path: /application-provider-test-page
          importName: TestPage
      mountPoints:
        - mountPoint: application/provider
          importName: CrashProviderWithoutErrorBoundary
        - mountPoint: application/provider
          importName: TestProviderOne
        - mountPoint: application/provider
          importName: TestProviderTwo

    red-hat-developer-hub.backstage-plugin-application-listener-test:
      dynamicRoutes:
        - path: /application-provider-test-page
          importName: TestPage
      mountPoints:
        - mountPoint: application/listener
          importName: CrashListenerWithoutErrorBoundary
        - mountPoint: application/listener
          importName: LocationListener
```

![image](https://github.com/user-attachments/assets/a7ca469b-2d4a-4806-a764-3cb7ac7213e1)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
