### PR TITLE
fix(orchestrator): make inputs in workflow execution form always editable

### DIFF
--- a/workspaces/orchestrator/.changeset/clever-crabs-fetch.md
+++ b/workspaces/orchestrator/.changeset/clever-crabs-fetch.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+remove setting inputs as readonly when execute from nextWorkflows as this was part of deprecated assessment workflow type

--- a/workspaces/orchestrator/plugins/orchestrator-common/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-common/report.api.md
@@ -1134,11 +1134,6 @@ export type ProcessInstanceVariables = Record<string, unknown>;
 // @public (undocumented)
 export const QUERY_PARAM_INSTANCE_ID: "instanceId";
 
-// Warning: (ae-missing-release-tag) "QUERY_PARAM_PREVIOUS_INSTANCE_ID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const QUERY_PARAM_PREVIOUS_INSTANCE_ID: "previousInstanceId";
-
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@export" is not defined in this configuration
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@interface" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "RetriggerInstanceRequestDTO" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1635,7 +1630,6 @@ export interface WorkflowRunStatusDTO {
 // Warnings were encountered during analysis:
 //
 // src/QueryParams.d.ts:1:22 - (ae-undocumented) Missing documentation for "QUERY_PARAM_INSTANCE_ID".
-// src/QueryParams.d.ts:2:22 - (ae-undocumented) Missing documentation for "QUERY_PARAM_PREVIOUS_INSTANCE_ID".
 // src/constants.d.ts:9:22 - (ae-undocumented) Missing documentation for "DEFAULT_SONATAFLOW_PERSISTENCE_PATH".
 // src/constants.d.ts:10:22 - (ae-undocumented) Missing documentation for "DEFAULT_SONATAFLOW_BASE_URL".
 // src/constants.d.ts:11:22 - (ae-undocumented) Missing documentation for "DEFAULT_WORKFLOWS_PATH".

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/QueryParams.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/QueryParams.ts
@@ -15,4 +15,3 @@
  */
 
 export const QUERY_PARAM_INSTANCE_ID = 'instanceId' as const;
-export const QUERY_PARAM_PREVIOUS_INSTANCE_ID = 'previousInstanceId' as const;

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
@@ -11,7 +11,7 @@ import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-p
 import { default as React_2 } from 'react';
 
 // @public
-export const OrchestratorForm: ({ schema: rawSchema, updateSchema, handleExecute, isExecuting, initialFormData, isDataReadonly, setAuthTokenDescriptors, }: OrchestratorFormProps) => JSX_2.Element;
+export const OrchestratorForm: ({ schema: rawSchema, updateSchema, handleExecute, isExecuting, initialFormData, setAuthTokenDescriptors, }: OrchestratorFormProps) => JSX_2.Element;
 
 // @public
 export type OrchestratorFormProps = {
@@ -21,7 +21,6 @@ export type OrchestratorFormProps = {
     isExecuting: boolean;
     handleExecute: (parameters: JsonObject) => Promise<void>;
     initialFormData: JsonObject;
-    isDataReadonly?: boolean;
 };
 
 // @public

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -50,7 +50,6 @@ export type OrchestratorFormProps = {
   isExecuting: boolean;
   handleExecute: (parameters: JsonObject) => Promise<void>;
   initialFormData: JsonObject;
-  isDataReadonly?: boolean;
 };
 
 /**
@@ -105,7 +104,6 @@ const OrchestratorForm = ({
   handleExecute,
   isExecuting,
   initialFormData,
-  isDataReadonly,
   setAuthTokenDescriptors,
 }: OrchestratorFormProps) => {
   // make the form a controlled component so the state will remain when moving between steps. see https://rjsf-team.github.io/react-jsonschema-form/docs/quickstart#controlled-component
@@ -133,12 +131,8 @@ const OrchestratorForm = ({
   );
 
   const uiSchema = useMemo<UiSchema<JsonObject>>(() => {
-    return generateUiSchema(
-      schema,
-      isMultiStep,
-      isDataReadonly ? initialFormData : undefined,
-    );
-  }, [schema, isMultiStep, isDataReadonly, initialFormData]);
+    return generateUiSchema(schema, isMultiStep);
+  }, [schema, isMultiStep]);
 
   const reviewStep = useMemo(
     () => (

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateUiSchema.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateUiSchema.test.ts
@@ -366,7 +366,7 @@ describe('extract ui schema', () => {
     expect(uiSchema).toEqual(expected);
   });
 
-  it('should handle a complex schema with various ui: properties and $ref, including readonly data', () => {
+  it('should handle a complex schema with various ui: properties and $ref', () => {
     const complexSchema = {
       title: 'Complex Schema Example',
       type: 'object',
@@ -499,7 +499,6 @@ describe('extract ui schema', () => {
           done: {
             'ui:widget': 'checkbox',
           },
-          'ui:readonly': true,
         },
       },
       preferences: {
@@ -518,15 +517,7 @@ describe('extract ui schema', () => {
       },
     };
 
-    const uiSchema = generateUiSchema(complexSchema, true, {
-      tasks: {
-        items: {
-          title: 'purple',
-          details: 'abc',
-          done: true,
-        },
-      },
-    });
+    const uiSchema = generateUiSchema(complexSchema, true);
     expect(uiSchema).toEqual(expected);
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateUiSchema.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateUiSchema.ts
@@ -172,34 +172,6 @@ function extractUiSchema(mixedSchema: JSONSchema7): UiSchema<JsonObject> {
   return replaceSparseArrayElementsdWithEmptyObject(result);
 }
 
-const addReadonly = (
-  data: JsonObject,
-  uiSchema: UiSchema<JsonObject>,
-  isMultiStep: boolean,
-) => {
-  // make inputs that came from existing instance variables readonly
-  if (!isMultiStep) {
-    for (const key of Object.keys(data)) {
-      uiSchema[key] = {
-        ...uiSchema[key],
-        'ui:readonly': true,
-      };
-    }
-    return;
-  }
-  for (const [stepKey, stepValue] of Object.entries(data)) {
-    uiSchema[stepKey] = {
-      ...uiSchema[stepKey],
-    };
-    for (const key of Object.keys(stepValue as JsonObject)) {
-      uiSchema[stepKey][key] = {
-        ...uiSchema[stepKey][key],
-        'ui:readonly': true,
-      };
-    }
-  }
-};
-
 const addFocusOnFirstElement = (
   schema: JSONSchema7,
   uiSchema: UiSchema<JsonObject>,
@@ -239,12 +211,8 @@ const addFocusOnFirstElement = (
 const generateUiSchema = (
   schema: JSONSchema7,
   isMultiStep: boolean,
-  readonlyData?: JsonObject,
 ): UiSchema<JsonObject> => {
   const uiSchema = extractUiSchema(schema);
-  if (readonlyData) {
-    addReadonly(readonlyData, uiSchema, isMultiStep);
-  }
   addFocusOnFirstElement(schema, uiSchema, isMultiStep);
   return uiSchema;
 };

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -38,7 +38,6 @@ import {
   AuthTokenDescriptor,
   InputSchemaResponseDTO,
   QUERY_PARAM_INSTANCE_ID,
-  QUERY_PARAM_PREVIOUS_INSTANCE_ID,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 import { OrchestratorForm } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
 
@@ -63,9 +62,6 @@ export const ExecuteWorkflowPage = () => {
   const [isExecuting, setIsExecuting] = useState(false);
   const [updateError, setUpdateError] = React.useState<Error>();
   const [instanceId] = useQueryParamState<string>(QUERY_PARAM_INSTANCE_ID);
-  const [previousInstanceId] = useQueryParamState<string>(
-    QUERY_PARAM_PREVIOUS_INSTANCE_ID,
-  );
   const navigate = useNavigate();
   const instanceLink = useRouteRef(workflowInstanceRouteRef);
   const entityInstanceLink = useRouteRef(entityInstanceRouteRef);
@@ -76,7 +72,7 @@ export const ExecuteWorkflowPage = () => {
   } = useAsync(async (): Promise<InputSchemaResponseDTO> => {
     const res = await orchestratorApi.getWorkflowDataInputSchema(
       workflowId,
-      previousInstanceId || instanceId,
+      instanceId,
     );
     return res.data;
   }, [orchestratorApi, workflowId]);
@@ -177,7 +173,6 @@ export const ExecuteWorkflowPage = () => {
                 updateSchema={updateSchema}
                 handleExecute={handleExecute}
                 isExecuting={isExecuting}
-                isDataReadonly={!!previousInstanceId}
                 initialFormData={initialFormData}
                 setAuthTokenDescriptors={setAuthTokenDescriptors}
               />

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -38,7 +38,7 @@ import {
   ProcessInstanceDTO,
   ProcessInstanceErrorDTO,
   ProcessInstanceStatusDTO,
-  QUERY_PARAM_PREVIOUS_INSTANCE_ID,
+  QUERY_PARAM_INSTANCE_ID,
   WorkflowOverviewDTO,
   WorkflowResultDTO,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
@@ -233,7 +233,7 @@ const NextWorkflows = ({
           workflowId: currentOpenedWorkflowDescriptionModalID,
         }),
         {
-          [QUERY_PARAM_PREVIOUS_INSTANCE_ID]: instanceId,
+          [QUERY_PARAM_INSTANCE_ID]: instanceId,
         },
       ),
     [currentOpenedWorkflowDescriptionModalID, executeWorkflowLink, instanceId],


### PR DESCRIPTION
https://issues.redhat.com/browse/FLPATH-2494
Remove complex logic for making parent workflow inputs read only when running from next workflows section in results card, since this logic is related to deprecated assessment workflow.