### PR TITLE
fix(extensions): hide tab layout when there's only one tab left

### DIFF
--- a/workspaces/marketplace/.changeset/fast-carrots-behave.md
+++ b/workspaces/marketplace/.changeset/fast-carrots-behave.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace': patch
+---
+
+hide tab layout when there's only one tab left

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplacePluginInstallContent.tsx
@@ -446,22 +446,24 @@ export const MarketplacePluginInstallContent = ({
                     px: 0,
                   }}
                 >
-                  <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-                    <Tabs
-                      value={tabIndex}
-                      onChange={handleTabChange}
-                      aria-label="Plugin tabs"
-                      sx={{ px: 0 }}
-                    >
-                      {availableTabs.map((tab, index) => (
-                        <Tab
-                          key={tab.key}
-                          value={index}
-                          label={tab.label ?? ''}
-                        />
-                      ))}
-                    </Tabs>
-                  </Box>
+                  {availableTabs.length > 1 && (
+                    <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                      <Tabs
+                        value={tabIndex}
+                        onChange={handleTabChange}
+                        aria-label="Plugin tabs"
+                        sx={{ px: 0 }}
+                      >
+                        {availableTabs.map((tab, index) => (
+                          <Tab
+                            key={tab.key}
+                            value={index}
+                            label={tab.label ?? ''}
+                          />
+                        ))}
+                      </Tabs>
+                    </Box>
+                  )}
                   <Box
                     sx={{
                       flex: 1,
@@ -479,6 +481,11 @@ export const MarketplacePluginInstallContent = ({
                             index={index}
                             markdownContent={tab.content ?? ''}
                             others={tab.others}
+                            title={
+                              availableTabs.length === 1
+                                ? availableTabs[0].label
+                                : ''
+                            }
                           />
                         ),
                     )}

--- a/workspaces/marketplace/plugins/marketplace/src/components/TabPanel.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/TabPanel.tsx
@@ -29,6 +29,7 @@ interface TabPanelProps {
   markdownContent: string | ExtensionsPackageAppConfigExamples[];
   index: number;
   value: number;
+  title?: string;
   others?: { [key: string]: any };
 }
 
@@ -37,6 +38,7 @@ export const TabPanel = ({
   index,
   value,
   others,
+  title,
 }: TabPanelProps) => {
   const alertApi = useApi(alertApiRef);
   const codeEditor = useCodeEditor();
@@ -77,6 +79,7 @@ export const TabPanel = ({
       sx={{ flex: 1, overflow: 'auto', p: 2, scrollbarWidth: 'thin' }}
     >
       <Typography component="div">
+        {title && <Typography variant="h5">{title}</Typography>}
         {Array.isArray(markdownContent) ? (
           markdownContent.map((item, idx) => (
             <Box key={idx} sx={{ mb: 3 }}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves**
https://issues.redhat.com/browse/RHDHBUGS-719

Before
<img width="1639" height="797" alt="Screenshot 2025-08-04 at 11 53 42 PM" src="https://github.com/user-attachments/assets/73c75632-0187-4532-ad67-211a23c6aadc" />

After
<img width="1639" height="797" alt="Screenshot 2025-08-04 at 11 48 34 PM" src="https://github.com/user-attachments/assets/97096568-e9fe-4489-9a5d-91e470d51007" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
