### PR TITLE
docs: fix incorrect file path 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,6 +331,6 @@ This repository uses [Renovate](https://docs.renovatebot.com/) to automatically 
 
 ### Opt-in to Knip Reports Check
 
-Plugin owners can opt in to Knip reports check in CI by creating a `bcp.json` file in the root of their workspace (`workspaces/${WORKSPACE}/.auto-version-bump`) and adding `"knip-reports": true`. This ensures that knip reports in your workspace stay up to date.
+Plugin owners can opt in to Knip reports check in CI by creating a `bcp.json` file in the root of their workspace (`workspaces/${WORKSPACE}/bcp.json`) and adding `"knip-reports": true`. This ensures that knip reports in your workspace stay up to date.
 
 [Knip](https://knip.dev/) is a tool that helps with clean-up and maintenance by identifying unused dependencies within workspaces. Regularly reviewing and addressing these reports can significantly improve code quality and reduce bloat.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To opt in for knip-reports check, a bcp.json file should be created and not a .auto-version-bump. This PR updates the docs to fix this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
