### PR TITLE
fix(orchestrator): fix warped details card

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowRunDetails.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowRunDetails.tsx
@@ -76,13 +76,6 @@ export const WorkflowRunDetails: React.FC<WorkflowDetailsCardProps> = ({
           </Typography>
         </AboutField>
       </Grid>
-      <Grid item md={5} key="Duration">
-        <AboutField label="Duration">
-          <Typography variant="subtitle2" component="div">
-            <b>{details.duration}</b>
-          </Typography>
-        </AboutField>
-      </Grid>
       <Grid item md={7} key="Workflow Status">
         <AboutField label="Workflow Status">
           <Typography variant="subtitle2" component="div">
@@ -96,10 +89,10 @@ export const WorkflowRunDetails: React.FC<WorkflowDetailsCardProps> = ({
           </Typography>
         </AboutField>
       </Grid>
-      <Grid item md={5} key="Started">
-        <AboutField label="Started">
+      <Grid item md={5} key="Duration">
+        <AboutField label="Duration">
           <Typography variant="subtitle2" component="div">
-            <b>{details.start}</b>
+            <b>{details.duration}</b>
           </Typography>
         </AboutField>
       </Grid>
@@ -107,6 +100,13 @@ export const WorkflowRunDetails: React.FC<WorkflowDetailsCardProps> = ({
         <AboutField label="Description">
           <Typography variant="subtitle2" component="div">
             <b>{details.description ?? VALUE_UNAVAILABLE}</b>
+          </Typography>
+        </AboutField>
+      </Grid>
+      <Grid item md={5} key="Started">
+        <AboutField label="Started">
+          <Typography variant="subtitle2" component="div">
+            <b>{details.start}</b>
           </Typography>
         </AboutField>
       </Grid>


### PR DESCRIPTION
After [PR](https://github.com/redhat-developer/rhdh-plugins/pull/1089) that removed workflow category, the workflow run details card became warped. This PR fixes it according to updated [figma](https://www.figma.com/design/XjdTCb4vDQ7L4Jz1TdHKGq/Workflow-Orchestrator?node-id=4896-5438&t=Cq06pOVqH36LEroJ-0). 

Before:
<img width="855" height="412" alt="image" src="https://github.com/user-attachments/assets/ce466872-6561-48f9-bea7-5b957c6e5dcb" />

After:
<img width="577" height="384" alt="image" src="https://github.com/user-attachments/assets/4529a190-a629-499e-8dd9-5fcdc88799ef" />
