### PR TITLE
chore(theme): makefile - use rhdh-cli instead of janus-cli

### DIFF
--- a/workspaces/theme/Makefile
+++ b/workspaces/theme/Makefile
@@ -44,9 +44,9 @@ add-tests-to-showcase:
 	@echo
 	@echo Will build and install test plugins into ${showcase}
 	@echo
-	cd plugins/bc-test && npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
-	cd plugins/mui4-test && npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
-	cd plugins/mui5-test && npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
+	cd plugins/bc-test && npx --yes @red-hat-developer-hub/cli@latest plugin export --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
+	cd plugins/mui4-test && npx --yes @red-hat-developer-hub/cli@latest plugin export --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
+	cd plugins/mui5-test && npx --yes @red-hat-developer-hub/cli@latest plugin export --dynamic-plugins-root "${dproot}" --clean "${clean}" --dev "${dev}"
 
 remove-from-showcase:
 	@echo


### PR DESCRIPTION
## Hey, I just made a Pull Request!


`janus-idp/cli` is being deprecated; plugins should now use https://github.com/redhat-developer/rhdh-cli


fixes https://issues.redhat.com/browse/RHIDP-8531

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
