### PR TITLE
fix(sandbox): hide footer, minor readme fixes

### DIFF
--- a/workspaces/sandbox/README.md
+++ b/workspaces/sandbox/README.md
@@ -4,41 +4,11 @@ This plugin provides the new developer sandbox experience for the Red Hat Develo
 
 ## Configuration
 
-This plugin needs the following to be configured in the `app-config.yaml` file:
+This plugin needs the following to be configured in the `app-config.local.yaml` file:
 
 1. The URL of the registration-service-api production server.
 2. The URL of the kube-api production server.
 3. The site key for Google Recaptcha. The keys can be obtained from the Google Recaptcha admin console.
-
-## Dynamic Plugin Configuration
-
-This is the configuration that needs to be added to the `app-config.yaml` file to enable the sandbox dynamic plugin:
-
-```yaml
-dynamicPlugins:
-  frontend:
-    red-hat-developer-hub.backstage-plugin-sandbox:
-      appIcons:
-        - name: homeIcon
-          importName: SandboxHomeIcon
-        - name: activitiesIcon
-          importName: SandboxActivitiesIcon
-      dynamicRoutes:
-        - path: /
-          importName: SandboxPage
-          menuItem:
-            icon: homeIcon
-            text: Home
-        - path: /activities
-          importName: SandboxActivitiesPage
-          menuItem:
-            icon: activitiesIcon
-            text: Activities
-```
-
-## Development
-
-To start the app, run:
 
 ```sh
 yarn install
@@ -51,14 +21,16 @@ To generate knip reports for this app, run:
 yarn backstage-repo-tools knip-reports
 ```
 
-## Local Frontend Setup (provisional)
+## Development
 
-The Sandbox plugin uses Red Hat SSO to authenticate users accessing the Sandbox backend. This section explains how to configure your local RHDH Sandbox UI to connect with Red Hat SSO and the Sandbox backend.
+To start the app locally, run:
 
-0. `export QUAY_NAMESPACE=<your-quay-namespace>`
 1. `cd workspaces/sandbox`
 2. `yarn install`
 3. `make start-rhdh-local`
 
 Please, note that every time you want to re deploy, you need to run:
 `make stop-rhdh-local`
+
+NOTE: the app uses prod RH SSO as auth provider and sandbox stage backend by default
+( those can be configured in `app-config.local.yaml` )

--- a/workspaces/sandbox/plugins/sandbox/src/components/SandboxCatalog/SandboxCatalogPage.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/SandboxCatalog/SandboxCatalogPage.tsx
@@ -20,7 +20,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Page, Content } from '@backstage/core-components';
 import { SandboxCatalogBanner } from './SandboxCatalogBanner';
 import { SandboxCatalogGrid } from './SandboxCatalogGrid';
-import { SandboxCatalogFooter } from './SandboxCatalogFooter';
 import { SandboxProvider } from '../../hooks/useSandboxContext';
 import { SandboxHeader } from '../SandboxHeader';
 
@@ -42,7 +41,11 @@ export const SandboxCatalogPage = () => {
           <Box style={{ padding: '48px 60px 48px 60px' }}>
             <SandboxCatalogGrid />
           </Box>
+
+          {/*
+           /* TODO enable this later once https://issues.redhat.com/browse/SANDBOX-1161 is implemented
           <SandboxCatalogFooter />
+          */}
         </Content>
       </Page>
     </SandboxProvider>


### PR DESCRIPTION
Hide the footer temporarily, until we update the backend for the activation-code. See: https://issues.redhat.com/browse/SANDBOX-1161

Also some minor Readme fixes and removal of outadated information.  
