### PR TITLE
fix(ai-experience): make model displayName optional in ai homepage

### DIFF
--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/ModelSection/ModelSection.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/ModelSection/ModelSection.tsx
@@ -117,7 +117,7 @@ export const ModelSection = () => {
           >
             <CardWrapper
               link={`/catalog/default/resource/${item.metadata.name}`}
-              title={item.spec.profile.displayName}
+              title={item.spec?.profile?.displayName ?? item.metadata.name}
               version="latest"
               description={item.metadata.description ?? ''}
               tags={item.metadata?.tags ?? []}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

make model displayName optional in ai homepage, fallback to the model name if the displayName is missing.




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
