### PR TITLE
add log message around registering the 'rhdh-rhoai-bridge' location type

### DIFF
--- a/workspaces/ai-integrations/.changeset/cold-papers-listen.md
+++ b/workspaces/ai-integrations/.changeset/cold-papers-listen.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog': patch
+---
+
+add a log message around registering the 'rhdh-rhoai-bridge' location type

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.ts
@@ -108,7 +108,7 @@ export const catalogModuleRHDHRHOAILocationsExtensionPoint =
         async init({ catalog, logger }) {
           // setAllowedLocationTypes does not add to the list but replaces it, so we preserve the default options of 'file' and 'url'
           logger
-            .child({ source: 'ai-workspace' })
+            .child({ source: 'catalog-backend-module-model-catalog"' })
             .info("Registering the 'rhdh-rhoai-bridge' location type");
           const allowedLocationTypes = ['file', 'url', 'rhdh-rhoai-bridge'];
           catalog.setAllowedLocationTypes(allowedLocationTypes);

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/module.ts
@@ -103,9 +103,13 @@ export const catalogModuleRHDHRHOAILocationsExtensionPoint =
       env.registerInit({
         deps: {
           catalog: catalogLocationsExtensionPoint,
+          logger: coreServices.logger,
         },
-        async init({ catalog }) {
+        async init({ catalog, logger }) {
           // setAllowedLocationTypes does not add to the list but replaces it, so we preserve the default options of 'file' and 'url'
+          logger
+            .child({ source: 'ai-workspace' })
+            .info("Registering the 'rhdh-rhoai-bridge' location type");
           const allowedLocationTypes = ['file', 'url', 'rhdh-rhoai-bridge'];
           catalog.setAllowedLocationTypes(allowedLocationTypes);
         },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

add a log message around our location extension as part of diagnosing the location type not getting registered when we run as a dynamic plugin in RHDH (vs. running via yarn from out laptop)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ /] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ n/a] Added or Updated documentation
- [ n/a] Tests for new functionality and regression tests for bug fixes
- [ n/a] Screenshots attached (for UI changes)
