### PR TITLE
fix(extensions): clear processors logging

### DIFF
--- a/workspaces/marketplace/.changeset/friendly-pugs-applaud.md
+++ b/workspaces/marketplace/.changeset/friendly-pugs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace': patch
+---
+
+Clear processors log messages

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.test.ts
@@ -114,7 +114,7 @@ describe('DynamicPackageInstallStatusProcessor', () => {
       );
 
       expect(entity.spec?.installStatus).toBe(undefined);
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         "Entity package:default/testpackage is missing 'spec.packageName', unable to determine 'spec.installStatus'",
       );
     });
@@ -199,7 +199,7 @@ describe('DynamicPackageInstallStatusProcessor', () => {
         cache,
       );
       expect(result.spec?.installStatus).toBe(undefined);
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         "Entity package:default/testpackage is missing 'spec.dynamicArtifact', unable to determine 'spec.installStatus'",
       );
     });

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.test.ts
@@ -115,7 +115,7 @@ describe('DynamicPackageInstallStatusProcessor', () => {
 
       expect(entity.spec?.installStatus).toBe(undefined);
       expect(logger.warn).toHaveBeenCalledWith(
-        "Entity package:default/testpackage is missing spec.packageName, unable to determine 'spec.installStatus'",
+        "Entity package:default/testpackage is missing 'spec.packageName', unable to determine 'spec.installStatus'",
       );
     });
 
@@ -200,7 +200,7 @@ describe('DynamicPackageInstallStatusProcessor', () => {
       );
       expect(result.spec?.installStatus).toBe(undefined);
       expect(logger.warn).toHaveBeenCalledWith(
-        "Missing 'entity.spec.dynamicArtifact', unable to determine 'spec.installStatus'",
+        "Entity package:default/testpackage is missing 'spec.dynamicArtifact', unable to determine 'spec.installStatus'",
       );
     });
 

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.ts
@@ -104,7 +104,7 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
     installedPackages: Plugins,
   ): MarketplacePackageInstallStatus | undefined {
     if (!marketplacePackage.spec?.packageName) {
-      this.logger.warn(
+      this.logger.debug(
         `Entity ${stringifyEntityRef(marketplacePackage)} is missing 'spec.packageName', unable to determine 'spec.installStatus'`,
       );
       return undefined;
@@ -133,7 +133,7 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
     }
 
     if (!marketplacePackage.spec?.dynamicArtifact) {
-      this.logger.warn(
+      this.logger.debug(
         `Entity ${stringifyEntityRef(marketplacePackage)} is missing 'spec.dynamicArtifact', unable to determine 'spec.installStatus'`,
       );
       return undefined;
@@ -155,7 +155,7 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
   ): Promise<Entity> {
     if (isMarketplacePackage(entity)) {
       if (!entity.spec?.packageName) {
-        this.logger.warn(
+        this.logger.debug(
           `Entity ${stringifyEntityRef(entity)} is missing 'spec.packageName', unable to determine 'spec.installStatus'`,
         );
         return entity;

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/DynamicPackageInstallStatusProcessor.ts
@@ -105,7 +105,7 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
   ): MarketplacePackageInstallStatus | undefined {
     if (!marketplacePackage.spec?.packageName) {
       this.logger.warn(
-        "Missing 'entity.spec.packageName', unable to determine 'spec.installStatus'",
+        `Entity ${stringifyEntityRef(marketplacePackage)} is missing 'spec.packageName', unable to determine 'spec.installStatus'`,
       );
       return undefined;
     }
@@ -134,7 +134,7 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
 
     if (!marketplacePackage.spec?.dynamicArtifact) {
       this.logger.warn(
-        "Missing 'entity.spec.dynamicArtifact', unable to determine 'spec.installStatus'",
+        `Entity ${stringifyEntityRef(marketplacePackage)} is missing 'spec.dynamicArtifact', unable to determine 'spec.installStatus'`,
       );
       return undefined;
     }
@@ -156,7 +156,7 @@ export class DynamicPackageInstallStatusProcessor implements CatalogProcessor {
     if (isMarketplacePackage(entity)) {
       if (!entity.spec?.packageName) {
         this.logger.warn(
-          `Entity ${stringifyEntityRef(entity)} is missing spec.packageName, unable to determine 'spec.installStatus'`,
+          `Entity ${stringifyEntityRef(entity)} is missing 'spec.packageName', unable to determine 'spec.installStatus'`,
         );
         return entity;
       }

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/LocalPackageInstallStatusProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/LocalPackageInstallStatusProcessor.ts
@@ -120,7 +120,10 @@ export class LocalPackageInstallStatusProcessor implements CatalogProcessor {
 
       return null;
     } catch (error) {
-      console.warn('xxx', error);
+      console.warn(
+        `Error occurred while processing local install status of ${packageName}`,
+        error,
+      );
       return null;
     }
   }

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.test.ts
@@ -181,7 +181,7 @@ describe('PluginInstallStatusProcessor', () => {
       );
 
       expect(entity.spec?.installStatus).toBe(undefined);
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         "Entity plugin:default/plugin1 is missing packages, unable to determine 'spec.installStatus'",
       );
     });
@@ -290,7 +290,7 @@ describe('PluginInstallStatusProcessor', () => {
       );
 
       expect(entity.spec?.installStatus).toBe(undefined);
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         "Entity plugin:marketplace-plugin-demo/marketplace is missing all definitions of 'spec.installStatus' in its packages, unable to determine 'spec.installStatus'",
       );
     });
@@ -314,7 +314,7 @@ describe('PluginInstallStatusProcessor', () => {
       );
 
       expect(entity.spec?.installStatus).toBe(undefined);
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
         "Entity plugin:marketplace-plugin-demo/marketplace is missing all definitions of 'spec.installStatus' in its packages, unable to determine 'spec.installStatus'",
       );
     });

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.test.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.test.ts
@@ -291,7 +291,7 @@ describe('PluginInstallStatusProcessor', () => {
 
       expect(entity.spec?.installStatus).toBe(undefined);
       expect(logger.warn).toHaveBeenCalledWith(
-        "Missing all definitions for plugin:marketplace-plugin-demo/marketplace packages installStatus, unable to determine 'spec.installStatus'",
+        "Entity plugin:marketplace-plugin-demo/marketplace is missing all definitions of 'spec.installStatus' in its packages, unable to determine 'spec.installStatus'",
       );
     });
 
@@ -315,7 +315,7 @@ describe('PluginInstallStatusProcessor', () => {
 
       expect(entity.spec?.installStatus).toBe(undefined);
       expect(logger.warn).toHaveBeenCalledWith(
-        "Missing all definitions for plugin:marketplace-plugin-demo/marketplace packages installStatus, unable to determine 'spec.installStatus'",
+        "Entity plugin:marketplace-plugin-demo/marketplace is missing all definitions of 'spec.installStatus' in its packages, unable to determine 'spec.installStatus'",
       );
     });
 

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.ts
@@ -206,7 +206,7 @@ export class PluginInstallStatusProcessor implements CatalogProcessor {
       await this.getPluginPackageInstallStatuses(pluginPackageRefs);
     if (pluginPackageRefs.length !== pluginPackageStatuses.length) {
       this.logger.warn(
-        `Missing all definitions for ${stringifyEntityRef(marketplacePlugin)} packages installStatus, unable to determine 'spec.installStatus'`,
+        `Entity ${stringifyEntityRef(marketplacePlugin)} is missing all definitions of 'spec.installStatus' in its packages, unable to determine 'spec.installStatus'`,
       );
       return undefined;
     }

--- a/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.ts
+++ b/workspaces/marketplace/plugins/catalog-backend-module-marketplace/src/processors/PluginInstallStatusProcessor.ts
@@ -196,7 +196,7 @@ export class PluginInstallStatusProcessor implements CatalogProcessor {
     );
 
     if (!pluginPackageRefs || pluginPackageRefs.length === 0) {
-      this.logger.warn(
+      this.logger.debug(
         `Entity ${stringifyEntityRef(marketplacePlugin)} is missing 'spec.packages', unable to determine 'spec.installStatus'`,
       );
       return undefined;
@@ -205,7 +205,7 @@ export class PluginInstallStatusProcessor implements CatalogProcessor {
     const pluginPackageStatuses =
       await this.getPluginPackageInstallStatuses(pluginPackageRefs);
     if (pluginPackageRefs.length !== pluginPackageStatuses.length) {
-      this.logger.warn(
+      this.logger.debug(
         `Entity ${stringifyEntityRef(marketplacePlugin)} is missing all definitions of 'spec.installStatus' in its packages, unable to determine 'spec.installStatus'`,
       );
       return undefined;
@@ -261,7 +261,7 @@ export class PluginInstallStatusProcessor implements CatalogProcessor {
   ): Promise<Entity> {
     if (isMarketplacePlugin(entity)) {
       if (!entity.spec?.packages || entity.spec.packages.length === 0) {
-        this.logger.warn(
+        this.logger.debug(
           `Entity ${stringifyEntityRef(entity)} is missing packages, unable to determine 'spec.installStatus'`,
         );
         return entity;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Clear processors logging to include entity name of processed entity. Switch to debug for now as some of our default entities are missing needed specs and those cases were not previously logged.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes: https://issues.redhat.com/browse/RHDHBUGS-1905

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
