### PR TITLE
fix: ensure partition start and end date are created in UTC timezone

### DIFF
--- a/workspaces/adoption-insights/.changeset/sad-doodles-bake.md
+++ b/workspaces/adoption-insights/.changeset/sad-doodles-bake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+---
+
+Ensure Dates created for partitioning always are created with the UTC timezone

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/package.json
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/package.json
@@ -52,6 +52,7 @@
     "@backstage/backend-test-utils": "^1.5.0",
     "@backstage/cli": "^0.32.1",
     "@types/express": "^4.17.6",
+    "@types/luxon": "^3.5.0",
     "@types/supertest": "^2.0.12",
     "supertest": "^6.2.4"
   },

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.test.ts
@@ -86,4 +86,13 @@ describe('createPartition', () => {
 
     expect(mockRaw).toHaveBeenCalledTimes(1);
   });
+
+  it('should create a partition for the right date range', () => {
+    createPartition(knex, 2025, 5);
+    expect(mockRaw).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `FOR VALUES FROM ('2025-05-01') TO ('2025-06-01');`,
+      ),
+    );
+  });
 });

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.ts
@@ -32,11 +32,11 @@ export const createPartition = async (
   maxRetries = 1,
 ) => {
   const startObject = DateTime.fromObject(
-    { year, month: month - 1, day: 1 },
+    { year, month, day: 1 },
     { zone: 'UTC' },
   );
   const endObject = DateTime.fromObject(
-    { year, month, day: 1 },
+    { year, month: month + 1, day: 1 },
     { zone: 'UTC' },
   );
   if (!endObject.isValid || !startObject.isValid) {

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/partition.ts
@@ -20,6 +20,7 @@ import {
   isPartitionOverlapError,
   parsePartitionDate,
 } from '../utils/partition';
+import { DateTime } from 'luxon';
 
 type AttemptTracker = Map<string, number>;
 
@@ -30,11 +31,22 @@ export const createPartition = async (
   attempts: AttemptTracker = new Map(),
   maxRetries = 1,
 ) => {
-  const start = new Date(year, month - 1, 1);
-  const end = new Date(year, month, 1);
+  const startObject = DateTime.fromObject(
+    { year, month: month - 1, day: 1 },
+    { zone: 'UTC' },
+  );
+  const endObject = DateTime.fromObject(
+    { year, month, day: 1 },
+    { zone: 'UTC' },
+  );
+  if (!endObject.isValid || !startObject.isValid) {
+    throw new Error(
+      `The combination of year ${year} and month ${month} is invalid.`,
+    );
+  }
 
-  const startDate = start.toISOString().slice(0, 10);
-  const endDate = end.toISOString().slice(0, 10);
+  const startDate = startObject.toISODate();
+  const endDate = endObject.toISODate();
 
   const partitionName = `events_${year}_${month.toString().padStart(2, '0')}`;
   const key = `${year}_${month}`;

--- a/workspaces/adoption-insights/yarn.lock
+++ b/workspaces/adoption-insights/yarn.lock
@@ -13085,17 +13085,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:^3.0.0, @types/luxon@npm:~3.4.0":
-  version: 3.4.2
-  resolution: "@types/luxon@npm:3.4.2"
-  checksum: 6f92d5bd02e89f310395753506bcd9cef3a56f5940f7a50db2a2b9822bce753553ac767d143cb5b4f9ed5ddd4a84e64f89ff538082ceb4d18739af7781b56925
-  languageName: node
-  linkType: hard
-
-"@types/luxon@npm:^3.5.0":
+"@types/luxon@npm:^3.0.0, @types/luxon@npm:^3.5.0":
   version: 3.6.2
   resolution: "@types/luxon@npm:3.6.2"
   checksum: fa7bf7d74544c77c2010739337d359c5d6f9b0424de0e0eb273f7bae203996168cc33c2ad6f3b35771eac8fea8b7e5bcce72b91d129924d0f84b91dc216de42e
+  languageName: node
+  linkType: hard
+
+"@types/luxon@npm:~3.4.0":
+  version: 3.4.2
+  resolution: "@types/luxon@npm:3.4.2"
+  checksum: 6f92d5bd02e89f310395753506bcd9cef3a56f5940f7a50db2a2b9822bce753553ac767d143cb5b4f9ed5ddd4a84e64f89ff538082ceb4d18739af7781b56925
   languageName: node
   linkType: hard
 

--- a/workspaces/adoption-insights/yarn.lock
+++ b/workspaces/adoption-insights/yarn.lock
@@ -9928,6 +9928,7 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.9.0
     "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "workspace:^"
     "@types/express": ^4.17.6
+    "@types/luxon": ^3.5.0
     "@types/supertest": ^2.0.12
     express: ^4.17.1
     express-promise-router: ^4.1.0
@@ -13088,6 +13089,13 @@ __metadata:
   version: 3.4.2
   resolution: "@types/luxon@npm:3.4.2"
   checksum: 6f92d5bd02e89f310395753506bcd9cef3a56f5940f7a50db2a2b9822bce753553ac767d143cb5b4f9ed5ddd4a84e64f89ff538082ceb4d18739af7781b56925
+  languageName: node
+  linkType: hard
+
+"@types/luxon@npm:^3.5.0":
+  version: 3.6.2
+  resolution: "@types/luxon@npm:3.6.2"
+  checksum: fa7bf7d74544c77c2010739337d359c5d6f9b0424de0e0eb273f7bae203996168cc33c2ad6f3b35771eac8fea8b7e5bcce72b91d129924d0f84b91dc216de42e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I changed the code for the adoption insights partitions to ensure new dates are created in the UTC timezone. (also by changing to Luxon, we can use toIsoDate() instead of slicing the result)

Reason for this was that my local run of backstage for some reason takes timezones into account in this script. That results in the partition to be created for the timerange `FOR VALUES FROM ('2025-05-31 00:00:00+00') TO ('2025-06-30 00:00:00+00')` which fails today (30th of June) because the value is outside of the range, while a new partition is not yet created.

Example from the browser:
```
new Date(2025,5,1)
Date Sun Jun 01 2025 00:00:00 GMT+0200 (Central European Summer Time)

new Date(2025,5,1).toISOString()
"2025-05-31T22:00:00.000Z" 
```

Unfortunately, I could not create a test to verify the bug is fixed. I could not find a way to control the timezone for new Date() in a test.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
