### PR TITLE
fix(global-header): Global header dropdown empty state corners looks off

### DIFF
--- a/workspaces/global-header/.changeset/fix-dropdown-empty-state-border-radius.md
+++ b/workspaces/global-header/.changeset/fix-dropdown-empty-state-border-radius.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Fixed dropdown empty state corners by removing the border line

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/DropdownEmptyState.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/DropdownEmptyState.tsx
@@ -34,31 +34,38 @@ export const DropdownEmptyState: FC<DropdownEmptyStateProps> = ({
   icon,
 }) => {
   return (
-    <InfoCard>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          textAlign: 'center',
-          py: 4,
-          px: 2, // Added padding to control width
-          maxWidth: 300, // Set max width to constrain text expansion
-          mx: 'auto',
-        }}
-      >
-        {icon}
-        <Typography variant="h6" sx={{ mt: 2, color: 'text.primary' }}>
-          {title}
-        </Typography>
-        <Typography
-          variant="body2"
-          sx={{ mt: 1, color: 'text.secondary', maxWidth: 250 }}
+    <Box
+      sx={{
+        borderRadius: theme => theme.spacing(2.5),
+        overflow: 'hidden',
+      }}
+    >
+      <InfoCard>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            py: 4,
+            px: 2, // Added padding to control width
+            maxWidth: 300, // Set max width to constrain text expansion
+            mx: 'auto',
+          }}
         >
-          {subTitle}
-        </Typography>
-      </Box>
-    </InfoCard>
+          {icon}
+          <Typography variant="h6" sx={{ mt: 2, color: 'text.primary' }}>
+            {title}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{ mt: 1, color: 'text.secondary', maxWidth: 250 }}
+          >
+            {subTitle}
+          </Typography>
+        </Box>
+      </InfoCard>
+    </Box>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Fixes:**
https://issues.redhat.com/browse/RHDHBUGS-1921

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

<img width="463" height="438" alt="Screenshot 2025-08-21 at 3 12 33 PM" src="https://github.com/user-attachments/assets/552eda61-815d-4e76-a3b3-76d7337507fe" />

<img width="572" height="508" alt="Screenshot 2025-08-21 at 3 15 29 PM" src="https://github.com/user-attachments/assets/3e91406e-c458-46a8-a506-bcf911ce7fac" />


<img width="474" height="358" alt="Screenshot 2025-08-21 at 3 13 00 PM" src="https://github.com/user-attachments/assets/50f273c1-b15c-47ae-af4b-b5eb5788e22e" />

Fixed dropdown empty state corners by removing the border line


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
