### PR TITLE
fix(global-header): fix global-header to prioritize 'spec.profile.displayname'

### DIFF
--- a/workspaces/global-header/.changeset/grumpy-trainers-turn.md
+++ b/workspaces/global-header/.changeset/grumpy-trainers-turn.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+fix global-header to prioritize 'spec.profile.displayname' or 'metadata.title' over profilename

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { screen } from '@testing-library/react';
+import type { CatalogApi } from '@backstage/catalog-client';
+import { useUserProfile } from '@backstage/plugin-user-settings';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { ProfileDropdown } from './ProfileDropdown';
+
+jest.mock('@backstage/plugin-user-settings', () => ({
+  useUserProfile: jest.fn(),
+}));
+
+jest.mock('../../hooks/useProfileDropdownMountPoints', () => ({
+  useProfileDropdownMountPoints: () => [
+    {
+      Component: jest.fn(),
+      config: {
+        props: {
+          icon: 'someicon',
+          title: 'sometitle',
+          link: 'somelink',
+        },
+        priority: '100',
+      },
+    },
+  ],
+}));
+
+describe('ProfileDropdown', () => {
+  it('should render the configured profile displayname', async () => {
+    (useUserProfile as jest.Mock).mockReturnValue({
+      displayName: 'Test User',
+      backstageIdentity: { userEntityRef: 'user:default/test-user' },
+      profile: { picture: 'picture' },
+      loading: false,
+    });
+    const mockCatalogApi = {
+      getEntityByRef: () => ({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: {
+          name: 'test-user',
+          title: 'Test User',
+        },
+        spec: {
+          profile: { displayName: 'Test User DN' },
+          memberOf: ['janus-authors'],
+        },
+      }),
+    } as any as CatalogApi;
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
+        <ProfileDropdown />
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText(/Test User DN/i)).toBeInTheDocument();
+  });
+
+  it('should render the title if profile displayname is not configured', async () => {
+    (useUserProfile as jest.Mock).mockReturnValue({
+      displayName: 'testuser1',
+      backstageIdentity: { userEntityRef: 'user:default/test-user' },
+      profile: { picture: 'picture' },
+      loading: false,
+    });
+    const mockCatalogApi = {
+      getEntityByRef: () => ({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: {
+          name: 'test-user',
+          title: 'Test User',
+        },
+        spec: {
+          memberOf: ['janus-authors'],
+        },
+      }),
+    } as any as CatalogApi;
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
+        <ProfileDropdown />
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText(/Test User/i)).toBeInTheDocument();
+  });
+
+  it('should render the user entity ref when user is not configured in the catalog', async () => {
+    (useUserProfile as jest.Mock).mockReturnValue({
+      displayName: 'user:default/test',
+      backstageIdentity: { userEntityRef: 'user:default/test' },
+      profile: { picture: 'picture' },
+      loading: false,
+    });
+    const mockCatalogApi = {
+      getEntityByRef: () => ({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: {
+          name: 'test-user',
+        },
+        spec: {
+          memberOf: ['janus-authors'],
+        },
+      }),
+    } as any as CatalogApi;
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
+        <ProfileDropdown />
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText(/Test/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Part of :  https://github.com/redhat-developer/rhdh-plugins/pull/732
Resolves: https://issues.redhat.com/browse/RHIDP-7057


Description: 

Only relying on `displayname` will not render the displayname configured by the user in `spec.profile.displayname`  or `metadata.title` property in the user entity.
The reporter who raised the concern mentioned that he wishes to see his configured display name in the global-header's profile dropdown.
So, considering that we prioritize the configured displayname, if that is not specified, we fall back to `displayname` generated by the `useProfileInfo` hook that returns user-friendly displaynames


Screenshots:

When `spec.profile.displayname` is configured
```
apiVersion: backstage.io/v1alpha1
kind: User
metadata:
  name: debsmita1
  title: Debsmita Santra
spec:
  profile:
    displayName: Debsmita Santra DN
  memberOf: [janus-authors]
```
![Screenshot 2025-05-16 at 5 59 10 PM](https://github.com/user-attachments/assets/f1ed1313-a57d-4949-8477-c98930264896)



When `spec.profile.displayname` is not configured , but `metadata.title` is configured
```
apiVersion: backstage.io/v1alpha1
kind: User
metadata:
  name: debsmita1
  title: Debsmita Santra Title
spec:
  memberOf: [janus-authors]
```

![Screenshot 2025-05-19 at 11 25 31 AM](https://github.com/user-attachments/assets/0e0cfc4f-c016-4d9a-aed1-c4f1c4c67440)




When neither `spec.profile.displayname` nor `title` is not configured
```
apiVersion: backstage.io/v1alpha1
kind: User
metadata:
  name: debsmita1
spec:
  memberOf: [janus-authors]
```
![Screenshot 2025-05-16 at 5 21 53 PM](https://github.com/user-attachments/assets/76e2e758-42f0-4676-af0d-3096cfd1a06a)

Falls back to `metadata.name` when user entity is not registered
![Screenshot 2025-05-17 at 12 10 16 AM](https://github.com/user-attachments/assets/27f9c5fe-809f-41ad-8675-ee34f69b1170)


New tests
<img width="561" alt="Screenshot 2025-05-17 at 12 10 44 AM" src="https://github.com/user-attachments/assets/58b0c9ed-217b-43aa-a34c-22cf8c8505f3" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
