### PR TITLE
feat(global-header): Add support for width and height props in CompanyLogo via configuration

### DIFF
--- a/workspaces/global-header/plugins/global-header/src/components/CompanyLogo/CompanyLogo.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/CompanyLogo/CompanyLogo.tsx
@@ -24,10 +24,12 @@ const LogoRender = ({
   base64Logo,
   defaultLogo,
   width = 150,
+  height = 40,
 }: {
   base64Logo: string | undefined;
   defaultLogo: JSX.Element;
-  width?: number;
+  width?: number | string;
+  height?: number | string;
 }) => {
   return base64Logo ? (
     <img
@@ -37,7 +39,7 @@ const LogoRender = ({
       style={{
         objectFit: 'contain',
         objectPosition: 'left',
-        maxHeight: '40px', // "kind of" aligns with PF's MastheadLogo height
+        maxHeight: height, // "kind of" aligns with PF's MastheadLogo height
       }}
       width={width}
     />
@@ -74,7 +76,9 @@ export interface CompanyLogoProps {
    * You likely do not need to set this prop, but we recommend setting it
    * to a value under 200px.
    */
-  logoWidth?: number;
+  width?: string | number;
+  /** The maximum height of the logo in pixels (defaults to 40px). **/
+  height?: string | number;
   /** This prop is not used by this component. */
   layout?: CSSProperties;
 }
@@ -105,11 +109,15 @@ const useFullLogo = (logo: LogoURLs): string | undefined => {
 
 export const CompanyLogo = ({
   logo,
-  logoWidth,
+  width,
+  height,
   to = '/',
 }: CompanyLogoProps) => {
   const logoURL = useFullLogo(logo);
-
+  const configApi = useApi(configApiRef);
+  const fullLogoWidth = configApi.getOptional<number | string>(
+    'app.branding.fullLogoWidth',
+  );
   return (
     <Box
       data-testid="global-header-company-logo"
@@ -134,7 +142,8 @@ export const CompanyLogo = ({
         <LogoRender
           base64Logo={logoURL}
           defaultLogo={<DefaultLogo />}
-          width={logoWidth}
+          width={width || fullLogoWidth}
+          height={height}
         />
       </Link>
     </Box>


### PR DESCRIPTION
## Description 

This PR introduces support for setting the `width` and `height` of the `CompanyLogo` component through configuration.

 **Width Resolution Priority**
 1. `props.width` (provided via configuration) 
 2. `app.branding.fullLogoWidth` (from `app-config.yaml`) 
 3. **Default:** `150px` 
 
 **Height Resolution Priority** 
 
 1. `props.height` (provided via configuration) 
 2. **Default maximum height:** `40px` 
 
 **Logo Behavior** 
 The logo uses `object-fit: contain` and maintains the original aspect ratio. This ensures the logo is **never cropped** or distorted. - If the configured `width` would result in a height exceeding the max (default: `40px`), the image is automatically **scaled down**. - As a result, in some cases the provided `width` might appear to have no visible effect unless `height` is also adjusted.

**Configuration Examples** 

 ```yaml
- mountPoint: global.header/component
  importName: CompanyLogo
  config:
    priority: 200
    props:
      to: '/'
      logo:
        light: <image>
        dark: <image>
      width: 300
      height: 100
      
   ```

**App Config Fallback**

```
app
  branding
    fullLogoWidth: 200px
    
  ```

* * *

>**Note:**
> 
> *   Increasing the `height` will increase the **overall height of the global header**.
>     
> *   To achieve consistent rendering, both `width` and `height` should be adjusted in tandem where necessary.
>     

* * *

This enhancement provides more flexibility and control over the branding experience in the global header while preserving layout safety and responsiveness.
