### PR TITLE
fix(adoption-insights): align legends, show trends, and remove empty space

### DIFF
--- a/workspaces/adoption-insights/.changeset/gentle-radios-tease.md
+++ b/workspaces/adoption-insights/.changeset/gentle-radios-tease.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Align legends in Active users card, display trends on initial load, and remove empty space in no results card

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/ActiveUsers.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/ActiveUsers.tsx
@@ -63,7 +63,7 @@ const ActiveUsers = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/CustomLegend.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/CustomLegend.tsx
@@ -39,7 +39,7 @@ const CustomLegend = (props: any) => {
             <div
               style={{
                 width: 20,
-                height: 3,
+                height: 4,
                 backgroundColor: entry.color,
               }}
             />

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/CatalogEntities/CatalogEntities.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/CatalogEntities/CatalogEntities.tsx
@@ -115,7 +115,7 @@ const CatalogEntities = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Plugins/Plugins.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Plugins/Plugins.tsx
@@ -35,14 +35,12 @@ import { usePlugins } from '../../hooks/usePlugins';
 import TableFooterPagination from '../CardFooter';
 import { Line, LineChart, ResponsiveContainer } from 'recharts';
 import EmptyChartState from '../Common/EmptyChartState';
-import { useDateRange } from '../Header/DateRangeContext';
 
 const Plugins = () => {
   const [page, setPage] = useState(0);
   const [limit] = useState(20);
   const [rowsPerPage, setRowsPerPage] = useState(3);
 
-  const { isDefaultDateRange } = useDateRange();
   const { plugins, loading, error } = usePlugins({ limit });
 
   const handleChangePage = useCallback((_event: unknown, newPage: number) => {
@@ -79,7 +77,7 @@ const Plugins = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>
@@ -93,7 +91,6 @@ const Plugins = () => {
         <TableHead>
           <TableRow>
             {PLUGINS_TABLE_HEADERS.map(header => {
-              if (isDefaultDateRange && header.id === 'percent') return null;
               return (
                 <TableCell
                   key={header.id}
@@ -125,11 +122,11 @@ const Plugins = () => {
                   borderBottom: theme => `1px solid ${theme.palette.grey[300]}`,
                 }}
               >
-                <TableCell sx={isDefaultDateRange ? {} : { width: '20%' }}>
+                <TableCell sx={{ width: '20%' }}>
                   {plugin.plugin_id ?? '--'}
                 </TableCell>
                 <TableCell sx={{ width: '40%' }}>
-                  {plugin.trend?.length > 0 ? (
+                  {plugin.trend?.length > 1 ? (
                     <ResponsiveContainer width={250} height={50}>
                       <LineChart data={plugin.trend}>
                         <Line
@@ -145,21 +142,19 @@ const Plugins = () => {
                     '--'
                   )}
                 </TableCell>
-                {!isDefaultDateRange && (
-                  <TableCell sx={isDefaultDateRange ? {} : { width: '20%' }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      {Math.round(Number(plugin.trend_percentage)) < 0 ? (
-                        <TrendingDownIcon sx={{ color: 'red' }} />
-                      ) : (
-                        <TrendingUpIcon sx={{ color: 'green' }} />
-                      )}
-                      <Typography variant="body2">
-                        {Math.abs(Math.round(Number(plugin.trend_percentage)))}%
-                      </Typography>
-                    </Box>
-                  </TableCell>
-                )}
-                <TableCell sx={isDefaultDateRange ? {} : { width: '20%' }}>
+                <TableCell sx={{ width: '20%' }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {Math.round(Number(plugin.trend_percentage)) < 0 ? (
+                      <TrendingDownIcon sx={{ color: 'red' }} />
+                    ) : (
+                      <TrendingUpIcon sx={{ color: 'green' }} />
+                    )}
+                    <Typography variant="body2">
+                      {Math.abs(Math.round(Number(plugin.trend_percentage)))}%
+                    </Typography>
+                  </Box>
+                </TableCell>
+                <TableCell sx={{ width: '20%' }}>
                   {Number(plugin.visit_count).toLocaleString('en-US') ?? '--'}
                 </TableCell>
               </TableRow>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Plugins/__tests__/Plugins.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Plugins/__tests__/Plugins.test.tsx
@@ -32,10 +32,6 @@ jest.mock('../../../hooks/usePlugins', () => ({
   usePlugins: jest.fn(),
 }));
 
-jest.mock('../../Header/DateRangeContext', () => ({
-  useDateRange: jest.fn(() => ({ isDefaultDateRange: true })),
-}));
-
 jest.mock('../../CardFooter', () => () => <div data-testid="pagination" />);
 
 jest.mock('recharts', () => {

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Searches/Searches.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Searches/Searches.tsx
@@ -62,7 +62,7 @@ const Searches = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Techdocs/Techdocs.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Techdocs/Techdocs.tsx
@@ -75,7 +75,7 @@ const Techdocs = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Templates/Templates.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Templates/Templates.tsx
@@ -75,7 +75,7 @@ const Templates = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Users/Users.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Users/Users.tsx
@@ -60,7 +60,7 @@ const Users = () => {
           display="flex"
           justifyContent="center"
           alignItems="center"
-          height={200}
+          minHeight={80}
         >
           <EmptyChartState />
         </Box>


### PR DESCRIPTION

### Fixes
- Removed empty space when empty message - [RHDHBUGS-1943](https://issues.redhat.com/browse/RHDHBUGS-1943).
- Show proper indication in "Top 3 plugins" card when no trends exist - [RHDHBUGS-1965](https://issues.redhat.com/browse/RHDHBUGS-1965).
- Display trend percentage in top plugins chart on initial load - [RHDHBUGS-1956](https://issues.redhat.com/browse/RHDHBUGS-1956).
- Align legend correctly in "Active users" card - [RHDHBUGS-1962](https://issues.redhat.com/browse/RHDHBUGS-1962).

Improves overall UI consistency and readability in the Adoption Insights dashboard.

Screenshots

<img width="1920" height="1163" alt="screencapture-localhost-3000-adoption-insights-2025-08-19-10_15_56" src="https://github.com/user-attachments/assets/d439e88d-07c3-430f-af79-2259f136bcb6" />

<img width="1920" height="1965" alt="screencapture-localhost-3000-adoption-insights-2025-08-19-10_17_44" src="https://github.com/user-attachments/assets/53f761c0-e653-499c-a3c4-26380a997286" />



## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
