### PR TITLE
fix(extensions): add a no-icon-icon when the icon is missing in the plugin metadata

### DIFF
--- a/workspaces/marketplace/.changeset/tender-tables-clean.md
+++ b/workspaces/marketplace/.changeset/tender-tables-clean.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+add a no-icon-icon when the icon is missing in the plugin metadata

--- a/workspaces/marketplace/plugins/marketplace/src/components/PluginIcon.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/PluginIcon.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import CardMedia from '@mui/material/CardMedia';
+import NoIconIcon from '@mui/icons-material/PowerOutlined';
 
 import { MarketplacePlugin } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 
@@ -28,6 +29,29 @@ export const PluginIcon = ({
   size: number;
 }) => {
   const icon = plugin?.spec?.icon;
+
+  if (!icon) {
+    return (
+      <CardMedia
+        sx={{
+          width: size,
+          height: size,
+          flexShrink: 0,
+          backgroundColor: 'action.disabledBackground',
+        }}
+      >
+        <NoIconIcon
+          sx={{
+            width: size,
+            height: size,
+            padding: '10px',
+            color: 'action.disabled',
+          }}
+        />
+      </CardMedia>
+    );
+  }
+
   return (
     <CardMedia
       image={icon}
@@ -35,7 +59,6 @@ export const PluginIcon = ({
         width: size,
         height: size,
         flexShrink: 0,
-        backgroundColor: icon ? undefined : 'grey.400',
       }}
     />
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes [RHIDP-6688](https://issues.redhat.com/browse/RHIDP-6688) Extension catalog: Grey box when an extension provides no icon

Add missing "no icon"-icon to the extensions/marketplace catalog, aligned with this [figma design](https://www.figma.com/design/E6C9X3OSVzlWkW7ZsbxN7s/Administration?node-id=8216-14428&t=07B04w0kFhjBT5SS-4).

Tested as dynamic plugin with RHDH:

**Before:**

Light theme:

![image](https://github.com/user-attachments/assets/5b68bd68-5dbe-4210-9d8e-ec9a45052660)

Dark theme:

![image](https://github.com/user-attachments/assets/28d33ccc-b5fa-4896-9853-565933bfc63c)

**With this PR:**

Light theme:

![image](https://github.com/user-attachments/assets/e2e8232c-6349-4682-b856-348f11245c79)

Dark theme:

![image](https://github.com/user-attachments/assets/64957557-494a-4892-b790-084f4fd7596b)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
