### PR TITLE
chore: adopt auto-version-bump action from BCP

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,52 @@
+name: Auto Version Bump
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: auto-version-bump
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Generate workspace matrix
+        id: set-matrix
+        run: |
+          matrix=$(node scripts/ci/generate-auto-bump-matrix.js)
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  batch-dispatch:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Delay batches (5 min between)
+        if: ${{ strategy.job-index != 0 }}
+        run: |
+          delay=$(( ${{ strategy.job-index }} * 300 ))
+          echo "Sleeping $delay seconds before triggering batch ${{ strategy.job-index }}..."
+          sleep $delay
+
+      - name: Trigger Version Bump Workflow via GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+        run: |
+          echo "Triggering version bump for workspace ${{ matrix.workspace }}"
+          json_input='${{ toJson(matrix.workspace) }}'
+          echo "Rendered json_input: $json_input"
+          gh workflow run version-bump.yml \
+            --ref main \
+            --field release_line=main \
+            --field workspace_input="$json_input" \
+            --field version-bump-type=minor

--- a/scripts/ci/generate-auto-bump-matrix.js
+++ b/scripts/ci/generate-auto-bump-matrix.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const workspacesDir = path.resolve('workspaces');
+
+// Only include directories that contain a `.auto-version-bump` marker file
+function getWorkspaceDirs() {
+  return fs.readdirSync(workspacesDir).filter(entry => {
+    const dirPath = path.join(workspacesDir, entry);
+    const bumpFile = path.join(dirPath, '.auto-version-bump');
+
+    return fs.statSync(dirPath).isDirectory() && fs.existsSync(bumpFile);
+  });
+}
+
+const workspaces = getWorkspaceDirs().sort();
+
+// Final matrix: one workspace per job
+const matrix = workspaces.map(workspace => ({ workspace }));
+
+console.log(JSON.stringify(matrix));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR introduces a new `auto-version-bump.yml` GitHub Action, adapted from the [BCP](https://github.com/backstage/community-plugins/blob/main/docs/plugin-maintainers-guide.md#opt-in-to-automatic-version-bump-prs), to automate triggering version bumps across plugin workspaces. This setup allows us to selectively and automatically bump plugin versions by simply adding an empty `.auto-version-bump` file to a workspace.

Major changes:

1. Copied `.github/workflows/auto-version-bump.yml` and `scripts/ci/generate-auto-bump-matrix.js` from the BCP repo.
2. Updated `auto-version-bump.yml`:
   - Changed matrix key from `batch` to `workspace` to match our `version-bump.yml` logic, which handles one workspace per job.
   - Updated the CLI `workspace_input` field to pass a JSON array of one workspace, e.g., `["global-header"]`, aligning with the expectations in `version-bump.yml`.
3. Modified `generate-auto-bump-matrix.js` to output a matrix of `{ workspace: <name> }` items (instead of BCP's `batch` format).
4. Added a delay between jobs (5 minutes) to space out version bump triggers and reduce contention in CI.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
