### PR TITLE
fix(extensions): introduce package integrity

### DIFF
--- a/workspaces/marketplace/.changeset/two-foxes-run.md
+++ b/workspaces/marketplace/.changeset/two-foxes-run.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace-backend': patch
+'@red-hat-developer-hub/backstage-plugin-marketplace-common': patch
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+Introduce `spec.integrity` field for Marketplace package

--- a/workspaces/marketplace/examples/packages/backstage-community-plugin-quay.yaml
+++ b/workspaces/marketplace/examples/packages/backstage-community-plugin-quay.yaml
@@ -17,7 +17,8 @@ metadata:
   tags: []
 spec:
   packageName: '@backstage-community/plugin-quay'
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-quay
+  dynamicArtifact: '@backstage-community/plugin-quay'
+  integrity: sha512-qaZgy2lV28qlwsNnympCUbkewYCqXxLmXQXr3WWpS7gREWj4YBpytU/hQnDnqxAnQ+dQB/9U/rPdGJnLLAOB3w==
   version: 1.18.1
   backstage:
     role: frontend-plugin

--- a/workspaces/marketplace/json-schema/packages.json
+++ b/workspaces/marketplace/json-schema/packages.json
@@ -93,6 +93,9 @@
         "dynamicArtifact": {
           "type": "string"
         },
+        "integrity": {
+          "type": "string"
+        },
         "version": {
           "type": "string"
         },

--- a/workspaces/marketplace/plugins/marketplace-backend/src/validation/configValidation.test.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/validation/configValidation.test.ts
@@ -32,6 +32,7 @@ describe('validateConfigurationFormat', () => {
         - package: package1
         - package: package2
           disabled: false
+          integrity: dummyabcd
           pluginConfig:
             key: value
     `);
@@ -103,6 +104,15 @@ describe('validatePackageFormat', () => {
         disabled: "not a boolean"
       `,
       error: "optional 'disabled' field in package item must be a boolean",
+    },
+    {
+      testCase: "'integrity' is not a string",
+      yaml: `
+        package: package1
+        integrity: []
+      `,
+      error:
+        "optional 'integrity' field in package item must be a non-empty string",
     },
     {
       testCase: "'pluginConfig' is not a map",

--- a/workspaces/marketplace/plugins/marketplace-backend/src/validation/configValidation.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/validation/configValidation.ts
@@ -73,6 +73,13 @@ export function validatePackageFormat(
     );
   }
 
+  const integrity = item.get('integrity');
+  if (integrity && (typeof integrity !== 'string' || integrity.trim() === '')) {
+    throw new ConfigFormatError(
+      "Invalid installation configuration, optional 'integrity' field in package item must be a non-empty string",
+    );
+  }
+
   if (packageName && packageToValidate !== packageName) {
     throw new ConfigFormatError(
       `Invalid installation configuration, 'package' field value in package item differs from '${packageName}'`,

--- a/workspaces/marketplace/plugins/marketplace-common/report.api.md
+++ b/workspaces/marketplace/plugins/marketplace-common/report.api.md
@@ -382,6 +382,8 @@ export interface MarketplacePackageSpec extends JsonObject {
     // (undocumented)
     installStatus?: MarketplacePackageInstallStatus;
     // (undocumented)
+    integrity?: string;
+    // (undocumented)
     lifecycle?: string;
     // (undocumented)
     owner?: string;

--- a/workspaces/marketplace/plugins/marketplace-common/src/types/MarketplacePackage.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/types/MarketplacePackage.ts
@@ -58,6 +58,7 @@ export interface MarketplacePackageSpec extends JsonObject {
   appConfigExamples?: MarketplacePackageSpecAppConfigExample[];
   owner?: string;
   partOf?: string[];
+  integrity?: string;
   installStatus?: MarketplacePackageInstallStatus;
 }
 

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
@@ -36,6 +36,7 @@ import { useNavigate } from 'react-router-dom';
 
 import {
   MarketplacePackage,
+  MarketplacePackageSpec,
   MarketplacePackageSpecAppConfigExample,
   MarketplacePlugin,
   MarketplacePluginInstallStatus,
@@ -274,10 +275,16 @@ export const MarketplacePluginInstallContent = ({
       codeEditor.setValue(configYaml);
     } else {
       const dynamicPluginYaml = {
-        plugins: (packages ?? []).map(pkg => ({
-          package: pkg.spec?.dynamicArtifact ?? './dynamic-plugins/dist/....',
-          disabled: false,
-        })),
+        plugins: (packages ?? []).map(pkg => {
+          const pkgEntry: MarketplacePackageSpec = {
+            package: pkg.spec?.dynamicArtifact ?? './dynamic-plugins/dist/....',
+            disabled: false,
+          };
+          if (pkg.spec?.integrity) {
+            pkgEntry.integrity = pkg.spec.integrity;
+          }
+          return pkgEntry;
+        }),
       };
       codeEditor.setValue(yaml.stringify(dynamicPluginYaml));
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Plugins from NPM registry and packaged as a TGZ can be installed by introducing `spec.integrity` field for Marketplace package
[Docs about possible installations of third party plugins](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-third-party-plugins#assembly-package-publish-third-party-dynamic-plugin)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes: https://issues.redhat.com/browse/RHDHBUGS-1882

#### Demo

https://github.com/user-attachments/assets/29427d49-5229-4909-a4dc-99d750241e70

#### How to test in rhdh-local

##### To test npm:
You can use quay entity I updated in this PR with integrity (add to catalog locations both plugin and package, you need to add via url or simpler, add the entities under app-config/marketplace/all.yaml and reference as `target: /opt/app-root/src/configs/app-config/marketplace/all.yaml`, make sure you have Plugin and Package in allow rules). Using this entity, quay will be pulled and installed but it won't be properly mounted in rhdh since you need derived package in the npm registry, which this is not.

To run your local npm registry to properly mount Quay plugin, you can follow [this](https://medium.com/@mgundogdu/how-to-publish-and-test-your-npm-packages-in-your-local-machine-with-verdaccio-87c8998d21de) setup guide.
Once you have your local npm registry running, you can follow https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/release-1.7/plugins-rhdh-install/#assembly-package-publish-third-party-dynamic-plugin and https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/release-1.7/plugins-rhdh-install/#assembly-install-third-party-plugins-rhdh for the Loading a plugin packaged as a JavaScript package.
Note: for frontend plugins exported via npx ... - dist-dynamic directory might not be created, you need to publish the whole plugin, that has dist-scalprum directory in it.

To make npm registry work in rhdh local, you can update your .npmrc file with: `registry=<your-ip>:4873`

##### To test `.tgz`:
You can follow https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/release-1.7/plugins-rhdh-install/#assembly-package-publish-third-party-dynamic-plugin and https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/release-1.7/plugins-rhdh-install/#assembly-install-third-party-plugins-rhdh for `.tgz` setup.
I did this:
```
cd folder-with-exported-package
npm pack --pack-destination path/to/test-dynamic-plugins-root --json | head -n 10
```
This will create .tgz package under `test-dynamic-plugins-root`. 
```
cd test-dynamic-plugins-root
python3 -m http.server 8000
```
You can check uploaded files: http://localhost:8000/

Then I reference it as 
```
package: http://<your-ip>:8000/backstage-community-plugin-quay-1.21.1.tgz
integrity: integrity-from-npm-pack-command
```
The plugin was correctly downloaded: 
<img width="1359" height="137" alt="Screenshot 2025-07-18 at 17 18 31" src="https://github.com/user-attachments/assets/ae167c91-f7ac-47c5-bf83-0cf221a76659" />
Plugin was not mounted correctly, but that should be unrelated to this PR and instead has something to do with the packaging.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
