### PR TITLE
fix(orchestrator): build array from ActiveMultiSelect selector result

### DIFF
--- a/workspaces/orchestrator/.changeset/blue-carrots-heal.md
+++ b/workspaces/orchestrator/.changeset/blue-carrots-heal.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+ActiveMultiSelect automatically builds an array from simple strings returned by jsonata selector.

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/applySelector.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/applySelector.ts
@@ -24,9 +24,14 @@ export const applySelectorArray = async (
   data: JsonObject,
   selector: string,
   createArrayIfNeeded: boolean = false,
+  emptyArrayIfNeeded: boolean = false,
 ): Promise<string[]> => {
   const expression = jsonata(selector);
   const value = await expression.evaluate(data);
+
+  if (emptyArrayIfNeeded && !value) {
+    return [];
+  }
 
   if (typeof value === 'string' && createArrayIfNeeded) {
     return [value];

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
@@ -95,6 +95,8 @@ export const ActiveMultiSelect: Widget<
         const autocompleteValues = await applySelectorArray(
           data,
           autocompleteSelector,
+          true,
+          true,
         );
         setAutocompleteOptions(autocompleteValues);
       }


### PR DESCRIPTION
Fixes: FLPATH-2455


The `fetch:response:autocomplete` selector of ActiveMultiSelect is expected to result in an array of strings.

This patch eases this requirement, if just a single string is produced, the array is built automatically from it.