### PR TITLE
chore(global-header): update default mount points with quick links

### DIFF
--- a/workspaces/global-header/.changeset/soft-nails-boil.md
+++ b/workspaces/global-header/.changeset/soft-nails-boil.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Updated the default mount points and dynamic plugin config to include application launcher quick links.

--- a/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
+++ b/workspaces/global-header/plugins/global-header/app-config.dynamic.yaml
@@ -42,6 +42,31 @@ dynamicPlugins:
             priority: 85
 
         - mountPoint: global.header/component
+          importName: ApplicationLauncherDropdown
+          config:
+            priority: 82
+
+        - mountPoint: global.header/application-launcher
+          importName: MenuItemLink
+          config:
+            section: Documentation
+            priority: 150
+            props:
+              title: Developer Hub
+              icon: developerHub
+              link: https://docs.redhat.com/en/documentation/red_hat_developer_hub
+
+        - mountPoint: global.header/application-launcher
+          importName: MenuItemLink
+          config:
+            section: Developer Tools
+            priority: 100
+            props:
+              title: RHDH Local
+              icon: developerHub
+              link: https://github.com/redhat-developer/rhdh-local
+
+        - mountPoint: global.header/component
           importName: SupportButton
           config:
             priority: 80

--- a/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
+++ b/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
@@ -163,50 +163,24 @@ export const defaultApplicationLauncherDropdownMountPoints: ApplicationLauncherD
     {
       Component: MenuItemLink as ComponentType,
       config: {
-        section: 'Red Hat AI',
-        sectionLink: 'https://www.redhat.com/en/products/ai',
-        sectionLinkLabel: 'Read more',
-        priority: 200,
-        props: {
-          title: 'Podman Desktop',
-          icon: 'https://podman-desktop.io/img/logo.svg',
-          link: 'https://podman-desktop.io/',
-        },
-      },
-    },
-    {
-      Component: MenuItemLink as ComponentType,
-      config: {
-        section: 'Red Hat AI',
-        priority: 180,
-        props: {
-          title: 'OpenShift AI',
-          icon: 'https://upload.wikimedia.org/wikipedia/commons/d/d8/Red_Hat_logo.svg',
-          link: 'https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai',
-        },
-      },
-    },
-    {
-      Component: MenuItemLink as ComponentType,
-      config: {
-        section: 'Quick Links',
+        section: 'Documentation',
         priority: 150,
         props: {
-          title: 'Slack',
-          icon: 'https://upload.wikimedia.org/wikipedia/commons/d/d5/Slack_icon_2019.svg',
-          link: 'https://slack.com/',
+          title: 'Developer Hub',
+          icon: 'developerHub',
+          link: 'https://docs.redhat.com/en/documentation/red_hat_developer_hub',
         },
       },
     },
     {
       Component: MenuItemLink as ComponentType,
       config: {
-        section: 'Quick Links',
+        section: 'Developer Tools',
         priority: 130,
         props: {
-          title: 'ArgoCD',
-          icon: 'https://argo-cd.readthedocs.io/en/stable/assets/logo.png',
-          link: 'https://argo-cd.readthedocs.io/en/stable/',
+          title: 'RHDH Local',
+          icon: 'developerHub',
+          link: 'https://github.com/redhat-developer/rhdh-local',
         },
       },
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the default mount points and dynamic plugin config to include starred dropdown and application launcher with quick links.

### Fixes - https://issues.redhat.com/browse/RHDHPAI-907 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

<img width="2535" alt="Screenshot 2025-06-24 at 4 13 21 PM" src="https://github.com/user-attachments/assets/e6faa299-ea3e-42e3-a745-21d01ada10f6" />

