### PR TITLE
fix(extensions): load all the package configurations

### DIFF
--- a/workspaces/marketplace/.changeset/good-colts-exist.md
+++ b/workspaces/marketplace/.changeset/good-colts-exist.md
@@ -1,5 +1,6 @@
 ---
 '@red-hat-developer-hub/backstage-plugin-marketplace': patch
+'@red-hat-developer-hub/backstage-plugin-marketplace-common': patch
 ---
 
 load all the package configurations

--- a/workspaces/marketplace/.changeset/good-colts-exist.md
+++ b/workspaces/marketplace/.changeset/good-colts-exist.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+load all the package configurations

--- a/workspaces/marketplace/plugins/marketplace-common/report.api.md
+++ b/workspaces/marketplace/plugins/marketplace-common/report.api.md
@@ -84,6 +84,12 @@ export const encodeGetEntityFacetsRequest: (request: GetEntityFacetsRequest) => 
 export const EXTENSIONS_API_VERSION = "extensions.backstage.io/v1alpha1";
 
 // @public (undocumented)
+export interface ExtensionsPackageAppConfigExamples {
+    // (undocumented)
+    [key: string]: MarketplacePackageSpecAppConfigExample[];
+}
+
+// @public (undocumented)
 export const extensionsPermissions: ResourcePermission<"extensions-plugin">[];
 
 // @public
@@ -347,12 +353,6 @@ export enum MarketplaceKind {
 export interface MarketplacePackage extends Entity {
     // (undocumented)
     spec?: MarketplacePackageSpec;
-}
-
-// @public (undocumented)
-export interface MarketplacePackageAppConfigExamples {
-    // (undocumented)
-    [key: string]: MarketplacePackageSpecAppConfigExample[];
 }
 
 // @public (undocumented)

--- a/workspaces/marketplace/plugins/marketplace-common/report.api.md
+++ b/workspaces/marketplace/plugins/marketplace-common/report.api.md
@@ -350,6 +350,12 @@ export interface MarketplacePackage extends Entity {
 }
 
 // @public (undocumented)
+export interface MarketplacePackageAppConfigExamples {
+    // (undocumented)
+    [key: string]: MarketplacePackageSpecAppConfigExample[];
+}
+
+// @public (undocumented)
 export interface MarketplacePackageBackstage extends JsonObject {
     // (undocumented)
     role?: string;

--- a/workspaces/marketplace/plugins/marketplace-common/src/types/MarketplacePackage.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/types/MarketplacePackage.ts
@@ -72,7 +72,7 @@ export interface MarketplacePackageSpecAppConfigExample extends JsonObject {
 /**
  * @public
  */
-export interface MarketplacePackageAppConfigExamples {
+export interface ExtensionsPackageAppConfigExamples {
   [key: string]: MarketplacePackageSpecAppConfigExample[];
 }
 

--- a/workspaces/marketplace/plugins/marketplace-common/src/types/MarketplacePackage.ts
+++ b/workspaces/marketplace/plugins/marketplace-common/src/types/MarketplacePackage.ts
@@ -69,6 +69,12 @@ export interface MarketplacePackageSpecAppConfigExample extends JsonObject {
   title: string;
   content: string | JsonObject;
 }
+/**
+ * @public
+ */
+export interface MarketplacePackageAppConfigExamples {
+  [key: string]: MarketplacePackageSpecAppConfigExample[];
+}
 
 /**
  * @public

--- a/workspaces/marketplace/plugins/marketplace/src/components/CodeEditorCard.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/CodeEditorCard.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Grid from '@mui/material/Grid';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import { CodeEditor } from './CodeEditor';
+
+export const CodeEditorCard = ({ onLoad }: { onLoad: () => void }) => {
+  return (
+    <Grid
+      item
+      xs={12}
+      md={6.5}
+      sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+    >
+      <Card
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          borderRadius: 0,
+        }}
+      >
+        <CardContent
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'auto',
+            scrollbarWidth: 'thin',
+          }}
+        >
+          <CodeEditor defaultLanguage="yaml" onLoaded={onLoad} />
+        </CardContent>
+      </Card>
+    </Grid>
+  );
+};

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePackageInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePackageInstallContent.tsx
@@ -19,21 +19,15 @@ import type { SetStateAction } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
 import { ErrorPage, Progress } from '@backstage/core-components';
-import {
-  alertApiRef,
-  useApi,
-  useRouteRef,
-  useRouteRefParams,
-} from '@backstage/core-plugin-api';
+import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
 
 import yaml from 'yaml';
 import { useNavigate } from 'react-router-dom';
 
 import {
   MarketplacePackage,
-  MarketplacePackageAppConfigExamples,
+  ExtensionsPackageAppConfigExamples,
 } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
-import { JsonObject } from '@backstage/types';
 
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
@@ -51,103 +45,18 @@ import {
   pluginInstallRouteRef,
   pluginRouteRef,
 } from '../routes';
-import { applyContent, getExampleAsMarkdown } from '../utils';
 
-import {
-  CodeEditorContextProvider,
-  CodeEditor,
-  useCodeEditor,
-} from './CodeEditor';
-import { Markdown } from './Markdown';
+import { CodeEditorContextProvider, useCodeEditor } from './CodeEditor';
 import { usePackage } from '../hooks/usePackage';
+import { CodeEditorCard } from './CodeEditorCard';
+import { TabPanel } from './TabPanel';
 
 interface TabItem {
   label: string;
-  content: string | MarketplacePackageAppConfigExamples[];
+  content: string | ExtensionsPackageAppConfigExamples[];
   key: string;
   others?: { [key: string]: any };
 }
-
-interface TabPanelProps {
-  markdownContent: string | MarketplacePackageAppConfigExamples[];
-  index: number;
-  value: number;
-  others?: { [key: string]: any };
-}
-
-const TabPanel = ({ markdownContent, index, value, others }: TabPanelProps) => {
-  const alertApi = useApi(alertApiRef);
-  const codeEditor = useCodeEditor();
-  if (value !== index) return null;
-
-  const handleApplyContent = (content: string | JsonObject, pkg: string) => {
-    try {
-      const codeEditorContent = codeEditor.getValue();
-      const newContent = applyContent(
-        codeEditorContent || '',
-        pkg,
-        others?.packageName,
-        content,
-      );
-      const selection = codeEditor.getSelection();
-      const position = codeEditor.getPosition();
-      if (newContent) {
-        codeEditor.setValue(newContent);
-        if (selection) {
-          codeEditor.setSelection(selection);
-        }
-        if (position) {
-          codeEditor.setPosition(position);
-        }
-      }
-    } catch (error) {
-      alertApi.post({
-        display: 'transient',
-        severity: 'warning',
-        message: `Could not apply YAML: ${error}`,
-      });
-    }
-  };
-
-  return (
-    <Box
-      role="tabpanel"
-      sx={{ flex: 1, overflow: 'auto', p: 2, scrollbarWidth: 'thin' }}
-    >
-      <Typography component="div">
-        {Array.isArray(markdownContent) ? (
-          markdownContent.map((item, idx) => (
-            <Box key={idx} sx={{ mb: 3 }}>
-              <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 1 }}>
-                {Object.keys(item)[0]}
-              </Typography>
-              {item[Object.keys(item)[0]]?.map?.(ex => (
-                <>
-                  <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
-                    {ex.title}
-                    {ex.content !== 'string' && (
-                      <Button
-                        sx={{ float: 'right' }}
-                        onClick={() =>
-                          handleApplyContent(ex.content, Object.keys(item)[0])
-                        }
-                      >
-                        Apply
-                      </Button>
-                    )}
-                  </Typography>
-                  <Markdown content={getExampleAsMarkdown(ex.content)} />
-                </>
-              ))}
-            </Box>
-          ))
-        ) : (
-          <Markdown content={markdownContent} />
-        )}
-      </Typography>
-    </Box>
-  );
-};
 
 export const MarketplacePackageInstallContent = ({
   pkg,
@@ -188,14 +97,14 @@ export const MarketplacePackageInstallContent = ({
   const navigate = useNavigate();
   const examples = [
     {
-      [`${pkg.metadata.name}`]: pkg?.spec?.appConfigExamples,
+      [`${pkg.metadata.name}`]: pkg.spec?.appConfigExamples,
     },
   ];
   const packageDynamicArtifacts = {
     [`${pkg.metadata.name}`]: pkg.spec?.dynamicArtifact,
   };
   const availableTabs = [
-    examples && {
+    !!Object.values(examples[0])[0] && {
       label: 'Examples',
       content: examples,
       key: 'examples',
@@ -224,34 +133,7 @@ export const MarketplacePackageInstallContent = ({
         spacing={3}
         sx={{ flex: 1, overflow: 'hidden', height: '100%', pb: 1 }}
       >
-        <Grid
-          item
-          xs={12}
-          md={6.5}
-          sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
-        >
-          <Card
-            sx={{
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              borderRadius: 0,
-            }}
-          >
-            <CardContent
-              sx={{
-                flex: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                overflow: 'auto',
-                scrollbarWidth: 'thin',
-              }}
-            >
-              <CodeEditor defaultLanguage="yaml" onLoaded={onLoaded} />
-            </CardContent>
-          </Card>
-        </Grid>
+        <CodeEditorCard onLoad={onLoaded} />
 
         {showRightCard && (
           <Grid

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
@@ -309,9 +309,14 @@ export const MarketplacePluginInstallContent = ({
     onLoaded();
   }, [onLoaded, pluginConfig.data?.configYaml]);
 
-  const examples = packages.map(pkg => ({
-    [`${pkg.metadata.name}`]: pkg?.spec?.appConfigExamples,
-  }));
+  const examples = packages
+    .map(pkg =>
+      Array.isArray(pkg?.spec?.appConfigExamples) &&
+      pkg.spec.appConfigExamples.length > 0
+        ? { [`${pkg.metadata.name}`]: pkg.spec.appConfigExamples }
+        : null,
+    )
+    .filter(Boolean);
   const packageDynamicArtifacts = packages.reduce((acc, pkg) => {
     const temp = {
       ...acc,
@@ -322,7 +327,7 @@ export const MarketplacePluginInstallContent = ({
   const installationInstructions = plugin.spec?.installation;
   const aboutMarkdown = plugin.spec?.description;
   const availableTabs = [
-    examples && {
+    examples.length > 0 && {
       label: 'Examples',
       content: examples,
       key: 'examples',

--- a/workspaces/marketplace/plugins/marketplace/src/components/TabPanel.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/TabPanel.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExtensionsPackageAppConfigExamples } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import { JsonObject } from '@backstage/types';
+
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { useCodeEditor } from './CodeEditor';
+import { Markdown } from './Markdown';
+import { applyContent, getExampleAsMarkdown } from '../utils';
+
+interface TabPanelProps {
+  markdownContent: string | ExtensionsPackageAppConfigExamples[];
+  index: number;
+  value: number;
+  others?: { [key: string]: any };
+}
+
+export const TabPanel = ({
+  markdownContent,
+  index,
+  value,
+  others,
+}: TabPanelProps) => {
+  const alertApi = useApi(alertApiRef);
+  const codeEditor = useCodeEditor();
+  if (value !== index) return null;
+
+  const handleApplyContent = (content: string | JsonObject, pkg: string) => {
+    try {
+      const codeEditorContent = codeEditor.getValue();
+      const newContent = applyContent(
+        codeEditorContent || '',
+        pkg,
+        others?.packageNames,
+        content,
+      );
+      const selection = codeEditor.getSelection();
+      const position = codeEditor.getPosition();
+      if (newContent) {
+        codeEditor.setValue(newContent);
+        if (selection) {
+          codeEditor.setSelection(selection);
+        }
+        if (position) {
+          codeEditor.setPosition(position);
+        }
+      }
+    } catch (error) {
+      alertApi.post({
+        display: 'transient',
+        severity: 'warning',
+        message: `Could not apply YAML: ${error}`,
+      });
+    }
+  };
+
+  return (
+    <Box
+      role="tabpanel"
+      sx={{ flex: 1, overflow: 'auto', p: 2, scrollbarWidth: 'thin' }}
+    >
+      <Typography component="div">
+        {Array.isArray(markdownContent) ? (
+          markdownContent.map((item, idx) => (
+            <Box key={idx} sx={{ mb: 3 }}>
+              <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 1 }}>
+                {Object.keys(item)[0]}
+              </Typography>
+              {item?.[Object.keys(item)[0]]?.map?.(ex => (
+                <>
+                  <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {ex.title}
+                    {ex.content !== 'string' && (
+                      <Button
+                        sx={{ float: 'right' }}
+                        onClick={() =>
+                          handleApplyContent(ex.content, Object.keys(item)[0])
+                        }
+                      >
+                        Apply
+                      </Button>
+                    )}
+                  </Typography>
+                  <Markdown content={getExampleAsMarkdown(ex.content)} />
+                </>
+              ))}
+            </Box>
+          ))
+        ) : (
+          <Markdown content={markdownContent} />
+        )}
+      </Typography>
+    </Box>
+  );
+};

--- a/workspaces/marketplace/plugins/marketplace/src/utils.test.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/utils.test.ts
@@ -16,6 +16,12 @@
 import { applyContent, getExampleAsMarkdown } from './utils';
 
 describe('marketplace utils', () => {
+  const packages = {
+    'backstage-community-plugin-quay':
+      './dynamic-plugins/dist/backstage-community-plugin-quay',
+    'backstage-community-plugin-sonarcloud':
+      './dynamic-plugins/dist/backstage-community-plugin-sonarcloud',
+  };
   describe('applyContent', () => {
     const newContent = {
       catalog: {
@@ -36,7 +42,8 @@ describe('marketplace utils', () => {
           - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
             disabled: false
   `,
-        './dynamic-plugins/dist/backstage-community-plugin-quay',
+        'backstage-community-plugin-quay',
+        packages,
         newContent,
       );
       expect(content).toEqual(
@@ -62,7 +69,8 @@ describe('marketplace utils', () => {
           # some more comment
           disabled: false
 `,
-        './dynamic-plugins/dist/backstage-community-plugin-quay',
+        'backstage-community-plugin-quay',
+        packages,
         newContent,
       );
       expect(content).toEqual(
@@ -90,7 +98,8 @@ plugins:
           - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
             disabled: false
   `,
-        './dynamic-plugins/dist/backstage-community-plugin-quay',
+        'backstage-community-plugin-quay',
+        packages,
         newContent,
       );
       expect(content).toEqual(

--- a/workspaces/marketplace/plugins/marketplace/src/utils.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/utils.ts
@@ -74,6 +74,7 @@ export const getExampleAsMarkdown = (content: string | JsonObject) => {
 export const applyContent = (
   editorContent: string,
   packageName: string,
+  otherPackageNames: { [key: string]: string },
   newContent: string | JsonObject,
 ) => {
   if (!editorContent) {
@@ -85,10 +86,12 @@ export const applyContent = (
   if (plugins instanceof YAMLSeq && Array.isArray(plugins?.items)) {
     (plugins?.items || []).forEach((plugin: any) => {
       if (plugin instanceof Object) {
-        const pluginPackage = plugin.items?.find(
-          (i: Pair<Scalar, Scalar>) =>
-            i.key.value === 'package' && i.value?.value === packageName,
-        );
+        const pluginPackage = plugin.items?.find((i: Pair<Scalar, Scalar>) => {
+          return (
+            i.key.value === 'package' &&
+            i.value?.value === otherPackageNames[`${packageName}`]
+          );
+        });
         if (pluginPackage) {
           if (typeof newContent === 'string') {
             plugin.set('pluginConfig', parseDocument(newContent));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes:

https://issues.redhat.com/browse/RHDHBUGS-1874

- With this fix, the Examples tab will load all the appConfigExamples for all the packages associated to the plugin. It adds the package title with the default configuration below.
- Not displaying the Examples tab if no appConfigExamples are present.
- Removed duplicated code and created reusable components

https://github.com/user-attachments/assets/e0a05e1d-0e87-4b12-9d41-51fbe744a90a

**Before**

https://drive.google.com/file/d/1r_i4j9AM8jRCb8mZdux6jmWfGbWEy6nG/view

**After**

<img width="1864" height="857" alt="Screenshot 2025-07-23 at 11 38 02 PM" src="https://github.com/user-attachments/assets/290da302-45b1-41ef-aeb8-59b73e91c209" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
