### PR TITLE
feat(orchestrator): template units can be evaluated to complex objects and arrays

### DIFF
--- a/workspaces/orchestrator/.changeset/shiny-glasses-draw.md
+++ b/workspaces/orchestrator/.changeset/shiny-glasses-draw.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Template units can be evaluated to primitive values, complex objects and arrays.

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/evaluateTemplate.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/evaluateTemplate.test.ts
@@ -16,21 +16,26 @@
 
 import { JsonValue } from '@backstage/types/index';
 import { evaluateTemplate, evaluateTemplateProps } from './evaluateTemplate';
+import get from 'lodash/get';
 
 const unitEvaluator: evaluateTemplateProps['unitEvaluator'] = async (
   unit,
-  _,
+  formData,
 ) => {
   if (!unit) {
     throw new Error('Template unit can not be empty');
   }
 
   // Just a copy for testing purposes
-  return Promise.resolve(unit);
+  return Promise.resolve(get(formData, unit));
 };
 
 describe('evaluate template', () => {
-  const props = { unitEvaluator, key: 'myKey', formData: {} };
+  const props = {
+    unitEvaluator,
+    key: 'myKey',
+    formData: { foo: 'foo', bar: 'BAR', current: { bar: 'CURRENT_BAR' } },
+  };
 
   it('fails on incorrect input', async () => {
     const cases = [
@@ -41,34 +46,12 @@ describe('evaluate template', () => {
       { input: '$${{}}', throws: 'Template unit can not be empty' },
       { input: '$${{foo', throws: 'Template unit is not closed by }}' },
       {
-        input: ['constant', []],
-        throws:
-          'Items of array templates can be strings only, template: "["constant",[]]"',
-      },
-      {
-        input: [[]],
-        throws:
-          'Items of array templates can be strings only, template: "[[]]"',
-      },
-      {
-        input: [{}],
-        throws:
-          'Items of array templates can be strings only, template: "[{}]"',
-      },
-      {
-        input: ['constant', {}],
-        throws:
-          'Items of array templates can be strings only, template: "["constant",{}]"',
-      },
-      {
         input: [undefined],
-        throws:
-          'Items of array templates can be strings only, template: "[null]"',
+        throws: 'Template can not be undefined, key: myKey',
       },
       {
         input: ['constant', undefined],
-        throws:
-          'Items of array templates can be strings only, template: "["constant",null]"',
+        throws: 'Template can not be undefined, key: myKey',
       },
     ];
 
@@ -91,11 +74,14 @@ describe('evaluate template', () => {
       { input: '}}', expected: '}}' },
       { input: '${{foo}}', expected: '${{foo}}' },
       { input: '$${{foo}}', expected: 'foo' },
-      { input: '$${{foo}} $${{bar}}', expected: 'foo bar' },
-      { input: '$${{foo}}$${{bar}}', expected: 'foobar' },
-      { input: ' $${{foo}}$${{bar}} ', expected: ' foobar ' },
-      { input: 'a$${{foo}}$${{bar}} b', expected: 'afoobar b' },
-      { input: 'a$${{foo}}$${{bar}} b$${{zz}}', expected: 'afoobar bzz' },
+      { input: '$${{foo}} $${{current.bar}}', expected: 'foo CURRENT_BAR' },
+      { input: '$${{foo}}$${{bar}}', expected: 'fooBAR' },
+      { input: ' $${{foo}}$${{bar}} ', expected: ' fooBAR ' },
+      { input: 'a$${{foo}}$${{bar}} b', expected: 'afooBAR b' },
+      {
+        input: 'a$${{foo}}$${{bar}} b$${{zz}}',
+        expected: 'afooBAR b___undefined___',
+      },
     ];
 
     await Promise.all(
@@ -109,8 +95,8 @@ describe('evaluate template', () => {
 
   it('can parse input template to units without nesting', async () => {
     await expect(
-      evaluateTemplate({ ...props, template: 'a$${{foo}}$${{$${{xx}}}}b' }),
-    ).resolves.toBe('afoo$${{xx}}b');
+      evaluateTemplate({ ...props, template: 'a$${{foo}}$${{$${{foo}}}}b' }),
+    ).resolves.toBe('afoo___undefined___}}b');
   });
 
   it('can parse array templates', async () => {
@@ -124,9 +110,96 @@ describe('evaluate template', () => {
       { input: ['$${{foo}}'], expected: ['foo'] },
       {
         input: ['$${{foo}}', 'constant', '$${{bar}}'],
-        expected: ['foo', 'constant', 'bar'],
+        expected: ['foo', 'constant', 'BAR'],
       },
-      { input: ['$${{foo}}$${{bar}}'], expected: ['foobar'] },
+      { input: ['$${{foo}}$${{bar}}'], expected: ['fooBAR'] },
+      {
+        input: ['constantA', { foo: 'fff', zz: '$${{foo}}', aa: ['aaValue'] }],
+        expected: ['constantA', { foo: 'fff', zz: 'foo', aa: ['aaValue'] }],
+      },
+      {
+        input: ['constant', []],
+        expected: ['constant', []],
+      },
+      {
+        input: [[]],
+        expected: [[]],
+      },
+      {
+        input: [{}],
+        expected: [{}],
+      },
+      {
+        input: ['constant', {}],
+        expected: ['constant', {}],
+      },
+    ];
+
+    await Promise.all(
+      cases.map(c =>
+        expect(
+          evaluateTemplate({ ...props, template: c.input }),
+        ).resolves.toStrictEqual(c.expected),
+      ),
+    );
+  });
+
+  it('can parse object templates', async () => {
+    const cases = [
+      { input: {}, expected: {} },
+      { input: { foo: 'bar' }, expected: { foo: 'bar' } },
+      {
+        input: { foo: 'bar', zz: '$${{foo}}' },
+        expected: { foo: 'bar', zz: 'foo' },
+      },
+      {
+        input: { foo: 'bar', zz: 'Hi$${{foo}}$${{bar}}' },
+        expected: { foo: 'bar', zz: 'HifooBAR' },
+      },
+      {
+        input: { foo: 'bar', zz: '$${{foo}}', nested: {} },
+        expected: { foo: 'bar', zz: 'foo', nested: {} },
+      },
+      {
+        input: { foo: 'bar', zz: '$${{foo}}', nested: { aa: 'aa' } },
+        expected: { foo: 'bar', zz: 'foo', nested: { aa: 'aa' } },
+      },
+      {
+        input: { foo: 'bar', zz: '$${{foo}}', nested: { aa: '$${{foo}}' } },
+        expected: { foo: 'bar', zz: 'foo', nested: { aa: 'foo' } },
+      },
+      {
+        input: {
+          foo: 'bar',
+          zz: '$${{foo}}',
+          nested: { aa: '$${{foo}}', bb: ['bbValue'] },
+        },
+        expected: {
+          foo: 'bar',
+          zz: 'foo',
+          nested: { aa: 'foo', bb: ['bbValue'] },
+        },
+      },
+      {
+        input: {
+          foo: 'bar',
+          zz: '$${{foo}}',
+          nested: {
+            aa: '$${{foo}}',
+            bb: ['bbValue'],
+            nestedNested: { cc: 'ccValue' },
+          },
+        },
+        expected: {
+          foo: 'bar',
+          zz: 'foo',
+          nested: {
+            aa: 'foo',
+            bb: ['bbValue'],
+            nestedNested: { cc: 'ccValue' },
+          },
+        },
+      },
     ];
 
     await Promise.all(

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetch.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetch.ts
@@ -65,6 +65,18 @@ export const useFetch = (
       const fetchData = async () => {
         try {
           setError(undefined);
+          if (typeof evaluatedFetchUrl !== 'string') {
+            // eslint-disable-next-line no-console
+            console.error('The fetch:url is not evaluated to a string: ', {
+              fetchUrl,
+              evaluatedFetchUrl,
+            });
+            setError(
+              `The fetch:url is not evaluated to a string: "${fetchUrl}"`,
+            );
+            return;
+          }
+
           setLoading(true);
 
           const response = await fetchApi.fetch(

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetchAndEvaluate.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetchAndEvaluate.ts
@@ -62,7 +62,7 @@ export const useFetchAndEvaluate = (
             responseData: data,
             uiProps,
           });
-          setResultText(evaluatedText);
+          setResultText(evaluatedText?.toString());
         } catch (err) {
           const prefix = `Failed to evaluate text '${template}' for field ${fieldId}`;
           const msg = getErrorMessage(prefix, err);

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
@@ -93,33 +93,44 @@ export const useGetExtraErrors = () => {
             formData,
           });
 
-          const evaluatedRequestInit = await getRequestInit(
-            uiProps,
-            'validate',
-            templateUnitEvaluator,
-            formData,
-          );
-
-          const response = await fetchApi.fetch(
-            evaluatedValidateUrl,
-            evaluatedRequestInit,
-          );
-          if (response.status !== 200) {
-            const data = (await response.json()) as JsonObject;
-
-            Object.keys(data).forEach(key => {
-              // @ts-ignore
-              const issues = data[key];
-              if (issues) {
-                const array = (
-                  Array.isArray(issues) ? issues : [issues]
-                ) as string[];
-
-                safeSet(errors, path, {
-                  [ERRORS_KEY]: array.map(e => e?.toString()),
-                });
-              }
+          if (typeof evaluatedValidateUrl !== 'string') {
+            // eslint-disable-next-line no-console
+            console.error('The validate:url is not evaluated to a string: ', {
+              validateUrl,
+              evaluatedValidateUrl,
             });
+            safeSet(errors, path, {
+              [ERRORS_KEY]: `The validate:url is not evaluated to a string: "${validateUrl}"`,
+            });
+          } else {
+            const evaluatedRequestInit = await getRequestInit(
+              uiProps,
+              'validate',
+              templateUnitEvaluator,
+              formData,
+            );
+
+            const response = await fetchApi.fetch(
+              evaluatedValidateUrl,
+              evaluatedRequestInit,
+            );
+            if (response.status !== 200) {
+              const data = (await response.json()) as JsonObject;
+
+              Object.keys(data).forEach(key => {
+                // @ts-ignore
+                const issues = data[key];
+                if (issues) {
+                  const array = (
+                    Array.isArray(issues) ? issues : [issues]
+                  ) as string[];
+
+                  safeSet(errors, path, {
+                    [ERRORS_KEY]: array.map(e => e?.toString()),
+                  });
+                }
+              });
+            }
           }
         }
       }

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useRequestInit.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useRequestInit.ts
@@ -86,17 +86,27 @@ export const getRequestInit = async (
 
       const keys = Object.keys(headers);
       const values = await Promise.all(
-        keys.map(key =>
-          evaluateTemplateString({
+        keys.map(key => {
+          const value = headersObject[key];
+          if (typeof value !== 'string') {
+            throw new Error(
+              `HTTP header must be a string. See "${key}" header.`,
+            );
+          }
+
+          return evaluateTemplateString({
             unitEvaluator,
             key,
             formData,
-            template: headersObject[key],
-          }),
-        ),
+            template: value,
+          });
+        }),
       );
       keys.forEach((key, idx) => {
-        headersInit[key] = values[idx];
+        // Header must be a string
+        const value = values[idx];
+        headersInit[key] =
+          typeof value === 'string' ? value : JSON.stringify(value);
       });
     } else {
       throw new Error('fetch:body must be object for POST requests');

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useCallback, useMemo } from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { JsonObject } from '@backstage/types';
 import {
   atlassianAuthApiRef,


### PR DESCRIPTION
Fixes: FLPATH-2432

The templates can be evaluated to primitive values (string, number), complex (nested) objects or arrays (items can be primitive values, objects or arrays).