### PR TITLE
fix(marketplace): use namespace also for packages location

### DIFF
--- a/workspaces/marketplace/.changeset/ten-tigers-dream.md
+++ b/workspaces/marketplace/.changeset/ten-tigers-dream.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/marketplace-cli': patch
+---
+
+use namespace parameter also for packages location

--- a/workspaces/marketplace/packages/cli/src/commands/generate/index.ts
+++ b/workspaces/marketplace/packages/cli/src/commands/generate/index.ts
@@ -197,6 +197,7 @@ export default async (opts: OptionValues) => {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Location',
       metadata: {
+        namespace,
         name: 'packages',
       },
       spec: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

use namespace parameter also for packages location

When running the generate command in rhdh as below, it doesn't create the namespace for the Location entity.

```
cd rhdh
npx -y @red-hat-developer-hub/marketplace-cli generate --namespace rhdh -p dynamic-plugins.default.yaml -o catalog-entities/marketplace/packages
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
