### PR TITLE
fix(orchestrator): results card renders boolean values properly

### DIFF
--- a/workspaces/orchestrator/.changeset/fuzzy-ghosts-attack.md
+++ b/workspaces/orchestrator/.changeset/fuzzy-ghosts-attack.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix Results card to render boolean values correctly.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowResult.tsx
@@ -273,7 +273,7 @@ const WorkflowOutputs = ({
     [key: string]: any;
   }>((data, item) => {
     let value = item.value || '';
-    if (typeof value !== 'string') {
+    if (!['string', 'number', 'boolean'].includes(typeof value)) {
       // This is a workaround for malformed returned data. It should not happen if the sender does WorkflowResult validation properly.
       if (typeof value === 'object') {
         value = `Object: ${JSON.stringify(value)}`;


### PR DESCRIPTION
Prior this fix, value `Unexpected type` was rendered.