### PR TITLE
chore(marketplace): makefile - use rhdh-cli instead of janus-cli

### DIFF
--- a/workspaces/marketplace/Makefile
+++ b/workspaces/marketplace/Makefile
@@ -36,19 +36,19 @@ add-frontend-to-rhdh:
 	@echo
 	@echo Will build and install ${workspace} frontend into ${rhdh}
 	@echo
-	cd plugins/marketplace && npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
+	cd plugins/marketplace && npx --yes @red-hat-developer-hub/cli plugin export --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
 
 add-backend-to-rhdh:
 	@echo
 	@echo Will build and install ${workspace} backend into ${rhdh}
 	@echo
-	cd plugins/marketplace-backend && npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
+	cd plugins/marketplace-backend && npx --yes @red-hat-developer-hub/cli plugin export --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
 
 add-catalog-modules-to-rhdh:
 	@echo
 	@echo Will build and install catalog modules into ${rhdh}
 	@echo
-	cd plugins/catalog-backend-module-marketplace && npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}" --embed-package "@red-hat-developer-hub/backstage-plugin-marketplace-common"
+	cd plugins/catalog-backend-module-marketplace && npx --yes @red-hat-developer-hub/cli plugin export --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}" --embed-package "@red-hat-developer-hub/backstage-plugin-marketplace-common"
 
 copy-config-to-rhdh:
 	@echo


### PR DESCRIPTION
## Hey, I just made a Pull Request!


`janus-idp/cli` is being deprecated; plugins should now use https://github.com/redhat-developer/rhdh-cli


fixes https://issues.redhat.com/browse/RHIDP-8531

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
