### PR TITLE
chore(orchestrator): update prettier to 3.6.2 [Backport]

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-backend/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/package.json
@@ -99,7 +99,7 @@
     "@types/express": "4.17.23",
     "@types/fs-extra": "11.0.4",
     "@types/json-schema": "7.0.15",
-    "prettier": "3.5.3"
+    "prettier": "3.6.2"
   },
   "peerDependencies": {
     "@backstage-community/plugin-rbac-common": "^1.12.1",

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/package.json
@@ -41,7 +41,7 @@
     "@backstage/cli": "^0.31.1",
     "@types/json-schema": "7.0.15",
     "@types/react": "^18.2.58",
-    "prettier": "3.5.3",
+    "prettier": "3.6.2",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.3.0"

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
@@ -55,7 +55,7 @@
     "@types/json-schema": "7.0.15",
     "@types/lodash": "^4.14.151",
     "@types/react": "^18.2.58",
-    "prettier": "3.5.3",
+    "prettier": "3.6.2",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.3.0"

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/http-workflow-dev-server/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/http-workflow-dev-server/package.json
@@ -16,7 +16,7 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
-    "prettier": "3.5.3"
+    "prettier": "3.6.2"
   },
   "maintainers": [
     "@mlibra"

--- a/workspaces/orchestrator/plugins/orchestrator/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator/package.json
@@ -95,7 +95,7 @@
     "@types/react": "^18.2.58",
     "@types/react-dom": "^18.2.19",
     "@types/uuid": "^9.0.0",
-    "prettier": "3.5.3"
+    "prettier": "3.6.2"
   },
   "peerDependencies": {
     "@mui/icons-material": "^5.17.1",

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -11436,7 +11436,7 @@ __metadata:
     lodash: ^4.17.21
     moment: ^2.29.4
     openapi-backend: ^5.10.5
-    prettier: 3.5.3
+    prettier: 3.6.2
     yn: ^5.0.0
   peerDependencies:
     "@backstage-community/plugin-rbac-common": ^1.12.1
@@ -11473,7 +11473,7 @@ __metadata:
     "@types/json-schema": 7.0.15
     "@types/react": ^18.2.58
     json-schema: ^0.4.0
-    prettier: 3.5.3
+    prettier: 3.6.2
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
@@ -11502,7 +11502,7 @@ __metadata:
     "@types/react": ^18.2.58
     json-schema-library: ^9.0.0
     lodash: ^4.17.21
-    prettier: 3.5.3
+    prettier: 3.6.2
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
@@ -11583,7 +11583,7 @@ __metadata:
     json-schema: ^0.4.0
     lodash: ^4.17.21
     moment: ^2.29.4
-    prettier: 3.5.3
+    prettier: 3.6.2
     react-json-view: ^1.21.3
     react-moment: ^1.1.3
     react-use: ^17.4.0
@@ -30855,6 +30855,15 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 61e97bb8e71a95d8f9c71f1fd5229c9aaa9d1e184dedb12399f76aa802fb6fdc8954ecac9df25a7f82ee7311cf8ddbd06baf5507388fc98e5b44036cc6a88a1b
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.6.2":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 0206f5f437892e8858f298af8850bf9d0ef1c22e21107a213ba56bfb9c2387a2020bfda244a20161d8e3dad40c6b04101609a55d370dece53d0a31893b64f861
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport #1059 

The reason for backporting this devDependency is to have smooth feature backports in the future.