### PR TITLE
fix(lightspeed): rename conversations to chat in lightspeed plugins

### DIFF
--- a/workspaces/lightspeed/.changeset/blue-eagles-confess.md
+++ b/workspaces/lightspeed/.changeset/blue-eagles-confess.md
@@ -1,0 +1,11 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
+'@red-hat-developer-hub/backstage-plugin-lightspeed-common': patch
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Renamed permissions to align with the updated naming convention:
+
+- `lightspeed.conversations.read` → `lightspeed.chat.read`
+- `lightspeed.conversations.create` → `lightspeed.chat.create`
+- `lightspeed.conversations.delete` → `lightspeed.chat.delete`

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -256,9 +256,7 @@ test.describe('Conversation', () => {
     const chats = sidePanel.locator('li.pf-chatbot__menu-item');
     await expect(chats).toHaveCount(2);
 
-    const searchBox = sidePanel.getByPlaceholder(
-      'Search previous conversations...',
-    );
+    const searchBox = sidePanel.getByPlaceholder('Search previous chats...');
     await searchBox.fill('new');
     await expect(chats).toHaveCount(1);
     await expect(chats).toHaveText(moreConversations[1].topic_summary);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/README.md
@@ -66,9 +66,9 @@ The Lightspeed Backend plugin has support for the permission framework.
 - When [RBAC permission](https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend#installation) framework is enabled, for non-admin users to access lightspeed backend API, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file named `rbac-policy.csv`:
 
 ```CSV
-p, role:default/team_a, lightspeed.conversations.read, read, allow
-p, role:default/team_a, lightspeed.conversations.create, create, allow
-p, role:default/team_a, lightspeed.conversations.delete, delete, allow
+p, role:default/team_a, lightspeed.chat.read, read, allow
+p, role:default/team_a, lightspeed.chat.create, create, allow
+p, role:default/team_a, lightspeed.chat.delete, delete, allow
 
 g, user:default/<your-user-name>, role:default/team_a
 

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -25,9 +25,9 @@ import fetch from 'node-fetch';
 // const fetch = (await import('node-fetch')).default;
 
 import {
-  lightspeedConversationsCreatePermission,
-  lightspeedConversationsDeletePermission,
-  lightspeedConversationsReadPermission,
+  lightspeedChatCreatePermission,
+  lightspeedChatDeletePermission,
+  lightspeedChatReadPermission,
   lightspeedPermissions,
 } from '@red-hat-developer-hub/backstage-plugin-lightspeed-common';
 
@@ -74,10 +74,7 @@ export async function createRouter(
 
     logger.info(`receives call from user: ${userEntity}`);
     try {
-      await authorizer.authorizeUser(
-        lightspeedConversationsReadPermission,
-        credentials,
-      );
+      await authorizer.authorizeUser(lightspeedChatReadPermission, credentials);
     } catch (error) {
       if (error instanceof NotAllowedError) {
         logger.error(error.message);
@@ -112,12 +109,12 @@ export async function createRouter(
     try {
       if (req.method === 'GET') {
         await authorizer.authorizeUser(
-          lightspeedConversationsReadPermission,
+          lightspeedChatReadPermission,
           credentials,
         );
       } else if (req.method === 'DELETE') {
         await authorizer.authorizeUser(
-          lightspeedConversationsDeletePermission,
+          lightspeedChatDeletePermission,
           credentials,
         );
       }
@@ -166,7 +163,7 @@ export async function createRouter(
         logger.info(`/v1/query receives call from user: ${user_id}`);
 
         await authorizer.authorizeUser(
-          lightspeedConversationsCreatePermission,
+          lightspeedChatCreatePermission,
           credentials,
         );
         const userQueryParam = `user_id=${encodeURIComponent(user_id)}`;

--- a/workspaces/lightspeed/plugins/lightspeed-common/report.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed-common/report.api.md
@@ -7,13 +7,13 @@
 import { BasicPermission } from '@backstage/plugin-permission-common';
 
 // @public
-export const lightspeedConversationsCreatePermission: BasicPermission;
+export const lightspeedChatCreatePermission: BasicPermission;
 
 // @public
-export const lightspeedConversationsDeletePermission: BasicPermission;
+export const lightspeedChatDeletePermission: BasicPermission;
 
 // @public
-export const lightspeedConversationsReadPermission: BasicPermission;
+export const lightspeedChatReadPermission: BasicPermission;
 
 // @public
 export const lightspeedPermissions: BasicPermission[];

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
@@ -19,8 +19,8 @@ import { createPermission } from '@backstage/plugin-permission-common';
 /** This permission is used to access the lightspeed read conversations endpoint
  * @public
  */
-export const lightspeedConversationsReadPermission = createPermission({
-  name: 'lightspeed.conversations.read',
+export const lightspeedChatReadPermission = createPermission({
+  name: 'lightspeed.chat.read',
   attributes: {
     action: 'read',
   },
@@ -29,8 +29,8 @@ export const lightspeedConversationsReadPermission = createPermission({
 /** This permission is used to access the lightspeed create conversations endpoint
  * @public
  */
-export const lightspeedConversationsCreatePermission = createPermission({
-  name: 'lightspeed.conversations.create',
+export const lightspeedChatCreatePermission = createPermission({
+  name: 'lightspeed.chat.create',
   attributes: {
     action: 'create',
   },
@@ -39,8 +39,8 @@ export const lightspeedConversationsCreatePermission = createPermission({
 /** This permission is used to access the lightspeed delete endpoint
  * @public
  */
-export const lightspeedConversationsDeletePermission = createPermission({
-  name: 'lightspeed.conversations.delete',
+export const lightspeedChatDeletePermission = createPermission({
+  name: 'lightspeed.chat.delete',
   attributes: {
     action: 'delete',
   },
@@ -51,7 +51,7 @@ export const lightspeedConversationsDeletePermission = createPermission({
  * @public
  */
 export const lightspeedPermissions = [
-  lightspeedConversationsReadPermission,
-  lightspeedConversationsCreatePermission,
-  lightspeedConversationsDeletePermission,
+  lightspeedChatReadPermission,
+  lightspeedChatCreatePermission,
+  lightspeedChatDeletePermission,
 ];

--- a/workspaces/lightspeed/plugins/lightspeed/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed/README.md
@@ -17,9 +17,9 @@ The Lightspeed plugin has support for the permission framework.
 - When [RBAC permission](https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend#installation) framework is enabled, for non-admin users to access lightspeed UI, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file named `rbac-policy.csv`:
 
 ```CSV
-p, role:default/team_a, lightspeed.conversations.read, read, allow
-p, role:default/team_a, lightspeed.conversations.create, create, allow
-p, role:default/team_a, lightspeed.conversations.delete, delete, allow
+p, role:default/team_a, lightspeed.chat.read, read, allow
+p, role:default/team_a, lightspeed.chat.create, create, allow
+p, role:default/team_a, lightspeed.chat.delete, delete, allow
 
 g, user:default/<your-user-name>, role:default/team_a
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -434,6 +434,7 @@ export const LightspeedChat = ({
           conversations={filterConversations(filterValue)}
           onNewChat={newChatCreated ? undefined : onNewChat}
           handleTextInputChange={handleFilter}
+          searchInputPlaceholder="Search previous chats..."
           drawerContent={
             <FileDropZone
               onFileDrop={(e, data) => handleAttach(data, e)}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
@@ -45,8 +45,8 @@ const PermissionRequiredState = () => {
         description={
           <Typography variant="subtitle1">
             To view lightspeed plugin, contact your administrator to give the{' '}
-            <b>lightspeed.conversations.read</b> and{' '}
-            <b>lightspeed.conversations.create</b> permissions.
+            <b>lightspeed.chat.read</b> and <b>lightspeed.chat.create</b>{' '}
+            permissions.
           </Typography>
         }
         missing={{ customImage: <PermissionRequiredIcon /> }}

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedDeletePermission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedDeletePermission.ts
@@ -16,11 +16,11 @@
 
 import { usePermission } from '@backstage/plugin-permission-react';
 
-import { lightspeedConversationsDeletePermission } from '@red-hat-developer-hub/backstage-plugin-lightspeed-common';
+import { lightspeedChatDeletePermission } from '@red-hat-developer-hub/backstage-plugin-lightspeed-common';
 
 export const useLightspeedDeletePermission = () => {
   const lightspeedDeletePermissionResult = usePermission({
-    permission: lightspeedConversationsDeletePermission,
+    permission: lightspeedChatDeletePermission,
   });
 
   return lightspeedDeletePermissionResult;

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedViewPermission.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedViewPermission.ts
@@ -17,21 +17,21 @@
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import {
-  lightspeedConversationsCreatePermission,
-  lightspeedConversationsReadPermission,
+  lightspeedChatCreatePermission,
+  lightspeedChatReadPermission,
 } from '@red-hat-developer-hub/backstage-plugin-lightspeed-common';
 
 export const useLightspeedViewPermission = () => {
-  const canReadConversations = usePermission({
-    permission: lightspeedConversationsReadPermission,
+  const canReadChats = usePermission({
+    permission: lightspeedChatReadPermission,
   });
 
-  const canCreateConversations = usePermission({
-    permission: lightspeedConversationsCreatePermission,
+  const canCreateChats = usePermission({
+    permission: lightspeedChatCreatePermission,
   });
 
   return {
-    loading: canReadConversations.loading || canCreateConversations.loading,
-    allowed: canReadConversations.allowed && canCreateConversations.allowed,
+    loading: canReadChats.loading || canCreateChats.loading,
+    allowed: canReadChats.allowed && canCreateChats.allowed,
   };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Renamed placeholder text in chat history sidebar.
- Renamed permissions to align with the updated naming convention:

  - `lightspeed.conversations.read` → `lightspeed.chat.read`
  - `lightspeed.conversations.create` → `lightspeed.chat.create`
  - `lightspeed.conversations.delete` → `lightspeed.chat.delete`
  
## Screenshots
  
**Missing permissions alert:**
  
![missing_permissions](https://github.com/user-attachments/assets/37e46323-9311-49be-af7c-ea9beab1f6f6)
---
**Chatbot:**  
![chats](https://github.com/user-attachments/assets/8368c43e-8a91-4cb6-bf7e-4e3f5c164146)


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
