### PR TITLE
fix(bulk-import): removing extra apis call

### DIFF
--- a/workspaces/bulk-import/.changeset/selfish-brooms-heal.md
+++ b/workspaces/bulk-import/.changeset/selfish-brooms-heal.md
@@ -1,0 +1,12 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Improve Bulk Import UI performance by optimizing API call behavior:
+
+- Prevent unnecessary API calls when switching between **Organizations** and **Repositories** tabs.
+- Avoid redundant calls when clicking on pagination controls without changing page or page size.
+- Suppress extraneous API requests triggered by random screen clicks.
+- Introduce **debouncing** to the search input to reduce network load during fast typing.
+
+These changes reduce client-side overhead and improve the responsiveness of the Bulk Import page.

--- a/workspaces/bulk-import/plugins/bulk-import/package.json
+++ b/workspaces/bulk-import/plugins/bulk-import/package.json
@@ -72,7 +72,6 @@
     "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "14.6.1",
     "@types/lodash": "^4.14.151",
-    "@types/lodash.debounce": "^4.0.9",
     "@types/react": "^18.2.58",
     "msw": "1.3.5",
     "prettier": "3.5.3",

--- a/workspaces/bulk-import/plugins/bulk-import/package.json
+++ b/workspaces/bulk-import/plugins/bulk-import/package.json
@@ -51,7 +51,6 @@
     "formik": "^2.4.5",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "lodash.debounce": "^4.0.8",
     "react-use": "^17.2.4",
     "yaml": "^2.0.0",
     "yup": "^1.4.0"

--- a/workspaces/bulk-import/plugins/bulk-import/package.json
+++ b/workspaces/bulk-import/plugins/bulk-import/package.json
@@ -51,6 +51,7 @@
     "formik": "^2.4.5",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "lodash.debounce": "^4.0.8",
     "react-use": "^17.2.4",
     "yaml": "^2.0.0",
     "yup": "^1.4.0"
@@ -72,6 +73,7 @@
     "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "14.6.1",
     "@types/lodash": "^4.14.151",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/react": "^18.2.58",
     "msw": "1.3.5",
     "prettier": "3.5.3",

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import { useFormikContext } from 'formik';
+import debounce from 'lodash.debounce';
 
 import { useNumberOfApprovalTools } from '../../hooks';
 import {
@@ -41,10 +42,29 @@ export const AddRepositoriesTable = ({ title }: { title?: string }) => {
   }, [values.approvalTool]);
   const [searchString, setSearchString] = useState<string>('');
   const [page, setPage] = useState<number>(0);
-  const handleSearch = (str: string) => {
-    setSearchString(str);
-    setPage(0);
-  };
+
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((str: string) => {
+        setSearchString(str);
+        setPage(0);
+      }, 300),
+    [],
+  );
+
+  const handleSearch = useCallback(
+    (str: string) => {
+      debouncedSearch(str);
+    },
+    [debouncedSearch],
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedSearch.cancel();
+    };
+  }, [debouncedSearch]);
+
   const { numberOfApprovalTools } = useNumberOfApprovalTools();
 
   return (

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useDebounce } from 'react-use';
 
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import { useFormikContext } from 'formik';
-import debounce from 'lodash.debounce';
 
 import { useNumberOfApprovalTools } from '../../hooks';
 import {
@@ -41,29 +41,17 @@ export const AddRepositoriesTable = ({ title }: { title?: string }) => {
     setIsApprovalToolGitlab(values.approvalTool === ApprovalToolEnum.Gitlab);
   }, [values.approvalTool]);
   const [searchString, setSearchString] = useState<string>('');
+  const [searchInput, setSearchInput] = useState<string>('');
   const [page, setPage] = useState<number>(0);
 
-  const debouncedSearch = useMemo(
-    () =>
-      debounce((str: string) => {
-        setSearchString(str);
-        setPage(0);
-      }, 300),
-    [],
-  );
-
-  const handleSearch = useCallback(
-    (str: string) => {
-      debouncedSearch(str);
+  useDebounce(
+    () => {
+      setSearchString(searchInput);
+      setPage(0);
     },
-    [debouncedSearch],
+    300,
+    [searchInput],
   );
-
-  useEffect(() => {
-    return () => {
-      debouncedSearch.cancel();
-    };
-  }, [debouncedSearch]);
 
   const { numberOfApprovalTools } = useNumberOfApprovalTools();
 
@@ -81,7 +69,7 @@ export const AddRepositoriesTable = ({ title }: { title?: string }) => {
             title ||
             `Selected  ${isApprovalToolGitlab ? 'projects' : 'repositories'}`
           }
-          setSearchString={handleSearch}
+          setSearchString={setSearchInput}
           onPageChange={setPage}
           isApprovalToolGitlab={isApprovalToolGitlab}
         />

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
@@ -99,7 +99,7 @@ export const useRepositories = (
   } = useQuery(
     [options?.showOrganizations ? 'organizations' : 'repositories', options],
     () => fetchRepositories(options),
-    { refetchInterval: pollInterval || 60000 },
+    { refetchInterval: pollInterval || 60000, refetchOnWindowFocus: false },
   );
 
   const prepareData = useMemo(() => {

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -10791,6 +10791,7 @@ __metadata:
     "@testing-library/react": ^15.0.0
     "@testing-library/user-event": 14.6.1
     "@types/lodash": ^4.14.151
+    "@types/lodash.debounce": ^4.0.9
     "@types/react": ^18.2.58
     formik: ^2.4.5
     js-yaml: ^4.1.0
@@ -13865,6 +13866,22 @@ __metadata:
   dependencies:
     keyv: "*"
   checksum: 8713da9382b9346d664866a6cab2f91b0fd479f61379af891303a618e9a2abad6f347adc38a0850540e3f2dad278427de24e7555339264fddb04d1d17d3b50e0
+  languageName: node
+  linkType: hard
+
+"@types/lodash.debounce@npm:^4.0.9":
+  version: 4.0.9
+  resolution: "@types/lodash.debounce@npm:4.0.9"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 8183a152e01928e3b97ca773f6ae6038b8695e76493ba8bf6b743ec143948a62294fbc9d49fa4a78b52265b3ba4892ef57534e0c13d04aa0f111671b5a944feb
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.17.17
+  resolution: "@types/lodash@npm:4.17.17"
+  checksum: cfa34a752f3c540a196e9f92dbaff93ae15fe4058da8cce1918dd9219076dc19eec33b043aae45865e2b3ef8234a845bb57366144ec8e52551e2bc3f119e04a1
   languageName: node
   linkType: hard
 

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -13879,17 +13879,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:*":
+"@types/lodash@npm:*, @types/lodash@npm:^4.14.151":
   version: 4.17.17
   resolution: "@types/lodash@npm:4.17.17"
   checksum: cfa34a752f3c540a196e9f92dbaff93ae15fe4058da8cce1918dd9219076dc19eec33b043aae45865e2b3ef8234a845bb57366144ec8e52551e2bc3f119e04a1
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:^4.14.151":
-  version: 4.17.13
-  resolution: "@types/lodash@npm:4.17.13"
-  checksum: d0bf8fbd950be71946e0076b30fd40d492293baea75f05931b6b5b906fd62583708c6229abdb95b30205ad24ce1ed2f48bc9d419364f682320edd03405cc0c7e
   languageName: node
   linkType: hard
 

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -10796,6 +10796,7 @@ __metadata:
     formik: ^2.4.5
     js-yaml: ^4.1.0
     lodash: ^4.17.21
+    lodash.debounce: ^4.0.8
     msw: 1.3.5
     prettier: 3.5.3
     react: 16.13.1 || ^17.0.0 || ^18.0.0

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -10796,7 +10796,6 @@ __metadata:
     formik: ^2.4.5
     js-yaml: ^4.1.0
     lodash: ^4.17.21
-    lodash.debounce: ^4.0.8
     msw: 1.3.5
     prettier: 3.5.3
     react: 16.13.1 || ^17.0.0 || ^18.0.0

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -10791,7 +10791,6 @@ __metadata:
     "@testing-library/react": ^15.0.0
     "@testing-library/user-event": 14.6.1
     "@types/lodash": ^4.14.151
-    "@types/lodash.debounce": ^4.0.9
     "@types/react": ^18.2.58
     formik: ^2.4.5
     js-yaml: ^4.1.0
@@ -13869,16 +13868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash.debounce@npm:^4.0.9":
-  version: 4.0.9
-  resolution: "@types/lodash.debounce@npm:4.0.9"
-  dependencies:
-    "@types/lodash": "*"
-  checksum: 8183a152e01928e3b97ca773f6ae6038b8695e76493ba8bf6b743ec143948a62294fbc9d49fa4a78b52265b3ba4892ef57534e0c13d04aa0f111671b5a944feb
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:*, @types/lodash@npm:^4.14.151":
+"@types/lodash@npm:^4.14.151":
   version: 4.17.17
   resolution: "@types/lodash@npm:4.17.17"
   checksum: cfa34a752f3c540a196e9f92dbaff93ae15fe4058da8cce1918dd9219076dc19eec33b043aae45865e2b3ef8234a845bb57366144ec8e52551e2bc3f119e04a1


### PR DESCRIPTION
## Description

This PR focuses on improving the performance and efficiency of the Bulk Import page by reducing unnecessary API calls and improving user experience.

###  Problem
- When switching between the **Organizations** and **Repositories** tabs, API calls for both tabs were being made — even if only one was actively in view.
- Unintended API requests were triggered by generic screen clicks.
- Pagination controls triggered API calls even when the page number or page size didn't change.
- Search input was missing **debounce**, resulting in multiple API requests for each keystroke (e.g., typing “test” sent 4 requests).

### Fixes 
Fixing https://issues.redhat.com/browse/RHIDP-7658

###  Fixes Implemented
1. **Tab Switching Optimization**  
   - Ensured that only the active tab triggers its respective API call.

2. **Reduced Redundant Triggers**  
   - Eliminated unnecessary API calls triggered by unrelated user interactions (e.g., page clicks).

3. **Pagination Optimization**  
   - API calls now only trigger when actual changes occur (e.g., page or page size changes).

4. **Search Input Debounce**  
   - Added `lodash.debounce` to avoid excessive API calls on fast typing.

---
### Recording for Before Changes

https://github.com/user-attachments/assets/2f20751f-1553-4a7b-989e-7e1a56f51c5d

### Recording for After Changes

https://github.com/user-attachments/assets/786f9d49-a0ae-4943-aebe-a3d7e84eaabe


---
###  How to Test
1. Go to the Bulk Import Add repository page.
2. Switch between Organizations and Repositories.
3. Interact with the pagination control without changing values.
4. Type quickly in the search bar and observe the number of requests.

---

### Result
- Lower network traffic.
- Smoother UX for users dealing with large sets of repositories/organizations.
- Increased frontend responsiveness.

