### PR TITLE
fix(global-header): remove search bar underline

### DIFF
--- a/workspaces/global-header/.changeset/tiny-phones-jam.md
+++ b/workspaces/global-header/.changeset/tiny-phones-jam.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+remove search bar underline

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
@@ -81,7 +81,6 @@ export const SearchBar = (props: SearchBarProps) => {
                 sx: {
                   borderRadius: '4px',
                   outline: 'unset',
-                  border: `1px solid ${theme.palette.divider}`,
                   boxShadow:
                     theme.palette.mode === 'dark'
                       ? `0 2px 6px 2px rgba(0, 0, 0, 0.50), 0 1px 2px 0 rgba(0, 0, 0, 0.50)`


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves : https://issues.redhat.com/browse/RHIDP-6531

Removed the solid white underline from the Search Bar

GIF:

https://github.com/user-attachments/assets/760c37a4-af3b-4ba3-9d4a-0bdeb44ecf8b




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
