### PR TITLE
feat(homepage): fixing title in top & recent card on refresh

### DIFF
--- a/workspaces/homepage/.changeset/happy-boxes-explode.md
+++ b/workspaces/homepage/.changeset/happy-boxes-explode.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dynamic-home-page': patch
+---
+
+Correcting the home page title for `Recent Visits` and `Top Visits` on initial load and page reload.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/HomePage.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/HomePage.tsx
@@ -48,7 +48,7 @@ export const HomePage = (props: HomePageProps) => {
 
   return (
     <Page themeId="home">
-      <Header {...props} />
+      <Header {...props} title="Welcome back!" />
       <Content>
         {filteredAndSortedHomePageCards.length === 0 ? (
           <EmptyState


### PR DESCRIPTION
### Which issue(s) does this PR fix
Fixes : https://issues.redhat.com/browse/RHIDP-7009
### Before Fix :

https://github.com/user-attachments/assets/2040236b-d317-485d-94ad-3e48bfbe975d


### After Fix


https://github.com/user-attachments/assets/41f76061-f980-4721-bca4-65c8972689d4

For testing 

1. Take this PR change in  RHDH 

```
npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root  <path-to=rhdh>/rhdh/dynamic-plugins-root --dev
```
2. Add `Top Visited` and `Recent Visited` Card in homepage by adding below config

```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
  frontend:
    red-hat-developer-hub.backstage-plugin-dynamic-home-page:
      dynamicRoutes:
        - path: /
          importName: DynamicHomePage
      mountPoints:
        - mountPoint: application/listener
          importName: VisitListener
        - mountPoint: home.page/cards
          importName: RecentlyVisitedCard
          config:
            layouts:
              xl: { w: 6, h: 4, x: 6 }
              lg: { w: 6, h: 4, x: 6 }
              md: { w: 6, h: 4, x: 6 }
              sm: { w: 6, h: 4, x: 6 }
              xs: { w: 6, h: 4, x: 6 }
              xxs: { w: 6, h: 4, x: 6 }
        - mountPoint: home.page/cards
          importName: TopVisitedCard
          config:
            layouts:
              xl: { w: 6, h: 4 }
              lg: { w: 6, h: 4 }
              md: { w: 6, h: 4 }
              sm: { w: 6, h: 4 }
              xs: { w: 6, h: 4 }
              xxs: { w: 6, h: 4 }
```
