### PR TITLE
fix(marketplace): hiding yaml editor for plugins without packages

### DIFF
--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
@@ -261,34 +261,36 @@ export const MarketplacePluginInstallContent = ({
         spacing={3}
         sx={{ flex: 1, overflow: 'hidden', height: '100%', pb: 1 }}
       >
-        <Grid
-          item
-          xs={12}
-          md={6.5}
-          sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
-        >
-          <Card
-            sx={{
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              borderRadius: 0,
-            }}
+        {packages.length > 0 && (
+          <Grid
+            item
+            xs={12}
+            md={6.5}
+            sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
           >
-            <CardContent
+            <Card
               sx={{
                 flex: 1,
                 display: 'flex',
                 flexDirection: 'column',
-                overflow: 'auto',
-                scrollbarWidth: 'thin',
+                overflow: 'hidden',
+                borderRadius: 0,
               }}
             >
-              <CodeEditor defaultLanguage="yaml" onLoaded={onLoaded} />
-            </CardContent>
-          </Card>
-        </Grid>
+              <CardContent
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  overflow: 'auto',
+                  scrollbarWidth: 'thin',
+                }}
+              >
+                <CodeEditor defaultLanguage="yaml" onLoaded={onLoaded} />
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
 
         {showRightCard && (
           <Grid


### PR DESCRIPTION
Fix : https://issues.redhat.com/browse/RHIDP-6996

#Description 
Hide `yaml editor` for plugins having no packages 

#UI after changes 
![Screenshot 2025-05-05 at 9 28 53 PM (2)](https://github.com/user-attachments/assets/88590132-8d6e-4b5e-93b7-3797248b20db)


