### PR TITLE
chore(orchestrator): make OrchestratorFormContext singleton in dynamic plugins

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -4,14 +4,12 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { ApiRef } from '@backstage/core-plugin-api';
+import { Context } from 'react';
 import { ErrorSchema } from '@rjsf/utils';
 import { FormProps } from '@rjsf/core';
 import { JsonObject } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
-import { default as React_2 } from 'react';
+import type { JSONSchema7 } from 'json-schema';
 import { UiSchema } from '@rjsf/utils';
 
 // @public
@@ -21,6 +19,7 @@ export type FormDecoratorProps = Pick<FormProps<JsonObject, JSONSchema7>, 'formD
 
 // @public
 export interface OrchestratorFormApi {
+    getFormContext(): Context<OrchestratorFormContextProps | null>;
     getFormDecorator(): OrchestratorFormDecorator;
 }
 
@@ -32,7 +31,7 @@ export type OrchestratorFormContextProps = {
     schema: JSONSchema7;
     updateSchema: OrchestratorFormSchemaUpdater;
     numStepsInMultiStepSchema?: number;
-    children: React_2.ReactNode;
+    children: React.ReactNode;
     onSubmit: (formData: JsonObject) => void;
     uiSchema: UiSchema<JsonObject, JSONSchema7>;
     formData: JsonObject;
@@ -50,15 +49,16 @@ export type SchemaChunksResponse = {
     [key: string]: JsonObject;
 };
 
+// @public (undocumented)
+export const useOrchestratorFormApiOrDefault: () => OrchestratorFormApi;
+
 // @public
 export const useWrapperFormPropsContext: () => OrchestratorFormContextProps;
 
-// @public
-export const WrapperFormPropsContext: React_2.Context<OrchestratorFormContextProps | null>;
-
 // Warnings were encountered during analysis:
 //
-// src/context.d.ts:9:1 - (ae-undocumented) Missing documentation for "OrchestratorFormContextProps".
+// src/api.d.ts:58:1 - (ae-undocumented) Missing documentation for "OrchestratorFormContextProps".
+// src/context.d.ts:6:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
 
 // (No @packageDocumentation comment for this package)
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/DefaultFormApi.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/DefaultFormApi.tsx
@@ -14,15 +14,28 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { Context } from 'react';
 
 import {
   FormDecoratorProps,
   OrchestratorFormApi,
+  OrchestratorFormContextProps,
   OrchestratorFormDecorator,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
 class DefaultFormApi implements OrchestratorFormApi {
+  private readonly context: Context<OrchestratorFormContextProps | null>;
+
+  public constructor() {
+    this.context = React.createContext<OrchestratorFormContextProps | null>(
+      null,
+    );
+  }
+
+  getFormContext(): React.Context<OrchestratorFormContextProps | null> {
+    return this.context;
+  }
+
   getFormDecorator(): OrchestratorFormDecorator {
     // eslint-disable-next-line no-console
     console.log(

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { Context } from 'react';
+
 import { createApiRef } from '@backstage/core-plugin-api';
 import { JsonObject } from '@backstage/types';
 
 import { FormProps } from '@rjsf/core';
-import { ErrorSchema } from '@rjsf/utils';
+import { ErrorSchema, UiSchema } from '@rjsf/utils';
 import type { JSONSchema7 } from 'json-schema';
 
 /**
@@ -84,10 +86,34 @@ export type OrchestratorFormSchemaUpdater = (
 
 /**
  * @public
+ *
+ */
+export type OrchestratorFormContextProps = {
+  schema: JSONSchema7;
+  updateSchema: OrchestratorFormSchemaUpdater;
+  numStepsInMultiStepSchema?: number;
+  children: React.ReactNode;
+  onSubmit: (formData: JsonObject) => void;
+  uiSchema: UiSchema<JsonObject, JSONSchema7>;
+  formData: JsonObject;
+  setFormData: (data: JsonObject) => void;
+};
+
+/**
+ * @public
  * OrchestratorFormApi
  * API to be implemented by factory in a custom plugin
  */
 export interface OrchestratorFormApi {
+  /**
+   * @public
+   * Context wrapping the RJSF form on Workflow execution page, making it available for the custom widgets.
+   *
+   * Must be created by the API to share just a single instance within both the OrchestratorFormApi and
+   * the Orchestrator where the context is actually provided (see OrchestratorFormWrapper).
+   */
+  getFormContext(): Context<OrchestratorFormContextProps | null>;
+
   /**
    * @public
    * getFormDecorator

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/context.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/context.ts
@@ -15,33 +15,21 @@
  */
 import React from 'react';
 
-import { JsonObject } from '@backstage/types';
+import { useApiHolder } from '@backstage/core-plugin-api';
 
-import { UiSchema } from '@rjsf/utils';
-import { JSONSchema7 } from 'json-schema';
-
-import { OrchestratorFormSchemaUpdater } from './api';
+import {
+  OrchestratorFormApi,
+  orchestratorFormApiRef,
+  OrchestratorFormContextProps,
+} from './api';
+import { defaultFormExtensionsApi } from './DefaultFormApi';
 
 /**
  * @public
+ *
  */
-export type OrchestratorFormContextProps = {
-  schema: JSONSchema7;
-  updateSchema: OrchestratorFormSchemaUpdater;
-  numStepsInMultiStepSchema?: number;
-  children: React.ReactNode;
-  onSubmit: (formData: JsonObject) => void;
-  uiSchema: UiSchema<JsonObject, JSONSchema7>;
-  formData: JsonObject;
-  setFormData: (data: JsonObject) => void;
-};
-
-/**
- * Context wrapping RJSF form on the Workflow execution page, making it available for the custom widgets.
- * @public
- */
-export const WrapperFormPropsContext =
-  React.createContext<OrchestratorFormContextProps | null>(null);
+export const useOrchestratorFormApiOrDefault = (): OrchestratorFormApi =>
+  useApiHolder().get(orchestratorFormApiRef) ?? defaultFormExtensionsApi;
 
 /**
  * @public
@@ -49,7 +37,9 @@ export const WrapperFormPropsContext =
  * Simplifies access to the form context in widgets.
  */
 export const useWrapperFormPropsContext = (): OrchestratorFormContextProps => {
-  const context = React.useContext(WrapperFormPropsContext);
+  const formApi = useOrchestratorFormApiOrDefault();
+  const context = React.useContext(formApi.getFormContext());
+
   if (context === null) {
     throw new Error('OrchestratorFormWrapperProps not provided');
   }

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/index.ts
@@ -21,6 +21,10 @@ export type {
   FormDecoratorProps,
   OrchestratorFormSchemaUpdater,
   SchemaChunksResponse,
+  OrchestratorFormContextProps,
 } from './api';
-export type { OrchestratorFormContextProps } from './context';
-export { WrapperFormPropsContext, useWrapperFormPropsContext } from './context';
+
+export {
+  useOrchestratorFormApiOrDefault,
+  useWrapperFormPropsContext,
+} from './context';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 
 import { ErrorPanel } from '@backstage/core-components';
-import { useApiHolder } from '@backstage/core-plugin-api';
 import { JsonObject } from '@backstage/types';
 
 import { Grid } from '@material-ui/core';
@@ -29,13 +28,11 @@ import omit from 'lodash/omit';
 
 import {
   FormDecoratorProps,
-  orchestratorFormApiRef,
   OrchestratorFormContextProps,
+  useOrchestratorFormApiOrDefault,
   useWrapperFormPropsContext,
-  WrapperFormPropsContext,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
-import { defaultFormExtensionsApi } from '../DefaultFormApi';
 import { useStepperContext } from '../utils/StepperContext';
 import useValidator from '../utils/useValidator';
 import StepperObjectField from './StepperObjectField';
@@ -137,13 +134,17 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
 type OrchestratorFormWrapperProps = OrchestratorFormContextProps;
 
 const OrchestratorFormWrapper = (props: OrchestratorFormWrapperProps) => {
-  const formApi =
-    useApiHolder().get(orchestratorFormApiRef) || defaultFormExtensionsApi;
+  const formApi = useOrchestratorFormApiOrDefault();
 
   const NewComponent = React.useMemo(() => {
     const formDecorator = formApi.getFormDecorator();
     return formDecorator(FormComponent);
   }, [formApi]);
+
+  const WrapperFormPropsContext = React.useMemo(
+    () => formApi.getFormContext(),
+    [formApi],
+  );
 
   return (
     <WrapperFormPropsContext.Provider value={props}>

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/report.api.md
@@ -7,6 +7,8 @@
 import { ApiFactory } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { OrchestratorFormApi } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import { default as React_2 } from 'react';
 
 // Warning: (ae-forgotten-export) The symbol "FormWidgetsApi" needs to be exported by the entry point index.d.ts
 //

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from 'react';
+import React, { Context, useCallback } from 'react';
 import {
   FormDecoratorProps,
   OrchestratorFormApi,
+  OrchestratorFormContextProps,
   useWrapperFormPropsContext,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 import { FormValidation } from '@rjsf/utils';
@@ -41,6 +42,18 @@ const widgets = {
 };
 
 export class FormWidgetsApi implements OrchestratorFormApi {
+  private readonly context: Context<OrchestratorFormContextProps | null>;
+
+  public constructor() {
+    this.context = React.createContext<OrchestratorFormContextProps | null>(
+      null,
+    );
+  }
+
+  getFormContext = () => {
+    return this.context;
+  };
+
   getFormDecorator: OrchestratorFormApi['getFormDecorator'] = () => {
     // eslint-disable-next-line no-console
     console.log('Using FormWidgetsApi by RHDH orchestrator-form-widgets.');


### PR DESCRIPTION
Fixes: FLPATH-2343

Contrary to the static plugins, the former way of creating a react context  lead to two instances created by two plugins at runtime when used in RHDH dynamic plugins.