### PR TITLE
fix(adoption-insights): Adoption insight export chat to append timestamp

### DIFF
--- a/workspaces/adoption-insights/.changeset/fix-csv-export-filename-timestamp.md
+++ b/workspaces/adoption-insights/.changeset/fix-csv-export-filename-timestamp.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Fixed CSV export filename to include timestamp for better file identification and to avoid naming conflicts. Active Users CSV exports now use format "active_users_YYYY-MM-DD_HH-mm-ss-SSS.csv" instead of generic "active_users"

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/ExportCSVButton.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/ExportCSVButton.tsx
@@ -34,6 +34,8 @@ const ExportCSVButton = () => {
 
   const handleCSVDownload = async () => {
     try {
+      const timestamp = format(new Date(), 'yyyy-MM-dd_HH-mm-ss-SSS');
+      const filename = `active_users_${timestamp}.csv`;
       await api.downloadBlob({
         type: 'active_users',
         start_date: startDateRange
@@ -42,6 +44,7 @@ const ExportCSVButton = () => {
         end_date: endDateRange ? format(endDateRange, 'yyyy-MM-dd') : undefined,
         timezone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
         format: 'csv',
+        blobName: filename,
       });
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/__tests__/ExportCSVButton.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/ActiveUsers/__tests__/ExportCSVButton.test.tsx
@@ -58,6 +58,9 @@ describe('ExportCSVButton', () => {
         end_date: '2025-01-31',
         format: 'csv',
         timezone: 'UTC',
+        blobName: expect.stringMatching(
+          /^active_users_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}\.csv$/,
+        ),
       });
     });
   });
@@ -83,5 +86,31 @@ describe('ExportCSVButton', () => {
     await waitFor(() =>
       expect(screen.getByText('Export CSV')).toBeInTheDocument(),
     );
+  });
+
+  it('should generate unique timestamped filenames for multiple downloads', async () => {
+    render(<ExportCSVButton />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+    await waitFor(() => expect(mockDownloadBlob).toHaveBeenCalledTimes(1));
+
+    const firstCall = mockDownloadBlob.mock.calls[0][0];
+    expect(firstCall.blobName).toMatch(
+      /^active_users_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}\.csv$/,
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    fireEvent.click(button);
+    await waitFor(() => expect(mockDownloadBlob).toHaveBeenCalledTimes(2));
+
+    const secondCall = mockDownloadBlob.mock.calls[1][0];
+    expect(secondCall.blobName).toMatch(
+      /^active_users_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}\.csv$/,
+    );
+
+    expect(firstCall.blobName).not.toBe(secondCall.blobName);
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:
https://issues.redhat.com/browse/RHDHBUGS-1957

#### Screenshot:
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
     
<img width="459" height="454" alt="Screenshot 2025-08-25 at 3 56 20 PM" src="https://github.com/user-attachments/assets/16d5a597-399f-4696-bcf4-51e2d9b6b523" />

------

- Added timestamped filenames: active_users_YYYY-MM-DD_HH-mm-ss.csv

------

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
