### PR TITLE
move off techdoc plugin depending on model catalog plugin

### DIFF
--- a/workspaces/ai-integrations/.changeset/calm-crabs-occur.md
+++ b/workspaces/ai-integrations/.changeset/calm-crabs-occur.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-techdoc-url-reader-backend': patch
+---
+
+remove backend catalog dependency

--- a/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/package.json
+++ b/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/package.json
@@ -38,7 +38,6 @@
     "@backstage/config": "^1.2.0",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-catalog-node": "^1.16.1",
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog": "workspace:^",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "zod": "^3.22.4"

--- a/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.test.ts
@@ -19,8 +19,8 @@ import { mockServices } from '@backstage/backend-test-utils';
 import {
   ModeCatalogBridgeTechdocUrlReader,
   ModelCatalogBridgeUrlReaderServiceReadTreeResponse,
+  readBridgeConfigs,
 } from './plugin';
-import { readModelCatalogApiEntityConfigs } from '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -45,7 +45,7 @@ jest.mock('fs', () => ({
 describe('readModelCatalogApiEntityConfigs', () => {
   it('should return empty array if no provider config', () => {
     const config = new ConfigReader({});
-    const result = readModelCatalogApiEntityConfigs(config);
+    const result = readBridgeConfigs(config);
     expect(result).toEqual([]);
   });
 
@@ -64,17 +64,15 @@ describe('readModelCatalogApiEntityConfigs', () => {
         },
       },
     });
-    const result = readModelCatalogApiEntityConfigs(config);
+    const result = readBridgeConfigs(config);
     expect(result).toEqual([
       {
         id: 'provider1',
         baseUrl: 'https://provider1.com:8080',
-        schedule: undefined,
       },
       {
         id: 'provider2',
         baseUrl: 'https://provider2.com:9000',
-        schedule: undefined,
       },
     ]);
   });

--- a/workspaces/ai-integrations/yarn.lock
+++ b/workspaces/ai-integrations/yarn.lock
@@ -10721,7 +10721,6 @@ __metadata:
     "@backstage/config": ^1.2.0
     "@backstage/errors": ^1.2.7
     "@backstage/plugin-catalog-node": ^1.16.1
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog": "workspace:^"
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.12
     express: ^4.17.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I could not get the npx command that builds our dynamic plugins to not use the workspace version of the backend model catalog plugin vs. trying to get the plugin from npm

the `yarn install --immutable` kept failing for the new techdocs plugin

```
gmontero /tmp/package-dynamic-pluginsnSNCsz $ cat red-hat-developer-hub-backstage-plugin-catalog-techdoc-url-reader-backend/yarn-install.log 
➤ YN0000: ┌ Resolution step
➤ YN0035: │ @red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog@npm:0.5.0: The remote server failed to provide the requested resource
➤ YN0035: │   Response Code: 404 (Not Found)
➤ YN0035: │   Request Method: GET
➤ YN0035: │   Request URL: https://registry.npmjs.org/@red-hat-developer-hub%2fbackstage-plugin-catalog-backend-module-model-catalog
➤ YN0000: └ Completed in 0s 447ms
➤ YN0000: Failed with errors in 0s 451ms
```

So I am removing the dependency on `@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog` that I added with https://github.com/redhat-developer/rhdh-plugins/pull/1268 and re-adding some simpler config processing code, where I have varied it enough so that Sonar does not complain about duplicate code ... @johnmcollier and I can revisit this once we start pushing modules to npm

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [/ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [n/a ] Added or Updated documentation
- [ n/a] Tests for new functionality and regression tests for bug fixes
- [ n/a] Screenshots attached (for UI changes)
