### PR TITLE
feat(quickstart): added support to role-based quickstart

### DIFF
--- a/workspaces/quickstart/app-config.yaml
+++ b/workspaces/quickstart/app-config.yaml
@@ -4,6 +4,8 @@ app:
   quickstart:
     - title: Set up authentication
       icon: Admin
+      roles:
+        - admin
       description: Set up secure login credentials to protect your account from unauthorized access.
       cta:
         text: Learn more
@@ -26,6 +28,38 @@ app:
       cta:
         text: Explore plugins
         link: /extensions
+    - title: Import application
+      roles:
+        - developer
+      icon: Import
+      description: Import your existing code and services into the catalog to organize and access them through your developer portal.
+      cta:
+        text: Import
+        link: /bulk-import
+    - title: Learn about the Catalog
+      roles:
+        - developer
+      icon: Catalog
+      description: Discover all software components, services, and APIs, and view their owners and documentation.
+      cta:
+        text: View Catalog
+        link: /catalog
+    - title: Explore Self-service templates
+      roles:
+        - developer
+      icon: SelfService
+      description: Use our self-service templates to quickly set up new projects, services, or documentation.
+      cta:
+        text: Explore templates
+        link: /create
+    - title: Find all Learning Paths
+      roles:
+        - developer
+      icon: Learning
+      description: Integrate tailored e-learning into your workflows with Learning Paths to accelerate onboarding, close skill gaps, and promote best practices.
+      cta:
+        text: View Learning Paths
+        link: /docs
 
 organization:
   name: My Company

--- a/workspaces/quickstart/plugins/quickstart/config.d.ts
+++ b/workspaces/quickstart/plugins/quickstart/config.d.ts
@@ -30,6 +30,11 @@ export interface Config {
        */
       title: string;
       /**
+       * The roles associated with the quickstart.
+       * @visibility frontend
+       */
+      roles?: Array<string>;
+      /**
        * Optional icon for quickstart.
        * @visibility frontend
        */

--- a/workspaces/quickstart/plugins/quickstart/src/components/Quickstart.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/Quickstart.test.tsx
@@ -32,19 +32,23 @@ describe('Quickstart', () => {
     mockHandleDrawerClose.mockClear();
   });
 
+  const renderWithRole = async (role: string) => {
+    const items = filterQuickstartItemsByRole(mockQuickstartItems, role);
+    await renderInTestApp(
+      <Quickstart
+        quickstartItems={items}
+        handleDrawerClose={mockHandleDrawerClose}
+      />,
+    );
+  };
+
+  const expectHideButton = () => {
+    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+  };
+
   describe('Role-based item rendering', () => {
     it('renders admin-specific items and items with no roles', async () => {
-      const adminItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'admin',
-      );
-
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={adminItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('admin');
 
       // Admin-specific items should be visible
       expect(screen.getByText('Step 1 for Admin')).toBeInTheDocument();
@@ -66,21 +70,11 @@ describe('Quickstart', () => {
         screen.queryByText('Step 2 for Developer'),
       ).not.toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+      expectHideButton();
     });
 
     it('renders developer-specific items only', async () => {
-      const developerItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'developer',
-      );
-
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={developerItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('developer');
 
       // Developer-specific items should be visible
       expect(screen.getByText('Step 1 for Developer')).toBeInTheDocument();
@@ -96,43 +90,23 @@ describe('Quickstart', () => {
         screen.queryByText('Step 2 - No Roles Assigned'),
       ).not.toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+      expectHideButton();
     });
 
     it('shows empty state when no items match user role', async () => {
-      const managerItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'manager',
-      );
-
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={managerItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('manager');
 
       // Should show empty state
       expect(
         screen.getByText('Quickstart content not available for your role.'),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+      expectHideButton();
     });
   });
 
   describe('Progress calculation with role-based items', () => {
     it('calculates progress correctly for admin items', async () => {
-      const adminItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'admin',
-      );
-
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={adminItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('admin');
 
       expect(screen.getByText('Not started')).toBeInTheDocument();
 
@@ -160,17 +134,7 @@ describe('Quickstart', () => {
     });
 
     it('calculates progress correctly for developer items', async () => {
-      const developerItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'developer',
-      );
-
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={developerItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('developer');
 
       expect(screen.getByText('Not started')).toBeInTheDocument();
 
@@ -198,19 +162,10 @@ describe('Quickstart', () => {
     });
 
     it('reads existing progress from localStorage for role-specific items', async () => {
-      const adminItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'admin',
-      );
       // Mark first admin item as complete
       localStorage.setItem('Step 1 for Admin-0', 'true');
 
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={adminItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('admin');
 
       expect(screen.getByText('25% progress')).toBeInTheDocument();
     });
@@ -218,17 +173,7 @@ describe('Quickstart', () => {
 
   describe('Component interaction', () => {
     it('calls handleDrawerClose when Hide button is clicked', async () => {
-      const adminItems = filterQuickstartItemsByRole(
-        mockQuickstartItems,
-        'admin',
-      );
-
-      await renderInTestApp(
-        <Quickstart
-          quickstartItems={adminItems}
-          handleDrawerClose={mockHandleDrawerClose}
-        />,
-      );
+      await renderWithRole('admin');
 
       const hideBtn = screen.getByRole('button', { name: 'Hide' });
       fireEvent.click(hideBtn);
@@ -247,7 +192,7 @@ describe('Quickstart', () => {
       expect(
         screen.getByText('Quickstart content not available for your role.'),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+      expectHideButton();
     });
   });
 });

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.test.tsx
@@ -18,6 +18,7 @@ import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { QuickstartContent } from './QuickstartContent';
 import { renderInTestApp } from '@backstage/test-utils';
 import { mockQuickstartItems } from '../mockData';
+import { filterQuickstartItemsByRole } from '../../utils';
 
 jest.mock('@mui/material/Collapse', () => ({
   __esModule: true,
@@ -42,20 +43,119 @@ describe('QuickstartContent', () => {
     );
 
     expect(
-      screen.getByText('Quickstart content not available.'),
+      screen.getByText('Quickstart content not available for your role.'),
     ).toBeInTheDocument();
   });
 
-  it('renders all quickstart items passed in props', async () => {
+  it('renders all quickstart items for admin role', async () => {
+    const adminItems = filterQuickstartItemsByRole(
+      mockQuickstartItems,
+      'admin',
+    );
+
     await renderInTestApp(
       <QuickstartContent
-        quickstartItems={mockQuickstartItems}
+        quickstartItems={adminItems}
         setProgress={mockSetProgress}
-        itemCount={2}
+        itemCount={adminItems.length}
       />,
     );
-    expect(screen.getByText('Step 1')).toBeInTheDocument();
-    expect(screen.getByText('Step 2')).toBeInTheDocument();
+
+    // Admin-specific items should be visible
+    expect(screen.getByText('Step 1 for Admin')).toBeInTheDocument();
+    expect(screen.getByText('Step 2 for Admin')).toBeInTheDocument();
+    // Items with other roles should not be visible
+    expect(screen.queryByText('Step 1 for Developer')).not.toBeInTheDocument();
+    expect(screen.queryByText('Step 2 for Developer')).not.toBeInTheDocument();
+  });
+
+  it('treats items with no roles as admin items when rendering', async () => {
+    // Using actual filtering logic: items with no roles default to admin
+    const adminAndNoRoleItems = filterQuickstartItemsByRole(
+      mockQuickstartItems,
+      'admin',
+    );
+
+    await renderInTestApp(
+      <QuickstartContent
+        quickstartItems={adminAndNoRoleItems}
+        setProgress={mockSetProgress}
+        itemCount={adminAndNoRoleItems.length}
+      />,
+    );
+
+    // Both admin items and no-role items should be visible
+    expect(screen.getByText('Step 1 for Admin')).toBeInTheDocument();
+    expect(screen.getByText('Step 2 for Admin')).toBeInTheDocument();
+    expect(screen.getByText('Step 1 - No Roles Assigned')).toBeInTheDocument();
+    expect(screen.getByText('Step 2 - No Roles Assigned')).toBeInTheDocument();
+
+    // Developer items should not be visible
+    expect(screen.queryByText('Step 1 for Developer')).not.toBeInTheDocument();
+    expect(screen.queryByText('Step 2 for Developer')).not.toBeInTheDocument();
+  });
+
+  it('renders all quickstart items for developer role', async () => {
+    const developerItems = filterQuickstartItemsByRole(
+      mockQuickstartItems,
+      'developer',
+    );
+
+    await renderInTestApp(
+      <QuickstartContent
+        quickstartItems={developerItems}
+        setProgress={mockSetProgress}
+        itemCount={developerItems.length}
+      />,
+    );
+
+    // Developer-specific items should be visible
+    expect(screen.getByText('Step 1 for Developer')).toBeInTheDocument();
+    expect(screen.getByText('Step 2 for Developer')).toBeInTheDocument();
+    // Items with other roles should not be visible
+    expect(screen.queryByText('Step 1 for Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Step 2 for Admin')).not.toBeInTheDocument();
+  });
+
+  it('renders EmptyState when no quickstart items match the user role', async () => {
+    const managerItems = filterQuickstartItemsByRole(
+      mockQuickstartItems,
+      'manager',
+    );
+
+    await renderInTestApp(
+      <QuickstartContent
+        quickstartItems={managerItems}
+        setProgress={mockSetProgress}
+        itemCount={managerItems.length}
+      />,
+    );
+
+    // No items for manager, should show EmptyState
+    expect(
+      screen.getByText('Quickstart content not available for your role.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders EmptyState when no quickstart items match the current role', async () => {
+    const userRole = 'test'; // A role that doesn't exist in our mock data
+    const filteredItems = filterQuickstartItemsByRole(
+      mockQuickstartItems,
+      userRole,
+    );
+
+    await renderInTestApp(
+      <QuickstartContent
+        quickstartItems={filteredItems}
+        setProgress={mockSetProgress}
+        itemCount={filteredItems.length}
+      />,
+    );
+
+    // No quickstart items for the test role, should show EmptyState
+    expect(
+      screen.getByText('Quickstart content not available for your role.'),
+    ).toBeInTheDocument();
   });
 
   it('only opens one item at a time', async () => {

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.tsx
@@ -62,7 +62,10 @@ export const QuickstartContent = ({
           ))}
         </List>
       ) : (
-        <EmptyState title="Quickstart content not available." missing="data" />
+        <EmptyState
+          title="Quickstart content not available for your role."
+          missing="data"
+        />
       )}
     </Box>
   );

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItemIcon.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItemIcon.tsx
@@ -19,6 +19,10 @@ import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettin
 import VpnKeyOutlinedIcon from '@mui/icons-material/VpnKeyOutlined';
 import FileCopyOutlinedIcon from '@mui/icons-material/FileCopyOutlined';
 import PowerOutlinedIcon from '@mui/icons-material/PowerOutlined';
+import LoginIcon from '@mui/icons-material/Login';
+import CategoryOutlinedIcon from '@mui/icons-material/CategoryOutlined';
+import ControlPointOutlinedIcon from '@mui/icons-material/ControlPointOutlined';
+import SchoolOutlinedIcon from '@mui/icons-material/SchoolOutlined';
 import { SxProps, Theme } from '@mui/material/styles';
 import { useApp } from '@backstage/core-plugin-api';
 import Box from '@mui/material/Box';
@@ -35,6 +39,10 @@ const commonIcons: {
   Rbac: <VpnKeyOutlinedIcon />,
   Git: <FileCopyOutlinedIcon />,
   Plugins: <PowerOutlinedIcon />,
+  Import: <LoginIcon />,
+  Catalog: <CategoryOutlinedIcon />,
+  SelfService: <ControlPointOutlinedIcon />,
+  Learning: <SchoolOutlinedIcon />,
 };
 
 export const QuickstartItemIcon = ({ icon, sx }: QuickstartItemIconProps) => {

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartDrawer.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartDrawer.tsx
@@ -20,6 +20,7 @@ import { configApiRef, useApiHolder } from '@backstage/core-plugin-api';
 import { Quickstart } from './Quickstart';
 import { useQuickstartDrawerContext } from '../hooks/useQuickstartDrawerContext';
 import { QuickstartItemData } from '../types';
+import { filterQuickstartItemsByRole } from '../utils';
 
 export const QuickstartDrawer = () => {
   const { isDrawerOpen, closeDrawer, drawerWidth } =
@@ -34,11 +35,7 @@ export const QuickstartDrawer = () => {
   // This will be dynamically determined based on the logged-in user
   const userRole = 'developer'; // switch to 'admin', 'developer', or other roles for testing purposes
 
-  const filteredItems = quickstartItems.filter(item => {
-    // If roles is undefined or empty, default to 'admin'
-    const roles = item.roles?.length ? item.roles : ['admin'];
-    return roles.includes(userRole);
-  });
+  const filteredItems = filterQuickstartItemsByRole(quickstartItems, userRole);
 
   return (
     <Drawer

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartDrawer.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartDrawer.tsx
@@ -30,6 +30,16 @@ export const QuickstartDrawer = () => {
   const quickstartItems: QuickstartItemData[] = config?.has('app.quickstart')
     ? config.get('app.quickstart')
     : [];
+
+  // This will be dynamically determined based on the logged-in user
+  const userRole = 'developer'; // switch to 'admin', 'developer', or other roles for testing purposes
+
+  const filteredItems = quickstartItems.filter(item => {
+    // If roles is undefined or empty, default to 'admin'
+    const roles = item.roles?.length ? item.roles : ['admin'];
+    return roles.includes(userRole);
+  });
+
   return (
     <Drawer
       sx={{
@@ -56,7 +66,7 @@ export const QuickstartDrawer = () => {
       open={isDrawerOpen}
     >
       <Quickstart
-        quickstartItems={quickstartItems}
+        quickstartItems={filteredItems}
         handleDrawerClose={closeDrawer}
       />
     </Drawer>

--- a/workspaces/quickstart/plugins/quickstart/src/components/mockData.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/components/mockData.ts
@@ -16,67 +16,54 @@
 
 import { QuickstartItemData } from '../types';
 
-export const mockQuickstartItems: QuickstartItemData[] = [
-  // Steps for Admin
-  {
-    title: 'Step 1 for Admin',
-    description: 'Description for Step 1',
-    icon: 'bolt',
-    roles: ['admin'],
-    cta: {
-      text: 'Start Now',
-      link: '#',
-    },
-  },
-  {
-    title: 'Step 2 for Admin',
-    description: 'Description for Step 2',
-    icon: 'code',
-    roles: ['admin'],
-    cta: {
-      text: 'Continue',
-      link: '#',
-    },
-  },
+// Reusable CTA objects
+const CTAS = {
+  start: { text: 'Start Now', link: '#' },
+  continue: { text: 'Continue', link: '#' },
+} as const;
 
-  // Steps for Developer
+// Common icons
+const ICONS = {
+  step1: 'bolt',
+  step2: 'code',
+} as const;
+
+// Helper function to create role-based steps
+const createRoleSteps = (role: string): QuickstartItemData[] => [
   {
-    title: 'Step 1 for Developer',
+    title: `Step 1 for ${role}`,
     description: 'Description for Step 1',
-    icon: 'bolt',
-    roles: ['developer'],
-    cta: {
-      text: 'Start Now',
-      link: '#',
-    },
+    icon: ICONS.step1,
+    roles: [role.toLowerCase()],
+    cta: CTAS.start,
   },
   {
-    title: 'Step 2 for Developer',
+    title: `Step 2 for ${role}`,
     description: 'Description for Step 2',
-    icon: 'code',
-    roles: ['developer'],
-    cta: {
-      text: 'Continue',
-      link: '#',
-    },
+    icon: ICONS.step2,
+    roles: [role.toLowerCase()],
+    cta: CTAS.continue,
   },
-  // Step without any roles (Default to admin role if no roles are assigned)
+];
+
+// Helper function to create no-role steps
+const createNoRoleSteps = (): QuickstartItemData[] => [
   {
     title: 'Step 1 - No Roles Assigned',
     description: 'Description for Step 1 (No roles assigned)',
-    icon: 'bolt',
-    cta: {
-      text: 'Start Now',
-      link: '#',
-    },
+    icon: ICONS.step1,
+    cta: CTAS.start,
   },
   {
     title: 'Step 2 - No Roles Assigned',
     description: 'Description for Step 2 (No roles assigned)',
-    icon: 'code',
-    cta: {
-      text: 'Continue',
-      link: '#',
-    },
+    icon: ICONS.step2,
+    cta: CTAS.continue,
   },
+];
+
+export const mockQuickstartItems: QuickstartItemData[] = [
+  ...createRoleSteps('Admin'),
+  ...createRoleSteps('Developer'),
+  ...createNoRoleSteps(),
 ];

--- a/workspaces/quickstart/plugins/quickstart/src/components/mockData.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/components/mockData.ts
@@ -17,9 +17,53 @@
 import { QuickstartItemData } from '../types';
 
 export const mockQuickstartItems: QuickstartItemData[] = [
+  // Steps for Admin
   {
-    title: 'Step 1',
+    title: 'Step 1 for Admin',
     description: 'Description for Step 1',
+    icon: 'bolt',
+    roles: ['admin'],
+    cta: {
+      text: 'Start Now',
+      link: '#',
+    },
+  },
+  {
+    title: 'Step 2 for Admin',
+    description: 'Description for Step 2',
+    icon: 'code',
+    roles: ['admin'],
+    cta: {
+      text: 'Continue',
+      link: '#',
+    },
+  },
+
+  // Steps for Developer
+  {
+    title: 'Step 1 for Developer',
+    description: 'Description for Step 1',
+    icon: 'bolt',
+    roles: ['developer'],
+    cta: {
+      text: 'Start Now',
+      link: '#',
+    },
+  },
+  {
+    title: 'Step 2 for Developer',
+    description: 'Description for Step 2',
+    icon: 'code',
+    roles: ['developer'],
+    cta: {
+      text: 'Continue',
+      link: '#',
+    },
+  },
+  // Step without any roles (Default to admin role if no roles are assigned)
+  {
+    title: 'Step 1 - No Roles Assigned',
+    description: 'Description for Step 1 (No roles assigned)',
     icon: 'bolt',
     cta: {
       text: 'Start Now',
@@ -27,8 +71,8 @@ export const mockQuickstartItems: QuickstartItemData[] = [
     },
   },
   {
-    title: 'Step 2',
-    description: 'Description for Step 2',
+    title: 'Step 2 - No Roles Assigned',
+    description: 'Description for Step 2 (No roles assigned)',
     icon: 'code',
     cta: {
       text: 'Continue',

--- a/workspaces/quickstart/plugins/quickstart/src/types.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/types.ts
@@ -21,6 +21,7 @@ export interface QuickstartItemCtaData {
 
 export interface QuickstartItemData {
   title: string;
+  roles?: string[];
   icon?: string;
   description: string;
   cta?: QuickstartItemCtaData;

--- a/workspaces/quickstart/plugins/quickstart/src/utils/filterQuickstartItems.test.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/utils/filterQuickstartItems.test.ts
@@ -1,0 +1,339 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filterQuickstartItemsByRole } from './filterQuickstartItems';
+import { QuickstartItemData } from '../types';
+
+describe('filterQuickstartItemsByRole', () => {
+  const testItems: QuickstartItemData[] = [
+    // Admin-only item
+    {
+      title: 'Admin Step 1',
+      description: 'Admin task',
+      icon: 'admin',
+      roles: ['admin'],
+      cta: { text: 'Start', link: '#' },
+    },
+    // Developer-only item
+    {
+      title: 'Developer Step 1',
+      description: 'Developer task',
+      icon: 'code',
+      roles: ['developer'],
+      cta: { text: 'Code', link: '#' },
+    },
+    // Multi-role item (admin + developer)
+    {
+      title: 'Multi Role Step',
+      description: 'Task for both roles',
+      icon: 'multi',
+      roles: ['admin', 'developer'],
+      cta: { text: 'Multi', link: '#' },
+    },
+    // Item with no roles (should default to admin)
+    {
+      title: 'No Roles Step',
+      description: 'Task with no roles',
+      icon: 'default',
+      cta: { text: 'Default', link: '#' },
+    },
+    // Item with empty roles array (should default to admin)
+    {
+      title: 'Empty Roles Step',
+      description: 'Task with empty roles',
+      icon: 'empty',
+      roles: [],
+      cta: { text: 'Empty', link: '#' },
+    },
+    // Manager-only item
+    {
+      title: 'Manager Step 1',
+      description: 'Manager task',
+      icon: 'manager',
+      roles: ['manager'],
+      cta: { text: 'Manage', link: '#' },
+    },
+  ];
+
+  describe('Basic role filtering', () => {
+    it('filters items for admin role', () => {
+      const result = filterQuickstartItemsByRole(testItems, 'admin');
+
+      expect(result).toHaveLength(4);
+      expect(result.map(item => item.title)).toEqual([
+        'Admin Step 1',
+        'Multi Role Step',
+        'No Roles Step', // defaults to admin
+        'Empty Roles Step', // defaults to admin
+      ]);
+    });
+
+    it('filters items for developer role', () => {
+      const result = filterQuickstartItemsByRole(testItems, 'developer');
+
+      expect(result).toHaveLength(2);
+      expect(result.map(item => item.title)).toEqual([
+        'Developer Step 1',
+        'Multi Role Step',
+      ]);
+    });
+
+    it('filters items for manager role', () => {
+      const result = filterQuickstartItemsByRole(testItems, 'manager');
+
+      expect(result).toHaveLength(1);
+      expect(result.map(item => item.title)).toEqual(['Manager Step 1']);
+    });
+
+    it('returns empty array for non-existent role', () => {
+      const result = filterQuickstartItemsByRole(testItems, 'nonexistent');
+
+      expect(result).toHaveLength(0);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('Default role behavior', () => {
+    it('treats items with undefined roles as admin items', () => {
+      const itemsWithUndefinedRoles: QuickstartItemData[] = [
+        {
+          title: 'Undefined Roles',
+          description: 'No roles property',
+          icon: 'default',
+          cta: { text: 'Start', link: '#' },
+        },
+      ];
+
+      const adminResult = filterQuickstartItemsByRole(
+        itemsWithUndefinedRoles,
+        'admin',
+      );
+      const developerResult = filterQuickstartItemsByRole(
+        itemsWithUndefinedRoles,
+        'developer',
+      );
+
+      expect(adminResult).toHaveLength(1);
+      expect(adminResult[0].title).toBe('Undefined Roles');
+
+      expect(developerResult).toHaveLength(0);
+    });
+
+    it('treats items with empty roles array as admin items', () => {
+      const itemsWithEmptyRoles: QuickstartItemData[] = [
+        {
+          title: 'Empty Roles Array',
+          description: 'Empty roles array',
+          icon: 'default',
+          roles: [],
+          cta: { text: 'Start', link: '#' },
+        },
+      ];
+
+      const adminResult = filterQuickstartItemsByRole(
+        itemsWithEmptyRoles,
+        'admin',
+      );
+      const developerResult = filterQuickstartItemsByRole(
+        itemsWithEmptyRoles,
+        'developer',
+      );
+
+      expect(adminResult).toHaveLength(1);
+      expect(adminResult[0].title).toBe('Empty Roles Array');
+
+      expect(developerResult).toHaveLength(0);
+    });
+  });
+
+  describe('Multi-role support', () => {
+    it('includes items that have multiple roles when user has one of them', () => {
+      const multiRoleItems: QuickstartItemData[] = [
+        {
+          title: 'Admin Developer Item',
+          description: 'For admin and developer',
+          icon: 'multi',
+          roles: ['admin', 'developer'],
+          cta: { text: 'Multi', link: '#' },
+        },
+        {
+          title: 'Developer Manager Item',
+          description: 'For developer and manager',
+          icon: 'multi2',
+          roles: ['developer', 'manager'],
+          cta: { text: 'Multi2', link: '#' },
+        },
+      ];
+
+      const adminResult = filterQuickstartItemsByRole(multiRoleItems, 'admin');
+      expect(adminResult).toHaveLength(1);
+      expect(adminResult[0].title).toBe('Admin Developer Item');
+
+      const developerResult = filterQuickstartItemsByRole(
+        multiRoleItems,
+        'developer',
+      );
+      expect(developerResult).toHaveLength(2);
+      expect(developerResult.map(item => item.title)).toEqual([
+        'Admin Developer Item',
+        'Developer Manager Item',
+      ]);
+
+      const managerResult = filterQuickstartItemsByRole(
+        multiRoleItems,
+        'manager',
+      );
+      expect(managerResult).toHaveLength(1);
+      expect(managerResult[0].title).toBe('Developer Manager Item');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles empty input array', () => {
+      const result = filterQuickstartItemsByRole([], 'admin');
+
+      expect(result).toHaveLength(0);
+      expect(result).toEqual([]);
+    });
+
+    it('handles empty user role string', () => {
+      const result = filterQuickstartItemsByRole(testItems, '');
+
+      expect(result).toHaveLength(0);
+      expect(result).toEqual([]);
+    });
+
+    it('is case sensitive for role matching', () => {
+      const caseTestItems: QuickstartItemData[] = [
+        {
+          title: 'Lowercase Role',
+          description: 'lowercase admin role',
+          icon: 'test',
+          roles: ['admin'],
+          cta: { text: 'Test', link: '#' },
+        },
+      ];
+
+      const lowerResult = filterQuickstartItemsByRole(caseTestItems, 'admin');
+      const upperResult = filterQuickstartItemsByRole(caseTestItems, 'ADMIN');
+      const mixedResult = filterQuickstartItemsByRole(caseTestItems, 'Admin');
+
+      expect(lowerResult).toHaveLength(1);
+      expect(upperResult).toHaveLength(0);
+      expect(mixedResult).toHaveLength(0);
+    });
+
+    it('preserves original item structure in results', () => {
+      const singleItem: QuickstartItemData[] = [
+        {
+          title: 'Test Item',
+          description: 'Test description',
+          icon: 'test',
+          roles: ['admin'],
+          cta: { text: 'Test CTA', link: '#test' },
+        },
+      ];
+
+      const result = filterQuickstartItemsByRole(singleItem, 'admin');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(singleItem[0]);
+      expect(result[0].title).toBe('Test Item');
+      expect(result[0].description).toBe('Test description');
+      expect(result[0].icon).toBe('test');
+      expect(result[0].roles).toEqual(['admin']);
+      expect(result[0].cta).toEqual({ text: 'Test CTA', link: '#test' });
+    });
+
+    it('does not mutate original items array', () => {
+      const originalItems = [...testItems];
+      const originalFirstItem = { ...testItems[0] };
+
+      filterQuickstartItemsByRole(testItems, 'admin');
+
+      expect(testItems).toHaveLength(originalItems.length);
+      expect(testItems[0]).toEqual(originalFirstItem);
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('handles mixed configuration scenarios', () => {
+      const mixedItems: QuickstartItemData[] = [
+        // Standard admin item
+        {
+          title: 'Admin Only',
+          description: '',
+          icon: '',
+          roles: ['admin'],
+          cta: { text: '', link: '' },
+        },
+        // Standard developer item
+        {
+          title: 'Developer Only',
+          description: '',
+          icon: '',
+          roles: ['developer'],
+          cta: { text: '', link: '' },
+        },
+        // Legacy item without roles (defaults to admin)
+        {
+          title: 'Legacy Item',
+          description: '',
+          icon: '',
+          cta: { text: '', link: '' },
+        },
+        // Shared item
+        {
+          title: 'Shared Item',
+          description: '',
+          icon: '',
+          roles: ['admin', 'developer', 'manager'],
+          cta: { text: '', link: '' },
+        },
+        // Different role
+        {
+          title: 'QA Only',
+          description: '',
+          icon: '',
+          roles: ['qa'],
+          cta: { text: '', link: '' },
+        },
+      ];
+
+      const adminResult = filterQuickstartItemsByRole(mixedItems, 'admin');
+      expect(adminResult.map(item => item.title)).toEqual([
+        'Admin Only',
+        'Legacy Item', // defaults to admin
+        'Shared Item',
+      ]);
+
+      const developerResult = filterQuickstartItemsByRole(
+        mixedItems,
+        'developer',
+      );
+      expect(developerResult.map(item => item.title)).toEqual([
+        'Developer Only',
+        'Shared Item',
+      ]);
+
+      const qaResult = filterQuickstartItemsByRole(mixedItems, 'qa');
+      expect(qaResult.map(item => item.title)).toEqual(['QA Only']);
+
+      const unknownResult = filterQuickstartItemsByRole(mixedItems, 'unknown');
+      expect(unknownResult).toEqual([]);
+    });
+  });
+});

--- a/workspaces/quickstart/plugins/quickstart/src/utils/filterQuickstartItems.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/utils/filterQuickstartItems.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QuickstartItemData } from '../types';
+
+export const filterQuickstartItemsByRole = (
+  items: QuickstartItemData[],
+  userRole: string,
+): QuickstartItemData[] => {
+  return items.filter(item => {
+    // If roles is undefined or empty, default to 'admin'
+    const roles = item.roles?.length ? item.roles : ['admin'];
+    return roles.includes(userRole);
+  });
+};

--- a/workspaces/quickstart/plugins/quickstart/src/utils/index.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/utils/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { filterQuickstartItemsByRole } from './filterQuickstartItems';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For [RHIDP-8455](https://issues.redhat.com/browse/RHIDP-8455).

This PR adds role-based filtering for Quickstart items, so only steps relevant to the current user’s role (admin, developer, etc.) are shown in the UI. It updates config, data, and UI to support this, improves empty state messaging, adds new icons, and expands test coverage for these changes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

Sections for "developer" role
<img width="3024" height="1650" alt="image" src="https://github.com/user-attachments/assets/e2ec60dc-ca38-4fb3-bfba-f4a23a38fd96" />

When no content available for current role
<img width="3024" height="1652" alt="image" src="https://github.com/user-attachments/assets/4050615c-8305-44ad-827e-9771211b2ee4" />
