### PR TITLE
fix: auto-version-bump prepare step

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -20,7 +20,9 @@ jobs:
         id: set-matrix
         run: |
           matrix=$(node scripts/ci/generate-auto-bump-matrix.js)
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$matrix" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
   batch-dispatch:
     needs: prepare


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fixed the bash format in the prepare step for the following error:

```
Auto Version Bump
Error when evaluating 'strategy' for job 'batch-dispatch'. .github/workflows/auto-version-bump.yml (Line: 29, Col: 15): A sequence was not expected
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
