### PR TITLE
chore(openshift-image-registry): remove unused devdependency @types/node

### DIFF
--- a/workspaces/openshift-image-registry/.changeset/five-cars-dance.md
+++ b/workspaces/openshift-image-registry/.changeset/five-cars-dance.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-openshift-image-registry': patch
+---
+
+Remove unused devDependency for @types/node

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/package.json
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/package.json
@@ -64,7 +64,6 @@
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.5.2",
-    "@types/node": "18.19.87",
     "cross-fetch": "4.1.0",
     "msw": "1.3.5",
     "prettier": "3.4.2"

--- a/workspaces/openshift-image-registry/yarn.lock
+++ b/workspaces/openshift-image-registry/yarn.lock
@@ -10601,7 +10601,6 @@ __metadata:
     "@testing-library/jest-dom": 6.6.3
     "@testing-library/react": 14.3.1
     "@testing-library/user-event": 14.5.2
-    "@types/node": 18.19.87
     cross-fetch: 4.1.0
     msw: 1.3.5
     prettier: 3.4.2
@@ -13761,15 +13760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.19.87, @types/node@npm:^18.11.18, @types/node@npm:^18.11.9":
-  version: 18.19.87
-  resolution: "@types/node@npm:18.19.87"
-  dependencies:
-    undici-types: ~5.26.4
-  checksum: 83ca9e0c6b987702e0ff1deb2f7e4d176dc19d85fc6cc9241597047f248aca9aff29c1586ef391bc3b7b2f635e4c622131c2006336561c9aafa75490c30f7763
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^12.7.1":
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
@@ -13781,6 +13771,15 @@ __metadata:
   version: 16.18.113
   resolution: "@types/node@npm:16.18.113"
   checksum: 483bee0ba09b767910b810c499931a4786549c7c04134073e08c2ecc9cdbd23873786ae57db72010837a7662122ace72cfa6661e9fe7be0fb806cd0dd10032c9
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.11.18, @types/node@npm:^18.11.9":
+  version: 18.19.87
+  resolution: "@types/node@npm:18.19.87"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 83ca9e0c6b987702e0ff1deb2f7e4d176dc19d85fc6cc9241597047f248aca9aff29c1586ef391bc3b7b2f635e4c622131c2006336561c9aafa75490c30f7763
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

remove unused devdependency @types/node to reduce number of automated PRs that updates this package

see https://github.com/redhat-developer/rhdh-plugins/pulls?q=is%3Apr+update+dependency+%40types%2Fnode

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
