### PR TITLE
fix(sandbox-plugin): make sandbox plugin private

### DIFF
--- a/workspaces/sandbox/plugins/sandbox/package.json
+++ b/workspaces/sandbox/plugins/sandbox/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
+  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Mark Sandbox plugin as private as it is not supposed to be published to npm.