### PR TITLE
fix: catalog-techdoc-url-reader should hand unmodified http rc

### DIFF
--- a/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.ts
+++ b/workspaces/ai-integrations/plugins/catalog-techdoc-url-reader-backend/src/plugin.ts
@@ -34,7 +34,7 @@ import {
   LoggerService,
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { NotFoundError } from '@backstage/errors';
+import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import { Readable } from 'stream';
 import fs from 'fs';
 import platformPath from 'path';
@@ -173,6 +173,9 @@ export class ModeCatalogBridgeTechdocUrlReader implements UrlReaderService {
     const message = `could not read ${url}, ${response.status} ${response.statusText}`;
     if (response.status === 404) {
       throw new NotFoundError(message);
+    }
+    if (response.status === 304) {
+      throw new NotModifiedError();
     }
     throw new Error(message);
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this will allow backstage's leveraging of http 304's in order to avoid re-building techdocs and not surface the 304 as a error

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
