### PR TITLE
docs(global-header): add CompanyLogo to README

### DIFF
--- a/workspaces/global-header/README.md
+++ b/workspaces/global-header/README.md
@@ -60,31 +60,22 @@ Replace `test-token` if you provided a custom external access token.
 
 Then you will get real-time notifications in this dev app.
 
-# Theme-Specific Company Logo Support
+## CompanyLogo
 
-The Global Header in **Red Hat Developer Hub (RHDH)** now supports configurable **theme-specific company logos** with full control over navigation, theming, sizing, and fallback behavior.
+The Global Header plugin now supports **company logos** with full control over navigation, theming, sizing, and fallback behavior.
 
----
+### Key features
 
-## Key Enhancements
-
-- Company logo is now **part of the Global Header by default**.
-
-- Support for a **single logo** used across both Light and Dark themes.
-
-- Support for **theme-specific logos** (separate logos for Light and Dark themes).
-
-- Ability to **control logo dimensions** via width and height props.
-
+- Company logo is now part of the Global Header **by default**.
+- Support for **theme-specific logos** (separate logos for light and dark themes).
+- Support for a **single logo** used across all themes.
+- **Customizable logo dimensions** via width and height props.
 - **Clickable logo**: custom navigation path can be configured.
-
 - **Backward compatibility** with older `app.branding.fullLogo` configurations.
 
----
+### ⚙️ Configuration example
 
-## ⚙️ Configuration Example
-
-```
+```yaml
 # ...rest of the global header configuration
 red-hat-developer-hub.backstage-plugin-global-header:
   mountPoints:
@@ -101,87 +92,53 @@ red-hat-developer-hub.backstage-plugin-global-header:
           to: '/catalog'  # Path to navigate when logo is clicked
           width: 300       # Optional; fallback chain applies
           height: 200      # Optional; default max height is 40px
-         #logo: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAATQAAACkCAMAAAAuT...' #Single logo for all theme.
+         #logo: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAATQAAACkCAMAAAAuT...' # Single logo for all themes.
           logo:
-            dark: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAATQAAACkCAMAAAAuT...' #will be shown in dark theme
-            light: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgUAAABhCAMAAAB...'  #will be shown in light theme
+            dark: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAATQAAACkCAMAAAAuT...' # will be shown in dark theme
+            light: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgUAAABhCAMAAAB...'  # will be shown in light theme
 
 ```
 
-## Fallback Configuration Example
+### Fallback Configuration Example
 
-```
+In addition to the Global Header, theme-specific logo support is also available in RHDH's **sidebar logo**. This configuration is **used as a fallback** for `CompanyLogo` if props are not provided to the component. The sidebar logo and the `CompanyLogo` fallback can be configured with the following `app-config` configuration:
+
+```yaml
 app:
   branding:
     fullLogoWidth: 220 #fallback width
-  # fullLogo: "data:image/svg+xml;base64,PHN2ZyB4bWxu…" #Signle image for all theme
+  # fullLogo: "data:image/svg+xml;base64,PHN2ZyB4bWxu…" # Single image for all themes
     fullLogo:
-      light: "data:image/svg+xml;base64,PHN2ZyB4bWxu…"  # Light Theme
-      dark:  "data:image/svg+xml;base64,PHN2ZyB4bWxu…"  #Dark Theme
+      light: "data:image/svg+xml;base64,PHN2ZyB4bWxu…"  # will be shown in light theme
+      dark:  "data:image/svg+xml;base64,PHN2ZyB4bWxu…"  # will be shown in dark theme
 ```
 
----
+### Fallback Behavior
 
-## Fallback Behavior
+#### Logo Source Priority
 
-### Logo Source Priority
+1. `CompanyLogo` props (`logo` / `logo.light` / `logo.dark`)
+2. `app.branding.fullLogo`
+3. Default RHDH theme-specific logo
 
-1.  `CompanyLogo` props (`logo` / `logo.light` / `logo.dark`)
-2.  `app.branding.fullLogo`
-3.  Default RHDH theme-specific logo
+### Logo Sizing Behavior
 
----
+#### Width Priority
 
-## Logo Sizing Behavior
+1. `props.width` (from the dynamic plugin configuration)
+2. `app.branding.fullLogoWidth` (from `app-config.yaml`)
+3. Default: `150px`
 
-### Width Resolution Priority
+#### Height Priority
 
-1.  `props.width` (from the dynamic plugin configuration)
-2.  `app.branding.fullLogoWidth` (from `app-config.yaml`)
-3.  Default: `150px`
+Increasing the `height` also increases the overall height of the Global Header.
 
-### Height Resolution Priority
+1. `props.height` (from configuration)
+2. Default maximum height: `40px` (applied automatically if not specified)
 
-1.  `props.height` (from configuration)
-2.  Default maximum height: `40px` (applied automatically if not specified)
+#### Rendering Behavior
 
-> **Note:** Increasing the `height` also increases the overall height of the Global Header.
-
-### Rendering Behavior
-
-- The logo uses `object-fit: contain` to **maintain original aspect ratio**.
-- The image is **never cropped or distorted**.
+- The logo uses `object-fit: contain` to maintain the original aspect ratio.
+- The image is never cropped or distorted.
 - If the configured `width` would result in a height greater than the allowed maximum (default: 40px), it is **automatically scaled down**.
 - This means: in some cases, changing only the width may **not visibly affect** the logo unless height is also adjusted.
-
----
-
-## Sidebar Support
-
-In addition to the Global Header, **theme-specific logo support is also available in the sidebar**.
-
-### Single Logo for All Themes
-
-```
-app:
-  sidebar:
-    logo: true
-  branding:
-    fullLogoWidth: 220
-    fullLogo: "data:image/svg+xml;base64,PHN2ZyB4bWxu…"
-
-```
-
-### Theme-Specific Logos
-
-```
-app:
-  sidebar:
-    logo: true
-  branding:
-    fullLogoWidth: 220
-    fullLogo:
-      light: "data:image/svg+xml;base64,PHN2ZyB4bWxu…"  # Light Theme
-      dark:  "data:image/svg+xml;base64,PHN2ZyB4bWxu…"  # Dark Theme
-
-```


### PR DESCRIPTION

### Description

This PR updates the `README.md` to document support for **theme-specific company logos** in the **Global Header** and **Sidebar**. It includes detailed configuration examples, fallback behavior, logo sizing rules, and navigation path customization for the `CompanyLogo` component.

### Key Additions

*   Instructions for configuring a single or theme-specific logo using `app.branding.fullLogo`.
    
*   Example of configuring the logo via `CompanyLogo` dynamic plugin props.
    
*   Logo source and sizing fallback resolution order.
    
*   Explanation of how `object-fit: contain` preserves aspect ratio.
    
*   Note on how height affects overall header layout.
    
*   Sidebar logo branding support.
    
*   Clickable logo with configurable redirection path (`props.to`).
    

This helps platform engineers and developers apply consistent branding across themes while maintaining backward compatibility.
