### PR TITLE
Add test for multiple file upload

### DIFF
--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -32,6 +32,7 @@ import {
   uploadAndAssertDuplicate,
   supportedFileTypes,
   validateFailedUpload,
+  verifyAlertPopup,
 } from './utils/fileUpload';
 import {
   assertChatDialogInitialState,
@@ -136,7 +137,7 @@ test.describe('File Attachment Validation', () => {
   for (const { path, name } of testFiles) {
     test(`should validate file: ${name}`, async ({ page }) => {
       const fileExtension = `.${name.split('.').pop()}`;
-      await uploadFile(page, path);
+      await uploadFile(page, [path]);
 
       if (supportedFileTypes.includes(fileExtension)) {
         await uploadAndAssertDuplicate(page, path, name);
@@ -151,6 +152,23 @@ test.describe('File Attachment Validation', () => {
       }
     });
   }
+  test(`Multiple file upload`, async ({ page }) => {
+    const file1 = testFiles[0].path;
+    const file2 = 'backstage.json';
+    await uploadFile(page, [file1, file2]);
+
+    const heading = page.getByRole('heading', {
+      name: 'Danger alert: File upload',
+    });
+    const text = page.getByText('Uploaded more than one file.');
+    const closeBtn = page.getByRole('button', { name: 'Close Danger alert:' });
+
+    await verifyAlertPopup('visible', heading, text, closeBtn);
+
+    await closeBtn.click();
+
+    await verifyAlertPopup('hidden', heading, text, closeBtn);
+  });
 });
 
 test.describe('Conversation', () => {

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -32,7 +32,7 @@ import {
   uploadAndAssertDuplicate,
   supportedFileTypes,
   validateFailedUpload,
-  verifyAlertPopup,
+  assertVisibilityState,
 } from './utils/fileUpload';
 import {
   assertChatDialogInitialState,
@@ -163,11 +163,11 @@ test.describe('File Attachment Validation', () => {
     const text = page.getByText('Uploaded more than one file.');
     const closeBtn = page.getByRole('button', { name: 'Close Danger alert:' });
 
-    await verifyAlertPopup('visible', heading, text, closeBtn);
+    await assertVisibilityState('visible', heading, text, closeBtn);
 
     await closeBtn.click();
 
-    await verifyAlertPopup('hidden', heading, text, closeBtn);
+    await assertVisibilityState('hidden', heading, text, closeBtn);
   });
 });
 

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -28,7 +28,7 @@ import {
 } from './fixtures/responses';
 import { openLightspeed, sendMessage } from './utils/testHelper';
 import {
-  uploadFile,
+  uploadFiles,
   uploadAndAssertDuplicate,
   supportedFileTypes,
   validateFailedUpload,
@@ -137,7 +137,7 @@ test.describe('File Attachment Validation', () => {
   for (const { path, name } of testFiles) {
     test(`should validate file: ${name}`, async ({ page }) => {
       const fileExtension = `.${name.split('.').pop()}`;
-      await uploadFile(page, [path]);
+      await uploadFiles(page, [path]);
 
       if (supportedFileTypes.includes(fileExtension)) {
         await uploadAndAssertDuplicate(page, path, name);
@@ -155,7 +155,7 @@ test.describe('File Attachment Validation', () => {
   test(`Multiple file upload`, async ({ page }) => {
     const file1 = testFiles[0].path;
     const file2 = 'backstage.json';
-    await uploadFile(page, [file1, file2]);
+    await uploadFiles(page, [file1, file2]);
 
     const heading = page.getByRole('heading', {
       name: 'Danger alert: File upload',

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
@@ -28,7 +28,7 @@ export async function triggerFileChooser(
   return fileChooser;
 }
 
-export async function uploadFile(page: Page, filePath: string[]) {
+export async function uploadFiles(page: Page, filePath: string[]) {
   const attachButton = page.getByRole('button', { name: 'Attach' });
   await expect(attachButton).toBeVisible();
 
@@ -42,7 +42,7 @@ export async function uploadAndAssertDuplicate(
   fileName: string,
 ) {
   await validateSuccessfulUpload(page, fileName);
-  await uploadFile(page, [filePath]);
+  await uploadFiles(page, [filePath]);
   await expect(
     page.getByRole('heading', { name: 'File upload failed' }),
   ).toBeVisible();

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
@@ -28,7 +28,7 @@ export async function triggerFileChooser(
   return fileChooser;
 }
 
-export async function uploadFile(page: Page, filePath: string) {
+export async function uploadFile(page: Page, filePath: string[]) {
   const attachButton = page.getByRole('button', { name: 'Attach' });
   await expect(attachButton).toBeVisible();
 
@@ -42,7 +42,7 @@ export async function uploadAndAssertDuplicate(
   fileName: string,
 ) {
   await validateSuccessfulUpload(page, fileName);
-  await uploadFile(page, filePath);
+  await uploadFile(page, [filePath]);
   await expect(
     page.getByRole('heading', { name: 'File upload failed' }),
   ).toBeVisible();
@@ -92,4 +92,13 @@ export async function validateFailedUpload(page: Page) {
   await page.getByRole('button', { name: 'Close Danger alert' }).click();
   await expect(alertHeader).toBeHidden();
   await expect(alertText).toBeHidden();
+}
+
+export async function verifyAlertPopup(
+  state: 'visible' | 'hidden',
+  ...locators: Locator[]
+) {
+  for (const locator of locators) {
+    await expect(locator)[state === 'visible' ? 'toBeVisible' : 'toBeHidden']();
+  }
 }

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/fileUpload.ts
@@ -94,7 +94,7 @@ export async function validateFailedUpload(page: Page) {
   await expect(alertText).toBeHidden();
 }
 
-export async function verifyAlertPopup(
+export async function assertVisibilityState(
   state: 'visible' | 'hidden',
   ...locators: Locator[]
 ) {


### PR DESCRIPTION
📝 **PR Description:**
This PR introduces an automated Playwright test for verifying the application's behavior when multiple files are uploaded simultaneously.

✅ **Changes:**

* Added a test that uploads two files using the `uploadFile` utility.
* Asserted the presence of a danger alert with:

  * Heading: **"Danger alert: File upload"**
  * Message: **"Uploaded more than one file."**
* Verified the alert is visible when multiple files are uploaded.
* Clicked the close button on the alert and validated it is no longer visible.
* Introduced a `verifyAlertPopup` helper function to check alert visibility or hidden state based on expectations.

📎 **Trace Attachment:**

* A trace file is attached to this PR for inspection and debugging.

🛠️ **To view the trace:**

* Run `npx playwright show-trace <path-to-trace.zip>` in your terminal.
* Or simply visit [https://trace.playwright.dev/](https://trace.playwright.dev/) and **drag & drop the trace zip file** to launch the Trace Viewer in your browser.

🧪 **Why:**
These changes ensure the application properly notifies users of invalid file upload behavior, improving user experience and UI resilience.

📦 **Impact:**
Enhanced test reliability and coverage for file upload scenarios.
No breaking changes to existing workflows.

**Trace:**
[Mutiple file Upload trace.zip](https://github.com/user-attachments/files/20752780/Mutiple.file.Upload.trace.zip)
