### PR TITLE
fix(lightspeed): reset localstorage when the conversations are empty 

### DIFF
--- a/workspaces/lightspeed/.changeset/brown-papayas-wave.md
+++ b/workspaces/lightspeed/.changeset/brown-papayas-wave.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Reset localstorage if the conversations are empty

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -141,7 +141,11 @@ export const LightspeedChat = ({
 
   const queryClient = useQueryClient();
 
-  const { data: conversations = [] } = useConversations();
+  const {
+    data: conversations = [],
+    isLoading,
+    isRefetching,
+  } = useConversations();
   const { mutateAsync: deleteConversation } = useDeleteConversation();
   const { allowed: hasDeleteAccess } = useLightspeedDeletePermission();
   const samplePrompts = useWelcomePrompts();
@@ -151,6 +155,18 @@ export const LightspeedChat = ({
       setNewChatCreated(true);
     }
   }, [user, isReady, lastOpenedId, setConversationId]);
+
+  React.useEffect(() => {
+    // Clear last opened conversationId when there are no conversations.
+    if (
+      !isLoading &&
+      !isRefetching &&
+      conversations.length === 0 &&
+      lastOpenedId
+    ) {
+      clearLastOpenedId();
+    }
+  }, [isLoading, isRefetching, conversations, lastOpenedId, clearLastOpenedId]);
 
   React.useEffect(() => {
     // Update last opened conversation whenever `conversationId` changes

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+import {
+  configApiRef,
+  IdentityApi,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { mockApis, TestApiProvider } from '@backstage/test-utils';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import FileAttachmentContextProvider from '../AttachmentContext';
+import { LightspeedChat } from '../LightSpeedChat';
+
+const identityApi = {
+  async getCredentials() {
+    return { token: 'test-token' };
+  },
+  getBackstageIdentity: jest
+    .fn()
+    .mockReturnValue({ userEntityRef: 'user:test' }),
+} as unknown as IdentityApi;
+
+// Create a query client with no retries for test purposes
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      experimental_prefetchInRender: true,
+    },
+  },
+});
+
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: jest.fn(),
+  RequirePermission: jest.fn(),
+}));
+
+jest.mock('../../hooks/useConversations', () => ({
+  useConversations: jest.fn().mockReturnValue({
+    data: [],
+    isRefetching: false,
+    isLoading: false,
+  }),
+}));
+jest.mock('../../hooks/useDeleteConversation', () => ({
+  useDeleteConversation: jest.fn().mockResolvedValue({
+    data: [],
+  }),
+}));
+
+jest.mock('../../hooks/useConversationMessages', () => ({
+  useConversationMessages: jest.fn().mockReturnValue({
+    conversationMessages: [],
+  }),
+}));
+
+jest.mock('@patternfly/chatbot', () => {
+  const actual = jest.requireActual('@patternfly/chatbot');
+  return {
+    ...actual,
+    MessageBox: () => <>MessageBox</>,
+  };
+});
+
+const mockUsePermission = usePermission as jest.MockedFunction<
+  typeof usePermission
+>;
+
+const configAPi = mockApis.config({});
+
+const setupLightspeedChat = () => (
+  <TestApiProvider
+    apis={[
+      [identityApiRef, identityApi],
+      [configApiRef, configAPi],
+    ]}
+  >
+    <FileAttachmentContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <LightspeedChat
+          selectedModel="granite"
+          profileLoading={false}
+          handleSelectedModel={() => {}}
+          models={[]}
+          avatar="test"
+          userName="user:test"
+        />
+      </QueryClientProvider>
+    </FileAttachmentContextProvider>
+  </TestApiProvider>
+);
+
+describe('LightspeedChat', () => {
+  beforeEach(() => {
+    mockUsePermission.mockReturnValue({ loading: true, allowed: true });
+  });
+  const localStorageKey = 'lastOpenedConversation';
+  const mockUser = 'user:test';
+
+  it('should render lightspeed chat', async () => {
+    render(setupLightspeedChat());
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer Hub Lightspeed')).toBeInTheDocument();
+    });
+  });
+
+  it('should not reset localstorage if the conversations are available', async () => {
+    jest.mock('../../hooks/useConversations', () => ({
+      useConversations: jest.fn().mockReturnValue({
+        data: [
+          {
+            conversation_id: 'test-conversation-id',
+            topic_summary: 'Greetings',
+            last_message_timestamp: 1749023603.806369,
+          },
+        ],
+        isRefetching: false,
+        isLoading: false,
+      }),
+    }));
+
+    const storedData = JSON.stringify({ [mockUser]: 'test-conversation-id' });
+    localStorage.setItem(localStorageKey, storedData);
+
+    render(setupLightspeedChat());
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer Hub Lightspeed')).toBeInTheDocument();
+
+      expect(screen.queryByText('New chat')).not.toBeInTheDocument();
+      expect(JSON.parse(localStorage.getItem(localStorageKey)!)).toEqual({});
+    });
+  });
+
+  it('should reset localstorage if the conversations are empty', async () => {
+    const storedData = JSON.stringify({ [mockUser]: 'test-conversation-id' });
+    localStorage.setItem(localStorageKey, storedData);
+
+    render(setupLightspeedChat());
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer Hub Lightspeed')).toBeInTheDocument();
+
+      expect(screen.queryByText('New chat')).not.toBeInTheDocument();
+      expect(JSON.parse(localStorage.getItem(localStorageKey)!)).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
##  Clear localstorage when there are no conversations 

Fixes:
https://issues.redhat.com/browse/RHDHPAI-844

Clear the last opened conversation ID saved in the browser local storage
-  when there are no conversations available for the logged in user. 
-  If user deletes all their conversation manually.



Before:

Conversation ID formats are modified and it is creating conflicts.

![image](https://github.com/user-attachments/assets/08176001-736c-46b8-9944-f96df4faf337)


After:

Since there are no conversations yet, we reset the browser storage too.

![image](https://github.com/user-attachments/assets/e84c01d3-0b15-40d0-a113-7a3c8b4748de)

## How to test:

1. Run an older version of lightspeed (without RCS) and create a conversation.

    - Option 1 : Use older commit `git checkout f406790cc5f1ed2e5de85398352152cc7f6b89e8` and run the application.
    
       
    - Option 2: (Using image): Use an old image [quay.io/repository/karthik_jk/lightspeed:stable](https://quay.io/repository/karthik_jk/lightspeed)
   
2. after creating a conversation from step 1, kill the application and re-run the application from `main` branch or using [quay.io/repository/karthik_jk/lightspeed:1.7](https://quay.io/repository/karthik_jk/lightspeed)
3. Visit the application in the same browser and create a conversation to reproduce the issue.

4.  Finally, now checkout and run the changes from this PR branch with the RCS setup. Alternatively you can use the latest lightspeed image with this PR changes [quay.io/repository/karthik_jk/lightspeed:latest](https://quay.io/repository/karthik_jk/lightspeed)



## unit tests

```
 PASS   @red-hat-developer-hub/backstage-plugin-lightspeed  plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
  LightspeedChat
    ✓ should render lightspeed chat (114 ms)
    ✓ should not reset localstorage if the conversations are available (63 ms)
    ✓ should reset localstorage if the conversations are empty (48 ms)
```     


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
