### PR TITLE
feat(marketplace): removing view plugins button

### DIFF
--- a/workspaces/marketplace/.changeset/chilly-pumas-heal.md
+++ b/workspaces/marketplace/.changeset/chilly-pumas-heal.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+removing `View plugins` button from no plugins found page

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
@@ -52,16 +52,6 @@ const NoPluginsFound = () => (
           <Grid container spacing={2}>
             <Grid item>
               <LinkButton
-                variant="contained"
-                color="primary"
-                to="https://developers.redhat.com/rhdh/plugins#redhatnotpreinstalled"
-                externalLinkIcon
-              >
-                View plugins
-              </LinkButton>
-            </Grid>
-            <Grid item>
-              <LinkButton
                 variant="outlined"
                 color="primary"
                 to="https://docs.redhat.com/en/documentation/red_hat_developer_hub/"


### PR DESCRIPTION
**Resolve** : https://issues.redhat.com/browse/RHIDP-6309

**Description** :  Remove View Plugins button from No Plugins / Empty Catalog Page

Before Change 
![Screenshot 2025-04-02 at 8 17 24 PM (2)](https://github.com/user-attachments/assets/511dc9ec-e1a3-45d7-a8f0-d99d76c202ea)
 
 After Changes 
 
 
<img width="1710" alt="Screenshot 2025-04-03 at 7 17 30 PM" src="https://github.com/user-attachments/assets/ff54bc35-2f91-49f2-b053-9ff6b58f8331" />
