### PR TITLE
feat(lightspeed): align with road-core API endpoints

### DIFF
--- a/workspaces/lightspeed/.changeset/shy-carrots-jog.md
+++ b/workspaces/lightspeed/.changeset/shy-carrots-jog.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
+---
+
+Align with road-core service API response

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
@@ -74,9 +74,19 @@ export class LightspeedApiClient implements LightspeedAPI {
     }
 
     if (!response.ok) {
-      throw new Error(
-        `failed to fetch data, status ${response.status}: ${response.statusText}`,
-      );
+      const body = await response.body.getReader();
+      const reader = body.read();
+      const decoder = new TextDecoder('utf-8');
+      const text = await reader.then(({ done, value }) => {
+        if (done) {
+          return '';
+        }
+        return decoder.decode(value);
+      });
+      const errorMessage = JSON.parse(text);
+      if (errorMessage?.error) {
+        throw new Error(`failed to create message: ${errorMessage.error}`);
+      }
     }
     return response.body.getReader();
   }

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
@@ -62,7 +62,9 @@ export class LightspeedApiClient implements LightspeedAPI {
             ? undefined
             : conversation_id,
         model: selectedModel,
-        provider: 'ollama',
+        provider: this.configApi
+          .getConfigArray('lightspeed.servers')[0]
+          .getOptionalString('id'), // Currently supports a single llm server
         query: prompt,
       }),
     });

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/LightspeedApiClient.ts
@@ -16,6 +16,7 @@
 
 import { ConfigApi, FetchApi } from '@backstage/core-plugin-api';
 
+import { TEMP_CONVERSATION_ID } from '../const';
 import { LightspeedAPI } from './api';
 
 export type Options = {
@@ -56,11 +57,13 @@ export class LightspeedApiClient implements LightspeedAPI {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        conversation_id,
-        serverURL: this.getServerUrl(),
+        conversation_id:
+          conversation_id === TEMP_CONVERSATION_ID
+            ? undefined
+            : conversation_id,
         model: selectedModel,
+        provider: 'ollama',
         query: prompt,
-        historyLength: 10,
       }),
     });
 
@@ -93,45 +96,46 @@ export class LightspeedApiClient implements LightspeedAPI {
   async getAllModels() {
     const baseUrl = await this.getBaseUrl();
     const result = await this.fetcher(`${baseUrl}/v1/models`);
+
+    if (!result.ok) {
+      throw new Error(
+        `failed to get models, status ${result.status}: ${result.statusText}`,
+      );
+    }
+
     const response = await result.json();
     return response?.data ? response.data : [];
   }
 
   async getConversationMessages(conversation_id: string) {
+    if (conversation_id === TEMP_CONVERSATION_ID) {
+      return [];
+    }
     const baseUrl = await this.getBaseUrl();
     const result = await this.fetcher(
       `${baseUrl}/conversations/${encodeURIComponent(conversation_id)}`,
     );
-    return await result.json();
+    if (!result.ok) {
+      throw new Error(
+        `failed to get conversation messages, status ${result.status}: ${result.statusText}`,
+      );
+    }
+    const response = await result.json();
+    return response.chat_history ?? [];
   }
 
   async getConversations() {
     const baseUrl = await this.getBaseUrl();
     const result = await this.fetcher(`${baseUrl}/conversations`);
-    return await result.json();
-  }
 
-  async createConversation() {
-    const baseUrl = await this.getBaseUrl();
-
-    const response = await this.fetchApi.fetch(`${baseUrl}/conversations`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({}),
-    });
-
-    if (!response.body) {
-      throw new Error('Something went wrong.');
-    }
-
-    if (!response.ok) {
+    if (!result.ok) {
       throw new Error(
-        `failed to create conversation, status ${response.status}: ${response.statusText}`,
+        `failed to get conversation, status ${result.status}: ${result.statusText}`,
       );
     }
-    return await response.json();
+
+    const response = await result.json();
+    return response.conversations ?? [];
   }
 
   async deleteConversation(conversation_id: string) {

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/api.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/api.ts
@@ -23,7 +23,6 @@ import { BaseMessage, ConversationList } from '../types';
 export type LightspeedAPI = {
   getAllModels: () => Promise<OpenAI.Models.Model[]>;
   getConversationMessages: (conversation_id: string) => Promise<BaseMessage[]>;
-  createConversation: () => Promise<{ conversation_id: string }>;
   createMessage: (
     prompt: string,
     selectedModel: string,

--- a/workspaces/lightspeed/plugins/lightspeed/src/const.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/const.ts
@@ -13,23 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { useApi } from '@backstage/core-plugin-api';
-
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-
-import { lightspeedApiRef } from '../api/api';
-
-export const useCreateConversation = () => {
-  const lightspeedApi = useApi(lightspeedApiRef);
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: () => {
-      return lightspeedApi.createConversation();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['conversations'] });
-    },
-  });
-};
+export const TEMP_CONVERSATION_ID = 'temp-conversation-id';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/index.ts
@@ -17,7 +17,6 @@ export * from './useAllModels';
 export * from './useBackstageUserIdentity';
 export * from './useConversationMessages';
 export * from './useConversations';
-export * from './useCreateConversation';
 export * from './useCreateCoversationMessage';
 export * from './useDeleteConversation';
 export * from './useIsMobile';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
@@ -309,6 +309,9 @@ export const useConversationMessages = (
 
           lastMessage.isLoading = false;
           lastMessage.content += e;
+          lastMessage.error = {
+            title: e.message,
+          };
           lastMessage.timestamp = getTimestamp(Date.now());
 
           const updatedConversation = [

--- a/workspaces/lightspeed/plugins/lightspeed/src/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { AlertProps } from '@patternfly/react-core';
+
 export type Conversations = {
   [key: string]: {
     user: string;
@@ -22,6 +24,7 @@ export type Conversations = {
     loading: boolean;
     timestamp: string;
     botTimestamp: string;
+    error?: AlertProps;
   };
 };
 
@@ -38,6 +41,7 @@ export interface BaseMessage {
   additional_kwargs: {
     [_key: string]: any;
   };
+  error?: AlertProps;
 }
 export type ConversationSummary = {
   conversation_id: string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/types.ts
@@ -26,25 +26,23 @@ export type Conversations = {
 };
 
 export interface BaseMessage {
-  lc: number;
+  name: string;
   type: string;
-  id: string[];
-  kwargs: {
-    content: string;
-    response_metadata: {
-      model?: string;
-      created_at: number;
-      role: string;
-    };
-    additional_kwargs: {
-      [_key: string]: any;
-    };
+  id: number;
+  content: string;
+  response_metadata: {
+    model?: string;
+    created_at: number;
+    role?: string;
+  };
+  additional_kwargs: {
+    [_key: string]: any;
   };
 }
 export type ConversationSummary = {
   conversation_id: string;
-  lastMessageTimestamp: number;
-  summary: string;
+  last_message_timestamp: number;
+  topic_summary: string;
 };
 
 export type ConversationList = ConversationSummary[];

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/lightspeed-chatbot-utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/lightspeed-chatbot-utils.test.ts
@@ -208,17 +208,21 @@ describe('createBotMessage', () => {
 describe('getMessageData', () => {
   it('should return content and timestamp from message.kwargs', () => {
     const message = {
-      kwargs: {
-        content: 'This is the message content',
-        response_metadata: {
-          created_at: 1730121598867,
-        },
+      content: 'This is the message content',
+      response_metadata: {
+        created_at: 1744695548.101305,
+        model: 'granite3-dense:8b',
       },
+      additional_kwargs: {},
+      id: 1,
+      type: 'human',
+      name: '',
     };
-    const result = getMessageData(message as any);
+    const result = getMessageData(message);
     expect(result).toEqual({
       content: 'This is the message content',
-      timestamp: '28/10/2024, 13:19:58',
+      model: 'granite3-dense:8b',
+      timestamp: '15/04/2025, 05:39:08',
     });
   });
 
@@ -240,36 +244,28 @@ describe('getCategorizeMessages', () => {
   const messages: ConversationList = [
     {
       conversation_id: '1',
-      lastMessageTimestamp: new Date().toISOString(),
-      summary: 'Today message',
+      last_message_timestamp: Date.now() / 1000,
+      topic_summary: 'Today message',
     },
     {
       conversation_id: '2',
-      lastMessageTimestamp: new Date(
-        Date.now() - 24 * 60 * 60 * 1000,
-      ).toISOString() as any,
-      summary: 'Yesterday message',
+      last_message_timestamp: (Date.now() - 24 * 60 * 60 * 1000) / 1000,
+      topic_summary: 'Yesterday message',
     },
     {
       conversation_id: '3',
-      lastMessageTimestamp: new Date(
-        Date.now() - 5 * 24 * 60 * 60 * 1000,
-      ).toISOString(),
-      summary: '5 days ago',
+      last_message_timestamp: (Date.now() - 5 * 24 * 60 * 60 * 1000) / 1000,
+      topic_summary: '5 days ago',
     },
     {
       conversation_id: '4',
-      lastMessageTimestamp: new Date(
-        Date.now() - 15 * 24 * 60 * 60 * 1000,
-      ).toISOString(),
-      summary: '15 days ago',
+      last_message_timestamp: (Date.now() - 15 * 24 * 60 * 60 * 1000) / 1000,
+      topic_summary: '15 days ago',
     },
     {
       conversation_id: '5',
-      lastMessageTimestamp: new Date(
-        Date.now() - 45 * 24 * 60 * 60 * 1000,
-      ).toISOString(),
-      summary: '45 days ago',
+      last_message_timestamp: (Date.now() - 45 * 24 * 60 * 60 * 1000) / 1000,
+      topic_summary: '45 days ago',
     },
   ];
 
@@ -289,7 +285,7 @@ describe('getCategorizeMessages', () => {
     expect(result['Previous 30 Days'][0].text).toBe('15 days ago');
 
     const monthYearKey = new Date(
-      messages[4].lastMessageTimestamp,
+      messages[4].last_message_timestamp * 1000,
     ).toLocaleString('default', {
       month: 'long',
       year: 'numeric',

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.ts
@@ -85,6 +85,9 @@ type MessageProps = {
   name?: string;
   avatar?: string | any;
   isLoading?: boolean;
+  error?: {
+    title: string;
+  };
 };
 
 export const createMessage = ({
@@ -94,6 +97,7 @@ export const createMessage = ({
   isLoading = false,
   content,
   timestamp,
+  error,
 }: MessageProps & { role: 'user' | 'bot' }) => ({
   role,
   name,
@@ -101,6 +105,7 @@ export const createMessage = ({
   isLoading,
   content,
   timestamp,
+  error,
 });
 
 export const createUserMessage = (props: MessageProps) =>


### PR DESCRIPTION
## Align Lightspeed with Road core service endpoints.

This PR contains following changes:

- Removes the `POST /conversations` endpoint.
- use `v1/query` without conversation_id to create a new conversation_id for the first conversation.
- Add inline error messages 

## Screen recording


https://github.com/user-attachments/assets/6a59bd0b-89a9-4b33-abfa-0554b9da04d0

---
Inline error messages:

![image](https://github.com/user-attachments/assets/26710ae0-1ae7-41f1-813a-6c7290ab0c00)

How to test:

1. clone [road-core service repo](https://github.com/road-core/service) & install python dependencies
2. save token to the team cluster in a file called `team_cluster_key.txt`
3. save following to a file called `rcsconfig.yaml`
```
llm_providers:
  - name: team_cluster
    type: openai
    url: "https://ibm-granite-8b-code-instruct-3scale-apicast-production.apps.rosa.redhat-ai-dev.m6no.p3.openshiftapps.com:443/v1"
    credentials_path: team_cluster_key.txt
    disable_model_check: true
ols_config:
  reference_content:
  conversation_cache:
    type: memory
    memory:
      max_entries: 1000
  logging_config:
    app_log_level: info
    lib_log_level: warning
    uvicorn_log_level: info
    suppress_metrics_in_log: false
    suppress_auth_checks_warning_in_log: false
  authentication_config:
    module: "noop"
  default_provider: team_cluster
  default_model: ibm-granite-31-8b-instruct
  query_validation_method: disabled
dev_config:
  enable_dev_ui: true
  disable_auth: false
  disable_tls: true
  enable_system_prompt_override: true

```
4. run `pdm start`

At this point, road-core service should be already start and running on `http://0.0.0.0:8080`, should see Swagger UI `http://0.0.0.0:8080/docs`

5. in lightspeed,  set the same llm server in app-config.yaml. the id should match the provider name set in rcs-config
```
lightspeed:
  servers:
    - id: 'team_cluster'
      url: 'https://ibm-granite-8b-code-instruct-3scale-apicast-production.apps.rosa.redhat-ai-dev.m6no.p3.openshiftapps.com:443/v1'
      token: <token>
```
6. run `yarn dev`

## E2E test report:

![image](https://github.com/user-attachments/assets/8cd357c2-bfb6-43d0-9ccc-8482d348bc19)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
