### PR TITLE
fix(sandbox): fix page title

### DIFF
--- a/workspaces/sandbox/plugins/sandbox/src/api/RegistrationBackendClient.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/api/RegistrationBackendClient.tsx
@@ -140,9 +140,15 @@ export class RegistrationBackendClient implements RegistrationService {
     });
 
     if (!response.ok) {
-      throw new Error(
-        'Invalid phone number. Please verify the country code and number format, then try again.',
-      );
+      const error: CommonResponse = await response.json();
+      // handle backend error messages and make it more user-friendly
+      if (error?.message.includes("Invalid 'To' Phone Number")) {
+        throw new Error(
+          'Invalid phone number. Please verify the country code and number format, then try again.',
+        );
+      } else {
+        throw new Error(error?.message);
+      }
     }
   };
 

--- a/workspaces/sandbox/plugins/sandbox/src/components/SandboxActivities/SandboxActivitiesGrid.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/SandboxActivities/SandboxActivitiesGrid.tsx
@@ -29,6 +29,7 @@ const FeaturedArticles: React.FC = () => {
       sx={{
         alignItems: 'center',
         justifyContent: 'space-between',
+        backgroundColor: theme.palette.background.paper,
         padding: '36px 60px 48px 60px',
       }}
     >

--- a/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.test.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.test.tsx
@@ -13,17 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { SandboxHeader } from './SandboxHeader';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { wrapInTestApp } from '@backstage/test-utils';
 
-test('renders the modal with the correct title and warning', () => {
+test('renders the modal with the correct title', () => {
   const theme = createTheme();
   render(
-    <ThemeProvider theme={theme}>
-      <SandboxHeader pageTitle="Developer Sandbox" />
-    </ThemeProvider>,
+    wrapInTestApp(
+      <ThemeProvider theme={theme}>
+        <SandboxHeader pageTitle="My Page Title" />
+      </ThemeProvider>,
+    ),
   );
-  expect(global.window.document.title).toBe('Developer Sandbox');
+  expect(screen.getByText('My Page Title')).toBeInTheDocument();
 });

--- a/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.test.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+import { SandboxHeader } from './SandboxHeader';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+test('renders the modal with the correct title and warning', () => {
+  const theme = createTheme();
+  render(
+    <ThemeProvider theme={theme}>
+      <SandboxHeader pageTitle="Developer Sandbox" />
+    </ThemeProvider>,
+  );
+  expect(global.window.document.title).toBe('Developer Sandbox');
+});

--- a/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.tsx
@@ -30,6 +30,7 @@ export const SandboxHeader: React.FC<SandboxHeaderProps> = ({ pageTitle }) => {
   const theme = useTheme();
   return (
     <Header
+      pageTitleOverride={pageTitle}
       title={
         <Typography
           color="textPrimary"


### PR DESCRIPTION
It contains the following fixes:

- fix the page title:
![image](https://github.com/user-attachments/assets/3a93d30f-2192-4a97-9232-64bab70e1509)

- add back the background color for the Activities page in light mode 

- improve custom error message for phone verification, as suggested in https://github.com/redhat-developer/rhdh-plugins/pull/752/files#r2084893090



