### PR TITLE
fix(adoption-insights):  partition overlap error and auto correct the invalid partitions

### DIFF
--- a/workspaces/adoption-insights/.changeset/tough-paws-invent.md
+++ b/workspaces/adoption-insights/.changeset/tough-paws-invent.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+---
+
+Fix partition overlap error

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createPartition } from './partition';
+import { Knex } from 'knex';
+
+const mockRaw = jest.fn();
+const knex = {
+  schema: { raw: mockRaw },
+} as unknown as Knex;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('createPartition', () => {
+  it('should create a partition without errors', async () => {
+    mockRaw.mockResolvedValueOnce(undefined);
+
+    await createPartition(knex, 2025, 5);
+
+    expect(mockRaw).toHaveBeenCalledWith(
+      expect.stringContaining(`CREATE TABLE IF NOT EXISTS events_2025_05`),
+    );
+  });
+
+  it('should handle overlapping partition error and retry', async () => {
+    const overlapError = new Error(
+      'partition "events_2025_05" would overlap partition "events_2025_04"',
+    );
+
+    mockRaw
+      .mockRejectedValueOnce(overlapError) // create fails
+      .mockResolvedValueOnce(undefined) // drop overlap partition
+      .mockResolvedValueOnce(undefined) // recreate dropped partition
+      .mockResolvedValueOnce(undefined); // retry create current partition
+
+    await createPartition(knex, 2025, 5);
+
+    expect(mockRaw).toHaveBeenCalledWith(
+      expect.stringContaining(`DROP TABLE IF EXISTS events_2025_04 CASCADE`),
+    );
+    expect(mockRaw).toHaveBeenCalledWith(
+      expect.stringContaining(`CREATE TABLE IF NOT EXISTS events_2025_04`),
+    );
+    expect(mockRaw).toHaveBeenCalledWith(
+      expect.stringContaining(`CREATE TABLE IF NOT EXISTS events_2025_05`),
+    );
+  });
+
+  it('should handle max retry when recreating dropped partition', async () => {
+    const overlapError = new Error(
+      'partition "events_2025_05" would overlap partition "events_2025_04"',
+    );
+
+    mockRaw
+      .mockRejectedValueOnce(overlapError) // create fails for events_2025_05
+      .mockResolvedValueOnce(undefined) // drop overlap partition events_2025_04
+      .mockRejectedValueOnce(overlapError) // create fails again for events_2025_04
+      .mockResolvedValueOnce(undefined); // retry create current partition -  events_2025_05
+
+    await expect(createPartition(knex, 2025, 5)).rejects.toThrow(
+      'Exceeded max retries for partition 2025_4',
+    );
+  });
+
+  it('should not retry for non-overlap errors', async () => {
+    const otherError = new Error('some other SQL error');
+    mockRaw.mockRejectedValueOnce(otherError);
+
+    await expect(createPartition(knex, 2025, 6)).rejects.toThrow(
+      'some other SQL error',
+    );
+
+    expect(mockRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/partition.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/partition.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  extractOverlappingPartition,
+  parsePartitionDate,
+  isPartitionOverlapError,
+} from './partition';
+
+describe('extractOverlappingPartition', () => {
+  it('should extract the overlapping partition name', () => {
+    const msg =
+      'partition "events_2025_05" would overlap partition "events_2025_04"';
+    expect(extractOverlappingPartition(msg)).toBe('events_2025_04');
+  });
+
+  it('should return empty string if pattern does not match', () => {
+    const msg = 'some other error message';
+    expect(extractOverlappingPartition(msg)).toBe('');
+  });
+});
+
+describe('parsePartitionDate', () => {
+  it('should parse valid partition name', () => {
+    const input = 'events_2025_04';
+    expect(parsePartitionDate(input)).toEqual({ year: 2025, month: 4 });
+  });
+
+  it('should parse single-digit month correctly', () => {
+    const input = 'events_2025_9';
+    expect(parsePartitionDate(input)).toEqual({ year: 2025, month: 9 });
+  });
+
+  it('should throw error for invalid format', () => {
+    const input = 'invalid_partition_name';
+    expect(() => parsePartitionDate(input)).toThrow(
+      'Cannot parse partition name: invalid_partition_name',
+    );
+  });
+});
+
+describe('isPartitionOverlapError', () => {
+  it('should return true for overlap error', () => {
+    const err = {
+      message:
+        'partition "events_2025_05" would overlap partition "events_2025_04"',
+    };
+    expect(isPartitionOverlapError(err)).toBe(true);
+  });
+
+  it('should return false for non-overlap error', () => {
+    const err = { message: 'some other error' };
+    expect(isPartitionOverlapError(err)).toBe(false);
+  });
+
+  it('should return false if message is missing', () => {
+    const err = { msg: 'missing message property' };
+    expect(isPartitionOverlapError(err)).toBe(false);
+  });
+
+  it('should return false for null error', () => {
+    expect(isPartitionOverlapError(null)).toBe(false);
+  });
+
+  it('should return false for non-object error', () => {
+    expect(isPartitionOverlapError('error string')).toBe(false);
+  });
+});

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/partition.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/partition.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const extractOverlappingPartition = (message: string): string => {
+  const match = message.match(/would overlap partition "(.*?)"$/);
+  return match?.[1] || '';
+};
+
+export const parsePartitionDate = (
+  name: string,
+): { year: number; month: number } => {
+  const match = name.match(/events_(\d{4})_(\d{1,2})/);
+  if (!match) throw new Error(`Cannot parse partition name: ${name}`);
+  return { year: parseInt(match[1], 10), month: parseInt(match[2], 10) };
+};
+
+export const isPartitionOverlapError = (error: unknown): boolean => {
+  return (
+    error !== null &&
+    typeof (error as any).message === 'string' &&
+    (error as any).message.includes('would overlap partition')
+  );
+};


### PR DESCRIPTION

**Fixes**:

https://issues.redhat.com/browse/RHDHSUPP-222

**Description:**

Partition overlap error is caused in adoption insights fails RHDH pod from starting up successfully.


```
redhat-developer-hub-9546d5b77-8z8r6 backstage-backend 2025-05-14T16:06:37.039199203-04:00 error:
redhat-developer-hub-9546d5b77-8z8r6 backstage-backend 2025-05-14T16:06:37.039204503-04:00 CREATE TABLE IF NOT EXISTS events_2025_5
redhat-developer-hub-9546d5b77-8z8r6 backstage-backend 2025-05-14T16:06:37.039210603-04:00 PARTITION OF events
redhat-developer-hub-9546d5b77-8z8r6 backstage-backend 2025-05-14T16:06:37.039216203-04:00 FOR VALUES FROM ('2025-05-01') TO ('2025-07-01');
```

**Root cause analysis:**

Partitions were created with date ranges between 2 months instead of 1 month. This is caused by the following code where `month` was already 1-based (index), while the Javascript `Date(year, month, day)` function expects it to be 0-based. 

```
const nextMonth = new Date(year, month, 1);
nextMonth.setMonth(nextMonth.getMonth() + 1);
```

Due to this the starDate and endDate range becomes `('2025-05-01') TO ('2025-07-01')` instead of `('2025-05-01') TO ('2025-06-01')`


**Solution:**
- Corrected startDate and endDate calculation
   ```
   const start = new Date(year, month - 1, 1); // Corrected: month - 1
   const end = new Date(year, month, 1);       // Next month
  
   const startDate = start.toISOString().slice(0, 10);
   const endDate = end.toISOString().slice(0, 10);
   ```
- If an historic invalid partition is found, then drop the invalid partition and re-create it with the correct range, to ensure no overlap occurs.


**How to test locally:**

Testing locally requires some code changes to recreate the scenario:

**Steps to reproduce the error:**
- Configure the application to use postgres database.
- from the main branch (without this fix), add the following below this [line](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.ts#L70) in `/adoption-insights-backend/src/database/partition.ts` 

```diff
   logger.info('[TASK] Running initial execution on startup...');
+  await client.schema.raw(
+    `CREATE TABLE IF NOT EXISTS events_2025_4  PARTITION OF events FOR VALUES FROM ('2025-04-01') TO ('2025-06-01')`,
+  );
   await partitionEventsTable();
```
- Start the application `yarn dev` to reproduce the error outlined in the Jira ticket.

 **Steps to verify the fix:**

- Now  checking out this PR and follow the same steps mentioned above, you should not see the errors anymore.


## Unit tests:
```
plugins/adoption-insights-backend/src/utils/partition.test.ts
  extractOverlappingPartition
    ✓ should extract the overlapping partition name (1 ms)
    ✓ should return empty string if pattern does not match (1 ms)
  parsePartitionDate
    ✓ should parse valid partition name
    ✓ should parse single-digit month correctly
    ✓ should throw error for invalid format (3 ms)
  isPartitionOverlapError
    ✓ should return true for overlap error
    ✓ should return false for non-overlap error
    ✓ should return false if message is missing
    ✓ should return false for null error
    ✓ should return false for non-object error

  createPartition
    ✓ should create a partition without errors (2 ms)
    ✓ should handle overlapping partition error and retry
    ✓ should handle max retry when recreating dropped partition (3 ms)
    ✓ should not retry for non-overlap errors (1 ms)
```



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
