### PR TITLE
fix(extensions): returns a 404 instead of 500 if a plugin wasn't configured yet

### DIFF
--- a/workspaces/marketplace/.changeset/strong-foxes-march.md
+++ b/workspaces/marketplace/.changeset/strong-foxes-march.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace-backend': patch
+---
+
+returns a 404 instead of 500 if a plugin wasn't configured yet

--- a/workspaces/marketplace/plugins/marketplace-backend/src/router.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/router.ts
@@ -401,8 +401,15 @@ export async function createRouter(
         req,
         extensionsPluginReadPermission,
       );
-      const result = await installationDataService.getPluginConfig(plugin);
-      res.status(200).json({ configYaml: result });
+      try {
+        const result = await installationDataService.getPluginConfig(plugin);
+        res.status(200).json({ configYaml: result });
+      } catch (e) {
+        if (e instanceof ConfigFormatError) {
+          throw new InputError(e.message);
+        }
+        throw e;
+      }
     },
   );
 

--- a/workspaces/marketplace/plugins/marketplace-backend/src/validation/configValidation.ts
+++ b/workspaces/marketplace/plugins/marketplace-backend/src/validation/configValidation.ts
@@ -30,10 +30,11 @@ export function validateConfigurationFormat(
 
   const plugins = doc.get('plugins');
 
-  if (!isSeq(plugins))
+  if (!isSeq(plugins)) {
     throw new ConfigFormatError(
       "Invalid installation configuration, 'plugins' field must be a list",
     );
+  }
   for (const item of plugins.items) {
     validatePackageFormat(item);
   }
@@ -93,10 +94,11 @@ export function validatePluginFormat(
 ): asserts doc is Document & {
   contents: YAMLSeq<YAMLMap<string, JsonValue>>;
 } {
-  if (!isSeq(doc.contents))
+  if (!isSeq(doc.contents)) {
     throw new ConfigFormatError(
       'Invalid installation configuration, plugin packages must be a list',
     );
+  }
   for (const item of doc.contents.items) {
     validatePackageFormat(item);
     const packageToValidate = item.get('package') as string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While testing the plugin I saw that sometimes I got a 500 error instead of an 404 if a plugin wasn't configured correctly.

The UI handled that but when I remember the error message was confusing.

I aligned the GET configuration calls with the other api calls that uses the same try catch block.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
