### PR TITLE
fix(extensions): restrict access to configuration endpoints in production

### DIFF
--- a/workspaces/marketplace/.changeset/proud-apes-cross.md
+++ b/workspaces/marketplace/.changeset/proud-apes-cross.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace-backend': patch
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+Restrict access to configuration endpoints in production

--- a/workspaces/marketplace/plugins/marketplace-backend/src/errors/InstallationInitError.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/errors/InstallationInitError.ts
@@ -16,6 +16,7 @@
 import { CustomErrorBase } from '@backstage/errors';
 
 export const InstallationInitErrorReason = {
+  INSTALLATION_DISABLED_IN_PRODUCTION: 'INSTALLATION_DISABLED_IN_PRODUCTION',
   INSTALLATION_DISABLED: 'INSTALLATION_DISABLED',
   FILE_CONFIG_VALUE_MISSING: 'FILE_CONFIG_VALUE_MISSING',
   FILE_NOT_EXISTS: 'FILE_NOT_EXISTS',
@@ -36,7 +37,11 @@ export class InstallationInitError extends CustomErrorBase {
     public cause?: Error,
   ) {
     super(message, cause);
-    if (this.reason === InstallationInitErrorReason.INSTALLATION_DISABLED) {
+    if (
+      this.reason ===
+        InstallationInitErrorReason.INSTALLATION_DISABLED_IN_PRODUCTION ||
+      this.reason === InstallationInitErrorReason.INSTALLATION_DISABLED
+    ) {
       this.statusCode = 503;
     } else {
       this.statusCode = 500;

--- a/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.test.ts
@@ -75,7 +75,7 @@ describe('InstallationDataService', () => {
         logger: mockLogger,
       });
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         'Installation feature is disabled in production',
       );
       expect(installationDataService.getInitializationError()).toBeDefined();
@@ -95,7 +95,7 @@ describe('InstallationDataService', () => {
         logger: mockLogger,
       });
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         `Installation feature is disabled under 'extensions.installation.enabled'`,
       );
       expect(installationDataService.getInitializationError()).toBeDefined();

--- a/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.test.ts
@@ -60,12 +60,30 @@ describe('InstallationDataService', () => {
     return Promise.resolve(isMatch ? [mockPackages[0], mockPackages[1]] : []);
   });
 
-  afterEach(async () => {
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'development';
     jest.clearAllMocks();
     mockFileInstallationStorage.initialize.mockReset();
   });
 
   describe('initialize', () => {
+    it("should return service with 'INSTALLATION_DISABLED_IN_PRODUCTION' error when production environment", () => {
+      process.env.NODE_ENV = 'production';
+      installationDataService = InstallationDataService.fromConfig({
+        config: validConfig,
+        marketplaceApi: mockMarketplaceApi,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Installation feature is disabled in production',
+      );
+      expect(installationDataService.getInitializationError()).toBeDefined();
+      expect(installationDataService.getInitializationError()?.reason).toBe(
+        InstallationInitErrorReason.INSTALLATION_DISABLED_IN_PRODUCTION,
+      );
+    });
+
     it("should return service with 'INSTALLATION_DISABLED' error when installation is disabled", () => {
       const disabledConfig = new ConfigReader({
         extensions: { installation: { enabled: false } },
@@ -78,7 +96,7 @@ describe('InstallationDataService', () => {
       });
 
       expect(mockLogger.info).toHaveBeenCalledWith(
-        'Installation feature is disabled',
+        `Installation feature is disabled under 'extensions.installation.enabled'`,
       );
       expect(installationDataService.getInitializationError()).toBeDefined();
       expect(installationDataService.getInitializationError()?.reason).toBe(

--- a/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.ts
@@ -65,7 +65,7 @@ export class InstallationDataService {
           InstallationInitErrorReason.INSTALLATION_DISABLED_IN_PRODUCTION ||
         reason === InstallationInitErrorReason.INSTALLATION_DISABLED
       ) {
-        logger.info(message);
+        logger.warn(message);
       } else {
         logger.error(
           `Installation feature is disabled. Error while loading data: ${message}`,

--- a/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/installation/InstallationDataService.ts
@@ -60,8 +60,12 @@ export class InstallationDataService {
       message: string,
       cause?: Error,
     ): InstallationDataService => {
-      if (reason === InstallationInitErrorReason.INSTALLATION_DISABLED) {
-        logger.info('Installation feature is disabled');
+      if (
+        reason ===
+          InstallationInitErrorReason.INSTALLATION_DISABLED_IN_PRODUCTION ||
+        reason === InstallationInitErrorReason.INSTALLATION_DISABLED
+      ) {
+        logger.info(message);
       } else {
         logger.error(
           `Installation feature is disabled. Error while loading data: ${message}`,
@@ -75,6 +79,14 @@ export class InstallationDataService {
     };
 
     try {
+      const node_env = process.env.NODE_ENV ?? 'development';
+      if (node_env === 'production') {
+        return serviceWithInitializationError(
+          InstallationInitErrorReason.INSTALLATION_DISABLED_IN_PRODUCTION,
+          'Installation feature is disabled in production',
+        );
+      }
+
       const installationEnabled = config.getOptionalBoolean(
         'extensions.installation.enabled',
       );

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
@@ -377,7 +377,9 @@ export const MarketplacePluginInstallContent = ({
   const showInstallationWarning =
     (pluginConfig.data as any)?.error?.message &&
     (pluginConfig.data as any)?.error?.reason !==
-      ExtensionsStatus.INSTALLATION_DISABLED;
+      ExtensionsStatus.INSTALLATION_DISABLED &&
+    (pluginConfig.data as any)?.error?.reason !==
+      ExtensionsStatus.INSTALLATION_DISABLED_IN_PRODUCTION;
 
   const getInstallButtonDatatestid = () => {
     if (isInstallDisabled) {

--- a/workspaces/marketplace/plugins/marketplace/src/utils.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/utils.ts
@@ -19,6 +19,7 @@ import { JsonObject } from '@backstage/types';
 import { MarketplacePluginInstallStatus } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 
 export enum ExtensionsStatus {
+  INSTALLATION_DISABLED_IN_PRODUCTION = 'INSTALLATION_DISABLED_IN_PRODUCTION',
   INSTALLATION_DISABLED = 'INSTALLATION_DISABLED',
   FILE_CONFIG_VALUE_MISSING = 'FILE_CONFIG_VALUE_MISSING',
   FILE_NOT_EXISTS = 'FILE_NOT_EXISTS',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Restricts access to configuration endpoints in production.

#### Fixes
Fixes https://issues.redhat.com/browse/RHDHBUGS-1888

#### Demo
https://github.com/user-attachments/assets/5f7d202f-56da-46be-ba77-67b25e549d93

#### How to test
rhdh-local
1. Build and push marketplace and marketplace backend plugin
2. change `compose`:
```
rhdh:
  ...    
  environment:
    NODE_OPTIONS: "--inspect=0.0.0.0:9229"
    NODE_ENV: "production"
```


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
