### PR TITLE
fix(adoption-insights): fix subquery alias in total_users endpoint to support older PG versions

### DIFF
--- a/workspaces/adoption-insights/.changeset/evil-rice-itch.md
+++ b/workspaces/adoption-insights/.changeset/evil-rice-itch.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+---
+
+fix subquery alias in total_users endpoint

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/BaseAdapter.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/BaseAdapter.ts
@@ -149,9 +149,9 @@ export abstract class BaseDatabaseAdapter implements EventDatabase {
         db('events')
           .select('user_ref')
           .whereBetween('created_at', [start_date, end_date])
-          .groupBy('user_ref'),
-      )
-      .as('sub');
+          .groupBy('user_ref')
+          .as('sub'),
+      );
 
     return query.then(result => {
       const { licensedUsers } = this.config!;


### PR DESCRIPTION
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
## Fixes:

https://github.com/redhat-developer/rhdh-plugins/issues/607     

## Problem:

 The failing API contains a sub query without an alias (alias was wrongly placed in the query), since sub-query alias was made optional in Postgres 16 onwards so it is not an issue with latest Postgres db versions, but it errors out in Postgres 15 or below. RHDH setup uses 
 
 This PR fixes database query failure for the earlier versions of Postgres. i.e Postgres 15 or below


**Before:**

<img width="933" alt="before" src="https://github.com/user-attachments/assets/7669ee7f-f009-4400-b0f5-15c47ba25861" />

---

**After:**

<img width="1065" alt="after" src="https://github.com/user-attachments/assets/b2ec080b-ea66-4cd4-8bf5-66bf33d20c74" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
