### PR TITLE
fix(adoption-insights): Adoption insights header does not use Backstage PageHeader, resulting in the wrong background colour

### DIFF
--- a/workspaces/adoption-insights/.changeset/fix-header-background-pageheader.md
+++ b/workspaces/adoption-insights/.changeset/fix-header-background-pageheader.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Fixed Adoption Insights header background color by removing custom background style override that was causing wrong theming

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
@@ -19,7 +19,6 @@ import type { FC, HTMLProps, MouseEvent } from 'react';
 import { Header } from '@backstage/core-components';
 import MenuItem from '@mui/material/MenuItem';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
-import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
 import Popover from '@mui/material/Popover';
 import Box from '@mui/material/Box';
@@ -38,7 +37,7 @@ interface InsightsHeaderProps extends HTMLProps<HTMLDivElement> {
   title: string;
 }
 
-const InsightsHeader: FC<InsightsHeaderProps> = ({ title }) => {
+const InsightsHeader: FC<InsightsHeaderProps> = () => {
   const [selectedOption, setSelectedOption] = useState<string>('last-28-days');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [startDate, setStartDate] = useState<Date | null>(null);
@@ -131,19 +130,7 @@ const InsightsHeader: FC<InsightsHeaderProps> = ({ title }) => {
   }, [startDateRange, endDateRange, t, locale]);
 
   return (
-    <Header
-      pageTitleOverride={t('header.title')}
-      title={
-        <Typography
-          variant="h3"
-          color="textPrimary"
-          sx={{ fontWeight: 'bold' }}
-        >
-          {title}
-        </Typography>
-      }
-      style={{ background: 'none' }}
-    >
+    <Header title={t('header.title')}>
       <Select
         displayEmpty
         open={menuOpen}

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/__tests__/Header.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/__tests__/Header.test.tsx
@@ -58,6 +58,7 @@ jest.mock('../../../utils/constants', () => ({
   DATE_RANGE_OPTIONS: [
     { value: 'today', labelKey: 'header.dateRange.today' },
     { value: 'last-week', labelKey: 'header.dateRange.lastWeek' },
+    { value: 'last-28-days', labelKey: 'header.dateRange.last28Days' },
     { value: 'last-month', labelKey: 'header.dateRange.lastMonth' },
     { value: 'last-year', labelKey: 'header.dateRange.lastYear' },
   ],
@@ -106,7 +107,7 @@ describe('InsightsHeader', () => {
 
   it('should render the header with correct title', () => {
     renderComponent();
-    expect(screen.getByText('Test Insights')).toBeInTheDocument();
+    expect(screen.getByText('Adoption Insights')).toBeInTheDocument();
   });
 
   it('should initialize with default date range', () => {
@@ -120,11 +121,15 @@ describe('InsightsHeader', () => {
     const select = screen.getByRole('combobox');
     await user.click(select);
 
-    expect(screen.getByText('Today')).toBeInTheDocument();
-    expect(screen.getByText('Last week')).toBeInTheDocument();
-    expect(screen.getByText('Last month')).toBeInTheDocument();
-    expect(screen.getByText('Last 28 days')).toBeInTheDocument();
-    expect(screen.getByText('Last year')).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    const optionTexts = options.map(option => option.textContent);
+
+    expect(optionTexts).toContain('Today');
+    expect(optionTexts).toContain('Last week');
+    expect(optionTexts).toContain('Last 28 days');
+    expect(optionTexts).toContain('Last month');
+    expect(optionTexts).toContain('Last year');
+    expect(optionTexts).toContain('Date range...');
   });
 
   it('should open date range picker when "Date range..." is clicked', async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:
https://issues.redhat.com/browse/RHDHBUGS-1933

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
-------
<img width="1728" height="942" alt="Screenshot 2025-08-25 at 4 26 00 PM" src="https://github.com/user-attachments/assets/505e0c79-85c8-459f-921a-428fc68b4d3c" />
--------
<img width="1722" height="945" alt="Screenshot 2025-08-25 at 4 26 20 PM" src="https://github.com/user-attachments/assets/2c5162f0-a9c9-4ca6-a5e2-71ddd08d8768" />
--------


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
