### PR TITLE
fix(lightspeed): Update lightspeed prompts and plugin page title

### DIFF
--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
@@ -117,6 +117,7 @@ const InsightsHeader: FC<InsightsHeaderProps> = ({ title }) => {
 
   return (
     <Header
+      pageTitleOverride="Adoption Insights"
       title={
         <Typography
           variant="h3"

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { useAsync } from 'react-use';
 
-import { Content, Page } from '@backstage/core-components';
+import { Content, Header, Page } from '@backstage/core-components';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 
 import { createStyles, makeStyles, useTheme } from '@material-ui/core/styles';
@@ -83,6 +83,11 @@ const LightspeedPageInner = () => {
 
   return (
     <Page themeId="tool">
+      <Header
+        title="Lightspeed"
+        style={{ display: 'none' }}
+        pageTitleOverride="Developer Lightspeed"
+      />
       <Content className={classes.container}>
         {!hasViewAccess ? (
           <PermissionRequiredState />

--- a/workspaces/lightspeed/plugins/lightspeed/src/const.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/const.ts
@@ -81,7 +81,7 @@ export const RHDH_SAMPLE_PROMPTS: SamplePrompts = [
     'Can you guide me through creating a new deployment in OpenShift for a containerized application?',
   ),
   createPrompt(
-    'Getting Started with Backstage',
-    'Can you guide me through the first steps to start using Backstage as a developer, like exploring the Software Catalog and adding my service?',
+    'Getting Started with Red Hat Developer Hub',
+    'Can you guide me through the first steps to start using Developer Hub as a developer, like exploring the Software Catalog and adding my service?',
   ),
 ];


### PR DESCRIPTION
## Updates in lightspeed and adoption insights

Update lightspeed prompts


![image](https://github.com/user-attachments/assets/3f545e9e-19d0-4f35-ad38-616d37e42b2c)



Plugin window tab titles:

Lightspeed:

![Screenshot 2025-07-02 at 6 14 11 PM](https://github.com/user-attachments/assets/962add38-1d81-464b-a992-1f8dcc6d13e9)

![Screenshot 2025-07-02 at 6 18 07 PM](https://github.com/user-attachments/assets/f9b03daa-6e79-4673-a9c0-21afa1980e54)

Adoption Insights:

![Screenshot 2025-07-02 at 6 19 31 PM](https://github.com/user-attachments/assets/e692b95d-de88-4883-b32e-762ee4697563)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
