### PR TITLE
feat(marketplace): add tech preview notice to header

### DIFF
--- a/workspaces/marketplace/.changeset/six-nails-drop.md
+++ b/workspaces/marketplace/.changeset/six-nails-drop.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': minor
+---
+
+Add a Tech preview banner to the UI

--- a/workspaces/marketplace/plugins/marketplace/src/components/TechPreviewNotice.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/TechPreviewNotice.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from 'react';
+
+import { Header } from '@backstage/core-components';
+
+import Box from '@mui/material/Box';
+import Popover from '@mui/material/Popover';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+import InfoIcon from '@mui/icons-material/Info';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+/**
+ * A clickable chip that shows a popover with a tech preview notice.
+ */
+export const TechPreviewChip = () => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null,
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'marketplace-tech-preview-popover' : undefined;
+
+  return (
+    <div>
+      <Button
+        aria-describedby={id}
+        variant="contained"
+        onClick={handleClick}
+        startIcon={<InfoIcon />}
+        color="error"
+        sx={{ borderRadius: 99 }}
+      >
+        Tech preview
+      </Button>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Box sx={{ maxWidth: 400 }}>
+          <Typography sx={{ px: 2, pt: 2 }}>
+            This feature is still in a Preview pre-release stage. You might find
+            bugs or issues with availability, stability, data, or performance.
+          </Typography>
+          <Button
+            variant="text"
+            onClick={handleClose}
+            sx={{ m: 1 }}
+            endIcon={<OpenInNewIcon />}
+            component="a"
+            href="https://access.redhat.com/support/offerings/techpreview"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Learn more about Tech Preview (opens in new tab)"
+          >
+            Learn more
+          </Button>
+        </Box>
+      </Popover>
+    </div>
+  );
+};
+
+/**
+ * A Backstage header with a tech preview notice.
+ */
+export const TechPreviewHeader = (
+  props: React.ComponentProps<typeof Header>,
+) => (
+  <Header
+    {...props}
+    pageTitleOverride={props.pageTitleOverride ?? String(props.title)}
+    title={
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box>{props.title}</Box> <TechPreviewChip />
+      </Box>
+    }
+  />
+);

--- a/workspaces/marketplace/plugins/marketplace/src/pages/DynamicMarketplacePluginRouter.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/DynamicMarketplacePluginRouter.tsx
@@ -17,12 +17,7 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import {
-  Page,
-  Header,
-  TabbedLayout,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, TabbedLayout, ErrorBoundary } from '@backstage/core-components';
 
 import { useScalprum } from '@scalprum/react-core';
 
@@ -42,6 +37,8 @@ import { MarketplacePluginInstallPage } from './MarketplacePluginInstallPage';
 // import { MarketplacePackagesTable } from '../components/MarketplacePackagesTable';
 import { MarketplacePackageDrawer } from '../components/MarketplacePackageDrawer';
 import { MarketplacePackageInstallPage } from './MarketplacePackageInstallPage';
+
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 export interface PluginTab {
   Component: React.ComponentType;
@@ -79,7 +76,7 @@ const Tabs = () => {
   return (
     <>
       <Page themeId={themeId}>
-        <Header title="Extensions" />
+        <TechPreviewHeader title="Extensions" />
         <TabbedLayout>
           {/* <TabbedLayout.Route path="/catalog" title="Marketplace">
             <ErrorBoundary>
@@ -99,7 +96,7 @@ const Tabs = () => {
             </TabbedLayout.Route>
           ))}
 
-          {/*       
+          {/*
           <TabbedLayout.Route path="/collections" title="Collections">
             <ErrorBoundary>
               <MarketplaceCollectionsGrid />

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceCollectionPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceCollectionPage.tsx
@@ -16,18 +16,14 @@
 
 import React from 'react';
 import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { collectionRouteRef, collectionsRouteRef } from '../routes';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { useCollection } from '../hooks/useCollection';
 import { MarketplaceCollectionGridLoader } from '../components/MarketplaceCollectionGrid';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 const CollectionHeader = () => {
   const params = useRouteRefParams(collectionRouteRef);
@@ -37,7 +33,11 @@ const CollectionHeader = () => {
   const collectionsLink = useRouteRef(collectionsRouteRef)();
 
   return (
-    <Header title={displayName} type="Collections" typeLink={collectionsLink} />
+    <TechPreviewHeader
+      title={displayName}
+      type="Collections"
+      typeLink={collectionsLink}
+    />
   );
 };
 

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceCollectionsPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceCollectionsPage.tsx
@@ -15,22 +15,18 @@
  */
 
 import React from 'react';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { MarketplaceCollectionsGrid } from '../components/MarketplaceCollectionsGrid';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 export const MarketplaceCollectionsPage = () => {
   return (
     <ReactQueryProvider>
       <Page themeId={themeId}>
-        <Header title="Collections" />
+        <TechPreviewHeader title="Collections" />
         <Content>
           <ErrorBoundary>
             <MarketplaceCollectionsGrid />

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceHomePage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceHomePage.tsx
@@ -16,22 +16,18 @@
 
 import React from 'react';
 
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { MarketplaceCatalogContent } from '../components/MarketplaceCatalogContent';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 export const MarketplaceHomePage = () => {
   return (
     <ReactQueryProvider>
       <Page themeId={themeId}>
-        <Header title="Marketplace" />
+        <TechPreviewHeader title="Marketplace" />
         <Content>
           <ErrorBoundary>
             <MarketplaceCatalogContent />

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePackageInstallPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePackageInstallPage.tsx
@@ -16,18 +16,14 @@
 
 import React from 'react';
 import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { packageInstallRouteRef, packageRouteRef } from '../routes';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { usePackage } from '../hooks/usePackage';
 import { MarketplacePackageInstallContentLoader } from '../components/MarketplacePackageInstallContent';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 const PackageInstallHeader = () => {
   const params = useRouteRefParams(packageInstallRouteRef);
@@ -41,7 +37,9 @@ const PackageInstallHeader = () => {
     name: params.name,
   });
 
-  return <Header title={title} type="Package" typeLink={packageLink} />;
+  return (
+    <TechPreviewHeader title={title} type="Package" typeLink={packageLink} />
+  );
 };
 
 export const MarketplacePackageInstallPage = () => (

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePackagePage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePackagePage.tsx
@@ -16,18 +16,14 @@
 
 import React from 'react';
 import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { packageRouteRef, packagesRouteRef } from '../routes';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { usePackage } from '../hooks/usePackage';
 import { MarketplacePackageContentLoader } from '../components/MarketplacePackageContent';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 const PackageHeader = () => {
   const params = useRouteRefParams(packageRouteRef);
@@ -36,7 +32,13 @@ const PackageHeader = () => {
   const displayName = pkg.data?.metadata.title ?? params.name;
   const packagesLink = useRouteRef(packagesRouteRef)();
 
-  return <Header title={displayName} type="Packages" typeLink={packagesLink} />;
+  return (
+    <TechPreviewHeader
+      title={displayName}
+      type="Packages"
+      typeLink={packagesLink}
+    />
+  );
 };
 
 export const MarketplacePackagePage = () => (

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePackagesPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePackagesPage.tsx
@@ -15,22 +15,18 @@
  */
 
 import React from 'react';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { MarketplacePackagesTable } from '../components/MarketplacePackagesTable';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 export const MarketplacePackagesPage = () => {
   return (
     <ReactQueryProvider>
       <Page themeId={themeId}>
-        <Header title="Packages" />
+        <TechPreviewHeader title="Packages" />
         <Content>
           <ErrorBoundary>
             <MarketplacePackagesTable />

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginInstallPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginInstallPage.tsx
@@ -16,18 +16,14 @@
 
 import React from 'react';
 import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { pluginInstallRouteRef, pluginRouteRef } from '../routes';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { usePlugin } from '../hooks/usePlugin';
 import { MarketplacePluginInstallContentLoader } from '../components/MarketplacePluginInstallContent';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 const PluginInstallHeader = () => {
   const params = useRouteRefParams(pluginInstallRouteRef);
@@ -40,7 +36,9 @@ const PluginInstallHeader = () => {
     name: params.name,
   });
 
-  return <Header title={title} type="Plugin" typeLink={pluginLink} />;
+  return (
+    <TechPreviewHeader title={title} type="Plugin" typeLink={pluginLink} />
+  );
 };
 
 export const MarketplacePluginInstallPage = () => (

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginPage.tsx
@@ -16,18 +16,14 @@
 
 import React from 'react';
 import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { pluginRouteRef, pluginsRouteRef } from '../routes';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { MarketplacePluginContentLoader } from '../components/MarketplacePluginContent';
 import { usePlugin } from '../hooks/usePlugin';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 const PluginHeader = () => {
   const params = useRouteRefParams(pluginRouteRef);
@@ -36,7 +32,13 @@ const PluginHeader = () => {
   const displayName = plugin.data?.metadata.title ?? params.name;
   const pluginsLink = useRouteRef(pluginsRouteRef)();
 
-  return <Header title={displayName} type="Plugins" typeLink={pluginsLink} />;
+  return (
+    <TechPreviewHeader
+      title={displayName}
+      type="Plugins"
+      typeLink={pluginsLink}
+    />
+  );
 };
 
 export const MarketplacePluginPage = () => (

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginsPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginsPage.tsx
@@ -15,22 +15,18 @@
  */
 
 import React from 'react';
-import {
-  Page,
-  Header,
-  Content,
-  ErrorBoundary,
-} from '@backstage/core-components';
+import { Page, Content, ErrorBoundary } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { MarketplacePluginsTable } from '../components/MarketplacePluginsTable';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 export const MarketplacePluginsPage = () => {
   return (
     <ReactQueryProvider>
       <Page themeId={themeId}>
-        <Header title="Plugins" />
+        <TechPreviewHeader title="Plugins" />
         <Content>
           <ErrorBoundary>
             <MarketplacePluginsTable />

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceTabbedPageRouter.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplaceTabbedPageRouter.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import { Page, Header, TabbedLayout } from '@backstage/core-components';
+import { Page, TabbedLayout } from '@backstage/core-components';
 
 import { themeId } from '../consts';
 
@@ -38,6 +38,7 @@ import { MarketplacePackageDrawer } from '../components/MarketplacePackageDrawer
 import { useCollections } from '../hooks/useCollections';
 
 import { MarketplacePackageInstallPage } from './MarketplacePackageInstallPage';
+import { TechPreviewHeader } from '../components/TechPreviewNotice';
 
 const Tabs = () => {
   const showCollections = !!useCollections({}).data?.items?.length;
@@ -45,7 +46,7 @@ const Tabs = () => {
   return (
     <>
       <Page themeId={themeId}>
-        <Header title="Marketplace" />
+        <TechPreviewHeader title="Marketplace" />
         <TabbedLayout>
           <TabbedLayout.Route path="/catalog" title="Catalog">
             <MarketplaceCatalogContent />


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/RHIDP-6084

## Hey, I just made a Pull Request!

Adds a "Tech preview" banner to each page in the marketplace UI

after:

![](https://i.imgur.com/GuYY4Pr.png)

deviated from the mockup a bit because:

a) it better matches with OCP console

![image](https://github.com/user-attachments/assets/580b584c-02b2-4edb-b823-c63528250ad3)

b) a banner component doesn't exist in MUI

c) having a div above the `Page` component introduces some issues with the container scrolling

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
