### PR TITLE
RHDHPAI-682: remove temporary duplicate model catalog bridge config code from url reader

### DIFF
--- a/workspaces/ai-integrations/.changeset/thirty-stars-wear.md
+++ b/workspaces/ai-integrations/.changeset/thirty-stars-wear.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-techdoc-url-reader-backend': patch
+---
+
+removing temporary duplicate code for model catalog bridge config now that 'catalog-backend-module-model-config' exposes the requisite types/methods

--- a/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/package.json
+++ b/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/package.json
@@ -38,6 +38,7 @@
     "@backstage/config": "^1.2.0",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-catalog-node": "^1.16.1",
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog": "workspace:^",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "zod": "^3.22.4"

--- a/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.test.ts
@@ -19,8 +19,8 @@ import { mockServices } from '@backstage/backend-test-utils';
 import {
   ModeCatalogBridgeTechdocUrlReader,
   ModelCatalogBridgeUrlReaderServiceReadTreeResponse,
-  readModelCatalogApiEntityConfigs,
 } from './plugin';
+import { readModelCatalogApiEntityConfigs } from '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';

--- a/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.ts
+++ b/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.ts
@@ -32,8 +32,6 @@ import {
   UrlReaderServiceReadTreeResponseFile,
   UrlReaderServiceReadTreeResponseDirOptions,
   LoggerService,
-  SchedulerServiceTaskScheduleDefinition,
-  readSchedulerServiceTaskScheduleDefinitionFromConfig,
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
@@ -41,49 +39,10 @@ import { Readable } from 'stream';
 import fs from 'fs';
 import platformPath from 'path';
 import os from 'os';
-
-// TODO: Remove this once the catalog-backend-module-model-catalog plugin is published
-export type ModelCatalogConfig = {
-  id: string;
-  baseUrl: string;
-  schedule?: SchedulerServiceTaskScheduleDefinition;
-};
-export function readModelCatalogApiEntityConfigs(
-  config: Config,
-): ModelCatalogConfig[] {
-  const providerConfigs = config.getOptionalConfig(
-    'catalog.providers.modelCatalog',
-  );
-  if (!providerConfigs) {
-    return [];
-  }
-  return providerConfigs
-    .keys()
-    .map(id =>
-      readModelCatalogApiEntityConfig(id, providerConfigs.getConfig(id)),
-    );
-}
-
-function readModelCatalogApiEntityConfig(
-  id: string,
-  config: Config,
-): ModelCatalogConfig {
-  const baseUrl = config.getString('baseUrl');
-
-  const schedule = config.has('schedule')
-    ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
-        config.getConfig('schedule'),
-      )
-    : undefined;
-
-  return {
-    id,
-    baseUrl,
-    schedule,
-  };
-}
-
-// TODO: end of temporary definitions
+import {
+  readModelCatalogApiEntityConfigs,
+  ModelCatalogConfig,
+} from '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog';
 
 export class ModelCatalogBridgeUrlReaderServiceReadTreeResponse
   implements UrlReaderServiceReadTreeResponse

--- a/workspaces/ai-integrations/yarn.lock
+++ b/workspaces/ai-integrations/yarn.lock
@@ -10721,6 +10721,7 @@ __metadata:
     "@backstage/config": ^1.2.0
     "@backstage/errors": ^1.2.7
     "@backstage/plugin-catalog-node": ^1.16.1
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog": "workspace:^"
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.12
     express: ^4.17.1


### PR DESCRIPTION

## Hey, I just made a Pull Request!

removes the temporary duplicate config code from the url reader dropped by https://github.com/redhat-developer/rhdh-plugins/pull/1256


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [/ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [n/a ] Added or Updated documentation
- [/ ] Tests for new functionality and regression tests for bug fixes
- [ n/a] Screenshots attached (for UI changes)
