### PR TITLE
fix(ocir): replaced formatByteSize implementation

### DIFF
--- a/workspaces/openshift-image-registry/.changeset/quiet-planes-cross.md
+++ b/workspaces/openshift-image-registry/.changeset/quiet-planes-cross.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-openshift-image-registry': patch
+---
+
+Dev dependency update.

--- a/workspaces/openshift-image-registry/.changeset/spicy-lamps-heal.md
+++ b/workspaces/openshift-image-registry/.changeset/spicy-lamps-heal.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-openshift-image-registry': patch
+---
+
+Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/package.json
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/package.json
@@ -45,6 +45,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",
+    "filesize": "^10.1.6",
     "react-use": "^17.4.0"
   },
   "peerDependencies": {

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useImageStreamsMetadataFromTag.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/hooks/useImageStreamsMetadataFromTag.ts
@@ -19,10 +19,9 @@ import { useAsync } from 'react-use';
 
 import { useApi } from '@backstage/core-plugin-api';
 
-import { formatByteSize } from '@janus-idp/shared-react';
-
 import { openshiftImageRegistryApiRef } from '../api';
 import { ImageStream, ImageStreamMetadata } from '../types';
+import { formatByteSize } from '../utils';
 
 export const useImageStreamsMetadataFromTag = (imageStreams: ImageStream[]) => {
   const client = useApi(openshiftImageRegistryApiRef);

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/utils.test.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/utils.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatByteSize } from './utils';
+
+describe('formatByteSize', () => {
+  it('should return N/A if sizeInBytes is not defined', () => {
+    expect(formatByteSize(undefined)).toEqual('N/A');
+  });
+
+  it('should return N/A if sizeInBytes is 0', () => {
+    expect(formatByteSize(0)).toEqual('N/A');
+  });
+
+  it('should format sizeInBytes', () => {
+    expect(formatByteSize(1)).toEqual('1 B');
+    expect(formatByteSize(1_000)).toEqual('1 kB');
+    expect(formatByteSize(1_000_000)).toEqual('1 MB');
+    expect(formatByteSize(1_000_000_000)).toEqual('1 GB');
+    expect(formatByteSize(1_000_000_000_000)).toEqual('1 TB');
+    expect(formatByteSize(1_000_000_000_000_000)).toEqual('1 PB');
+    expect(formatByteSize(1_000_000_000_000_000_000)).toEqual('1 EB');
+    expect(formatByteSize(1_000_000_000_000_000_000_000)).toEqual('1 ZB');
+    expect(formatByteSize(1_000_000_000_000_000_000_000_000)).toEqual('1 YB');
+  });
+
+  it('formats common sizes correctly', () => {
+    expect(formatByteSize(0)).toBe('N/A');
+    expect(formatByteSize(500)).toMatch(/500 B/);
+    expect(formatByteSize(1500)).toMatch(/1\.5 kB/);
+    expect(formatByteSize(1048576)).toMatch(/1\.05 MB/);
+  });
+});

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/utils.ts
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/src/utils.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { filesize } from 'filesize';
+
+export function formatByteSize(sizeInBytes: number | undefined): string {
+  if (!sizeInBytes) return 'N/A';
+
+  return filesize(sizeInBytes);
+}

--- a/workspaces/openshift-image-registry/yarn.lock
+++ b/workspaces/openshift-image-registry/yarn.lock
@@ -10312,6 +10312,7 @@ __metadata:
     "@testing-library/react": 14.3.1
     "@testing-library/user-event": 14.6.1
     cross-fetch: 4.1.0
+    filesize: ^10.1.6
     msw: 1.3.5
     prettier: 3.5.3
     react-use: ^17.4.0
@@ -20266,6 +20267,13 @@ __metadata:
   version: 1.0.0
   resolution: "file-uri-to-path@npm:1.0.0"
   checksum: b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
+  languageName: node
+  linkType: hard
+
+"filesize@npm:^10.1.6":
+  version: 10.1.6
+  resolution: "filesize@npm:10.1.6"
+  checksum: a797a9d41c8f27a9ae334d23f99fc5d903eac5d03c82190dc163901205435b56626fe1260c779ba3e87a2a34d426f19ff264c3f7d956e00f2d3ac69760b52e33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For [RHIDP-7506](https://issues.redhat.com/browse/RHIDP-7506)
Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
