### PR TITLE
fix(adoption-insights): Adoption Insights - 1 active users per day were conducted during this period.

### DIFF
--- a/workspaces/adoption-insights/.changeset/fix-text-wording-conducted-analytics.md
+++ b/workspaces/adoption-insights/.changeset/fix-text-wording-conducted-analytics.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Fixed confusing text in ActiveUsers and Searches components by replacing "were conducted" with professional analytics terminology using "Average peak active user count" and "Average search count"

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/ActiveUsers.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/ActiveUsers.tsx
@@ -85,12 +85,13 @@ const ActiveUsers = () => {
       ) : (
         <>
           <Typography style={{ margin: '20px 36px' }}>
+            Average peak active user count was{' '}
             <b>
               {`${Math.round(getAverage(data, 'total_users')).toLocaleString(
                 'en-Us',
-              )} active users per ${grouping === 'hourly' ? 'hour' : 'day'}`}
+              )} per ${grouping === 'hourly' ? 'hour' : 'day'}`}
             </b>{' '}
-            were conducted during this period.
+            for this period.
           </Typography>
           <Box sx={{ height: 310, mt: 4, mb: 4, ml: 0, mr: 0 }}>
             <ResponsiveContainer width="100%" height="100%">

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Searches/Searches.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Searches/Searches.tsx
@@ -86,13 +86,13 @@ const Searches = () => {
       ) : (
         <>
           <Typography style={{ margin: '20px 36px' }}>
-            An average of{' '}
+            Average search count was{' '}
             <b>
               {`${Math.round(getAverage(data, 'count')).toLocaleString(
                 'en-US',
-              )} searches per ${grouping === 'hourly' ? 'hour' : 'day'}`}
+              )} per ${grouping === 'hourly' ? 'hour' : 'day'}`}
             </b>{' '}
-            were conducted during this period.
+            for this period.
           </Typography>
           <Box sx={{ height: 310, mt: 4, mb: 4, ml: 0, mr: 0 }}>
             <ResponsiveContainer width="100%" height="100%">

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Searches/__tests__/Searches.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Searches/__tests__/Searches.test.tsx
@@ -61,6 +61,7 @@ describe('Searches Component', () => {
 
     render(<Searches />);
     expect(screen.getByText(/300 searches/i)).toBeInTheDocument();
-    expect(screen.getByText(/150 searches per day/i)).toBeInTheDocument();
+    expect(screen.getByText(/Average search count was/i)).toBeInTheDocument();
+    expect(screen.getByText(/150 per day/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:
https://issues.redhat.com/browse/RHDHBUGS-1963

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
<img width="718" height="524" alt="Screenshot 2025-08-25 at 3 40 56 PM" src="https://github.com/user-attachments/assets/709f6e9b-d88a-4ed0-9865-3e81cf3b76da" />
<img width="716" height="521" alt="Screenshot 2025-08-25 at 3 41 59 PM" src="https://github.com/user-attachments/assets/4d66c569-23fd-46a4-8e1a-a9a0bd2c9f14" />

- The ActiveUsers and Searches components displayed confusing text using "were conducted" .

Fix: Replaced with proper texts:
- ActiveUsers: "Average peak active user count was X per day for this period"
- Searches: "Average search count was X per day for this period"


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
