### PR TITLE
RHDHPAI-611: Convert the model catalog plugin to receive catalog JSON objects

### DIFF
--- a/workspaces/ai-integrations/.changeset/brown-peaches-try.md
+++ b/workspaces/ai-integrations/.changeset/brown-peaches-try.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog': minor
+---
+
+Switch model catalog entity provider and custom processor to use JSON object provided by the bridge

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/package.json
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/package.json
@@ -42,6 +42,7 @@
     "@backstage/plugin-catalog-common": "^1.1.3",
     "@backstage/plugin-catalog-node": "^1.15.1",
     "@redhat-ai-dev/model-catalog-types": "^1.0.1",
+    "js-yaml": "^4.1.0",
     "stream": "^0.0.3",
     "yaml": "^2.7.0"
   },

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/report.api.md
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/report.api.md
@@ -6,7 +6,6 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
-import { CatalogProcessorParser } from '@backstage/plugin-catalog-node';
 import type { Config } from '@backstage/config';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
@@ -79,7 +78,6 @@ export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
     location: LocationSpec,
     _optional: boolean,
     emit: CatalogProcessorEmit,
-    _: CatalogProcessorParser,
   ): Promise<boolean>;
 }
 ```

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/report.api.md
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/report.api.md
@@ -8,11 +8,11 @@ import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorParser } from '@backstage/plugin-catalog-node';
 import type { Config } from '@backstage/config';
-import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import type { SchedulerService } from '@backstage/backend-plugin-api';
 import type { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
@@ -32,7 +32,19 @@ export const catalogModuleRHDHRHOAILocationsExtensionPoint: BackendFeature;
 export const catalogModuleRHDHRHOAIReaderProcessor: BackendFeature;
 
 // @public
-export function fetchCatalogEntities(baseUrl: string): Promise<Entity[]>;
+export function fetchModelCatalogFromKey(
+  baseUrl: string,
+  modelCatalogKey: string,
+): Promise<ModelCatalog>;
+
+// @public
+export function fetchModelCatalogKeys(baseUrl: string): Promise<string[]>;
+
+// @public
+export interface ModelCatalogKeys {
+  // (undocumented)
+  uris: string[];
+}
 
 // @public
 export class ModelCatalogResourceEntityProvider implements EntityProvider {
@@ -67,7 +79,7 @@ export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
     location: LocationSpec,
     _optional: boolean,
     emit: CatalogProcessorEmit,
-    parser: CatalogProcessorParser,
+    _: CatalogProcessorParser,
   ): Promise<boolean>;
 }
 ```

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.test.ts
@@ -18,6 +18,7 @@ import { Stream } from 'stream';
 import {
   ModelCatalogKeys,
   fetchModelCatalogFromKey,
+  fetchModelCatalogKeys,
 } from './BridgeResourceConnector';
 
 const fakeCatalogKeys: ModelCatalogKeys = {
@@ -57,7 +58,6 @@ global.fetch = jest.fn(url => {
   });
 }) as jest.Mock;
 
-import { fetchModelCatalogKeys } from './BridgeResourceConnector';
 import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
 
 const httpsMock = require('https');

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.test.ts
@@ -14,58 +14,65 @@
  * limitations under the License.
  */
 
-import YAML from 'yaml';
 import { Stream } from 'stream';
+import {
+  ModelCatalogKeys,
+  fetchModelCatalogFromKey,
+} from './BridgeResourceConnector';
 
-const fakeCatalog: ModelCatalog[] = [
-  {
-    models: [
-      {
-        name: 'ibm-granite',
-        description: 'IBM Granite code model',
-        lifecycle: 'production',
-        owner: 'example-user',
-      },
-    ],
-  },
-];
+const fakeCatalogKeys: ModelCatalogKeys = {
+  uris: ['example-model', 'model-two', 'model-three'],
+};
 
-const blob = new Blob([YAML.stringify(fakeCatalog)], {
-  type: 'application/json',
-});
+const fakeCatalog: ModelCatalog = {
+  models: [
+    {
+      name: 'ibm-granite',
+      description: 'IBM Granite code model',
+      lifecycle: 'production',
+      owner: 'example-user',
+    },
+  ],
+};
 
 // Mock different fetch results based on the url passed in, to trigger success vs. error scenarios
 global.fetch = jest.fn(url => {
-  if (url === 'errorTest') {
+  if (url === 'errorTest/list') {
     return Promise.resolve({
       ok: false,
       status: 401,
       json: () => 'error',
     });
+  } else if (url === 'fake-url/example-model') {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => fakeCatalog,
+    });
   }
   return Promise.resolve({
     ok: true,
     status: 200,
-    blob: () => Promise.resolve(blob),
+    json: () => fakeCatalogKeys,
   });
 }) as jest.Mock;
 
-import { fetchModelCatalogEntries } from './BridgeResourceConnector';
+import { fetchModelCatalogKeys } from './BridgeResourceConnector';
 import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
 
 const httpsMock = require('https');
 
-describe('Bridge Resource Connector', () => {
-  it('should fetch catallog entities successfully', async () => {
+describe('fetchModelCatalogKeys', () => {
+  it('should fetch catalog keys successfully', async () => {
     const streamStream = new Stream();
     httpsMock.get = jest.fn().mockImplementation(cb => {
       cb(streamStream);
       streamStream.emit('data', 'test');
       streamStream.emit('end');
     });
-    const catalogs: ModelCatalog[] = await fetchModelCatalogEntries('fake-url');
-    expect(catalogs.length).toEqual(1);
-    expect(catalogs[0].models[0].name).toEqual('ibm-granite');
+    const catalogKeys: string[] = await fetchModelCatalogKeys('fake-url');
+    expect(catalogKeys.length).toEqual(3);
+    expect(catalogKeys).toEqual(['example-model', 'model-two', 'model-three']);
   });
   it('should error out if error encountered', async () => {
     const streamStream = new Stream();
@@ -75,7 +82,36 @@ describe('Bridge Resource Connector', () => {
       streamStream.emit('end');
     });
     await expect(
-      async () => await fetchModelCatalogEntries('errorTest'),
+      async () => await fetchModelCatalogKeys('errorTest'),
+    ).rejects.toThrow();
+  });
+});
+
+describe('fetchModelCatalogFromKey', () => {
+  it('should fetch catalog successfully', async () => {
+    const streamStream = new Stream();
+    httpsMock.get = jest.fn().mockImplementation(cb => {
+      cb(streamStream);
+      streamStream.emit('data', 'test');
+      streamStream.emit('end');
+    });
+    const catalog: ModelCatalog = await fetchModelCatalogFromKey(
+      'fake-url',
+      '/example-model',
+    );
+    expect(catalog.models === undefined).toBe(false);
+    expect(catalog.models.length).toEqual(1);
+    expect(catalog.models[0].name).toEqual('ibm-granite');
+  });
+  it('should error out if error encountered', async () => {
+    const streamStream = new Stream();
+    httpsMock.get = jest.fn().mockImplementation(cb => {
+      cb(streamStream);
+      streamStream.emit('data', 'test');
+      streamStream.emit('end');
+    });
+    await expect(
+      async () => await fetchModelCatalogKeys('errorTest'),
     ).rejects.toThrow();
   });
 });

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
@@ -31,7 +31,7 @@ export async function fetchModelCatalogKeys(
   baseUrl: string,
 ): Promise<string[]> {
   // ToDo: Discover catalog-info endpoint?
-  const res = await fetch(`${baseUrl}/fake/list`, {
+  const res = await fetch(`${baseUrl}/list`, {
     method: 'GET',
   });
 

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
@@ -31,7 +31,7 @@ export async function fetchModelCatalogKeys(
   baseUrl: string,
 ): Promise<string[]> {
   // ToDo: Discover catalog-info endpoint?
-  const res = await fetch(`${baseUrl}/list`, {
+  const res = await fetch(`${baseUrl}/fake/list`, {
     method: 'GET',
   });
 

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
+import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
 
 import YAML from 'yaml';
 
@@ -40,10 +41,12 @@ export async function listModels(
 }*/
 
 /**
- * fetchCatalogEntities retrieves model catalog entities from the Model Catalog Bridge services
+ * fetchModelCatalogEntries retrieves model catalog entities from the Model Catalog Bridge services
  * @public
  */
-export async function fetchCatalogEntities(baseUrl: string): Promise<Entity[]> {
+export async function fetchModelCatalogEntries(
+  baseUrl: string,
+): Promise<ModelCatalog[]> {
   // ToDo: Discover catalog-info endpoint?
   const res = await fetch(`${baseUrl}`, {
     method: 'GET',
@@ -53,11 +56,6 @@ export async function fetchCatalogEntities(baseUrl: string): Promise<Entity[]> {
     throw new Error(res.statusText);
   }
 
-  // ToDo: Look at seeing if we can use the parser provided by the CatalogProcessorProvider package
-  const data = await res
-    .blob()
-    .then(blob => blob.text())
-    .then(yamlStr => YAML.parseAllDocuments(yamlStr))
-    .then(yamlData => yamlData.map(item => item.toJS()));
-  return data;
+  const modelCatalogs: ModelCatalog[] = JSON.parse(res.json.toString());
+  return modelCatalogs;
 }

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/BridgeResourceConnector.ts
@@ -13,42 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
 import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
 
-import YAML from 'yaml';
-
-// listModels will list the models from an OpenAI compatible endpoint
-/*
-export async function listModels(
-  baseUrl: string,
-  access_token: string,
-): Promise<ModelList> {
-  const res = await fetch(`${baseUrl}/v1/models`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: access_token,
-    },
-    method: 'GET',
-  });
-
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-
-  const data = await res.json();
-  return data;
-}*/
-
 /**
- * fetchModelCatalogEntries retrieves model catalog entities from the Model Catalog Bridge services
+ * ModelCatalogKeys is the object used by the bridge to return the list of keys corresponding to each model catalog entry in the bridge
  * @public
  */
-export async function fetchModelCatalogEntries(
+export interface ModelCatalogKeys {
+  uris: string[];
+}
+
+/**
+ * fetchModelCatalogKeys retrieves the keys for each of the model catalog entries in the model catalog bridge service
+ * @public
+ */
+export async function fetchModelCatalogKeys(
   baseUrl: string,
-): Promise<ModelCatalog[]> {
+): Promise<string[]> {
   // ToDo: Discover catalog-info endpoint?
-  const res = await fetch(`${baseUrl}`, {
+  const res = await fetch(`${baseUrl}/list`, {
     method: 'GET',
   });
 
@@ -56,6 +39,26 @@ export async function fetchModelCatalogEntries(
     throw new Error(res.statusText);
   }
 
-  const modelCatalogs: ModelCatalog[] = JSON.parse(res.json.toString());
-  return modelCatalogs;
+  const modelCatalogKeys: ModelCatalogKeys = await res.json();
+  return modelCatalogKeys.uris;
+}
+
+/**
+ * fetchModelCatalogFromKey fetches a model catalog JSON object from the bridge based on a given key
+ * @public
+ */
+export async function fetchModelCatalogFromKey(
+  baseUrl: string,
+  modelCatalogKey: string,
+): Promise<ModelCatalog> {
+  const res = await fetch(`${baseUrl}${modelCatalogKey}`, {
+    method: 'GET',
+  });
+
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+
+  const modelCatalog: ModelCatalog = await res.json();
+  return modelCatalog;
 }

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
@@ -68,7 +68,7 @@ describe('Model Catalog Generator', () => {
         owner: 'example-user',
         description: 'Developer model service running on vLLM',
         homepageURL: 'https://example.com',
-        tags: ['vLLM', 'granite', 'ibm'],
+        tags: ['vllm', 'granite', 'ibm'],
         API: {
           url: 'https://api.example.com',
           type: Type.Openapi,
@@ -83,7 +83,7 @@ describe('Model Catalog Generator', () => {
           description: 'IBM Granite 20b model running on vLLM',
           artifactLocationURL:
             'https://huggingface.co/ibm-granite/granite-20b-code-instruct',
-          tags: ['IBM', 'granite', 'vllm', '20b'],
+          tags: ['ibm', 'granite', 'vllm', '20b'],
           owner: 'example-user',
           lifecycle: 'production',
         },
@@ -118,7 +118,7 @@ describe('Model Catalog Generator', () => {
         metadata: {
           name: 'ibm-granite-20b',
           description: 'IBM Granite 20b model running on vLLM',
-          tags: ['IBM', 'granite', 'vllm', '20b'],
+          tags: ['ibm', 'granite', 'vllm', '20b'],
           links: [
             {
               url: 'https://huggingface.co/ibm-granite/granite-20b-code-instruct',
@@ -183,7 +183,7 @@ describe('Model Catalog Generator', () => {
       metadata: {
         name: 'developer-model-service',
         description: 'Developer model service running on vLLM',
-        tags: ['vLLM', 'granite', 'ibm'],
+        tags: ['vllm', 'granite', 'ibm'],
         links: [
           {
             url: 'https://api.example.com',

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -29,7 +29,7 @@ import {
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 function isModelCatalog(o: any): o is ModelCatalog {
-  return 'models' in o || 'modelServers' in o;
+  return 'models' in o || 'modelServer' in o;
 }
 
 export function ParseCatalogJSON(jsonStr: string): ModelCatalog {

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -222,7 +222,7 @@ function sanitizeTags(tags: string[], logger?: LoggerService): string[] {
 
     // Call the Backstage tag validator and check if the tag conforms
     // If the tag is not valid, skip it
-    if (!makeValidator().isValidTag(sanitizeTags)) {
+    if (!makeValidator().isValidTag(sanitizedTag)) {
       if (logger !== undefined) {
         logger.error(
           `invalid tag: ${sanitizedTag}. Tags are expected to be less than 63 characters and conform to: ^[a-z0-9:+#]+(\-[a-z0-9:+#]+)*$`,

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -212,7 +212,7 @@ function sanitizeTags(tags: string[]): string[] {
     sanitizedTag = sanitizedTag.replace(/-+/g, '-');
 
     // Remove any dashes that may be at the beginning or end
-    sanitizedTag = sanitizedTag.replace(/^-|-$/g, '');
+    sanitizedTag = sanitizedTag.replace(/(^-)|(-$)/g, '');
 
     // Shorten to 63 characters maximum
     if (sanitizedTag.length > 63) {

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
@@ -17,7 +17,6 @@ import {
   processingResult,
   CatalogProcessor,
   CatalogProcessorEmit,
-  CatalogProcessorParser,
   CatalogProcessorResult,
   CatalogProcessorEntityResult,
 } from '@backstage/plugin-catalog-node';
@@ -76,7 +75,6 @@ export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
     location: LocationSpec,
     _optional: boolean,
     emit: CatalogProcessorEmit,
-    _: CatalogProcessorParser,
   ): Promise<boolean> {
     // Pick a custom location type string. A location will be
     // registered later with this type.

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
@@ -76,7 +76,7 @@ export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
     location: LocationSpec,
     _optional: boolean,
     emit: CatalogProcessorEmit,
-    parser: CatalogProcessorParser,
+    _: CatalogProcessorParser,
   ): Promise<boolean> {
     // Pick a custom location type string. A location will be
     // registered later with this type.

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/processors/RHDHRHOAIReaderProcessor.ts
@@ -19,6 +19,7 @@ import {
   CatalogProcessorEmit,
   CatalogProcessorParser,
   CatalogProcessorResult,
+  CatalogProcessorEntityResult,
 } from '@backstage/plugin-catalog-node';
 import {
   LoggerService,
@@ -33,7 +34,12 @@ import { readModelCatalogApiEntityConfigs } from '../providers/config';
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
+  Entity,
 } from '@backstage/catalog-model';
+import {
+  GenerateCatalogEntities,
+  ParseCatalogJSON,
+} from '../clients/ModelCatalogGenerator';
 
 /**
  * A processor that reads from the RHDH RHOAI Bridge
@@ -105,33 +111,41 @@ export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
       // for potential auth and access control checks (i.e. SARs) with the kubeflow MR
       const data = await this.reader.readUrl(location.target);
       const response = [{ url: location.target, data: await data.buffer() }];
-      // Repeatedly call emit(processingResult.entity(location, <entity>))
       const parseResults: CatalogProcessorResult[] = [];
+      // Repeatedly call emit(processingResult.entity(location, <entity>))
+
       for (const item of response) {
-        for await (const parseResult of parser({
-          data: item.data,
-          location: { type: location.type, target: item.url },
-        })) {
-          if (parseResult.type === 'entity') {
-            const locKey = `${location.type}:${location.target}`;
-            if (parseResult.entity.metadata.annotations === undefined) {
-              parseResult.entity.metadata.annotations = {
-                [ANNOTATION_LOCATION]: locKey,
-                [ANNOTATION_ORIGIN_LOCATION]: locKey,
-              };
-            } else {
-              parseResult.entity.metadata.annotations[ANNOTATION_LOCATION] =
-                locKey;
-              parseResult.entity.metadata.annotations[
-                ANNOTATION_ORIGIN_LOCATION
-              ] = locKey;
-            }
+        const modelCatalog = ParseCatalogJSON(item.data.toString());
+        let entities: Entity[] = [];
+
+        entities = GenerateCatalogEntities(modelCatalog);
+        entities.forEach(entity => {
+          const locKey = `${location.type}:${location.target}`;
+          const parseResult: CatalogProcessorEntityResult = {
+            type: 'entity',
+            entity: entity,
+            location: { type: location.type, target: item.url },
+            locationKey: locKey,
+          };
+
+          // ToDo: We can probably handle this in the generator now
+          if (parseResult.entity.metadata.annotations === undefined) {
+            parseResult.entity.metadata.annotations = {
+              [ANNOTATION_LOCATION]: locKey,
+              [ANNOTATION_ORIGIN_LOCATION]: locKey,
+            };
+          } else {
+            parseResult.entity.metadata.annotations[ANNOTATION_LOCATION] =
+              locKey;
+            parseResult.entity.metadata.annotations[
+              ANNOTATION_ORIGIN_LOCATION
+            ] = locKey;
           }
           parseResults.push(parseResult);
           emit(parseResult);
-        }
+        });
+        emit(processingResult.refresh(`${location.type}:${location.target}`));
       }
-      emit(processingResult.refresh(`${location.type}:${location.target}`));
     } catch (error) {
       const message = `Unable to read ${location.type}, ${error}`.substring(
         0,

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.test.ts
@@ -63,7 +63,7 @@ jest.mock('../clients/BridgeResourceConnector', () => ({
 }));
 
 class SchedulerServiceTaskRunnerMock implements SchedulerServiceTaskRunner {
-  private tasks: SchedulerServiceTaskInvocationDefinition[] = [];
+  private readonly tasks: SchedulerServiceTaskInvocationDefinition[] = [];
   async run(task: SchedulerServiceTaskInvocationDefinition) {
     this.tasks.push(task);
   }

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {
+  SchedulerServiceTaskInvocationDefinition,
+  SchedulerServiceTaskRunner,
+  SchedulerServiceTaskScheduleDefinition,
+} from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
+import type { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+
+import {
+  fetchModelCatalogFromKey,
+  fetchModelCatalogKeys,
+} from '../clients/BridgeResourceConnector';
+import { ModelCatalogResourceEntityProvider } from './ModelCatalogResourceEntityProvider';
+import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
+
+const CONFIG = {
+  catalog: {
+    providers: {
+      modelCatalog: {
+        development: {
+          baseUrl: 'http://localhost:9090',
+        },
+      },
+    },
+  },
+} as const;
+
+const fakeCatalog: ModelCatalog = {
+  models: [
+    {
+      name: 'ibm-granite',
+      description: 'IBM Granite code model',
+      lifecycle: 'production',
+      owner: 'example-user',
+    },
+  ],
+};
+
+const connection = {
+  applyMutation: jest.fn(),
+  refresh: jest.fn(),
+} as unknown as EntityProviderConnection;
+
+jest.mock('../clients/BridgeResourceConnector', () => ({
+  ...jest.requireActual('../clients/BridgeResourceConnector'),
+  fetchModelCatalogKeys: jest.fn().mockReturnValue({}),
+  fetchModelCatalogFromKey: jest.fn().mockReturnValue({}),
+}));
+
+class SchedulerServiceTaskRunnerMock implements SchedulerServiceTaskRunner {
+  private tasks: SchedulerServiceTaskInvocationDefinition[] = [];
+  async run(task: SchedulerServiceTaskInvocationDefinition) {
+    this.tasks.push(task);
+  }
+  async runAll() {
+    const abortSignal = jest.fn() as unknown as AbortSignal;
+    for await (const task of this.tasks) {
+      await task.fn(abortSignal);
+    }
+  }
+}
+
+const scheduler = mockServices.scheduler.mock({
+  createScheduledTaskRunner() {
+    return new SchedulerServiceTaskRunnerMock();
+  },
+});
+
+describe('ModelCatalogResourceEntityProvider', () => {
+  let schedule: SchedulerServiceTaskRunnerMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    schedule = scheduler.createScheduledTaskRunner(
+      '' as unknown as SchedulerServiceTaskScheduleDefinition,
+    ) as SchedulerServiceTaskRunnerMock;
+  });
+
+  it('should connect', async () => {
+    const mcprovider = ModelCatalogResourceEntityProvider.fromConfig(
+      {
+        config: mockServices.rootConfig({ data: CONFIG }),
+        logger: mockServices.logger.mock(),
+      },
+      {
+        schedule,
+      },
+    );
+
+    const result = await Promise.all(
+      mcprovider.map(async k => await k.connect(connection)),
+    );
+    expect(result).toEqual([undefined]);
+  });
+
+  /** ToDo:
+   * Write more detailed tests than just validating that run() triggers mutate x times
+   * 1) Ensure ingested catalog entities match what we expect
+   * 2) Properly mock model catalog bridge API calls as done in the BridgeResourceConnector tests
+   */
+  it('should connect and run should resolve', async () => {
+    (fetchModelCatalogKeys as jest.Mock).mockReturnValue(
+      Promise.resolve(['ibm-granite']),
+    );
+    (fetchModelCatalogFromKey as jest.Mock).mockReturnValue(
+      Promise.resolve(fakeCatalog),
+    );
+
+    const mcprovider = ModelCatalogResourceEntityProvider.fromConfig(
+      {
+        config: mockServices.rootConfig({ data: CONFIG }),
+        logger: mockServices.logger.mock(),
+      },
+      {
+        schedule,
+      },
+    );
+
+    for await (const k of mcprovider) {
+      await k.connect(connection);
+      await schedule.runAll();
+    }
+
+    expect(connection.applyMutation).toHaveBeenCalledTimes(1);
+    expect(
+      (connection.applyMutation as jest.Mock).mock.calls,
+    ).toMatchSnapshot();
+  });
+});

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/__snapshots__/ModelCatalogResourceEntityProvider.test.ts.snap
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/providers/__snapshots__/ModelCatalogResourceEntityProvider.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModelCatalogResourceEntityProvider should connect and run should resolve 1`] = `
+[
+  [
+    {
+      "entities": [
+        {
+          "entity": {
+            "apiVersion": "backstage.io/v1beta1",
+            "kind": "Resource",
+            "metadata": {
+              "annotations": {
+                "backstage.io/managed-by-location": "ModelCatalogResourceEntityProvider:development",
+                "backstage.io/managed-by-origin-location": "ModelCatalogResourceEntityProvider:development",
+              },
+              "description": "IBM Granite code model",
+              "links": [],
+              "name": "ibm-granite",
+              "tags": [],
+            },
+            "spec": {
+              "dependencyOf": [],
+              "owner": "example-user",
+              "type": "ai-model",
+            },
+          },
+          "locationKey": "ModelCatalogResourceEntityProvider:development",
+        },
+      ],
+      "type": "full",
+    },
+  ],
+]
+`;

--- a/workspaces/ai-integrations/yarn.lock
+++ b/workspaces/ai-integrations/yarn.lock
@@ -10699,6 +10699,7 @@ __metadata:
     "@backstage/plugin-catalog-common": ^1.1.3
     "@backstage/plugin-catalog-node": ^1.15.1
     "@redhat-ai-dev/model-catalog-types": ^1.0.1
+    js-yaml: ^4.1.0
     stream: ^0.0.3
     yaml: ^2.7.0
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the entity provider and custom processor to handle model catalog JSON objects rather than the raw entities it used to send. Now, both will receive arrays of `ModelCatalog` from the Model Catalog Bridge, and convert them into their corresponding entities. 

In summary:
- Updates Model Catalog EntityProvider to use the JSON object provided by the bridge
- Updates Model Catalog Custom Processor to use the JSON object provided by the bridge
- Calls the Model Catalog generator functions on the JSON object to convert the JSON objects to Backstage catalog entities
- Updates the generator functions to handle sanitization of `metadata.name` and `metadata.tags[]`
_Very_ basic test for the catalog entity provider

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
