### PR TITLE
fix(homepage): fixing homepage title not respecting value from app-config.yaml

### DIFF
--- a/workspaces/homepage/.changeset/good-squids-check.md
+++ b/workspaces/homepage/.changeset/good-squids-check.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dynamic-home-page': patch
+---
+
+Fixed homepage title which was not respecting the title received through configuration.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/HomePage.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/HomePage.tsx
@@ -48,7 +48,7 @@ export const HomePage = (props: HomePageProps) => {
 
   return (
     <Page themeId="home">
-      <Header {...props} title="Welcome back!" />
+      <Header title="Welcome back!" {...props} />
       <Content>
         {filteredAndSortedHomePageCards.length === 0 ? (
           <EmptyState


### PR DESCRIPTION
## Description 
This PR fixes an issue where the homepage title always displayed **"Welcome back!"**, ignoring the value configured through  `app-config.yaml`.

---

### Which issue(s) does this PR fix

Fixes: https://issues.redhat.com/browse/RHDHBUGS-1903

### Problem

The homepage title configuration is being ignored due to a `title="Welcome back!"` prop in the HomePage component. This prevents users from customizing the homepage title  configured through  `app-config.yaml`, causing it to always default to "Welcome back!" regardless of the configured value.

### Root Cause

The explicit `title="Welcome back!"` prop in HomePage.tsx overrides any title configuration passed  via configuration, breaking the customization functionality. This got  introduced as part of [PR #745](https://github.com/redhat-developer/rhdh-plugins/pull/745)


##  For Testing 

For testing 

1. Take this PR change in  RHDH 

```
npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root  <path-to=rhdh>/rhdh/dynamic-plugins-root --dev
```
2. Add `Top Visited` and `Recent Visited` Card in homepage by adding below config. You can set custom home page title (visible on the home page) from here. 

```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
      
  frontend:
    red-hat-developer-hub.backstage-plugin-dynamic-home-page:
      dynamicRoutes:
        - path: /
          importName: DynamicHomePage
          config:
            props:
             title: ''Custom Title"
      mountPoints:
        - mountPoint: application/listener
          importName: VisitListener
        - mountPoint: home.page/cards
          importName: RecentlyVisitedCard
          config:
            layouts:
              xl: { w: 6, h: 4, x: 6 }
              lg: { w: 6, h: 4, x: 6 }
              md: { w: 6, h: 4, x: 6 }
              sm: { w: 6, h: 4, x: 6 }
              xs: { w: 6, h: 4, x: 6 }
              xxs: { w: 6, h: 4, x: 6 }
        - mountPoint: home.page/cards
          importName: TopVisitedCard
          config:
            layouts:
              xl: { w: 6, h: 4 }
              lg: { w: 6, h: 4 }
              md: { w: 6, h: 4 }
              sm: { w: 6, h: 4 }
              xs: { w: 6, h: 4 }
              xxs: { w: 6, h: 4 }
```
3. Set the document title (seen in the browser tab, Recent and Top visited)
```
app:
  title: Custom Home Page Title From app.title
```
---
## UI after changes 

https://github.com/user-attachments/assets/82c85322-de1b-47e8-9033-723127c3ff63


## Related Links

- [Header Configuration Docs](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/homepage/docs/header.md#title)
- Related regression: [PR #745](https://github.com/redhat-developer/rhdh-plugins/pull/745)
