### PR TITLE
chore: rework renovate configs

### DIFF
--- a/.github/renovate-presets/base/rhdh-devdependency-presets.json
+++ b/.github/renovate-presets/base/rhdh-devdependency-presets.json
@@ -1,0 +1,9 @@
+{
+  "devDeps": {
+    "description": "Group all minor/patch devdependencies updates for RHDH {{arg0}} Plugins",
+    "matchUpdateTypes": ["minor", "patch"],
+    "matchDepTypes": ["devDependencies"],
+    "groupName": "RHDH {{arg0}} DevDependencies (non-major)",
+    "automerge": true
+  }
+}

--- a/.github/renovate-presets/base/rhdh-minor-presets.json
+++ b/.github/renovate-presets/base/rhdh-minor-presets.json
@@ -1,0 +1,8 @@
+{
+  "minor": {
+    "description": "Group all minor updates for RHDH {{arg0}} Plugins",
+    "matchUpdateTypes": ["minor"],
+    "matchDepTypes": ["dependencies", "peerDependencies"],
+    "groupName": "RHDH {{arg0}} Dependencies (minor)"
+  }
+}

--- a/.github/renovate-presets/base/rhdh-patch-presets.json
+++ b/.github/renovate-presets/base/rhdh-patch-presets.json
@@ -1,0 +1,9 @@
+{
+  "patch": {
+    "description": "Group all patch updates for RHDH {{arg0}} Plugins",
+    "matchUpdateTypes": ["patch"],
+    "matchDepTypes": ["dependencies", "peerDependencies"],
+    "groupName": "RHDH {{arg0}} Dependencies (patch)",
+    "automerge": true
+  }
+}

--- a/.github/renovate-presets/workspace/rhdh-adoption-insights-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-adoption-insights-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all RHDH Adoption Insights plugins minor updates",
+      "matchFileNames": ["workspaces/adoption-insights/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Adoption Insights)"
+      ],
+      "addLabels": ["team/pai", "adoption-insights"]
+    },
+    {
+      "description": "all RHDH Adoption Insights plugins patch updates",
+      "matchFileNames": ["workspaces/adoption-insights/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Adoption Insights)"
+      ],
+      "addLabels": ["team/pai", "adoption-insights"]
+    },
+    {
+      "description": "all RHDH Adoption Insights plugins dev dependency updates",
+      "matchFileNames": ["workspaces/adoption-insights/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Adoption Insights)"
+      ],
+      "addLabels": ["team/pai", "adoption-insights"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-ai-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-ai-presets.json
@@ -1,0 +1,37 @@
+{
+  "packageRules": [
+    {
+      "description": "all PAI workspaces minor updates",
+      "matchFileNames": [
+        "workspaces/ai-integrations/**",
+        "workspaces/lightspeed/**"
+      ],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(PAI)"
+      ],
+      "addLabels": ["team/pai", "pai"]
+    },
+    {
+      "description": "all PAI workspaces patch updates",
+      "matchFileNames": [
+        "workspaces/ai-integrations/**",
+        "workspaces/lightspeed/**"
+      ],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(PAI)"
+      ],
+      "addLabels": ["team/pai", "pai"]
+    },
+    {
+      "description": "all PAI workspaces dev dependency updates",
+      "matchFileNames": [
+        "workspaces/ai-integrations/**",
+        "workspaces/lightspeed/**"
+      ],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(PAI)"
+      ],
+      "addLabels": ["team/pai", "pai"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-bulk-import-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-bulk-import-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all RHDH Bulk Import patch updates",
+      "matchFileNames": ["workspaces/bulk-import/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Bulk Import)"
+      ],
+      "addLabels": ["team/rhdh", "bulk-import"]
+    },
+    {
+      "description": "all RHDH Bulk Import dev dependency updates",
+      "matchFileNames": ["workspaces/bulk-import/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Bulk Import)"
+      ],
+      "addLabels": ["team/rhdh", "bulk-import"]
+    },
+    {
+      "description": "all RHDH Bulk Import minor updates",
+      "matchFileNames": ["workspaces/bulk-import/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Bulk Import)"
+      ],
+      "addLabels": ["team/rhdh", "bulk-import"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-global-ui-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-global-ui-presets.json
@@ -1,0 +1,37 @@
+{
+  "packageRules": [
+    {
+      "description": "all global ui minor updates",
+      "matchFileNames": [
+        "workspaces/global-floating-action-button/**",
+        "workspaces/global-header/**"
+      ],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Global UI)"
+      ],
+      "addLabels": ["team/rhdh", "global-ui"]
+    },
+    {
+      "description": "all global ui patch updates",
+      "matchFileNames": [
+        "workspaces/global-floating-action-button/**",
+        "workspaces/global-header/**"
+      ],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Global UI)"
+      ],
+      "addLabels": ["team/rhdh", "global-ui"]
+    },
+    {
+      "description": "all global ui dev dependency updates",
+      "matchFileNames": [
+        "workspaces/global-floating-action-button/**",
+        "workspaces/global-header/**"
+      ],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Global UI)"
+      ],
+      "addLabels": ["team/rhdh", "global-ui"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-homepage-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-homepage-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all homepage minor updates",
+      "matchFileNames": ["workspaces/homepage/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Homepage)"
+      ],
+      "addLabels": ["team/rhdh", "homepage"]
+    },
+    {
+      "description": "all homepage patch updates",
+      "matchFileNames": ["workspaces/homepage/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Homepage)"
+      ],
+      "addLabels": ["team/rhdh", "homepage"]
+    },
+    {
+      "description": "all homepage dev dependency updates",
+      "matchFileNames": ["workspaces/homepage/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Homepage)"
+      ],
+      "addLabels": ["team/rhdh", "homepage"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-marketplace-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-marketplace-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all marketplace minor updates",
+      "matchFileNames": ["workspaces/marketplace/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Marketplace)"
+      ],
+      "addLabels": ["team/rhdh", "marketplace"]
+    },
+    {
+      "description": "all marketplace patch updates",
+      "matchFileNames": ["workspaces/marketplace/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Marketplace)"
+      ],
+      "addLabels": ["team/rhdh", "marketplace"]
+    },
+    {
+      "description": "all marketplace dev dependency updates",
+      "matchFileNames": ["workspaces/marketplace/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Marketplace)"
+      ],
+      "addLabels": ["team/rhdh", "marketplace"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all openshift image registry minor updates",
+      "matchFileNames": ["workspaces/openshift-image-registry/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(OIR)"
+      ],
+      "addLabels": ["team/rhdh", "openshift-image-registry"]
+    },
+    {
+      "description": "all openshift image registry patch updates",
+      "matchFileNames": ["workspaces/openshift-image-registry/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(OIR)"
+      ],
+      "addLabels": ["team/rhdh", "openshift-image-registry"]
+    },
+    {
+      "description": "all openshift image registry dev dependency updates",
+      "matchFileNames": ["workspaces/openshift-image-registry/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(OIR)"
+      ],
+      "addLabels": ["team/rhdh", "openshift-image-registry"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-orchestrator-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-orchestrator-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Orchestrator minor updates",
+      "matchFileNames": ["workspaces/orchestrator/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins/.github/renovate-presets/base/rhdh-minor-presets(Orchestrator)"
+      ],
+      "addLabels": ["team/orchestrator", "orchestrator"]
+    },
+    {
+      "description": "all Orchestrator patch updates",
+      "matchFileNames": ["workspaces/orchestrator/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Orchestrator)"
+      ],
+      "addLabels": ["team/orchestrator", "orchestrator"]
+    },
+    {
+      "description": "all Orchestrator dev dependency updates",
+      "matchFileNames": ["workspaces/orchestrator/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Orchestrator)"
+      ],
+      "addLabels": ["team/orchestrator", "orchestrator"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-sandbox-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-sandbox-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Sandbox minor updates",
+      "matchFileNames": ["workspaces/sandbox/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Sandbox)"
+      ],
+      "addLabels": ["team/sandbox", "sandbox"]
+    },
+    {
+      "description": "all Sandbox patch updates",
+      "matchFileNames": ["workspaces/sandbox/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Sandbox)"
+      ],
+      "addLabels": ["team/sandbox", "sandbox"]
+    },
+    {
+      "description": "all Sandbox dev dependency updates",
+      "matchFileNames": ["workspaces/sandbox/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Sandbox)"
+      ],
+      "addLabels": ["team/sandbox", "sandbox"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-theme-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-theme-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all theme minor updates",
+      "matchFileNames": ["workspaces/theme/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Theme)"
+      ],
+      "addLabels": ["team/rhdh", "theme"]
+    },
+    {
+      "description": "all theme patch updates",
+      "matchFileNames": ["workspaces/theme/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Theme)"
+      ],
+      "addLabels": ["team/rhdh", "theme"]
+    },
+    {
+      "description": "all theme dev dependency updates",
+      "matchFileNames": ["workspaces/theme/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Theme)"
+      ],
+      "addLabels": ["team/rhdh", "theme"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,12 +7,17 @@
     "group:test",
     ":preserveSemverRanges"
   ],
-  "ignorePresets": [":pinDevDependencies", ":pinDigest", "docker:pinDigests"],
+  "ignorePresets": [
+    ":pinDevDependencies",
+    ":pinDigest",
+    "docker:pinDigests",
+    "group:monorepos"
+  ],
   "labels": ["dependencies"],
   "postUpdateOptions": ["yarnDedupeHighest"],
-  "osvVulnerabilityAlerts": true,
+  "osvVulnerabilityAlerts": false,
   "vulnerabilityAlerts": {
-    "enabled": true,
+    "enabled": false,
     "labels": ["dependencies", "security"]
   },
   "npm": {
@@ -22,46 +27,6 @@
     "dependencyDashboardApproval": true
   },
   "packageRules": [
-    {
-      "groupName": "DevDependencies (minor)",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor"]
-    },
-    {
-      "groupName": "DevDependencies (patch)",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch"]
-    },
-    {
-      "groupName": "Test packages (minor)",
-      "matchDepNames": ["@playwright/{/,}**", "msw", "@testing-library/{/,}**"],
-      "matchUpdateTypes": ["minor"]
-    },
-    {
-      "groupName": "Test packages (patch)",
-      "matchDepNames": ["@playwright/{/,}**", "msw", "@testing-library/{/,}**"],
-      "matchUpdateTypes": ["patch"]
-    },
-    {
-      "groupName": "Kie Tools (minor)",
-      "matchDepNames": ["@kie-tools-core/{/,}**", "@kie-tools/{/,}**"],
-      "matchUpdateTypes": ["minor"]
-    },
-    {
-      "groupName": "Kie Tools (patch)",
-      "matchDepNames": ["@kie-tools-core/{/,}**", "@kie-tools/{/,}**"],
-      "matchUpdateTypes": ["patch"]
-    },
-    {
-      "groupName": "types (minor)",
-      "matchPackageNames": ["@types/{/,}**"],
-      "matchUpdateTypes": ["minor"]
-    },
-    {
-      "matchUpdateTypes": ["patch"],
-      "groupName": "types (patch)",
-      "matchPackageNames": ["@types/{/,}**"]
-    },
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
@@ -77,6 +42,20 @@
     {
       "matchPackageNames": ["yn"],
       "allowedVersions": "<5.0.0"
+    },
+    {
+      "description": "all RHDH Plugins workspaces",
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-bulk-import-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-homepage-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-theme-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-global-ui-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-marketplace-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-adoption-insights-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-ai-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-orchestrator-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets"
+      ]
     },
     {
       "groupName": "Core Backstage packages",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
Fixes: https://issues.redhat.com/browse/RHIDP-6050

This PR introduces a rework of the renovate config to include:

- creation of workspace specific PRs with automerge enabled for patch updates and dev dependencies.  Major updates will require dashboard approval as usual
- disabling vulnerability alerts as this causes additional memory consumption on the server which will likely cause failures.  Dependabot is currently enabled for this and works in a similar way

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
