### PR TITLE
feat(theme): add support to load the theme as dynamic plugin

### DIFF
--- a/workspaces/theme/.changeset/plenty-apples-remain.md
+++ b/workspaces/theme/.changeset/plenty-apples-remain.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': minor
+---
+
+Add support to load the theme as dynamic plugin

--- a/workspaces/theme/plugins/theme/app-config.dynamic.yaml
+++ b/workspaces/theme/plugins/theme/app-config.dynamic.yaml
@@ -1,0 +1,19 @@
+dynamicPlugins:
+  frontend:
+    red-hat-developer-hub.backstage-plugin-theme:
+      appIcons:
+        - importName: LightIcon
+          name: lightIcon
+        - importName: DarkIcon
+          name: darkIcon
+      themes:
+        - id: light-dynamic
+          icon: lightIcon
+          importName: lightThemeProvider
+          title: Light Dynamic
+          variant: light
+        - icon: darkIcon
+          id: dark-dynamic
+          importName: darkThemeProvider
+          title: Dark Dynamic
+          variant: dark

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -16,7 +16,11 @@
     "directory": "workspaces/theme/plugins/theme"
   },
   "backstage": {
-    "role": "web-library"
+    "role": "frontend-plugin",
+    "pluginId": "rhdh-theme",
+    "pluginPackages": [
+      "@red-hat-developer-hub/backstage-plugin-theme"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -56,6 +60,7 @@
   },
   "configSchema": "config.d.ts",
   "files": [
+    "app-config.dynamic.yaml",
     "config.d.ts",
     "dist"
   ],

--- a/workspaces/theme/plugins/theme/report.api.md
+++ b/workspaces/theme/plugins/theme/report.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 import { AppTheme } from '@backstage/core-plugin-api';
+import { default as DarkIcon } from '@mui/icons-material/Brightness2Rounded';
+import { default as LightIcon } from '@mui/icons-material/WbSunnyRounded';
+import { default as React_2 } from 'react';
 import { Theme } from '@mui/material/styles';
 import { UnifiedThemeOptions } from '@backstage/theme';
 
@@ -27,11 +30,25 @@ export interface Config {
     };
 }
 
+export { DarkIcon }
+
+// @public (undocumented)
+export const darkThemeProvider: (props: {
+    children: React_2.ReactNode;
+}) => JSX.Element | null;
+
 // @public (undocumented)
 export const getAllThemes: () => AppTheme[];
 
 // @public (undocumented)
 export const getThemes: () => AppTheme[];
+
+export { LightIcon }
+
+// @public (undocumented)
+export const lightThemeProvider: (props: {
+    children: React_2.ReactNode;
+}) => JSX.Element | null;
 
 // @public (undocumented)
 export interface RHDHThemePalette {

--- a/workspaces/theme/plugins/theme/src/index.ts
+++ b/workspaces/theme/plugins/theme/src/index.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+export { default as LightIcon } from '@mui/icons-material/WbSunnyRounded';
+export { default as DarkIcon } from '@mui/icons-material/Brightness2Rounded';
+
 export * from './hooks';
 export * from './themes';
 export type {

--- a/workspaces/theme/plugins/theme/src/themes.tsx
+++ b/workspaces/theme/plugins/theme/src/themes.tsx
@@ -30,6 +30,10 @@ import {
 import * as backstage from './backstage';
 import * as rhdh from './rhdh';
 
+export const lightThemeProvider = createThemeProviderForThemeName('light');
+
+export const darkThemeProvider = createThemeProviderForThemeName('dark');
+
 export const getAllThemes = (): AppTheme[] => {
   return [
     {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Part of https://issues.redhat.com/browse/RHIDP-7321

This change allows us to load the theme dynamically. With a wrapper or later as a container image.

Could be tested with:

```yaml
cd workspaces/theme/plugins/theme

# DP root needs to be changed, of course
npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root ~/git/rhd/rhdh/dynamic-plugins-root --clean --dev
```

Dynamic plugins configuration:

```yaml
dynamicPlugins:
  frontend:

    red-hat-developer-hub.backstage-plugin-theme:
      appIcons:
        - importName: LightIcon
          name: lightIcon
        - importName: DarkIcon
          name: darkIcon
      themes:
        - id: light-dynamic
          icon: lightIcon
          importName: lightThemeProvider
          title: Light Dynamic
          variant: light
        - icon: darkIcon
          id: dark-dynamic
          importName: darkThemeProvider
          title: Dark Dynamic
          variant: dark
```

I will work also on an update in https://github.com/redhat-developer/rhdh and https://github.com/redhat-developer/rhdh-plugin-export-overlays (both todo)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
