### PR TITLE
fix(sandbox): remove close button from ansible modal

### DIFF
--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/AnsibleLaunchInfoModal.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/AnsibleLaunchInfoModal.tsx
@@ -346,20 +346,6 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
                 Get started
               </Button>
             </Link>
-            <Button
-              variant="outlined"
-              onClick={handleClose}
-              sx={{
-                textTransform: 'none',
-                border: `1px solid ${theme.palette.primary.main}`,
-                '&:hover': {
-                  backgroundColor: 'rgba(25, 118, 210, 0.04)',
-                  borderColor: '#1976d2',
-                },
-              }}
-            >
-              Close
-            </Button>
           </DialogActions>
         </>
       ) : (

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/__tests__/AnsibleLaunchInfoModal.test.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/__tests__/AnsibleLaunchInfoModal.test.tsx
@@ -107,10 +107,6 @@ describe('AnsibleLaunchInfoModal', () => {
     // Check for logos (by alt text)
     expect(screen.getByAltText('Ansible')).toBeInTheDocument();
     expect(screen.getByAltText('Red Hat')).toBeInTheDocument();
-
-    // Find the close button
-    const closeButtons = screen.getAllByRole('button', { name: /Close/i });
-    expect(closeButtons.length).toBeGreaterThan(0);
   });
 
   it('renders the provisioning state with correct content', async () => {
@@ -136,15 +132,6 @@ describe('AnsibleLaunchInfoModal', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(
       /You can close this modal. Follow the status of your instance on the AAP sandbox card./i,
     );
-  });
-
-  it('calls setOpen with false when close button is clicked', () => {
-    renderModal();
-
-    const closeButton = screen.getByText('Close');
-    fireEvent.click(closeButton);
-
-    expect(mockSetOpen).toHaveBeenCalledWith(false);
   });
 
   it('calls setOpen when the X button is clicked', () => {


### PR DESCRIPTION
This is for removing the close button from the Ansible Info modal.

See: https://redhat-internal.slack.com/archives/C07UWTB1BPB/p1750885726468589?thread_ts=1749060005.628409&cid=C07UWTB1BPB

![image](https://github.com/user-attachments/assets/09bcd71f-7dae-4c41-97fb-cbd34b027805)
