### PR TITLE
chore(orchestrator): remove redundant monaco-editor dependency

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator/package.json
@@ -72,7 +72,6 @@
     "json-schema": "^0.4.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
-    "monaco-editor": "^0.52.2",
     "react-json-view": "^1.21.3",
     "react-moment": "^1.1.3",
     "react-use": "^17.4.0",

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/JsonTextAreaForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/JsonTextAreaForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import type { JsonObject } from '@backstage/types';
 
 import { Box, Grid, useTheme } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
-import { Editor } from '@monaco-editor/react';
+import Editor, { loader } from '@monaco-editor/react';
 
 import { SubmitButton } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
+
+loader.config({
+  // FLPATH-2358: If production env keeps downloading from jsdelivr.net, configure local path here
+});
 
 const DEFAULT_VALUE = JSON.stringify({ myKey: 'myValue' }, null, 4);
 

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -11536,7 +11536,6 @@ __metadata:
     json-schema: ^0.4.0
     lodash: ^4.17.21
     moment: ^2.29.4
-    monaco-editor: ^0.52.2
     prettier: 3.5.3
     react-json-view: ^1.21.3
     react-moment: ^1.1.3
@@ -28175,13 +28174,6 @@ __metadata:
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
   checksum: 859236bab1e88c3e5802afcf797fc801acdbd0ee509d34ea3df6eea21eb6bcc2abd4ae4e4e64aa7c986aa6cba563c6e62806218e6412a765010712e5fa121ba6
-  languageName: node
-  linkType: hard
-
-"monaco-editor@npm:^0.52.2":
-  version: 0.52.2
-  resolution: "monaco-editor@npm:0.52.2"
-  checksum: d5ff7b7a469afee25ac708d9ace0dcc5ef24ed328dfc526a52944a497f0d826cfb0685a778ff4b7becc0a8f7843f260c17ea6de3f6719481d53501d79ebb1260
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Recently we use `@monaco-editor/react` dependency instead.