### PR TITLE
fix(adoption-insights): fix timezone offset inconsistency in sqlite grouping queries

### DIFF
--- a/workspaces/adoption-insights/.changeset/tame-hornets-rescue.md
+++ b/workspaces/adoption-insights/.changeset/tame-hornets-rescue.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+---
+
+Fixed Timezone offset inconsistency in time-based SQLite grouping queries

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/SqliteAdapter.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/database/adapters/SqliteAdapter.ts
@@ -34,11 +34,15 @@ export class SqliteAdapter extends BaseDatabaseAdapter {
   }
 
   getDate(): string {
-    return `strftime('%Y-%m-%d', datetime(created_at, '${getTimeZoneOffsetString()}')) AS date`;
+    return `strftime('%Y-%m-%d', datetime(created_at, '${getTimeZoneOffsetString(
+      this.filters?.timezone,
+    )}')) AS date`;
   }
 
   getLastUsedDate(): string {
-    return `strftime('%Y-%m-%dT%H:%M:%SZ', MAX(datetime(created_at, '${getTimeZoneOffsetString()}'))) AS last_used`;
+    return `strftime('%Y-%m-%dT%H:%M:%SZ', MAX(datetime(created_at, '${getTimeZoneOffsetString(
+      this.filters?.timezone,
+    )}'))) AS last_used`;
   }
 
   getFormatedDate(column: string): string {
@@ -77,7 +81,7 @@ export class SqliteAdapter extends BaseDatabaseAdapter {
   }
 
   private getDateGroupingQuery(grouping: string): string {
-    const offsetStr = getTimeZoneOffsetString();
+    const offsetStr = getTimeZoneOffsetString(this.filters?.timezone);
     switch (grouping) {
       case 'hourly':
         return `strftime('%Y-%m-%d %H:00:00', datetime(created_at, '${offsetStr}'))`;

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.test.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { DateTime } from 'luxon';
 import {
   calculateDateRange,
   convertToTargetTimezone,
   getDateGroupingType,
+  getTimeZoneOffsetString,
   isSameMonth,
   toEndOfDayUTC,
   toStartOfDayUTC,
@@ -106,5 +108,43 @@ describe('convertToTargetTimezone', () => {
     expect(convertToTargetTimezone('2025-03-02T18:00:00.000Z')).toBe(
       '2025-03-02T23:30:00.000+05:30',
     );
+  });
+});
+
+describe('getTimeZoneOffsetString', () => {
+  const fixedISODate = '2025-07-09T12:00:00.000Z';
+
+  beforeAll(() => {
+    jest
+      .spyOn(DateTime, 'now')
+      .mockReturnValue(DateTime.fromISO(fixedISODate) as DateTime<true>);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return +05:30 for Asia/Kolkata', () => {
+    const offset = getTimeZoneOffsetString('Asia/Kolkata');
+    expect(offset).toBe('+05:30');
+  });
+
+  it('should return +00:00 for UTC', () => {
+    const offset = getTimeZoneOffsetString('UTC');
+    expect(offset).toBe('+00:00');
+  });
+
+  it('should return -04:00 for America/New_York (DST in July)', () => {
+    const offset = getTimeZoneOffsetString('America/New_York');
+    expect(offset).toBe('-04:00');
+  });
+
+  it('should use the default system timezone if none is provided', () => {
+    const offset = getTimeZoneOffsetString();
+    const systemZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const expected = DateTime.fromISO(fixedISODate)
+      .setZone(systemZone)
+      .toFormat('ZZ');
+    expect(offset).toBe(expected);
   });
 });

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.ts
@@ -82,8 +82,9 @@ export const convertToTargetTimezone = (
   return date;
 };
 
-export const getTimeZoneOffsetString = () => {
-  const timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+export const getTimeZoneOffsetString = (
+  timeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone,
+) => {
   const now = DateTime.now().setZone(timeZone);
   return now.toFormat('ZZ');
 };


### PR DESCRIPTION
## Fixes

https://issues.redhat.com/browse/RHDHPAI-941


Previously, timezone offsets were derived from the system environment, causing inconsistent aggregation results between local and containerized environments (e.g., UTC in Podman/Kubernetes Pod vs IST locally) in `better-sqlite3` settings.

This PR adds a fix by passing the user timezone to calculate the timezone offset rather than relying on the backend system environment's timezone.

**Before:**



Shows the time in UTC:

![image-2025-07-09-18-57-41-073](https://github.com/user-attachments/assets/700bd0f7-997a-46e8-9e63-5648aa61f6b4)

_Note: Follow Step 1 and Step 2 from the "How to test" section to reproduce this issue._

**After:**


Shows the time in user's timezone (IST in my case):

![Screenshot 2025-07-09 at 7 08 00 PM](https://github.com/user-attachments/assets/f8b3e637-dabb-47ec-a209-d952c84f6fa7)



**How to test:**
1. use latest RHDH image `quay.io/rhdh-community/rhdh:next` with adoption insights.
2. use `better-sqlite3` database client in app-config.yaml
```yaml
backend
    database:
    client: better-sqlite3
    connection: ':memory:'
```

3. use the following config in the cluster to disable the default plugins and enable adoption insights with this PR changes.
```
plugins:
  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-adoption-insights
    disabled: true
  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
    disabled: true
  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic
    disabled: true
  - package: oci://quay.io/karthik_jk/adoption-insights:pr-1134!red-hat-developer-hub-backstage-plugin-adoption-insights
    disabled: false
    pluginConfig:
      dynamicPlugins:
        frontend:
          red-hat-developer-hub.backstage-plugin-adoption-insights:
            appIcons:
              - name: adoptionInsightsIcon
                importName: AdoptionInsightsIcon
            dynamicRoutes:
              - path: /adoption-insights
                importName: AdoptionInsightsPage
                menuItem:
                  icon: adoptionInsightsIcon
                  text: Adoption Insights
            menuItems:
              adoption-insights:
                parent: admin
                icon: adoptionInsightsIcon
  - package: oci://quay.io/karthik_jk/adoption-insights:pr-1134!red-hat-developer-hub-backstage-plugin-adoption-insights-backend
    disabled: false
    pluginConfig:
      app:
        analytics:
          adoptionInsights:
            maxBufferSize: 20
            flushInterval: 5000
            debug: false
            licensedUsers: 100
  - package: oci://quay.io/karthik_jk/adoption-insights:pr-1134!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
    disabled: false
    pluginConfig:
      dynamicPlugins:
        frontend:
          red-hat-developer-hub.backstage-plugin-analytics-module-adoption-insights:
            analyticsApiExtensions:
              - importName: AdoptionInsightsAnalyticsApi
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
