### PR TITLE
chore(orchestrator): remove --no-embed-as-dependencies from export-dynamic for 3.5.0 janus-cli

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-backend/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/package.json
@@ -62,7 +62,7 @@
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --no-embed-as-dependencies"
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
   },
   "dependencies": {
     "@backstage/backend-common": "^0.25.0",

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/package.json
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/package.json
@@ -55,7 +55,7 @@
     "prettier:fix": "prettier --ignore-unknown --write .",
     "lint:check": "backstage-cli package lint",
     "lint:fix": "backstage-cli package lint --fix",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --no-embed-as-dependencies --embed-package '@red-hat-developer-hub/backstage-plugin-orchestrator-common'"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package '@red-hat-developer-hub/backstage-plugin-orchestrator-common'"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.2.1",


### PR DESCRIPTION
This CLI option was removed between janus-cli `3.2.0.` and recent `3.5.0`.
Let's give it try this way. 


