### PR TITLE
chore: add renovate presets for quickstart

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-quickstart-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-quickstart-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all quickstart minor updates",
+      "matchFileNames": ["workspaces/quickstart/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Quickstart)"
+      ],
+      "addLabels": ["team/rhdh", "quickstart"]
+    },
+    {
+      "description": "all quickstart patch updates",
+      "matchFileNames": ["workspaces/quickstart/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Quickstart)"
+      ],
+      "addLabels": ["team/rhdh", "quickstart"]
+    },
+    {
+      "description": "all quickstart dev dependency updates",
+      "matchFileNames": ["workspaces/quickstart/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Quickstart)"
+      ],
+      "addLabels": ["team/rhdh", "quickstart"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-orchestrator-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
       ]
     },
     {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The Quickstart workspace was newly added but it's missing renovate presets.  Newly created PRs are missing the groupings and labels that can clearly designate the types of updates and responsible team.

The Renovate config validation will error out because we're adding a new file.  We can safely ignore that. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
