### PR TITLE
fix(extensions): hide actions menu in view only mode

### DIFF
--- a/workspaces/marketplace/.changeset/strong-gorillas-bow.md
+++ b/workspaces/marketplace/.changeset/strong-gorillas-bow.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+hide actions menu in view only mode

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginContent.test.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginContent.test.tsx
@@ -245,4 +245,30 @@ describe('MarketplacePluginContent', () => {
     expect(getByTestId('actions-button')).toBeInTheDocument();
     expect(getByTestId('disable-plugin')).toBeInTheDocument();
   });
+
+  it('should have the View button when user has read only access even when the plugin is installed', async () => {
+    usePluginConfigurationPermissionsMock.mockReturnValue({
+      data: {
+        write: 'DENY',
+        read: 'ALLOW',
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    const installedPlugin = {
+      ...plugin,
+      spec: {
+        ...plugin.spec,
+        installStatus: MarketplacePluginInstallStatus.Installed,
+      },
+    };
+
+    const { getByText } = renderWithProviders(
+      <QueryClientProvider client={queryClient}>
+        <MarketplacePluginContent plugin={installedPlugin} />,
+      </QueryClientProvider>,
+    );
+    expect(getByText('View')).toBeInTheDocument();
+  });
 });

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginContent.tsx
@@ -209,7 +209,6 @@ export const MarketplacePluginContent = ({
     if (!plugin.spec) {
       return;
     }
-    // When Update API is ready, adjust this logic to apply the correct status
     if (
       plugin.spec?.installStatus === MarketplacePluginInstallStatus.Installed ||
       plugin.spec?.installStatus ===
@@ -299,6 +298,10 @@ export const MarketplacePluginContent = ({
     const disablePluginActions =
       pluginConfigPerm.data?.read !== 'ALLOW' &&
       pluginConfigPerm.data?.write !== 'ALLOW';
+    const viewOnly =
+      isProductionEnvironment ||
+      pluginConfigPerm.data?.write !== 'ALLOW' ||
+      !extensionsConfig.data?.enabled;
 
     const icon = isPluginEnabled ? (
       <ToggleOnOutlinedIcon />
@@ -335,6 +338,22 @@ export const MarketplacePluginContent = ({
       );
     }
 
+    if (viewOnly) {
+      return (
+        <LinkButton
+          to={getInstallPath({
+            namespace: plugin.metadata.namespace!,
+            name: plugin.metadata.name,
+          })}
+          color="primary"
+          variant="contained"
+          data-testId="view"
+        >
+          View
+        </LinkButton>
+      );
+    }
+
     if (
       plugin.spec?.installStatus === MarketplacePluginInstallStatus.Installed ||
       plugin.spec?.installStatus ===
@@ -363,14 +382,16 @@ export const MarketplacePluginContent = ({
             open={open}
             onClose={handleClose}
           >
-            {/* Comment out the Edit menu, if edit is not functional */}
-            <MenuItem onClick={handleEdit} disableRipple>
+            <MenuItem
+              data-testId="edit-configuration"
+              onClick={handleEdit}
+              disableRipple
+            >
               <ListItemIcon>
                 <EditIcon />
               </ListItemIcon>
               <ListItemText primary="Edit" secondary="Plugin configurations" />
             </MenuItem>
-            {/* Make the appropriate API call to check the plugin status and show Enable/Disable action accordingly */}
             <MenuItem
               data-testId={testId}
               onClick={handleToggle}
@@ -387,27 +408,20 @@ export const MarketplacePluginContent = ({
 
     return (
       <LinkButton
-        to={
-          pluginConfigPerm.data?.write === 'ALLOW' ||
-          pluginConfigPerm.data?.read === 'ALLOW'
-            ? getInstallPath({
-                namespace: plugin.metadata.namespace!,
-                name: plugin.metadata.name,
-              })
-            : ''
-        }
+        to={getInstallPath({
+          namespace: plugin.metadata.namespace!,
+          name: plugin.metadata.name,
+        })}
         color="primary"
         variant="contained"
-        data-testId="install-enabled"
+        data-testId="install"
       >
-        {isProductionEnvironment ||
-        pluginConfigPerm.data?.write !== 'ALLOW' ||
-        !extensionsConfig.data?.enabled
-          ? 'View'
-          : mapMarketplacePluginInstallStatusToButton[
-              plugin.spec?.installStatus ??
-                MarketplacePluginInstallStatus.NotInstalled
-            ]}
+        {
+          mapMarketplacePluginInstallStatusToButton[
+            plugin.spec?.installStatus ??
+              MarketplacePluginInstallStatus.NotInstalled
+          ]
+        }
       </LinkButton>
     );
   };

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
@@ -69,6 +69,7 @@ import {
   getErrorMessage,
   getExampleAsMarkdown,
   getPluginActionTooltipMessage,
+  isPluginInstalled,
 } from '../utils';
 
 import {
@@ -337,7 +338,11 @@ export const MarketplacePluginInstallContent = ({
       if (res?.status === 'OK') {
         const updatedPlugins: InstallationType = {
           ...installedPlugins,
-          [plugin.metadata.title ?? plugin.metadata.name]: 'Plugin installed',
+          [plugin.metadata.title ?? plugin.metadata.name]: isPluginInstalled(
+            plugin?.spec?.installStatus,
+          )
+            ? 'Plugin updated'
+            : 'Plugin installed',
         };
         setInstalledPlugins(updatedPlugins);
         navigate('/extensions');
@@ -373,6 +378,15 @@ export const MarketplacePluginInstallContent = ({
     (pluginConfig.data as any)?.error?.message &&
     (pluginConfig.data as any)?.error?.reason !==
       ExtensionsStatus.INSTALLATION_DISABLED;
+
+  const getInstallButtonDatatestid = () => {
+    if (isInstallDisabled) {
+      return isPluginInstalled(plugin?.spec?.installStatus)
+        ? 'edit-disabled'
+        : 'install-disabled';
+    }
+    return isPluginInstalled(plugin.spec?.installStatus) ? 'edit' : 'install';
+  };
 
   const installationWarning = () => {
     const errorMessage = getErrorMessage(
@@ -478,7 +492,9 @@ export const MarketplacePluginInstallContent = ({
                 <CardHeader
                   title={
                     <Typography variant="h3">
-                      Installation instructions
+                      {isPluginInstalled(plugin.spec?.installStatus)
+                        ? 'Edit instructions'
+                        : 'Installation instructions'}
                     </Typography>
                   }
                   action={
@@ -593,7 +609,7 @@ export const MarketplacePluginInstallContent = ({
                 color="primary"
                 onClick={handleInstall}
                 disabled={isInstallDisabled}
-                data-testid={isInstallDisabled ? 'install-disabled' : 'install'}
+                data-testid={getInstallButtonDatatestid()}
                 startIcon={
                   isSubmitting && (
                     <CircularProgress size="20px" color="inherit" />

--- a/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginInstallPage.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/pages/MarketplacePluginInstallPage.tsx
@@ -21,28 +21,23 @@ import {
   Content,
   ErrorBoundary,
 } from '@backstage/core-components';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
 
 import { themeId } from '../consts';
 import { pluginInstallRouteRef, pluginRouteRef } from '../routes';
 import { ReactQueryProvider } from '../components/ReactQueryProvider';
 import { usePlugin } from '../hooks/usePlugin';
 import { MarketplacePluginInstallContentLoader } from '../components/MarketplacePluginInstallContent';
-import Box from '@mui/material/Box';
-import { useTheme } from '@mui/material/styles';
-import { MarketplacePluginInstallStatus } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+
+import { isPluginInstalled } from '../utils';
 
 const PluginInstallHeader = () => {
   const params = useRouteRefParams(pluginInstallRouteRef);
   const plugin = usePlugin(params.namespace, params.name);
 
   const displayName = plugin.data?.metadata?.title ?? params.name;
-  const pluginInstallStatus = plugin.data?.spec?.installStatus;
-  const isPluginInstalled =
-    pluginInstallStatus === MarketplacePluginInstallStatus.Installed ||
-    pluginInstallStatus === MarketplacePluginInstallStatus.UpdateAvailable ||
-    pluginInstallStatus === MarketplacePluginInstallStatus.PartiallyInstalled ||
-    pluginInstallStatus === MarketplacePluginInstallStatus.Disabled;
-  const title = isPluginInstalled
+  const title = isPluginInstalled(plugin.data?.spec?.installStatus)
     ? `Edit ${displayName} configurations`
     : `Install ${displayName}`;
   const pluginLink = useRouteRef(pluginRouteRef)({

--- a/workspaces/marketplace/plugins/marketplace/src/utils.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/utils.ts
@@ -16,6 +16,7 @@
 
 import { Pair, parseDocument, Scalar, YAMLSeq, stringify } from 'yaml';
 import { JsonObject } from '@backstage/types';
+import { MarketplacePluginInstallStatus } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 
 export enum ExtensionsStatus {
   INSTALLATION_DISABLED = 'INSTALLATION_DISABLED',
@@ -147,4 +148,18 @@ export const getPluginActionTooltipMessage = (
   }
 
   return '';
+};
+
+export const isPluginInstalled = (
+  pluginInstallStatus: MarketplacePluginInstallStatus | undefined,
+) => {
+  if (!pluginInstallStatus) {
+    return false;
+  }
+  return (
+    pluginInstallStatus === MarketplacePluginInstallStatus.Installed ||
+    pluginInstallStatus === MarketplacePluginInstallStatus.UpdateAvailable ||
+    pluginInstallStatus === MarketplacePluginInstallStatus.PartiallyInstalled ||
+    pluginInstallStatus === MarketplacePluginInstallStatus.Disabled
+  );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://issues.redhat.com/browse/RHIDP-8121
Fixes the issues in the PR https://github.com/redhat-developer/rhdh-plugins/pull/1111

In the Edit flow on the plugin configuration page, it shows "Edit instructions" instead of "Installation instructions"
<img width="1715" height="917" alt="Screenshot 2025-07-12 at 4 09 14 PM" src="https://github.com/user-attachments/assets/5d5f2086-3b9b-4341-8247-8cfb93c392dc" />

In the edit flow, when the plugin configuration is updated, the notification alert shows plugin updated instead of plugin installed
<img width="1715" height="917" alt="Screenshot 2025-07-12 at 4 10 17 PM" src="https://github.com/user-attachments/assets/652adc9b-9bc8-48dd-a7d7-5dfcba12f667" />

When the user has only read access, it shows the View button

**Test setup**

`app-config.local.yaml`
```
permission:
  enabled: true
  rbac:
    pluginsWithPermission:
      - extensions
      - catalog
      - permission
    admin:
      users:
        - name: user:default/<your-username>
```

Create an RBAC role with your desired extension permissions

Note: To test on RHDH-local follow this [doc](https://docs.google.com/document/d/1_kLj5-R3Rg2zDd89mE3BPZLavMs-jhoLm3nMkBrOkQQ/edit?tab=t.0#heading=h.jsabhoh57en7)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
