### PR TITLE
feat(ai-integrations): Provide support for techdocs when present on the Model Catalog JSON object

### DIFF
--- a/workspaces/ai-integrations/.changeset/wild-schools-attend.md
+++ b/workspaces/ai-integrations/.changeset/wild-schools-attend.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog': minor
+---
+
+Add TechDocs annotations to generated Resource entities when present in the JSON object

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/package.json
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/package.json
@@ -41,7 +41,7 @@
     "@backstage/plugin-catalog-backend": "^1.30.0",
     "@backstage/plugin-catalog-common": "^1.1.3",
     "@backstage/plugin-catalog-node": "^1.15.1",
-    "@redhat-ai-dev/model-catalog-types": "^1.0.1",
+    "@redhat-ai-dev/model-catalog-types": "^1.1.0",
     "js-yaml": "^4.1.0",
     "stream": "^0.0.3",
     "yaml": "^2.7.0"

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
@@ -101,6 +101,46 @@ describe('Model Catalog Generator', () => {
     ];
     expect(modelCatalogEntities).toEqual(expectedModelEntities);
   });
+  it('should generate techdoc annotations when present on the json object even if unnecessary whitespace is present', () => {
+    const modelCatalog: ModelCatalog = {
+      models: [
+        {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          lifecycle: 'production',
+          owner: 'example-user',
+          annotations: {
+            TechDocs:
+              '      https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main           ',
+          },
+        },
+      ],
+    };
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+    expect(modelCatalogEntities.length).toEqual(1);
+
+    const expectedModelEntities: Entity[] = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          annotations: {
+            'backstage.io/techdocs-ref': `url:https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main`,
+          },
+          tags: [],
+          links: [],
+        },
+        spec: {
+          dependencyOf: [],
+          owner: 'example-user',
+          type: 'ai-model',
+        },
+      },
+    ];
+    expect(modelCatalogEntities).toEqual(expectedModelEntities);
+  });
   it('should generate catalog entities for multiple models and a model server with API', () => {
     const modelCatalog: ModelCatalog = {
       modelServer: {

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
@@ -61,6 +61,46 @@ describe('Model Catalog Generator', () => {
     ];
     expect(modelCatalogEntities).toEqual(expectedModelEntities);
   });
+  it('should generate techdoc annotations when present on the json object', () => {
+    const modelCatalog: ModelCatalog = {
+      models: [
+        {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          lifecycle: 'production',
+          owner: 'example-user',
+          annotations: {
+            TechDocs:
+              'https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main',
+          },
+        },
+      ],
+    };
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+    expect(modelCatalogEntities.length).toEqual(1);
+
+    const expectedModelEntities: Entity[] = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          annotations: {
+            'backstage.io/techdocs-ref': `url:https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main`,
+          },
+          tags: [],
+          links: [],
+        },
+        spec: {
+          dependencyOf: [],
+          owner: 'example-user',
+          type: 'ai-model',
+        },
+      },
+    ];
+    expect(modelCatalogEntities).toEqual(expectedModelEntities);
+  });
   it('should generate catalog entities for multiple models and a model server with API', () => {
     const modelCatalog: ModelCatalog = {
       modelServer: {

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -122,6 +122,20 @@ export function GenerateModelResourceEntities(
         `component:${modelServer.name}`,
       );
     }
+
+    // Handle any annotations present on the model resource
+    if (model.annotations !== undefined) {
+      // Add the techdocs annotation to the resource if present
+      if (model.annotations.TechDocs !== '') {
+        const techdocsUrl: string = model.annotations.TechDocs;
+        if (modelResourceEntity.metadata.annotations === undefined) {
+          modelResourceEntity.metadata.annotations = {};
+        }
+        modelResourceEntity.metadata.annotations[
+          'backstage.io/techdocs-ref'
+        ] = `url:${techdocsUrl}`;
+      }
+    }
     modelResourceEntities.push(modelResourceEntity);
   });
 

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -126,8 +126,9 @@ export function GenerateModelResourceEntities(
     // Handle any annotations present on the model resource
     if (model.annotations !== undefined) {
       // Add the techdocs annotation to the resource if present
+      let techdocsUrl: string = model.annotations.TechDocs;
+      techdocsUrl = techdocsUrl.trim();
       if (model.annotations.TechDocs !== '') {
-        const techdocsUrl: string = model.annotations.TechDocs;
         if (modelResourceEntity.metadata.annotations === undefined) {
           modelResourceEntity.metadata.annotations = {};
         }

--- a/workspaces/ai-integrations/yarn.lock
+++ b/workspaces/ai-integrations/yarn.lock
@@ -10698,7 +10698,7 @@ __metadata:
     "@backstage/plugin-catalog-backend": ^1.30.0
     "@backstage/plugin-catalog-common": ^1.1.3
     "@backstage/plugin-catalog-node": ^1.15.1
-    "@redhat-ai-dev/model-catalog-types": ^1.0.1
+    "@redhat-ai-dev/model-catalog-types": ^1.1.0
     js-yaml: ^4.1.0
     stream: ^0.0.3
     yaml: ^2.7.0
@@ -10736,10 +10736,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redhat-ai-dev/model-catalog-types@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@redhat-ai-dev/model-catalog-types@npm:1.0.1"
-  checksum: 6b85d92c85f34d675168ad1bebf1b48f015c5fe59f235f06a0d8e7271f5415e25e40cbe1d5eecf03ada85be8214f09353f1987a316f97b9d681e4ef6d32102de
+"@redhat-ai-dev/model-catalog-types@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@redhat-ai-dev/model-catalog-types@npm:1.1.0"
+  checksum: 1974a2b6a3cc7cc1ef9da13e2794482bc00404f70aa6bfaf349992a7df4ad4ae7d8fe856bcd814595fcfef9f6a16c72967e0e6cf3d3d4a4d22398a355ae00b41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the model catalog plugin to add the techdocs annotation (`backstage.io/techdocs-ref`) to the generated `ai-model` Resource entities when they are generated.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
