### PR TITLE
fix(sandbox): make modals in dark mode homogeneous

### DIFF
--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/AccessCodeInputModal.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/AccessCodeInputModal.tsx
@@ -110,7 +110,19 @@ export const AccessCodeInputModal: React.FC<AccessCodeInputModalProps> = ({
   };
 
   return (
-    <Dialog open={modalOpen} onClose={handleClose} fullWidth>
+    <Dialog
+      open={modalOpen}
+      onClose={handleClose}
+      fullWidth
+      PaperProps={{
+        sx: {
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? '#383838'
+              : theme.palette.background.paper,
+        },
+      }}
+    >
       <DialogTitle
         variant="h5"
         sx={{ fontWeight: 700, padding: '32px 24px 0 24px' }}
@@ -129,7 +141,9 @@ export const AccessCodeInputModal: React.FC<AccessCodeInputModalProps> = ({
       >
         <CloseIcon />
       </IconButton>
-      <DialogContent sx={{ padding: '6px 24px' }}>
+      <DialogContent
+        sx={{ padding: '6px 24px', backgroundColor: 'transparent !important' }}
+      >
         <DialogContentText
           id="alert-dialog-description"
           color="textPrimary"
@@ -148,7 +162,7 @@ export const AccessCodeInputModal: React.FC<AccessCodeInputModalProps> = ({
           sx={{
             mt: 2,
             marginRight: 20,
-            backgroundColor: theme.palette.mode === 'dark' ? '#47494b' : '#fff',
+            backgroundColor: 'transparent !important',
           }}
         >
           {accessCode.map((digit, index) => (

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/AnsibleLaunchInfoModal.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/AnsibleLaunchInfoModal.tsx
@@ -71,7 +71,19 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
   };
 
   return (
-    <Dialog open={modalOpen} onClose={handleClose} fullWidth>
+    <Dialog
+      open={modalOpen}
+      onClose={handleClose}
+      fullWidth
+      PaperProps={{
+        sx: {
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? '#383838'
+              : theme.palette.background.paper,
+        },
+      }}
+    >
       {ansibleStatus === AnsibleStatus.READY ? (
         <>
           <DialogTitle
@@ -104,7 +116,9 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
           >
             <CloseIcon />
           </IconButton>
-          <DialogContent sx={{ padding: '24px' }}>
+          <DialogContent
+            sx={{ padding: '24px', backgroundColor: 'transparent !important' }}
+          >
             <Typography
               variant="body1"
               sx={{ mb: 3, fontSize: '16px', fontWeight: 400 }}
@@ -117,9 +131,15 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
             </Typography>
 
             {/* Section 1: AAP admin account */}
-            <Box sx={{ mb: 4 }}>
+            <Box sx={{ mb: 4, backgroundColor: 'transparent !important' }}>
               <Box
-                sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  mb: 2,
+                  backgroundColor: 'transparent !important',
+                }}
               >
                 <Typography variant="h6" sx={{ fontWeight: 'bold', mr: 1 }}>
                   1.
@@ -143,7 +163,7 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
                 provided username and password to access your AAP instance.
               </Typography>
 
-              <Box sx={{ mb: 3 }}>
+              <Box sx={{ mb: 3, backgroundColor: 'transparent !important' }}>
                 <Stack
                   direction="row"
                   sx={{
@@ -151,6 +171,7 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
                     alignItems: 'center',
                     gap: '5px',
                     mb: 1,
+                    backgroundColor: 'transparent !important',
                   }}
                 >
                   <InputLabel
@@ -203,6 +224,7 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
                     display: 'flex',
                     alignItems: 'center',
                     gap: '5px',
+                    backgroundColor: 'transparent !important',
                   }}
                 >
                   <InputLabel
@@ -265,9 +287,15 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
             </Box>
 
             {/* Section 2: Red Hat account */}
-            <Box sx={{ mb: 4 }}>
+            <Box sx={{ mb: 4, backgroundColor: 'transparent !important' }}>
               <Box
-                sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  mb: 2,
+                  backgroundColor: 'transparent !important',
+                }}
               >
                 <Typography variant="h6" sx={{ fontWeight: 'bold', mr: 1 }}>
                   2.
@@ -373,7 +401,12 @@ export const AnsibleLaunchInfoModal: React.FC<AnsibleLaunchInfoModalProps> = ({
           >
             <CloseIcon />
           </IconButton>{' '}
-          <DialogContent sx={{ padding: '6px 24px' }}>
+          <DialogContent
+            sx={{
+              padding: '6px 24px',
+              backgroundColor: 'transparent !important',
+            }}
+          >
             <Typography
               variant="body1"
               sx={{ mr: 2, my: 0.5, fontSize: '16px', fontWeight: 420 }}

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationModal.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationModal.tsx
@@ -17,6 +17,7 @@ import React, { useState } from 'react';
 import { E164Number } from 'libphonenumber-js/types.cjs';
 import { Country, getCountryCallingCode } from 'react-phone-number-input';
 import Dialog from '@mui/material/Dialog';
+import { useTheme } from '@mui/material/styles';
 import { useApi } from '@backstage/core-plugin-api';
 import { registerApiRef } from '../../api';
 import {
@@ -41,6 +42,7 @@ export const PhoneVerificationModal: React.FC<PhoneVerificationModalProps> = ({
   setAnsibleCredsModalOpen,
   setRefetchingUserData,
 }) => {
+  const theme = useTheme();
   const registerApi = useApi(registerApiRef);
   const [enterOTP, setEnterOTP] = useState<boolean>(false);
   const [phoneNumber, setPhoneNumber] = useState<E164Number | undefined>();
@@ -90,7 +92,18 @@ export const PhoneVerificationModal: React.FC<PhoneVerificationModalProps> = ({
   };
 
   return (
-    <Dialog open={modalOpen} onClose={handleClose}>
+    <Dialog
+      open={modalOpen}
+      onClose={handleClose}
+      PaperProps={{
+        sx: {
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? '#383838'
+              : theme.palette.background.paper,
+        },
+      }}
+    >
       {!enterOTP ? (
         <PhoneNumberStep
           phoneNumber={phoneNumber}

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/PhoneNumberStep.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/PhoneNumberStep.tsx
@@ -169,7 +169,9 @@ export const PhoneNumberStep: React.FC<PhoneNumberFormProps> = ({
         <CloseIcon />
       </IconButton>
 
-      <DialogContent sx={{ padding: '6px 24px' }}>
+      <DialogContent
+        sx={{ padding: '6px 24px', backgroundColor: 'transparent !important' }}
+      >
         <DialogContentText
           id="alert-dialog-description"
           color="textPrimary"
@@ -182,7 +184,7 @@ export const PhoneNumberStep: React.FC<PhoneNumberFormProps> = ({
           style={{
             marginTop: '24px',
             display: 'flex',
-            backgroundColor: theme.palette.mode === 'dark' ? '#47494b' : '#fff',
+            backgroundColor: 'transparent',
           }}
         >
           <RPNInput

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/VerificationCodeStep.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/VerificationCodeStep.tsx
@@ -224,7 +224,9 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
       >
         <CloseIcon />
       </IconButton>
-      <DialogContent sx={{ padding: '6px 24px' }}>
+      <DialogContent
+        sx={{ padding: '6px 24px', backgroundColor: 'transparent !important' }}
+      >
         <DialogContentText
           data-testid="sent-message-dialog"
           id="alert-dialog-description"
@@ -241,7 +243,15 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
             <EditIcon />
           </IconButton>
         </DialogContentText>
-        <Stack direction="row" spacing={2} sx={{ mt: 2, marginRight: 20 }}>
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{
+            mt: 2,
+            marginRight: 20,
+            backgroundColor: 'transparent !important',
+          }}
+        >
           {otp.map((digit, index) => (
             <TextField
               key={index}
@@ -271,6 +281,7 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
             justifyContent: 'left',
             fontSize: '16px',
             fontWeight: 400,
+            backgroundColor: 'transparent !important',
           }}
           onClick={() => {
             handleResendCode();


### PR DESCRIPTION
This PR fixes the modals in dark mode.

Before:
<img width="3308" height="1278" alt="image" src="https://github.com/user-attachments/assets/0b4205f8-e493-4a70-887b-77f8eeebd808" />
<img width="3420" height="1087" alt="Screenshot 2025-07-16 at 16 55 31" src="https://github.com/user-attachments/assets/b5ec3ecf-e58e-4fb3-ae32-f537ca0b7cc4" />
<img width="1482" height="899" alt="Screenshot 2025-07-16 at 16 16 17" src="https://github.com/user-attachments/assets/2ffca53b-0e1a-4925-bfb3-c58e8e32ecde" />
<img width="757" height="450" alt="Screenshot 2025-07-16 at 16 13 41" src="https://github.com/user-attachments/assets/d9fb0a50-2ca1-4b7f-ae98-440edd151b0e" />

After:
<img width="1497" height="942" alt="Screenshot 2025-07-16 at 16 57 37" src="https://github.com/user-attachments/assets/a8b615b4-66cb-41f1-9046-9a30518f9337" />
<img width="1482" height="899" alt="Screenshot 2025-07-16 at 16 51 51" src="https://github.com/user-attachments/assets/823a3aaa-d6de-48bf-8bf7-de2b8fa83a20" />
<img width="757" height="450" alt="Screenshot 2025-07-16 at 16 15 50" src="https://github.com/user-attachments/assets/33a3d6b9-4672-4edd-8edc-8e2788303dec" />
<img width="3433" height="1305" alt="Screenshot 2025-07-16 at 15 56 23" src="https://github.com/user-attachments/assets/87e6dc9a-c137-4ea3-9d31-de2b16a04e99" />

