### PR TITLE
fix(orchestrator): multiple visibility issues

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/router.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/router.ts
@@ -684,7 +684,7 @@ function setupInternalRoutes(
           inputData = Object.keys(inputSchemaProps)
             .filter(k => k in workflowData)
             .reduce((result, k) => {
-              if (!workflowData[k]) {
+              if (workflowData[k] === undefined) {
                 return result;
               }
               result[k] = workflowData[k];

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInputs.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInputs.tsx
@@ -28,7 +28,8 @@ export const WorkflowInputs: React.FC<{
   value: any;
   loading: any;
   responseError: any;
-}> = ({ className, value, loading, responseError }) => {
+  cardClassName: string;
+}> = ({ className, value, loading, responseError, cardClassName }) => {
   const inputs = value?.data;
   return (
     <InfoCard
@@ -40,6 +41,7 @@ export const WorkflowInputs: React.FC<{
       }
       divider={false}
       className={className}
+      cardClassName={cardClassName}
     >
       {loading ? <Progress /> : null}
 

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
@@ -70,14 +70,9 @@ export const mapProcessInstanceToDetails = (
 const useStyles = makeStyles()(() => ({
   topRowCard: {
     height: '24rem',
-    overflow: 'auto',
-    '& > div:nth-child(2)': {
-      overflow: 'auto',
-    },
   },
   bottomRowCard: {
     height: '42rem',
-    overflow: 'auto',
   },
   recommendedLabelContainer: {
     display: 'flex',
@@ -85,6 +80,9 @@ const useStyles = makeStyles()(() => ({
     whiteSpace: 'nowrap',
   },
   recommendedLabel: { margin: '0 0.25rem' },
+  cardClassName: {
+    overflow: 'auto',
+  },
 }));
 
 export const WorkflowInstancePageContent: React.FC<{
@@ -164,6 +162,7 @@ export const WorkflowInstancePageContent: React.FC<{
             title="Details"
             divider={false}
             className={classes.topRowCard}
+            cardClassName={classes.cardClassName}
             icon={viewVariables}
           >
             <WorkflowRunDetails
@@ -176,6 +175,7 @@ export const WorkflowInstancePageContent: React.FC<{
         <Grid item xs={6}>
           <WorkflowResult
             className={classes.topRowCard}
+            cardClassName={classes.cardClassName}
             assessedInstance={assessedInstance}
           />
         </Grid>
@@ -183,6 +183,7 @@ export const WorkflowInstancePageContent: React.FC<{
         <Grid item xs={6}>
           <WorkflowInputs
             className={classes.bottomRowCard}
+            cardClassName={classes.cardClassName}
             value={value}
             loading={loading}
             responseError={responseError}
@@ -194,6 +195,7 @@ export const WorkflowInstancePageContent: React.FC<{
             title="Workflow progress"
             divider={false}
             className={classes.bottomRowCard}
+            cardClassName={classes.cardClassName}
           >
             <WorkflowProgress
               workflowError={assessedInstance.instance.error}

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -340,7 +340,7 @@ export const WorkflowResult: React.FC<{
       className={className}
       cardClassName={cardClassName}
     >
-      <Grid container alignContent="flex-start">
+      <Grid container alignContent="flex-start" spacing="1rem">
         <NextWorkflows
           instanceId={instance.id}
           nextWorkflows={result?.nextWorkflows}

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstanceStatusIndicator.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstanceStatusIndicator.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { Link } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 
+import { Box } from '@material-ui/core';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import ErrorOutlineOutlined from '@mui/icons-material/ErrorOutlineOutlined';
 import HourglassEmptyOutlined from '@mui/icons-material/HourglassEmptyOutlined';
@@ -79,10 +80,9 @@ export const WorkflowInstanceStatusIndicator = ({
   }
 
   return (
-    <div
-      style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}
-    >
+    <Box display="flex" alignItems="center">
       {icon}
+      &nbsp;{' '}
       {lastRunId ? (
         <Link to={workflowInstanceLink({ instanceId: lastRunId })}>
           {capitalize(title)}
@@ -90,6 +90,6 @@ export const WorkflowInstanceStatusIndicator = ({
       ) : (
         <>{capitalize(title)}</>
       )}
-    </div>
+    </Box>
   );
 };

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowRunDetails.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowRunDetails.tsx
@@ -59,7 +59,7 @@ export const WorkflowRunDetails: React.FC<WorkflowDetailsCardProps> = ({
   const workflowPageLink = useRouteRef(workflowRouteRef);
 
   return (
-    <Grid container alignContent="flex-start">
+    <Grid container alignContent="flex-start" spacing="1rem">
       <Grid item md={7} key="Workflow">
         <AboutField label="Workflow">
           <Link to={workflowPageLink({ workflowId: details.workflowId })}>


### PR DESCRIPTION
1. No space between the about fields in instance page results and details
2. No scrollbar in inputs and progress cards
3. Unified L & F or workflow status and instance status

Includes bug fix found while testing - when default input is false, it didn't show in the inputs card

Before

![image (5)](https://github.com/user-attachments/assets/63392c63-de7a-42d8-acf8-f75b7da7b26c)
![image](https://github.com/user-attachments/assets/b05bb93a-951b-44f9-aee7-cbc692d08a2b)

After

![image](https://github.com/user-attachments/assets/7e243476-f3eb-4c3e-a82e-bb7cf0ad2927)
![image (1)](https://github.com/user-attachments/assets/5160f726-ad67-4c17-9beb-000940e5a896)


resolves:
[FLPATH-2411](https://issues.redhat.com/browse/FLPATH-2411)
[FLPATH-2414](https://issues.redhat.com/browse/FLPATH-2414)