### PR TITLE
chore(version-bump): update version bump option to 1.37.1

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,7 +10,7 @@ on:
         options:
           - next
           - main
-          - '1.36.1'
+          - '1.37.1'
       workspace_input:
         description: 'Workspace (this must be a JSON array)'
         required: true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update the "temporary" solution to update plugins easily to Backstage 1.37.1 while Backstage 1.38.0 is already released... yesterday. :man_facepalming: 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
