### PR TITLE
fix(ai-experience): links should open pages in the same tab

### DIFF
--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/LearnSection/CardWrapper.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/LearnSection/CardWrapper.tsx
@@ -18,8 +18,10 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { Link } from '@backstage/core-components';
+import { makeStyles, useTheme } from '@material-ui/core';
+import { Theme } from '@mui/material/styles';
 
 interface CardWrapperProps {
   title: string;
@@ -28,12 +30,27 @@ interface CardWrapperProps {
   buttonLink: string;
 }
 
+const getStyles = makeStyles((theme: Theme) => ({
+  link: {
+    textTransform: 'none',
+    minWidth: '200px',
+    padding: theme.spacing(1),
+    display: 'flex',
+    fontSize: '16px',
+    border: `1px solid ${
+      theme.palette.mode === 'light' ? '#0066CC' : '#1FA7F8'
+    }`,
+  },
+}));
+
 const CardWrapper: React.FC<CardWrapperProps> = ({
   title,
   description,
   buttonText,
   buttonLink,
 }) => {
+  const theme = useTheme();
+  const classes = getStyles(theme);
   return (
     <Box>
       <CardContent sx={{ width: '220px', backgroundColor: 'transparent' }}>
@@ -61,24 +78,16 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
           </Typography>
         </Box>
         <Box>
-          <Button
-            variant="outlined"
-            href={buttonLink}
-            sx={{
-              textTransform: 'none',
-              minWidth: '200px',
-              p: 1,
-              justifyContent: 'flex-start',
-              fontSize: '16px',
-              fontWeight: '400',
-              border: theme =>
-                `1px solid ${
-                  theme.palette.mode === 'light' ? '#0066CC' : '#1FA7F8'
-                }`,
-            }}
-          >
-            {buttonText} <ArrowForwardIcon sx={{ pl: 0.5 }} />
-          </Button>
+          <Link to={buttonLink} underline="none" className={classes.link}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              {buttonText} <ArrowForwardIcon sx={{ pl: 0.5 }} />
+            </div>
+          </Link>
         </Box>
       </CardContent>
     </Box>

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/LearnSection/CardWrapper.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/LearnSection/CardWrapper.tsx
@@ -64,7 +64,6 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
           <Button
             variant="outlined"
             href={buttonLink}
-            target="_blank"
             sx={{
               textTransform: 'none',
               minWidth: '200px',

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/Links/ViewMoreLink.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/Links/ViewMoreLink.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Link, LinkProps } from '@backstage/core-components';
+import Typography from '@mui/material/Typography';
+
+interface ViewMoreLinkProps extends LinkProps {
+  to: string;
+  children: string | React.ReactNode;
+}
+
+export const ViewMoreLink: React.FC<ViewMoreLinkProps> = ({ to, children }) => {
+  return (
+    <Link to={to} underline="always">
+      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+        {children}
+      </Typography>
+    </Link>
+  );
+};

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/ModelSection/CardWrapper.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/ModelSection/CardWrapper.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import Link from '@mui/material/Link';
 import TagList from './TagList';
+import { Link } from '@backstage/core-components';
 
 interface CardWrapperProps {
   link: string;
@@ -54,9 +54,9 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
       >
         <Box sx={{ overflow: 'hidden' }}>
           <Link
-            href={link}
+            to={link}
             underline="always"
-            sx={{
+            style={{
               display: '-webkit-box',
               WebkitBoxOrient: 'vertical',
               WebkitLineClamp: 1,

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/ModelSection/ModelSection.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/ModelSection/ModelSection.tsx
@@ -17,7 +17,6 @@ import React from 'react';
 
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
-import Link from '@mui/material/Link';
 import IconButton from '@mui/material/IconButton';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
@@ -28,6 +27,7 @@ import { useTheme } from '@mui/material/styles';
 import CardWrapper from './CardWrapper';
 import HomePageAiModels from '../../images/homepage-ai-models.svg';
 import { useModels } from '../../hooks/useModels';
+import { ViewMoreLink } from '../Links/ViewMoreLink';
 
 export const ModelSection = () => {
   const [isRemoveFirstCard, setIsRemoveFirstCard] = React.useState(false);
@@ -126,11 +126,9 @@ export const ModelSection = () => {
         ))}
       </Grid>
       <Box sx={{ pt: 2 }}>
-        <Link href={catalogModelLink} underline="always">
-          <Typography variant="body2" sx={{ fontWeight: 500 }}>
-            View all {data?.totalItems ? data?.totalItems : ''} models
-          </Typography>
-        </Link>
+        <ViewMoreLink to={catalogModelLink}>
+          View all {data?.totalItems ? data?.totalItems : ''} models
+        </ViewMoreLink>
       </Box>
     </React.Fragment>
   );

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/TemplateSection/CardWrapper.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/TemplateSection/CardWrapper.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
-import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
+import { Link } from '@backstage/core-components';
 
 interface CardWrapperProps {
   link: string;
@@ -63,9 +63,9 @@ const CardWrapper: React.FC<CardWrapperProps> = ({
         </Box>
         <Box sx={{ margin: '8px 0', height: '21px', overflow: 'hidden' }}>
           <Link
-            href={link}
+            to={link}
             underline="always"
-            sx={{
+            style={{
               display: '-webkit-box',
               WebkitBoxOrient: 'vertical',
               WebkitLineClamp: 1,

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/TemplateSection/TemplateSection.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/TemplateSection/TemplateSection.tsx
@@ -16,12 +16,11 @@
 import React from 'react';
 
 import Grid from '@mui/material/Grid';
-import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 
 import CardWrapper from './CardWrapper';
 import { useTemplates } from '../../hooks/useTemplates';
+import { ViewMoreLink } from '../Links/ViewMoreLink';
 
 export const TemplateSection = () => {
   const { data: templates } = useTemplates();
@@ -46,12 +45,10 @@ export const TemplateSection = () => {
         ))}
       </Grid>
       <Box sx={{ pt: 2 }}>
-        <Link href={catalogTemplatesLink} underline="always">
-          <Typography variant="body2" sx={{ fontWeight: 500 }}>
-            View all {templates?.totalItems ? templates?.totalItems : ''}{' '}
-            templates
-          </Typography>
-        </Link>
+        <ViewMoreLink to={catalogTemplatesLink} underline="always">
+          View all {templates?.totalItems ? templates?.totalItems : ''}{' '}
+          templates
+        </ViewMoreLink>
       </Box>
     </React.Fragment>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR contains following changes:
- Fix the Link component import so the page transitions are smooth.
- removed "target=_blank" property from the UI to open links in the same page.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
