### PR TITLE
chore(redhat-resource-optimization): update dynamic-plugins.sh to use rhdh-cli instead of janus-cli

### DIFF
--- a/workspaces/redhat-resource-optimization/scripts/dynamic-plugins.sh
+++ b/workspaces/redhat-resource-optimization/scripts/dynamic-plugins.sh
@@ -39,7 +39,7 @@ function _januscli_dynamic_plugins {
   if [[ "$_pocker" =~ docker$ ]]; then
     args+=( --container-tool docker )
   fi
-  npx @janus-idp/cli@latest package package-dynamic-plugins "${args[@]}" "$@"
+  npx @red-hat-developer-hub/cli@latest plugin package --tag "${PLUGIN_CONTAINER_TAG}"
 }
 
 function clean {


### PR DESCRIPTION
janus-idp/cli is being deprecated; plugins should now use https://github.com/redhat-developer/rhdh-cli

fixes https://issues.redhat.com/browse/RHIDP-8531



## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
