### PR TITLE
fix(extensions): Set disabled for all plugin packages

### DIFF
--- a/workspaces/marketplace/.changeset/hip-pots-wink.md
+++ b/workspaces/marketplace/.changeset/hip-pots-wink.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace-backend': patch
+---
+
+Update all plugin packages via PATCH `/plugin/:namespace/:name/configuration/disable`

--- a/workspaces/marketplace/plugins/marketplace-backend/src/installation/FileInstallationStorage.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/installation/FileInstallationStorage.test.ts
@@ -426,7 +426,7 @@ describe('FileInstallationStorage', () => {
       );
     });
 
-    it('should set disabled for plugin packages that are already in the config', () => {
+    it('should set disabled for existing plugin in the config', () => {
       const configFileName = resolve(
         __dirname,
         '../../__fixtures__/data/validPluginsConfig.yaml',
@@ -447,11 +447,7 @@ describe('FileInstallationStorage', () => {
       fileInstallationStorage.initialize();
 
       fileInstallationStorage.setPackagesDisabled(
-        new Set([
-          mockDynamicPackage11.package,
-          mockDynamicPackage12.package,
-          './dynamic-plugins/dist/package13-backend-module-dynamic', // not added
-        ]),
+        new Set([mockDynamicPackage11.package, mockDynamicPackage12.package]),
         false,
       );
 
@@ -460,6 +456,37 @@ describe('FileInstallationStorage', () => {
       expect(configYaml.plugins).toEqual([
         ...updatedPlugin,
         mockDynamicPackage21,
+      ]);
+    });
+
+    it('should set disabled for new plugin in the config', () => {
+      const configFileName = resolve(
+        __dirname,
+        '../../__fixtures__/data/validPluginsConfig.yaml',
+      );
+      const newPlugin = [
+        {
+          package: newPackageName,
+          disabled: false,
+        },
+      ];
+      const fileInstallationStorage = new FileInstallationStorage(
+        configFileName,
+      );
+      fileInstallationStorage.initialize();
+
+      fileInstallationStorage.setPackagesDisabled(
+        new Set([newPackageName]),
+        false,
+      );
+
+      const updatedCatalogInfoYaml = fs.readFileSync(configFileName, 'utf8');
+      const configYaml = parse(updatedCatalogInfoYaml);
+      expect(configYaml.plugins).toEqual([
+        mockDynamicPackage11,
+        mockDynamicPackage12,
+        mockDynamicPackage21,
+        newPlugin[0],
       ]);
     });
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHDHBUGS-1880

#### Demo on cluster with helm:
https://github.com/user-attachments/assets/7ad9c256-2db7-473d-86c7-3e8b16741de1

Note: Plugin install status is for a little while set still to disabled, this is because processor hasn't yet started processing this entity and updating its status.



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
