### PR TITLE
fix(lightspeeed): Enable only supported file types while uploading attachments

### DIFF
--- a/workspaces/lightspeed/.changeset/orange-spiders-speak.md
+++ b/workspaces/lightspeed/.changeset/orange-spiders-speak.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+enable only supported file types in file picker

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -31,6 +31,7 @@ import {
   uploadFile,
   uploadAndAssertDuplicate,
   supportedFileTypes,
+  validateFailedUpload,
 } from './utils/fileUpload';
 import {
   assertChatDialogInitialState,
@@ -140,6 +141,7 @@ test.describe('File Attachment Validation', () => {
       if (supportedFileTypes.includes(fileExtension)) {
         await uploadAndAssertDuplicate(page, path, name);
       } else {
+        await validateFailedUpload(page);
         // Unsupported files will not be available to preview.
         const filePreview = page
           .locator('span', { hasText: name.split('.')[0] })

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -145,7 +145,7 @@ test.describe('File Attachment Validation', () => {
           .locator('span', { hasText: name.split('.')[0] })
           .first();
 
-        expect(filePreview).not.toBeVisible();
+        await expect(filePreview).not.toBeVisible();
       }
     });
   }

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -30,7 +30,6 @@ import { openLightspeed, sendMessage } from './utils/testHelper';
 import {
   uploadFile,
   uploadAndAssertDuplicate,
-  validateFailedUpload,
   supportedFileTypes,
 } from './utils/fileUpload';
 import {
@@ -141,7 +140,12 @@ test.describe('File Attachment Validation', () => {
       if (supportedFileTypes.includes(fileExtension)) {
         await uploadAndAssertDuplicate(page, path, name);
       } else {
-        await validateFailedUpload(page);
+        // Unsupported files will not be available to preview.
+        const filePreview = page
+          .locator('span', { hasText: name.split('.')[0] })
+          .first();
+
+        expect(filePreview).not.toBeVisible();
       }
     });
   }

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
@@ -79,3 +79,17 @@ export async function validateSuccessfulUpload(page: Page, fileName: string) {
     .locator('role=button[name="Close"]')
     .click();
 }
+
+export async function validateFailedUpload(page: Page) {
+  const alertHeader = page.getByText('File upload failed');
+  const alertText = page.getByText(
+    'Unsupported file type. Supported types are: .txt, .yaml, .json and .xml.',
+  );
+
+  await expect(alertHeader).toBeVisible();
+  await expect(alertText).toBeVisible();
+
+  await page.getByRole('button', { name: 'Close Danger alert' }).click();
+  await expect(alertHeader).toBeHidden();
+  await expect(alertText).toBeHidden();
+}

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
@@ -15,7 +15,7 @@
  */
 import { Page, Locator, FileChooser, expect } from '@playwright/test';
 
-export const supportedFileTypes = ['.txt', '.yaml', '.json'];
+export const supportedFileTypes = ['.txt', '.yaml', '.json', '.xml'];
 
 export async function triggerFileChooser(
   page: Page,
@@ -76,20 +76,6 @@ export async function validateSuccessfulUpload(page: Page, fileName: string) {
   await page.getByRole('button', { name: 'Save' }).click();
   await page
     .getByRole('contentinfo')
-    .getByRole('button', { name: 'Close' })
+    .locator('role=button[name="Close"]')
     .click();
-}
-
-export async function validateFailedUpload(page: Page) {
-  const alertHeader = page.getByText('File upload failed');
-  const alertText = page.getByText(
-    'Unsupported file type. Supported types are: .txt, .yaml, .json.',
-  );
-
-  await expect(alertHeader).toBeVisible();
-  await expect(alertText).toBeVisible();
-
-  await page.getByRole('button', { name: 'Close Danger alert' }).click();
-  await expect(alertHeader).toBeHidden();
-  await expect(alertText).toBeHidden();
 }

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/testHelper.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/testHelper.ts
@@ -24,7 +24,9 @@ export const openLightspeed = async (page: Page) => {
 };
 
 export const sendMessage = async (message: string, page: Page) => {
-  const inputLocator = page.getByRole('textbox', { name: 'Send a message...' });
+  const inputLocator = page.getByRole('textbox', {
+    name: 'Send a message and optionally upload a JSON, YAML, TXT, or XML file...',
+  });
   await inputLocator.fill(message);
   const sendButton = page.getByRole('button', { name: 'Send' });
   await sendButton.click();

--- a/workspaces/lightspeed/plugins/lightspeed/package.json
+++ b/workspaces/lightspeed/plugins/lightspeed/package.json
@@ -44,7 +44,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@mui/icons-material": "^6.1.8",
-    "@patternfly/chatbot": "6.3.0-prerelease.20",
+    "@patternfly/chatbot": "6.3.0-prerelease.23",
     "@patternfly/react-core": "6.3.0-prerelease.17",
     "@red-hat-developer-hub/backstage-plugin-lightspeed-common": "workspace:^",
     "@tanstack/react-query": "^5.59.15",

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/AttachmentContext.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/AttachmentContext.tsx
@@ -27,6 +27,7 @@ interface FileAttachmentContextType {
   handleFileUpload: (files: File[]) => void;
   setFileContents: React.Dispatch<React.SetStateAction<FileContent[]>>;
   setUploadError: React.Dispatch<React.SetStateAction<UploadError>>;
+  setShowAlert: React.Dispatch<React.SetStateAction<boolean>>;
   currentFileContent?: FileContent;
   setCurrentFileContent: React.Dispatch<
     React.SetStateAction<FileContent | undefined>
@@ -138,6 +139,7 @@ const FileAttachmentContextProvider: React.FC<{
         handleFileUpload,
         isLoadingFile,
         showAlert,
+        setShowAlert,
         uploadError,
         setUploadError,
         currentFileContent,

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/AttachmentContext.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/AttachmentContext.tsx
@@ -85,7 +85,7 @@ const FileAttachmentContextProvider: React.FC<{
       setShowAlert(true);
       setUploadError({
         message:
-          'Unsupported file type. Supported types are: .txt, .yaml, .json.',
+          'Unsupported file type. Supported types are: .txt, .yaml, .json and .xml.',
       });
       return;
     }

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/FilePreview.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/FilePreview.tsx
@@ -16,19 +16,16 @@
 import React from 'react';
 
 import { Divider } from '@material-ui/core';
-import { ChatbotAlert, FileDetailsLabel } from '@patternfly/chatbot';
+import { FileDetailsLabel } from '@patternfly/chatbot';
 
 import { useFileAttachmentContext } from './AttachmentContext';
 
 const FilePreview = () => {
   const {
-    showAlert,
     fileContents,
     isLoadingFile,
-    uploadError,
     modalState,
     setFileContents,
-    setUploadError,
     setCurrentFileContent,
   } = useFileAttachmentContext();
 
@@ -70,17 +67,6 @@ const FilePreview = () => {
             />
           ))}
         </div>
-      )}
-      {showAlert && uploadError.message && (
-        <ChatbotAlert
-          component="h4"
-          title="File upload failed"
-          variant={uploadError.type ?? 'danger'}
-          isInline
-          onClose={() => setUploadError({ message: null })}
-        >
-          {uploadError.message}
-        </ChatbotAlert>
       )}
     </>
   );

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { FileRejection } from 'react-dropzone/.';
 
 import { ErrorPanel } from '@backstage/core-components';
 
@@ -137,6 +138,7 @@ export const LightspeedChat = ({
     uploadError,
     showAlert,
     fileContents,
+    setShowAlert,
     setFileContents,
     handleFileUpload,
     setUploadError,
@@ -356,6 +358,18 @@ export const LightspeedChat = ({
     handleFileUpload(data);
   };
 
+  const onAttachRejected = (data: FileRejection[]) => {
+    data.forEach(attachment => {
+      if (!!attachment.errors.find(e => e.code === 'file-invalid-type')) {
+        setShowAlert(true);
+        setUploadError({
+          message:
+            'Unsupported file type. Supported types are: .txt, .yaml, .json and .xml.',
+        });
+      }
+    });
+  };
+
   if (error) {
     return (
       <Box padding={1}>
@@ -453,6 +467,7 @@ export const LightspeedChat = ({
                     'application/yaml': ['.yaml', '.yml'],
                     'application/xml': ['.xml'],
                   }}
+                  onAttachRejected={onAttachRejected}
                   placeholder="Send a message and optionally upload a JSON, YAML, TXT, or XML file..."
                 />
                 <ChatbotFootnote {...getFootnoteProps(classes.footerPopover)} />

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -428,6 +428,7 @@ export const LightspeedChat = ({
                     'text/plain': ['.txt'],
                     'application/json': ['.json'],
                     'application/yaml': ['.yaml', '.yml'],
+                    'application/xml': ['.xml'],
                   }}
                 />
                 <ChatbotFootnote {...getFootnoteProps(classes.footerPopover)} />

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -419,6 +419,16 @@ export const LightspeedChat = ({
                   hasAttachButton
                   handleAttach={handleAttach}
                   hasMicrophoneButton
+                  buttonProps={{
+                    attach: {
+                      inputTestId: 'attachment-input',
+                    },
+                  }}
+                  allowedFileTypes={{
+                    'text/plain': ['.txt'],
+                    'application/json': ['.json'],
+                    'application/yaml': ['.yaml', '.yml'],
+                  }}
                 />
                 <ChatbotFootnote {...getFootnoteProps(classes.footerPopover)} />
               </ChatbotFooter>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -430,6 +430,7 @@ export const LightspeedChat = ({
                     'application/yaml': ['.yaml', '.yml'],
                     'application/xml': ['.xml'],
                   }}
+                  placeholder="Send a message and optionally upload a JSON, YAML, TXT, or XML file..."
                 />
                 <ChatbotFootnote {...getFootnoteProps(classes.footerPopover)} />
               </ChatbotFooter>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -21,6 +21,7 @@ import { ErrorPanel } from '@backstage/core-components';
 import { Box, makeStyles } from '@material-ui/core';
 import {
   Chatbot,
+  ChatbotAlert,
   ChatbotContent,
   ChatbotDisplayMode,
   ChatbotFooter,
@@ -70,6 +71,9 @@ const useStyles = makeStyles(theme => ({
   },
   header: {
     padding: `${theme.spacing(3)}px !important`,
+  },
+  errorContainer: {
+    padding: theme.spacing(3),
   },
   headerMenu: {
     // align hamburger icon with title
@@ -129,8 +133,14 @@ export const LightspeedChat = ({
   const { isReady, lastOpenedId, setLastOpenedId, clearLastOpenedId } =
     useLastOpenedConversation(user);
 
-  const { fileContents, setFileContents, handleFileUpload } =
-    useFileAttachmentContext();
+  const {
+    uploadError,
+    showAlert,
+    fileContents,
+    setFileContents,
+    handleFileUpload,
+    setUploadError,
+  } = useFileAttachmentContext();
 
   // Sync conversationId with lastOpenedId whenever lastOpenedId changes
   React.useEffect(() => {
@@ -401,6 +411,19 @@ export const LightspeedChat = ({
           handleTextInputChange={handleFilter}
           drawerContent={
             <>
+              {showAlert && uploadError.message && (
+                <div className={classes.errorContainer}>
+                  <ChatbotAlert
+                    component="h4"
+                    title="File upload failed"
+                    variant={uploadError.type ?? 'danger'}
+                    isInline
+                    onClose={() => setUploadError({ message: null })}
+                  >
+                    {uploadError.message}
+                  </ChatbotAlert>
+                </div>
+              )}
               <ChatbotContent>
                 <LightspeedChatBox
                   userName={userName}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -27,6 +27,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { useConversations } from '../../hooks';
 import FileAttachmentContextProvider from '../AttachmentContext';
 import { LightspeedChat } from '../LightSpeedChat';
 
@@ -81,6 +82,7 @@ jest.mock('@patternfly/chatbot', () => {
   };
 });
 
+const mockUseConversations = useConversations as jest.Mock;
 const mockUsePermission = usePermission as jest.MockedFunction<
   typeof usePermission
 >;
@@ -112,6 +114,13 @@ const setupLightspeedChat = () => (
 describe('LightspeedChat', () => {
   beforeEach(() => {
     mockUsePermission.mockReturnValue({ loading: true, allowed: true });
+    mockUseConversations.mockReturnValue({
+      data: [],
+      isRefetching: false,
+      isLoading: false,
+    });
+
+    localStorage.clear();
   });
   const localStorageKey = 'lastOpenedConversation';
   const mockUser = 'user:test';
@@ -125,19 +134,17 @@ describe('LightspeedChat', () => {
   });
 
   it('should not reset localstorage if the conversations are available', async () => {
-    jest.mock('../../hooks/useConversations', () => ({
-      useConversations: jest.fn().mockReturnValue({
-        data: [
-          {
-            conversation_id: 'test-conversation-id',
-            topic_summary: 'Greetings',
-            last_message_timestamp: 1749023603.806369,
-          },
-        ],
-        isRefetching: false,
-        isLoading: false,
-      }),
-    }));
+    mockUseConversations.mockReturnValue({
+      data: [
+        {
+          conversation_id: 'test-conversation-id',
+          topic_summary: 'Greetings',
+          last_message_timestamp: 1749023603.806369,
+        },
+      ],
+      isRefetching: false,
+      isLoading: false,
+    });
 
     const storedData = JSON.stringify({ [mockUser]: 'test-conversation-id' });
     localStorage.setItem(localStorageKey, storedData);
@@ -147,14 +154,17 @@ describe('LightspeedChat', () => {
     await waitFor(() => {
       expect(screen.getByText('Developer Hub Lightspeed')).toBeInTheDocument();
 
-      expect(screen.queryByText('New chat')).not.toBeInTheDocument();
-      expect(JSON.parse(localStorage.getItem(localStorageKey)!)).toEqual({});
+      expect(screen.queryByText('New chat')).toBeInTheDocument();
+
+      expect(JSON.parse(localStorage.getItem(localStorageKey)!)).toEqual({
+        'user:test': 'test-conversation-id',
+      });
     });
   });
 
   it('should reset localstorage if the conversations are empty', async () => {
-    const storedData = JSON.stringify({ [mockUser]: 'test-conversation-id' });
-    localStorage.setItem(localStorageKey, storedData);
+    const initialData = JSON.stringify({ [mockUser]: 'test-conversation-id' });
+    localStorage.setItem(localStorageKey, initialData);
 
     render(setupLightspeedChat());
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -183,7 +183,7 @@ describe('LightspeedChat', () => {
     const input = screen.getByTestId('attachment-input') as HTMLInputElement;
     expect(input).toHaveAttribute(
       'accept',
-      'text/plain,.txt,application/json,.json,application/yaml,.yaml,.yml',
+      'text/plain,.txt,application/json,.json,application/yaml,.yaml,.yml,application/xml,.xml',
     );
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -25,6 +25,7 @@ import { mockApis, TestApiProvider } from '@backstage/test-utils';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import FileAttachmentContextProvider from '../AttachmentContext';
 import { LightspeedChat } from '../LightSpeedChat';
@@ -163,5 +164,16 @@ describe('LightspeedChat', () => {
       expect(screen.queryByText('New chat')).not.toBeInTheDocument();
       expect(JSON.parse(localStorage.getItem(localStorageKey)!)).toEqual({});
     });
+  });
+
+  it('should set correct accept attribute on file input', async () => {
+    render(setupLightspeedChat());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Attach' }));
+    const input = screen.getByTestId('attachment-input') as HTMLInputElement;
+    expect(input).toHaveAttribute(
+      'accept',
+      'text/plain,.txt,application/json,.json,application/yaml,.yaml,.yml',
+    );
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/types.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/types.ts
@@ -55,6 +55,7 @@ export enum SupportedFileType {
   JSON = 'application/json',
   YAML = 'application/x-yaml',
   TEXT = 'text/plain',
+  XML = 'text/xml',
 }
 export interface FileContent {
   content: string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/attachment-utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/attachment-utils.test.ts
@@ -51,10 +51,10 @@ describe('isSupportedFileType', () => {
   });
 
   it('should return true for XML file type', () => {
-    const file = new File(['<note>Test</note>'], 'test.xml', {
+    const xmlFile = new File(['<note>Test</note>'], 'test.xml', {
       type: 'application/xml',
     });
-    expect(isSupportedFileType(file)).toBe(true);
+    expect(isSupportedFileType(xmlFile)).toBe(true);
   });
 
   it('should return false for unsupported file type', () => {

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/attachment-utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/attachment-utils.test.ts
@@ -50,6 +50,13 @@ describe('isSupportedFileType', () => {
     expect(isSupportedFileType(file)).toBe(true);
   });
 
+  it('should return true for XML file type', () => {
+    const file = new File(['<note>Test</note>'], 'test.xml', {
+      type: 'application/xml',
+    });
+    expect(isSupportedFileType(file)).toBe(true);
+  });
+
   it('should return false for unsupported file type', () => {
     const file = new File(['<html></html>'], 'test.html', {
       type: 'text/html',

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/attachment-utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/attachment-utils.ts
@@ -22,7 +22,9 @@ export const isSupportedFileType = (file: File) => {
     file.name.endsWith('.yaml') ||
     file.name.endsWith('.yml');
   const isText = file.type === SupportedFileType.TEXT;
-  return isJson || isYaml || isText;
+  const isXml = file.name.endsWith('.xml');
+
+  return isJson || isYaml || isText || isXml;
 };
 
 export const readFileAsText = (file: File): Promise<string | null> =>
@@ -33,10 +35,16 @@ export const readFileAsText = (file: File): Promise<string | null> =>
     reader.readAsText(file);
   });
 
-export const sanitizeFileType = (fileContent: FileContent): string =>
-  fileContent.type === SupportedFileType.YAML
-    ? 'application/yaml'
-    : fileContent.type;
+export const sanitizeFileType = (fileContent: FileContent): string => {
+  switch (fileContent.type) {
+    case SupportedFileType.YAML:
+      return 'application/yaml';
+    case SupportedFileType.XML:
+      return 'application/xml';
+    default:
+      return fileContent.type;
+  }
+};
 
 export const getAttachments = (fileContents: FileContent[]): Attachment[] =>
   fileContents.map(file => ({

--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -9695,9 +9695,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/chatbot@npm:6.3.0-prerelease.20":
-  version: 6.3.0-prerelease.20
-  resolution: "@patternfly/chatbot@npm:6.3.0-prerelease.20"
+"@patternfly/chatbot@npm:6.3.0-prerelease.23":
+  version: 6.3.0-prerelease.23
+  resolution: "@patternfly/chatbot@npm:6.3.0-prerelease.23"
   dependencies:
     "@patternfly/react-code-editor": ^6.1.0
     "@patternfly/react-core": ^6.1.0
@@ -9718,7 +9718,7 @@ __metadata:
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: c1d4a561bb23dc96980477a2a17d251e85b2263cd99b7b5827e8cb71728b20dd826f325bacc7b1b17563eca8a998739cd8a2be4ac9f3dd8b0dd80711f472e863
+  checksum: 59e853d61fbee334ec2cae06a6461b4066d055d2afd138b43190eba19574d870cc823242ad9c531c86827bb95d696cc7aca848b1b77216872e72c1e483aa1aa2
   languageName: node
   linkType: hard
 
@@ -10591,7 +10591,7 @@ __metadata:
     "@material-ui/core": ^4.9.13
     "@material-ui/lab": ^4.0.0-alpha.61
     "@mui/icons-material": ^6.1.8
-    "@patternfly/chatbot": 6.3.0-prerelease.20
+    "@patternfly/chatbot": 6.3.0-prerelease.23
     "@patternfly/react-core": 6.3.0-prerelease.17
     "@red-hat-developer-hub/backstage-plugin-lightspeed-common": "workspace:^"
     "@spotify/prettier-config": ^15.0.0


### PR DESCRIPTION
## Fixes:

https://issues.redhat.com/browse/RHDHPAI-850

## Enable only supported file types while uploading attachments.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
     
While uploading attachments in lightspeed, users will now only see `.yaml`, `.json`,`.txt` and `.xml` files being enabled for them to choose from. 



| Before fix   | with this PR changes |
| -------- | ------- |
|![image](https://github.com/user-attachments/assets/d23b1f5d-1443-4afd-b0f2-0e6052c6a036)  | ![image](https://github.com/user-attachments/assets/e24dbd50-1402-4317-ad25-350622ff4a08) |
--- 

## Updated Placeholder to include support file types:

![image](https://github.com/user-attachments/assets/6a46df02-b5fb-4914-a503-02c14e83e4fc)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
