### PR TITLE
feat(orchestrator): add 'fetch:response:mandatory selector for ActiveMultiSelect

### DIFF
--- a/workspaces/orchestrator/.changeset/lucky-boxes-float.md
+++ b/workspaces/orchestrator/.changeset/lucky-boxes-float.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Added "fetch:response:mandatory" selector for the ActiveMultiSelect widget.

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -15,12 +15,7 @@ Key Differentiators:
   - Provide default data or option lists.
   - Handle complex validation logic for widgets.
 
-Implementation of the HTTP endpoints is out of the scope of this library.
-
-Deployment Considerations:
-
-- Use one or multiple servers depending on organizational needs.
-- Ensure endpoint structures and response formats exactly match the naming conventions and data structures defined in your schema’s `ui:props` by the creator of workflow's `data input schema`.
+Implementation of the HTTP endpoints is out of the scope of this library, they are expected to be custom developed to match rules and data sources of target environment.
 
 ## Content
 
@@ -29,13 +24,19 @@ The frontend plugin provides implementation of `OrchestratorFormApi` (for `orche
 ## Context
 
 The provided widgets enable forms to incorporate dynamically retrieved data.
+
 This data can be fetched from external HTTP servers, the Backstage API, as well as from other form fields, with all evaluations performed in real time during use.
+
+## Deployment considerations
+
+- Use one or multiple servers depending on organizational needs.
+- Ensure endpoint structures and response formats exactly match the naming conventions and data structures defined in your schema’s `ui:props` by the creator of workflow's `data input schema`.
 
 ## SchemaUpdater widget
 
 Referenced as: `"ui:widget": "SchemaUpdater"`.
 
-A headless widget used for fetching snippets of JSON schema and dynamically updating the RJSF form JSON schema on the fly.
+A **headless** widget used for fetching snippets of JSON schema and dynamically updating the RJSF form JSON schema on the fly.
 
 Thanks to this component, complex subparts of the form can be changed based on data entered in other fields by the user.
 
@@ -163,6 +164,12 @@ For the schema:
 }
 ```
 
+### Default mandatory data
+
+When the optional `fetch:response:mandatory` JSONata selector is provided, it must return an array of strings that act as default values, which the user can not unselect.
+
+Together with `fetch:retrigger` and other fetch-related parameters, the endpoint can continuously update the data for the selector.
+
 ### SchemaUpdater widget ui:props
 
 The widget supports following `ui:props`:
@@ -172,6 +179,7 @@ The widget supports following `ui:props`:
 - fetch:method
 - fetch:body
 - fetch:response:value
+- fetch:response:mandatory
 - fetch:retrigger
 
 [Check mode details](#content-of-uiprops)

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/applySelector.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/applySelector.ts
@@ -23,9 +23,14 @@ export function isJsonObject(value?: JsonValue): value is JsonObject {
 export const applySelectorArray = async (
   data: JsonObject,
   selector: string,
+  createArrayIfNeeded: boolean = false,
 ): Promise<string[]> => {
   const expression = jsonata(selector);
   const value = await expression.evaluate(data);
+
+  if (typeof value === 'string' && createArrayIfNeeded) {
+    return [value];
+  }
 
   if (Array.isArray(value) && value.every(item => typeof item === 'string')) {
     return value;


### PR DESCRIPTION
Adding "fetch:response:mandatory" selector for the `ActiveMultiSelect` widget which can be used to pick-up an array of strings as default but unselectable items of the list.

~~This will need rebase.~~ Based on:
- [x] #1003 
- [x] #1006 


Example in: https://github.com/rhdhorchestrator/orchestrator-demo/pull/39

---

![mandatoryDefault](https://github.com/user-attachments/assets/2ba708f7-70c0-4724-8e47-88a378414ae9)

![schema](https://github.com/user-attachments/assets/46fcae0f-44f7-474e-ade6-6050f32ee1d5)

![response](https://github.com/user-attachments/assets/8675f604-12c9-4f48-aaa3-b6a5f3ba7f8f)
