### PR TITLE
feat(i18n): add translation support to gloabl header

### DIFF
--- a/docs/backstage-i18n-guide.md
+++ b/docs/backstage-i18n-guide.md
@@ -1,0 +1,529 @@
+# Backstage Plugin Internationalization (i18n) Guide
+
+**Authors**: Rohit Rai  
+**Version**: 1.0  
+**Purpose**: Comprehensive guide for implementing i18n in Backstage plugins  
+**Audience**: Developers and AI assistants
+
+## Overview
+
+This guide provides comprehensive patterns for implementing internationalization in Backstage plugins. It's designed as a source of truth for both AI assistants and developers.
+
+**🚨 CRITICAL**: Never modify original English strings when implementing i18n - preserve them exactly as they were
+
+**Example Languages**: German (de), French (fr), Italian (it), Spanish (es)
+
+## Quick Implementation Checklist
+
+For AI: Follow this exact sequence for any plugin translation:
+
+- [ ] **1. Create translation reference** (`src/translations/ref.ts`)
+- [ ] **2. Create language files** (`src/translations/{de,fr,it,es}.ts` - add more as needed)
+- [ ] **3. Create translation resource** (`src/translations/index.ts`)
+- [ ] **4. Create hooks** (`src/hooks/useTranslation.ts`, `src/hooks/useLanguage.ts`)
+- [ ] **5. Create Trans component** (`src/components/Trans.tsx`)
+- [ ] **6. Replace hardcoded strings** (components, utilities, constants)
+- [ ] **7. Add test mocks** (`src/test-utils/mockTranslations.ts`)
+- [ ] **8. Update all tests** (apply mock pattern)
+- [ ] **9. Configure app integration** (dev mode + main app)
+- [ ] **10. Validate translations** (consistency, grammar, interpolation)
+
+## Decision Trees
+
+### When to Use What
+
+```
+String replacement needed?
+├── Simple text → Use t('key')
+├── Text with variables → Use t('key', {param: value})
+├── JSX content/formatting → Use <Trans message="key" params={...} />
+└── Reusable logic + fallbacks → Create utility function with t? parameter
+```
+
+### File Structure Decisions
+
+```
+Plugin structure:
+src/
+├── translations/
+│   ├── ref.ts          # English messages (nested objects)
+│   ├── de.ts           # German (flat keys)
+│   ├── fr.ts           # French (flat keys)
+│   ├── it.ts           # Italian (flat keys)
+│   ├── es.ts           # Spanish (flat keys)
+│   │                   # Add more language files as needed
+│   └── index.ts        # Translation resource
+├── hooks/
+│   ├── useTranslation.ts
+│   └── useLanguage.ts
+├── components/
+│   └── Trans.tsx
+└── test-utils/
+    └── mockTranslations.ts
+```
+
+## Core Implementation Templates
+
+### 1. Translation Reference (ref.ts)
+
+```typescript
+import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+// CRITICAL: Export messages separately for testing
+export const myPluginMessages = {
+  page: {
+    title: 'My Plugin',
+    subtitle: 'Plugin description',
+  },
+  header: {
+    title: 'Header Title',
+    dateRange: {
+      today: 'Today',
+      lastWeek: 'Last week',
+    },
+  },
+  table: {
+    headers: {
+      name: 'Name',
+      count: 'Count',
+    },
+    pagination: {
+      topN: 'Top {{count}}', // Use interpolation for dynamic values
+    },
+  },
+  common: {
+    exportCSV: 'Export CSV',
+    csvFilename: 'data-export.csv',
+    noResults: 'No results for this date range.',
+  },
+};
+
+export const myPluginTranslationRef = createTranslationRef({
+  id: 'plugin.my-plugin',
+  messages: myPluginMessages,
+});
+```
+
+### 2. Language Files Template
+
+```typescript
+// src/translations/de.ts
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { myPluginTranslationRef } from './ref';
+
+const myPluginTranslationDe = createTranslationMessages({
+  ref: myPluginTranslationRef,
+  messages: {
+    // CRITICAL: Use flat dot notation, not nested objects
+    'page.title': 'Mein Plugin',
+    'page.subtitle': 'Plugin-Beschreibung',
+    'header.title': 'Header-Titel',
+    'header.dateRange.today': 'Heute',
+    'header.dateRange.lastWeek': 'Letzte Woche',
+    'table.headers.name': 'Name',
+    'table.headers.count': 'Anzahl',
+    'table.pagination.topN': 'Top {{count}}',
+    'common.exportCSV': 'CSV exportieren',
+    'common.csvFilename': 'daten-export.csv',
+    'common.noResults': 'Keine Ergebnisse für diesen Zeitraum.',
+  },
+});
+
+export default myPluginTranslationDe;
+```
+
+**Why Different Key Formats Matter:**
+
+- ✅ Reference uses nested objects for TypeScript inference
+- ✅ Translation files use flat keys for `createTranslationMessages` API
+- ❌ Using nested objects in translation files causes TypeScript errors
+- ❌ Using flat keys in reference breaks the mock testing approach
+
+### 3. Translation Resource (index.ts)
+
+```typescript
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+import { myPluginTranslationRef } from './ref';
+
+export const myPluginTranslations = createTranslationResource({
+  ref: myPluginTranslationRef,
+  translations: {
+    de: () => import('./de'),
+    fr: () => import('./fr'),
+    it: () => import('./it'),
+    es: () => import('./es'),
+    // Add more languages as needed
+  },
+});
+
+export { myPluginTranslationRef };
+```
+
+### 4. Hooks Template
+
+```typescript
+// src/hooks/useTranslation.ts
+import {
+  useTranslationRef,
+  TranslationFunction,
+} from '@backstage/core-plugin-api/alpha';
+import { myPluginTranslationRef } from '../translations';
+
+export const useTranslation = (): {
+  t: TranslationFunction<typeof myPluginTranslationRef.T>;
+} => useTranslationRef(myPluginTranslationRef);
+
+// src/hooks/useLanguage.ts
+import { useApi } from '@backstage/core-plugin-api';
+import { appLanguageApiRef } from '@backstage/core-plugin-api/alpha';
+
+export const useLanguage = (): string =>
+  useApi(appLanguageApiRef).getLanguage().language;
+```
+
+### 5. Trans Component Template
+
+```typescript
+// src/components/Trans.tsx
+import { useTranslation } from '../hooks/useTranslation';
+import { myPluginTranslationRef } from '../translations';
+
+type Messages = typeof myPluginTranslationRef.T;
+
+interface TransProps<TMessages extends { [key in string]: string }> {
+  message: keyof TMessages;
+  params?: any;
+}
+
+export const Trans = ({ message, params }: TransProps<Messages>) => {
+  const { t } = useTranslation();
+  return t(message, params);
+};
+```
+
+## Implementation Patterns
+
+### Key Naming Convention
+
+- Use camelCase for key names
+- Group by semantic hierarchy: `${page}.${section}.${element}`
+- Common patterns:
+  - `${page}.title` - Page titles
+  - `${page}.subtitle` - Page subtitles
+  - `${page}.header.title` - Header titles
+  - `table.pagination.topN` - Use interpolation for dynamic values
+
+### Component Translation
+
+```typescript
+import { useTranslation } from '../hooks/useTranslation';
+
+const MyComponent = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <h1>{t('page.title')}</h1>
+      <p>{t('table.pagination.topN' as any, { count: '5' })}</p>
+      <Trans
+        message="complex.interpolation"
+        params={{ user: currentUser.name }}
+      />
+    </div>
+  );
+};
+```
+
+**Interpolation Guidelines:**
+
+- Use `{{paramName}}` syntax for interpolation
+- Pass parameters as strings: `{ count: '5' }`
+- Use `as any` type assertion for dynamic keys: `t('dynamic.key' as any, params)`
+- Use `Trans` component for complex JSX interpolation
+
+### Utility Functions with Fallbacks
+
+```typescript
+import { TranslationFunction } from '@backstage/core-plugin-api/alpha';
+import { myPluginTranslationRef } from '../translations';
+
+export const formatDate = (
+  date: Date,
+  t?: TranslationFunction<typeof myPluginTranslationRef.T>,
+) => {
+  if (isToday(date)) {
+    return t ? t('common.today') : 'Today';
+  }
+  if (isYesterday(date)) {
+    return t ? t('common.yesterday') : 'Yesterday';
+  }
+  return format(date, 'dd MMMM yyyy');
+};
+```
+
+### Constants with Translation Keys
+
+```typescript
+// GOOD: Use titleKey/labelKey for translation
+export const TABLE_HEADERS = [
+  { id: 'name', titleKey: 'table.headers.name' },
+  { id: 'count', titleKey: 'table.headers.count' },
+];
+
+export const DATE_OPTIONS = [
+  { value: 'today', labelKey: 'header.dateRange.today' },
+  { value: 'lastWeek', labelKey: 'header.dateRange.lastWeek' },
+];
+```
+
+## Advanced Patterns
+
+### Pluralization
+
+```typescript
+// In messages
+common: {
+  itemCount: {
+    zero: 'No items',
+    one: '{{count}} item',
+    other: '{{count}} items',
+  },
+}
+
+// Usage
+const getItemCountText = (count: number) => {
+  if (count === 0) return t('common.itemCount.zero');
+  if (count === 1) return t('common.itemCount.one', { count: count.toString() });
+  return t('common.itemCount.other', { count: count.toString() });
+};
+```
+
+### Conditional Translations
+
+```typescript
+// Permission-based content
+const getMessage = (hasAdminAccess: boolean) => {
+  return hasAdminAccess ? t('admin.welcomeMessage') : t('user.welcomeMessage');
+};
+
+// Feature flags
+const getFeatureText = (featureEnabled: boolean) => {
+  return featureEnabled
+    ? t('features.enabled.text')
+    : t('features.disabled.text');
+};
+```
+
+### Dynamic Translation Loading
+
+```typescript
+// For large translation sets, load dynamically
+const loadTranslations = async (category: string) => {
+  const { t } = useTranslation();
+  const keys = await import(`../translations/categories/${category}`);
+  return keys.map(key => t(key));
+};
+```
+
+### Localization with Intl APIs
+
+```typescript
+// Date formatting
+const locale = useLanguage();
+const formatDate = (date: Date) =>
+  new Intl.DateTimeFormat(locale, {
+    timeZone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+
+// Number formatting
+const formatNumber = (value: number) =>
+  new Intl.NumberFormat(locale, {
+    notation: 'compact',
+  }).format(value);
+```
+
+**Key Principles:**
+
+- ✅ **Use `Intl.NumberFormat`** instead of `.toLocaleString('en-US')`
+- ✅ **Pass locale from `useLanguage()`** for consistent formatting
+- ❌ **Avoid hardcoded locale strings** in components
+
+## Testing Implementation
+
+### Mock Helper (test-utils/mockTranslations.ts)
+
+```typescript
+import { myPluginMessages } from '../translations/ref';
+
+function flattenMessages(obj: any, prefix = ''): Record<string, string> {
+  const flattened: Record<string, string> = {};
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const value = obj[key];
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (typeof value === 'object' && value !== null) {
+        Object.assign(flattened, flattenMessages(value, newKey));
+      } else {
+        flattened[newKey] = value;
+      }
+    }
+  }
+  return flattened;
+}
+
+const flattenedMessages = flattenMessages(myPluginMessages);
+
+export const mockT = (key: string, params?: any) => {
+  let message = flattenedMessages[key] || key;
+  if (params) {
+    for (const [paramKey, paramValue] of Object.entries(params)) {
+      message = message.replace(
+        new RegExp(`{{${paramKey}}}`, 'g'),
+        String(paramValue),
+      );
+    }
+  }
+  return message;
+};
+
+export const mockUseTranslation = () => ({ t: mockT });
+export const MockTrans = ({
+  message,
+  params,
+}: {
+  message: string;
+  params?: any;
+}) => mockT(message, params);
+```
+
+### Test Pattern
+
+```typescript
+// CRITICAL: Import mocks BEFORE components
+import { MockTrans, mockUseTranslation } from '../../../test-utils/mockTranslations';
+
+jest.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../Trans', () => ({ Trans: MockTrans }));
+
+// Component imports AFTER mocks
+import MyComponent from '../MyComponent';
+
+describe('MyComponent', () => {
+  it('renders translated content', () => {
+    render(<MyComponent />);
+    expect(screen.getByText('Export CSV')).toBeInTheDocument();
+  });
+});
+```
+
+## App Integration
+
+### Development Mode
+
+```typescript
+// plugins/my-plugin/dev/index.tsx
+import { myPluginTranslations } from '../src/translations';
+
+createDevApp()
+  .registerPlugin(myPluginPlugin)
+  .addTranslationResource(myPluginTranslations)
+  .setAvailableLanguages(['en', 'de', 'fr', 'it', 'es']) // Add more languages as needed
+  .setDefaultLanguage('en')
+  .addPage({
+    /* ... */
+  });
+```
+
+### Main App
+
+```typescript
+// packages/app/src/App.tsx
+import { myPluginTranslations } from '@my-org/backstage-plugin-my-plugin';
+
+const app = createApp({
+  apis,
+  __experimentalTranslations: {
+    availableLanguages: ['en', 'de', 'fr', 'it', 'es'], // Add more languages as needed
+    resources: [myPluginTranslations],
+  },
+});
+```
+
+## Translation Quality Guidelines
+
+### Language-Specific Rules
+
+**German**
+
+- ✅ Compound words: `'Top-Vorlagen'` not `'Top Vorlagen'`
+- ✅ Proper capitalization: `'Benutzer-Dashboard'`
+
+**French**
+
+- ✅ Proper apostrophes: `'Aujourd\'hui'`
+- ✅ Space separation: `'Top recherches'` not `'Top-Recherches'`
+
+**Italian**
+
+- ✅ Article agreement: `'Gli utenti attivi'`
+- ✅ Adjective agreement: `'utenti attivi'`, `'nuovi utenti'`
+
+**Spanish**
+
+- ✅ Gender agreement: `'Usuarios activos'` (masculine)
+- ✅ Accent marks: `'último'`, `'período'`, `'búsquedas'`
+
+### General Quality Checklist
+
+- [ ] **No untranslated strings** - All keys fully translated
+- [ ] **Consistent terminology** - Same terms across related keys
+- [ ] **Interpolation preservation** - All `{{parameter}}` patterns match
+- [ ] **Cultural adaptation** - Concepts adapted, not literal translations
+- [ ] **Localized filenames** - CSV exports use translated names
+
+## Validation Steps
+
+### Pre-Implementation
+
+1. Identify all hardcoded strings in components
+2. Group strings by semantic meaning (page, table, common, etc.)
+3. Plan key structure using hierarchical naming
+
+### During Implementation
+
+1. Replace strings incrementally by component
+2. Test each component after translation
+3. Verify interpolation works correctly
+
+### Post-Implementation
+
+1. Test language switching functionality
+2. Verify fallback behavior (missing translations → English)
+3. Check E2E tests expect translated strings
+4. Validate all translation files have identical key sets
+
+## Common Patterns Reference
+
+| Use Case         | Pattern                     | Example                                           |
+| ---------------- | --------------------------- | ------------------------------------------------- |
+| Simple text      | `t('key')`                  | `t('page.title')`                                 |
+| With variables   | `t('key', {param})`         | `t('table.topN', {count: '5'})`                   |
+| Dynamic keys     | `t('key' as any, {param})`  | `t('table.topN' as any, {count: '3'})`            |
+| JSX content      | `<Trans />`                 | `<Trans message="complex.text" params={{...}} />` |
+| Utility fallback | `t ? t('key') : 'fallback'` | `t ? t('common.today') : 'Today'`                 |
+| Constants        | `titleKey/labelKey`         | `{titleKey: 'table.headers.name'}`                |
+
+## References
+
+- [Backstage i18n Documentation](https://backstage.io/docs/plugins/internationalization)
+- [Translation API Reference](https://backstage.io/docs/reference/core-plugin-api.translation)
+- Package: `@backstage/core-plugin-api/alpha`
+
+---
+
+**Success Metrics**: Zero hardcoded strings, 100% test coverage with real translations, seamless language switching.

--- a/workspaces/global-header/.changeset/slow-goats-serve.md
+++ b/workspaces/global-header/.changeset/slow-goats-serve.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': minor
+---
+
+Add internationalization (i18n) support with German, French, Italian, and Spanish translations.

--- a/workspaces/global-header/packages/app/src/App.tsx
+++ b/workspaces/global-header/packages/app/src/App.tsx
@@ -58,6 +58,7 @@ import { NotificationsPage } from '@backstage/plugin-notifications';
 import { githubAuthApiRef } from '@backstage/core-plugin-api';
 
 import { getAllThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
+import { globalHeaderTranslations } from '@red-hat-developer-hub/backstage-plugin-global-header';
 import ManageAccounts from '@mui/icons-material/ManageAccountsOutlined';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
 import Logout from '@mui/icons-material/LogoutOutlined';
@@ -69,6 +70,10 @@ const app = createApp({
     logout: Logout,
   },
   apis,
+  __experimentalTranslations: {
+    availableLanguages: ['en', 'de', 'es', 'fr', 'it'],
+    resources: [globalHeaderTranslations],
+  },
   bindRoutes({ bind }) {
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,

--- a/workspaces/global-header/plugins/global-header/dev/index.tsx
+++ b/workspaces/global-header/plugins/global-header/dev/index.tsx
@@ -46,6 +46,8 @@ import {
   Spacer,
 } from '../src/plugin';
 
+import { globalHeaderTranslations } from '../src/translations';
+
 import {
   defaultApplicationLauncherDropdownMountPoints,
   defaultCreateDropdownMountPoints,
@@ -168,6 +170,9 @@ const Providers = ({
 createDevApp()
   .registerPlugin(globalHeaderPlugin)
   .addThemes(getAllThemes())
+  .addTranslationResource(globalHeaderTranslations)
+  .setAvailableLanguages(['en', 'de', 'es', 'fr', 'it'])
+  .setDefaultLanguage('en')
   .addPage({
     element: (
       <Providers

--- a/workspaces/global-header/plugins/global-header/report.api.md
+++ b/workspaces/global-header/plugins/global-header/report.api.md
@@ -8,6 +8,8 @@ import type { ComponentType } from 'react';
 import { CSSProperties } from 'react';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { MenuItemProps } from '@mui/material/MenuItem';
+import { TranslationRef } from '@backstage/core-plugin-api/alpha';
+import { TranslationResource } from '@backstage/core-plugin-api/alpha';
 
 // @public
 export const ApplicationLauncherDropdown: () => JSX_2.Element;
@@ -83,6 +85,48 @@ export interface GlobalHeaderComponentProps {
 
 // @public
 export const globalHeaderPlugin: BackstagePlugin<{}, {}, {}>;
+
+// @public
+export const globalHeaderTranslationRef: TranslationRef<
+  'plugin.global-header',
+  {
+    readonly 'search.placeholder': string;
+    readonly 'search.noResults': string;
+    readonly 'search.errorFetching': string;
+    readonly 'help.tooltip': string;
+    readonly 'help.noSupportLinks': string;
+    readonly 'help.noSupportLinksSubtitle': string;
+    readonly 'help.quickStart': string;
+    readonly 'help.supportTitle': string;
+    readonly 'profile.picture': string;
+    readonly 'profile.settings': string;
+    readonly 'profile.myProfile': string;
+    readonly 'profile.signOut': string;
+    readonly 'applicationLauncher.tooltip': string;
+    readonly 'applicationLauncher.noLinksTitle': string;
+    readonly 'applicationLauncher.noLinksSubtitle': string;
+    readonly 'applicationLauncher.developerHub': string;
+    readonly 'applicationLauncher.rhdhLocal': string;
+    readonly 'applicationLauncher.sections.documentation': string;
+    readonly 'applicationLauncher.sections.developerTools': string;
+    readonly 'starred.title': string;
+    readonly 'starred.removeTooltip': string;
+    readonly 'starred.noItemsTitle': string;
+    readonly 'starred.noItemsSubtitle': string;
+    readonly 'notifications.title': string;
+    readonly 'notifications.unsupportedDismissOption': string;
+    readonly 'create.title': string;
+    readonly 'create.registerComponent.title': string;
+    readonly 'create.registerComponent.subtitle': string;
+    readonly 'create.templates.errorFetching': string;
+    readonly 'create.templates.sectionTitle': string;
+    readonly 'create.templates.allTemplates': string;
+    readonly 'create.templates.noTemplatesAvailable': string;
+  }
+>;
+
+// @public
+export const globalHeaderTranslations: TranslationResource<'plugin.global-header'>;
 
 // @public (undocumented)
 export const HeaderButton: ({

--- a/workspaces/global-header/plugins/global-header/src/alpha.ts
+++ b/workspaces/global-header/plugins/global-header/src/alpha.ts
@@ -14,6 +14,4 @@
  * limitations under the License.
  */
 
-export { useDropdownManager } from './useDropdownManager';
-export { useTranslation } from './useTranslation';
-export { useLanguage } from './useLanguage';
+export * from './translations';

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ApplicationLauncherDropdown.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ApplicationLauncherDropdown.test.tsx
@@ -15,6 +15,10 @@
  */
 import { screen, fireEvent } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
 import { ApplicationLauncherDropdown } from './ApplicationLauncherDropdown';
 import { useDropdownManager } from '../../hooks';
 import { useApplicationLauncherDropdownMountPoints } from '../../hooks/useApplicationLauncherDropdownMountPoints';
@@ -25,6 +29,15 @@ jest.mock('../../hooks', () => ({
 
 jest.mock('../../hooks/useApplicationLauncherDropdownMountPoints', () => ({
   useApplicationLauncherDropdownMountPoints: jest.fn(),
+}));
+
+// Mock translation hooks
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
 }));
 
 describe('ApplicationLauncherDropdown', () => {

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ApplicationLauncherDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ApplicationLauncherDropdown.tsx
@@ -23,9 +23,11 @@ import { useDropdownManager } from '../../hooks';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import { MenuSection } from './MenuSection';
 import { DropdownEmptyState } from './DropdownEmptyState';
+import { useTranslation } from '../../hooks/useTranslation';
 
 export const ApplicationLauncherDropdown = () => {
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
+  const { t } = useTranslation();
 
   const mountPoints = useApplicationLauncherDropdownMountPoints();
 
@@ -65,7 +67,7 @@ export const ApplicationLauncherDropdown = () => {
   return (
     <HeaderDropdownComponent
       buttonContent={<AppsIcon />}
-      tooltip="Application launcher"
+      tooltip={t('applicationLauncher.tooltip')}
       isIconButton
       onOpen={handleOpen}
       onClose={handleClose}
@@ -87,8 +89,8 @@ export const ApplicationLauncherDropdown = () => {
         )
       ) : (
         <DropdownEmptyState
-          title="No application links configured"
-          subTitle="Configure application links in dynamic plugin config for quick access from here."
+          title={t('applicationLauncher.noLinksTitle')}
+          subTitle={t('applicationLauncher.noLinksSubtitle')}
           icon={
             <AppRegistrationIcon
               sx={{ fontSize: 64, color: 'text.disabled' }}

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/CreateDropdown.tsx
@@ -21,6 +21,7 @@ import ArrowDropDownOutlinedIcon from '@mui/icons-material/ArrowDropDownOutlined
 
 import { MenuItemConfig } from './MenuSection';
 import { useCreateDropdownMountPoints } from '../../hooks/useCreateDropdownMountPoints';
+import { useTranslation } from '../../hooks/useTranslation';
 import { useDropdownManager } from '../../hooks';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import Box from '@mui/material/Box';
@@ -44,6 +45,7 @@ export interface CreateDropdownProps {
 }
 
 export const CreateDropdown = ({ layout }: CreateDropdownProps) => {
+  const { t } = useTranslation();
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
 
   const createDropdownMountPoints = useCreateDropdownMountPoints();
@@ -65,7 +67,7 @@ export const CreateDropdown = ({ layout }: CreateDropdownProps) => {
     <HeaderDropdownComponent
       buttonContent={
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          Self-service <ArrowDropDownOutlinedIcon sx={{ ml: 1 }} />
+          {t('create.title')} <ArrowDropDownOutlinedIcon sx={{ ml: 1 }} />
         </Box>
       }
       buttonProps={{

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HelpDropdown.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HelpDropdown.test.tsx
@@ -15,6 +15,10 @@
  */
 import { screen, fireEvent } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
 import { HelpDropdown } from './HelpDropdown';
 import { useDropdownManager } from '../../hooks';
 import { useHelpDropdownMountPoints } from '../../hooks/useHelpDropdownMountPoints';
@@ -26,6 +30,15 @@ jest.mock('../../hooks', () => ({
 
 jest.mock('../../hooks/useHelpDropdownMountPoints', () => ({
   useHelpDropdownMountPoints: jest.fn(),
+}));
+
+// Mock translation hooks
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
 }));
 
 const MockComponent = ({ title, icon }: any) => (

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HelpDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HelpDropdown.tsx
@@ -24,6 +24,7 @@ import { MenuSection } from './MenuSection';
 import { DropdownEmptyState } from './DropdownEmptyState';
 import SupportAgentIcon from '@mui/icons-material/SupportAgent';
 import { useValidComponentTracker } from '../../hooks/useValidComponentTracker';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * @public
@@ -85,6 +86,7 @@ const ValidityTracker = ({
 export const HelpDropdown = ({ layout }: HelpDropdownProps) => {
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
   const helpDropdownMountPoints = useHelpDropdownMountPoints();
+  const { t } = useTranslation();
 
   const { shouldShowEmpty, updateComponentValidity } = useValidComponentTracker(
     helpDropdownMountPoints?.length ?? 0,
@@ -124,7 +126,7 @@ export const HelpDropdown = ({ layout }: HelpDropdownProps) => {
   return (
     <HeaderDropdownComponent
       isIconButton
-      tooltip="Help"
+      tooltip={t('help.tooltip')}
       buttonContent={<HelpOutlineIcon />}
       buttonProps={{
         color: 'inherit',
@@ -138,8 +140,8 @@ export const HelpDropdown = ({ layout }: HelpDropdownProps) => {
         <MenuSection hideDivider items={menuItems} handleClose={handleClose} />
       ) : (
         <DropdownEmptyState
-          title="No support links"
-          subTitle="Your administrator needs to set up support links."
+          title={t('help.noSupportLinks')}
+          subTitle={t('help.noSupportLinksSubtitle')}
           icon={
             <SupportAgentIcon sx={{ fontSize: 64, color: 'text.disabled' }} />
           }

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
@@ -22,6 +22,7 @@ import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import { Link } from '@backstage/core-components';
 import { MenuItemLinkProps } from '../MenuItemLink/MenuItemLink';
 import ListSubheader from '@mui/material/ListSubheader';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * Menu item configuration
@@ -53,8 +54,15 @@ export const MenuSection: FC<MenuSectionConfig> = ({
   hideDivider = false,
   handleClose,
 }) => {
+  const { t } = useTranslation();
   const hasClickableSubheader =
     optionalLink && optionalLinkLabel && items.length > 0;
+
+  // Check if sectionLabel looks like a translation key (contains dots)
+  const translatedSectionLabel =
+    sectionLabel && sectionLabel.includes('.')
+      ? t(sectionLabel as any, {}) || sectionLabel // Fallback to original if translation fails
+      : sectionLabel;
 
   return (
     <>
@@ -79,7 +87,7 @@ export const MenuSection: FC<MenuSectionConfig> = ({
               fontWeight: 400,
             }}
           >
-            {sectionLabel}
+            {translatedSectionLabel}
           </ListSubheader>
 
           {optionalLinkLabel && (

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.test.tsx
@@ -19,10 +19,23 @@ import { useUserProfile } from '@backstage/plugin-user-settings';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
 import { ProfileDropdown } from './ProfileDropdown';
 
 jest.mock('@backstage/plugin-user-settings', () => ({
   useUserProfile: jest.fn(),
+}));
+
+// Mock translation hooks
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
 }));
 
 jest.mock('../../hooks/useProfileDropdownMountPoints', () => {
@@ -33,11 +46,11 @@ jest.mock('../../hooks/useProfileDropdownMountPoints', () => {
         Component: MockComponent,
         config: {
           props: {
-            icon: 'someicon',
-            title: 'sometitle',
-            link: 'somelink',
+            icon: 'manageAccounts',
+            title: 'profile.settings',
+            link: '/settings',
           },
-          priority: '100',
+          priority: 200,
         },
       },
       {
@@ -45,9 +58,9 @@ jest.mock('../../hooks/useProfileDropdownMountPoints', () => {
         config: {
           props: {
             icon: 'account',
-            title: 'My profile',
+            title: 'profile.myProfile',
           },
-          priority: '90',
+          priority: 150,
         },
       },
     ],

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
@@ -31,6 +31,7 @@ import { MenuItemConfig, MenuSection } from './MenuSection';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import { useProfileDropdownMountPoints } from '../../hooks/useProfileDropdownMountPoints';
 import { useDropdownManager } from '../../hooks';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * @public
@@ -44,6 +45,7 @@ export const ProfileDropdown = ({ layout }: ProfileDropdownProps) => {
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
   const [user, setUser] = useState<string | null>();
   const [profileLink, setProfileLink] = useState<string | null>();
+  const { t } = useTranslation();
   const {
     displayName,
     backstageIdentity,
@@ -115,16 +117,22 @@ export const ProfileDropdown = ({ layout }: ProfileDropdownProps) => {
           icon = '',
           link: staticLink = '',
         } = mp.config?.props ?? {};
-        const isMyProfile = title.toLowerCase() === 'my profile';
+        const isMyProfile = title === 'profile.myProfile';
         const link = isMyProfile ? profileLink ?? '' : staticLink;
 
         if (!link && title) {
           return null;
         }
 
+        // Check if title looks like a translation key (contains dots)
+        const translatedTitle =
+          title && title.includes('.')
+            ? t(title as any, {}) || title // Fallback to original title if translation fails
+            : title;
+
         return {
           Component: mp.Component,
-          label: title,
+          label: translatedTitle,
           link,
           priority: mp.config?.priority ?? 0,
           ...(icon && { icon }),
@@ -132,7 +140,7 @@ export const ProfileDropdown = ({ layout }: ProfileDropdownProps) => {
       })
       .filter((item: MenuItemConfig) => item !== null)
       .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
-  }, [profileDropdownMountPoints, profileLink]);
+  }, [profileDropdownMountPoints, profileLink, t]);
 
   if (menuItems.length === 0) {
     return null;
@@ -160,7 +168,7 @@ export const ProfileDropdown = ({ layout }: ProfileDropdownProps) => {
                 <Avatar
                   src={profile.picture}
                   sx={{ mr: 2, height: '32px', width: '32px' }}
-                  alt="Profile picture"
+                  alt={t('profile.picture')}
                 />
               ) : (
                 <AccountCircleOutlinedIcon fontSize="small" sx={{ mr: 1 }} />

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/RegisterAComponentSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/RegisterAComponentSection.tsx
@@ -16,6 +16,7 @@
 import type { ComponentType } from 'react';
 import { MenuSection } from './MenuSection';
 import { MenuItemLink } from '../MenuItemLink/MenuItemLink';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * Register A Component Section properties
@@ -31,13 +32,15 @@ export const RegisterAComponentSection = ({
   hideDivider,
   handleClose,
 }: RegisterAComponentSectionProps) => {
+  const { t } = useTranslation();
+
   return (
     <MenuSection
       hideDivider={hideDivider}
       items={[
         {
-          label: 'Register a component',
-          subLabel: 'Import it to the catalog page',
+          label: t('create.registerComponent.title'),
+          subLabel: t('create.registerComponent.subtitle'),
           link: '/catalog-import',
           icon: 'category',
           Component: MenuItemLink as ComponentType,

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/SoftwareTemplatesSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/SoftwareTemplatesSection.tsx
@@ -27,6 +27,7 @@ import Typography from '@mui/material/Typography';
 
 import { MenuSection } from './MenuSection';
 import { MenuItemLink } from '../MenuItemLink/MenuItemLink';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * Software Templates Section properties
@@ -43,6 +44,7 @@ export const SoftwareTemplatesSection = ({
   hideDivider,
 }: SoftwareTemplatesSectionProps) => {
   const catalogApi = useApi(catalogApiRef);
+  const { t } = useTranslation();
 
   const [entities, setEntities] = useState<Entity[]>([]);
   // TODO: handle loading
@@ -81,7 +83,7 @@ export const SoftwareTemplatesSection = ({
     return (
       <Box display="flex" justifyContent="center" alignItems="center" p={2}>
         <Typography variant="body1" color="error">
-          Error fetching templates
+          {t('create.templates.errorFetching')}
         </Typography>
       </Box>
     );
@@ -94,7 +96,7 @@ export const SoftwareTemplatesSection = ({
           variant="body2"
           sx={{ mx: 2, my: 1, color: 'text.disabled' }}
         >
-          No templates available
+          {t('create.templates.noTemplatesAvailable')}
         </Typography>
         {!hideDivider && <Divider sx={{ my: 0.5 }} />}
       </>
@@ -103,9 +105,9 @@ export const SoftwareTemplatesSection = ({
   return (
     <MenuSection
       hideDivider={hideDivider}
-      sectionLabel="Use a template"
+      sectionLabel={t('create.templates.sectionTitle')}
       optionalLink="/create"
-      optionalLinkLabel="All templates"
+      optionalLinkLabel={t('create.templates.allTemplates')}
       items={items}
       handleClose={handleClose}
     />

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.test.tsx
@@ -19,6 +19,10 @@ import {
   useEntityPresentation,
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
 import { StarredDropdown } from './StarredDropdown';
 import { useDropdownManager } from '../../hooks';
 
@@ -29,6 +33,15 @@ jest.mock('@backstage/plugin-catalog-react', () => ({
 
 jest.mock('../../hooks', () => ({
   useDropdownManager: jest.fn(),
+}));
+
+// Mock translation hooks
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
 }));
 
 describe('StarredDropdown', () => {

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
@@ -40,6 +40,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { useDropdownManager } from '../../hooks';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import { DropdownEmptyState } from './DropdownEmptyState';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * @public
@@ -62,6 +63,7 @@ const StarredItem: FC<SectionComponentProps> = ({
     useEntityPresentation(entityRef);
   const { name, kind, namespace } = parseEntityRef(entityRef as string);
   const theme = useTheme();
+  const { t } = useTranslation();
 
   return (
     <MenuItem
@@ -86,7 +88,7 @@ const StarredItem: FC<SectionComponentProps> = ({
         // inset={!Icon}
         sx={{ ml: 1, mr: 1 }}
       />
-      <Tooltip title="Remove from list">
+      <Tooltip title={t('starred.removeTooltip')}>
         <IconButton
           onClick={e => {
             e.preventDefault();
@@ -104,6 +106,7 @@ const StarredItem: FC<SectionComponentProps> = ({
 export const StarredDropdown = () => {
   const { anchorEl, handleOpen, handleClose } = useDropdownManager();
   const { starredEntities, toggleStarredEntity } = useStarredEntities();
+  const { t } = useTranslation();
 
   const entitiesArray = Array.from(starredEntities);
 
@@ -113,13 +116,13 @@ export const StarredDropdown = () => {
       onOpen={handleOpen}
       onClose={handleClose}
       anchorEl={anchorEl}
-      tooltip="Your starred items"
+      tooltip={t('starred.title')}
       isIconButton
     >
       {entitiesArray.length > 0 ? (
         <>
           <ListItemText
-            primary="Your starred items"
+            primary={t('starred.title')}
             sx={{ pl: 2, mt: 1, fontWeight: 'bold', color: 'text.secondary' }}
           />
           {entitiesArray.map(enitityRef => (
@@ -133,8 +136,8 @@ export const StarredDropdown = () => {
         </>
       ) : (
         <DropdownEmptyState
-          title="No starred items yet"
-          subTitle="Click the star icon next to an entity's name to save it here for quick access."
+          title={t('starred.noItemsTitle')}
+          subTitle={t('starred.noItemsSubtitle')}
           icon={<AutoAwesomeIcon sx={{ fontSize: 64 }} color="disabled" />}
         />
       )}

--- a/workspaces/global-header/plugins/global-header/src/components/LogoutButton/LogoutButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/LogoutButton/LogoutButton.tsx
@@ -24,10 +24,12 @@ import MenuItem from '@mui/material/MenuItem';
 import Divider from '@mui/material/Divider';
 
 import { MenuItemLinkContent } from '../MenuItemLink/MenuItemLinkContent';
+import { useTranslation } from '../../hooks/useTranslation';
 
 export const LogoutButton = () => {
   const errorApi = useApi(errorApiRef);
   const identityApi = useApi(identityApiRef);
+  const { t } = useTranslation();
 
   const handleLogout = () => {
     identityApi.signOut().catch(error => errorApi.post(error));
@@ -44,7 +46,7 @@ export const LogoutButton = () => {
           color: 'inherit',
         }}
       >
-        <MenuItemLinkContent icon="logout" label="Sign out" />
+        <MenuItemLinkContent icon="logout" label={t('profile.signOut')} />
       </MenuItem>
     </>
   );

--- a/workspaces/global-header/plugins/global-header/src/components/MenuItemLink/MenuItemLink.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/MenuItemLink/MenuItemLink.tsx
@@ -15,6 +15,7 @@
  */
 
 import Tooltip from '@mui/material/Tooltip';
+import { useTranslation } from '../../hooks/useTranslation';
 import { MenuItemLinkContent } from './MenuItemLinkContent';
 
 /**
@@ -36,12 +37,20 @@ export const MenuItemLink = ({
   icon,
   tooltip,
 }: MenuItemLinkProps) => {
-  const isExternalLink = to.startsWith('http://') || to.startsWith('https://');
+  const { t } = useTranslation();
+  const isExternalLink =
+    to?.startsWith('http://') || to?.startsWith('https://');
+
+  // Check if title looks like a translation key (contains dots)
+  const translatedTitle =
+    title && title.includes('.')
+      ? t(title as any, {}) || title // Fallback to original title if translation fails
+      : title;
 
   const headerLinkContent = () => (
     <MenuItemLinkContent
       icon={icon}
-      label={title}
+      label={translatedTitle}
       subLabel={subTitle}
       isExternalLink={isExternalLink}
     />

--- a/workspaces/global-header/plugins/global-header/src/components/NotificationBanner.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/NotificationBanner.tsx
@@ -22,6 +22,7 @@ import { MarkdownContent } from '@backstage/core-components';
 import Alert from '@mui/material/Alert';
 
 import { HeaderIcon } from './HeaderIcon/HeaderIcon';
+import { useTranslation } from '../hooks/useTranslation';
 
 /**
  * @public
@@ -46,6 +47,7 @@ export interface NotificationBannerProps {
 }
 
 export const NotificationBanner = (props: NotificationBannerProps) => {
+  const { t } = useTranslation();
   const [dismissed, setDismissed] = useState<boolean>(() => {
     if (props.dismiss === 'localstorage') {
       try {
@@ -86,10 +88,12 @@ export const NotificationBanner = (props: NotificationBannerProps) => {
     }
     // eslint-disable-next-line no-console
     console.warn(
-      `Unsupported dismiss option "${props.dismiss}", currently supported "none", "session" or "localstorage"!`,
+      t('notifications.unsupportedDismissOption' as any, {
+        option: props.dismiss,
+      }),
     );
     return undefined;
-  }, [props.id, props.title, props.dismiss]);
+  }, [props.id, props.title, props.dismiss, t]);
 
   if (dismissed || !props.title) {
     return null;

--- a/workspaces/global-header/plugins/global-header/src/components/NotificationButton/NotificationButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/NotificationButton/NotificationButton.tsx
@@ -24,6 +24,7 @@ import Tooltip from '@mui/material/Tooltip';
 import NotificationIcon from '@mui/icons-material/NotificationsOutlined';
 
 import { useNotificationCount } from '../../hooks/useNotificationCount';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * @public
@@ -62,7 +63,7 @@ const Link = (props: any) => (
  * @public
  */
 export const NotificationButton = ({
-  title = 'Notifications',
+  title,
   tooltip,
   color = 'inherit',
   size = 'small',
@@ -70,7 +71,10 @@ export const NotificationButton = ({
   to = '/notifications',
   layout,
 }: NotificationButtonProps) => {
+  const { t } = useTranslation();
   const { available, unreadCount } = useNotificationCount();
+
+  const displayTitle = title || t('notifications.title');
 
   if (!available) {
     return null;
@@ -78,14 +82,14 @@ export const NotificationButton = ({
 
   return (
     <Box sx={layout}>
-      <Tooltip title={tooltip ?? title}>
+      <Tooltip title={tooltip ?? displayTitle}>
         <div>
           <IconButton
             component={Link}
             color={color}
             size={size}
             to={to}
-            aria-label={title}
+            aria-label={displayTitle}
           >
             {unreadCount > 0 ? (
               <Badge badgeContent={unreadCount} color={badgeColor} max={999}>

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.test.tsx
@@ -17,7 +17,6 @@
 import type { ReactElement } from 'react';
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { SearchBar } from './SearchBar';
 import {
   searchApiRef,
   SearchContextProvider,
@@ -25,9 +24,22 @@ import {
 import { mockApis, TestApiProvider } from '@backstage/test-utils';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { configApiRef } from '@backstage/core-plugin-api';
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
+import { SearchBar } from './SearchBar';
 
 jest.mock('../../hooks/useDebouncedCallback', () => ({
   useDebouncedCallback: (fn: (...args: any[]) => void) => fn,
+}));
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
 }));
 
 const createInitialState = ({

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
@@ -27,6 +27,7 @@ import { SearchInput } from './SearchInput';
 import { SearchOption } from './SearchOption';
 import { useTheme } from '@mui/material/styles';
 import { useDebouncedCallback } from '../../hooks/useDebouncedCallback';
+import { useTranslation } from '../../hooks/useTranslation';
 
 interface SearchBarProps {
   query: SearchResultProps['query'];
@@ -39,6 +40,7 @@ export const SearchBar = (props: SearchBarProps) => {
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const highlightedIndexRef = useRef(highlightedIndex);
   const { setTerm } = useSearch();
+  const { t } = useTranslation();
 
   const onInputChange = useDebouncedCallback((_, inputValue) => {
     setSearchTerm(inputValue);
@@ -55,7 +57,7 @@ export const SearchBar = (props: SearchBarProps) => {
         const results = query?.term ? value?.results ?? [] : [];
         let options: string[] = [];
         if (query?.term && results.length === 0) {
-          options = ['No results found'];
+          options = [t('search.noResults')];
         }
         if (results.length > 0) {
           options = [
@@ -114,7 +116,7 @@ export const SearchBar = (props: SearchBarProps) => {
               <SearchInput
                 params={params}
                 error={!!error}
-                helperText={error ? 'Error fetching results' : ''}
+                helperText={error ? t('search.errorFetching') : ''}
               />
             )}
             renderOption={(renderProps, option, { index }) => (

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchInput.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchInput.test.tsx
@@ -15,9 +15,22 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
 import { SearchInput } from './SearchInput';
 import InputAdornment from '@mui/material/InputAdornment';
 import SearchIcon from '@mui/icons-material/Search';
+
+// Mock translation hooks
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
+}));
 
 describe('SearchInput', () => {
   const params = {

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchInput.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchInput.tsx
@@ -17,6 +17,7 @@
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import SearchIcon from '@mui/icons-material/Search';
+import { useTranslation } from '../../hooks/useTranslation';
 
 interface SearchInputProps {
   params: any;
@@ -28,26 +29,30 @@ export const SearchInput = ({
   params,
   error,
   helperText,
-}: SearchInputProps) => (
-  <TextField
-    {...params}
-    placeholder="Search..."
-    variant="standard"
-    error={error}
-    helperText={helperText}
-    InputProps={{
-      ...params.InputProps,
-      disableUnderline: true,
-      startAdornment: (
-        <InputAdornment position="start">
-          <SearchIcon style={{ color: 'inherit' }} />
-        </InputAdornment>
-      ),
-    }}
-    sx={{
-      input: { color: 'inherit' },
-      button: { color: 'inherit' },
-      '& fieldset': { border: 'none' },
-    }}
-  />
-);
+}: SearchInputProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <TextField
+      {...params}
+      placeholder={t('search.placeholder')}
+      variant="standard"
+      error={error}
+      helperText={helperText}
+      InputProps={{
+        ...params.InputProps,
+        disableUnderline: true,
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon style={{ color: 'inherit' }} />
+          </InputAdornment>
+        ),
+      }}
+      sx={{
+        input: { color: 'inherit' },
+        button: { color: 'inherit' },
+        '& fieldset': { border: 'none' },
+      }}
+    />
+  );
+};

--- a/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.test.tsx
@@ -21,7 +21,20 @@ import {
   TestApiProvider,
 } from '@backstage/test-utils';
 
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
 import { SupportButton } from './SupportButton';
+
+// Mock translation hooks
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
+}));
 
 const configWithSupportUrl = mockApis.config({
   data: {

--- a/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SupportButton/SupportButton.tsx
@@ -19,6 +19,7 @@ import { Link } from '@backstage/core-components';
 import MenuItem from '@mui/material/MenuItem';
 import { MenuItemLink } from '../MenuItemLink/MenuItemLink';
 import { CSSProperties } from 'react';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * @public
@@ -35,7 +36,7 @@ export interface SupportButtonProps {
  * @public
  */
 export const SupportButton = ({
-  title = 'Support',
+  title,
   to,
   icon = 'support',
   tooltip,
@@ -44,6 +45,9 @@ export const SupportButton = ({
 }: SupportButtonProps) => {
   const apiHolder = useApiHolder();
   const config = apiHolder.get(configApiRef);
+  const { t } = useTranslation();
+
+  const displayTitle = title || t('help.supportTitle');
   const supportUrl = to ?? config?.getOptionalString('app.support.url');
 
   if (!supportUrl) {
@@ -60,7 +64,7 @@ export const SupportButton = ({
     >
       <MenuItemLink
         to={supportUrl}
-        title={title}
+        title={displayTitle}
         icon={icon}
         tooltip={tooltip}
       />

--- a/workspaces/global-header/plugins/global-header/src/components/Trans.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/Trans.tsx
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
-export { useDropdownManager } from './useDropdownManager';
-export { useTranslation } from './useTranslation';
-export { useLanguage } from './useLanguage';
+import { useTranslation } from '../hooks/useTranslation';
+
+import { globalHeaderTranslationRef } from '../translations';
+
+type Messages = typeof globalHeaderTranslationRef.T;
+
+interface TransProps<
+  TMessages extends {
+    [key in string]: string;
+  },
+> {
+  message: keyof TMessages;
+  params?: any;
+}
+
+export const Trans = ({ message, params }: TransProps<Messages>) => {
+  const { t } = useTranslation();
+  return t(message, params);
+};

--- a/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
+++ b/workspaces/global-header/plugins/global-header/src/defaultMountPoints/defaultMountPoints.tsx
@@ -146,7 +146,7 @@ export const defaultProfileDropdownMountPoints: ProfileDropdownMountPoint[] = [
     config: {
       priority: 200,
       props: {
-        title: 'Settings',
+        title: 'profile.settings',
         icon: 'manageAccounts',
         link: '/settings',
       },
@@ -157,7 +157,7 @@ export const defaultProfileDropdownMountPoints: ProfileDropdownMountPoint[] = [
     config: {
       priority: 150,
       props: {
-        title: 'My profile',
+        title: 'profile.myProfile',
         icon: 'account',
       },
     },
@@ -176,7 +176,7 @@ export const defaultHelpDropdownMountPoints: HelpDropdownMountPoint[] = [
     config: {
       priority: 100,
       props: {
-        title: 'Quick start',
+        title: 'help.quickStart',
         icon: 'quickstart',
         link: 'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/',
       },
@@ -195,10 +195,10 @@ export const defaultApplicationLauncherDropdownMountPoints: ApplicationLauncherD
     {
       Component: MenuItemLink as ComponentType,
       config: {
-        section: 'Documentation',
+        section: 'applicationLauncher.sections.documentation',
         priority: 150,
         props: {
-          title: 'Developer Hub',
+          title: 'applicationLauncher.developerHub',
           icon: 'developerHub',
           link: 'https://docs.redhat.com/en/documentation/red_hat_developer_hub',
         },
@@ -207,10 +207,10 @@ export const defaultApplicationLauncherDropdownMountPoints: ApplicationLauncherD
     {
       Component: MenuItemLink as ComponentType,
       config: {
-        section: 'Developer Tools',
+        section: 'applicationLauncher.sections.developerTools',
         priority: 130,
         props: {
-          title: 'RHDH Local',
+          title: 'applicationLauncher.rhdhLocal',
           icon: 'developerHub',
           link: 'https://github.com/redhat-developer/rhdh-local',
         },

--- a/workspaces/global-header/plugins/global-header/src/hooks/useLanguage.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useLanguage.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
-export { useDropdownManager } from './useDropdownManager';
-export { useTranslation } from './useTranslation';
-export { useLanguage } from './useLanguage';
+import { useApi } from '@backstage/core-plugin-api';
+import { appLanguageApiRef } from '@backstage/core-plugin-api/alpha';
+
+/**
+ * Hook to get the current language setting
+ * @returns The current language code (e.g., 'en', 'de', 'fr')
+ */
+export const useLanguage = (): string =>
+  useApi(appLanguageApiRef).getLanguage().language;

--- a/workspaces/global-header/plugins/global-header/src/hooks/useTranslation.ts
+++ b/workspaces/global-header/plugins/global-header/src/hooks/useTranslation.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
-export { useDropdownManager } from './useDropdownManager';
-export { useTranslation } from './useTranslation';
-export { useLanguage } from './useLanguage';
+import {
+  useTranslationRef,
+  TranslationFunction,
+} from '@backstage/core-plugin-api/alpha';
+
+import { globalHeaderTranslationRef } from '../translations';
+
+export const useTranslation = (): {
+  t: TranslationFunction<typeof globalHeaderTranslationRef.T>;
+} => useTranslationRef(globalHeaderTranslationRef);

--- a/workspaces/global-header/plugins/global-header/src/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/index.ts
@@ -22,3 +22,5 @@ ClassNameGenerator.configure(componentName => {
 });
 
 export * from './plugin';
+
+export * from './alpha';

--- a/workspaces/global-header/plugins/global-header/src/test-utils/mockTranslations.ts
+++ b/workspaces/global-header/plugins/global-header/src/test-utils/mockTranslations.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { globalHeaderMessages } from '../translations/ref';
+
+// Simple function to flatten nested objects into dot notation
+function flattenMessages(obj: any, prefix = ''): Record<string, string> {
+  const flattened: Record<string, string> = {};
+
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const value = obj[key];
+      const newKey = prefix ? `${prefix}.${key}` : key;
+
+      if (typeof value === 'object' && value !== null) {
+        Object.assign(flattened, flattenMessages(value, newKey));
+      } else {
+        flattened[newKey] = value;
+      }
+    }
+  }
+
+  return flattened;
+}
+
+const flattenedMessages = flattenMessages(globalHeaderMessages);
+
+// Simple mock translation function
+export const mockT = (key: string, params?: any) => {
+  let message = flattenedMessages[key] || key;
+
+  // Simple interpolation: replace {{param}} with values
+  if (params) {
+    for (const [paramKey, paramValue] of Object.entries(params)) {
+      message = message.replace(
+        new RegExp(`{{${paramKey}}}`, 'g'),
+        String(paramValue),
+      );
+    }
+  }
+
+  return message;
+};
+
+// Mock useTranslation hook
+export const mockUseTranslation = () => ({
+  t: mockT,
+});
+
+// Mock Trans component
+export const MockTrans = ({
+  message,
+  params,
+}: {
+  message: string;
+  params?: any;
+}) => {
+  return mockT(message, params);
+};

--- a/workspaces/global-header/plugins/global-header/src/translations/de.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/de.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { globalHeaderTranslationRef } from './ref';
+
+const globalHeaderTranslationDe = createTranslationMessages({
+  ref: globalHeaderTranslationRef,
+  messages: {
+    'help.tooltip': 'Hilfe',
+    'help.noSupportLinks': 'Keine Support-Links',
+    'help.noSupportLinksSubtitle':
+      'Ihr Administrator muss Support-Links einrichten.',
+    'help.quickStart': 'Schnellstart',
+    'help.supportTitle': 'Support',
+    'profile.picture': 'Profilbild',
+    'profile.signOut': 'Abmelden',
+    'search.placeholder': 'Suchen...',
+    'search.noResults': 'Keine Ergebnisse gefunden',
+    'search.errorFetching': 'Fehler beim Abrufen der Ergebnisse',
+    'applicationLauncher.tooltip': 'Anwendungs-Starter',
+    'applicationLauncher.noLinksTitle': 'Keine Anwendungslinks konfiguriert',
+    'applicationLauncher.noLinksSubtitle':
+      'Konfigurieren Sie Anwendungslinks in der dynamischen Plugin-Konfiguration für schnellen Zugriff von hier aus.',
+    'starred.title': 'Ihre markierten Elemente',
+    'starred.removeTooltip': 'Aus Liste entfernen',
+    'starred.noItemsTitle': 'Noch keine markierten Elemente',
+    'starred.noItemsSubtitle':
+      'Klicken Sie auf das Stern-Symbol neben dem Namen einer Entität, um sie hier für schnellen Zugriff zu speichern.',
+    'notifications.title': 'Benachrichtigungen',
+    'notifications.unsupportedDismissOption':
+      'Nicht unterstützte Dismiss-Option "{{option}}", derzeit unterstützt "none", "session" oder "localstorage"!',
+    'create.title': 'Selbstbedienung',
+    'create.registerComponent.title': 'Eine Komponente registrieren',
+    'create.registerComponent.subtitle': 'In die Katalogseite importieren',
+    'create.templates.sectionTitle': 'Eine Vorlage verwenden',
+    'create.templates.allTemplates': 'Alle Vorlagen',
+    'create.templates.errorFetching': 'Fehler beim Abrufen der Vorlagen',
+    'create.templates.noTemplatesAvailable': 'Keine Vorlagen verfügbar',
+    'profile.settings': 'Einstellungen',
+    'profile.myProfile': 'Mein Profil',
+    'applicationLauncher.developerHub': 'Developer Hub',
+    'applicationLauncher.rhdhLocal': 'RHDH Lokal',
+    'applicationLauncher.sections.documentation': 'Dokumentation',
+    'applicationLauncher.sections.developerTools': 'Entwickler-Tools',
+  },
+});
+
+export default globalHeaderTranslationDe;

--- a/workspaces/global-header/plugins/global-header/src/translations/es.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/es.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { globalHeaderTranslationRef } from './ref';
+
+const globalHeaderTranslationEs = createTranslationMessages({
+  ref: globalHeaderTranslationRef,
+  messages: {
+    'help.tooltip': 'Ayuda',
+    'help.noSupportLinks': 'Sin enlaces de soporte',
+    'help.noSupportLinksSubtitle':
+      'Tu administrador necesita configurar los enlaces de soporte.',
+    'help.quickStart': 'Inicio rápido',
+    'help.supportTitle': 'Soporte',
+    'profile.picture': 'Imagen de perfil',
+    'profile.settings': 'Configuración',
+    'profile.myProfile': 'Mi perfil',
+    'profile.signOut': 'Cerrar sesión',
+    'search.placeholder': 'Buscar...',
+    'search.noResults': 'No se encontraron resultados',
+    'search.errorFetching': 'Error al obtener resultados',
+    'applicationLauncher.tooltip': 'Lanzador de aplicaciones',
+    'applicationLauncher.noLinksTitle':
+      'No hay enlaces de aplicación configurados',
+    'applicationLauncher.noLinksSubtitle':
+      'Configura enlaces de aplicaciones en la configuración del plugin dinámico para acceso rápido desde aquí.',
+    'applicationLauncher.developerHub': 'Developer Hub',
+    'applicationLauncher.rhdhLocal': 'RHDH Local',
+    'applicationLauncher.sections.documentation': 'Documentación',
+    'applicationLauncher.sections.developerTools': 'Herramientas de desarrollo',
+    'starred.title': 'Tus elementos destacados',
+    'starred.removeTooltip': 'Eliminar de la lista',
+    'starred.noItemsTitle': 'Aún no hay elementos destacados',
+    'starred.noItemsSubtitle':
+      'Haz clic en el icono de estrella junto al nombre de una entidad para guardarla aquí para acceso rápido.',
+    'notifications.title': 'Notificaciones',
+    'notifications.unsupportedDismissOption':
+      'Opción de descarte no compatible "{{option}}", actualmente compatible "none", "session" o "localstorage"!',
+    'create.title': 'Autoservicio',
+    'create.registerComponent.title': 'Registrar un componente',
+    'create.registerComponent.subtitle': 'Importarlo a la página de catálogo',
+    'create.templates.sectionTitle': 'Usar una plantilla',
+    'create.templates.allTemplates': 'Todas las plantillas',
+    'create.templates.errorFetching': 'Error al obtener plantillas',
+    'create.templates.noTemplatesAvailable': 'No hay plantillas disponibles',
+  },
+});
+
+export default globalHeaderTranslationEs;

--- a/workspaces/global-header/plugins/global-header/src/translations/fr.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/fr.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { globalHeaderTranslationRef } from './ref';
+
+const globalHeaderTranslationFr = createTranslationMessages({
+  ref: globalHeaderTranslationRef,
+  messages: {
+    'help.tooltip': 'Aide',
+    'help.noSupportLinks': 'Aucun lien de support',
+    'help.noSupportLinksSubtitle':
+      'Votre administrateur doit configurer les liens de support.',
+    'help.quickStart': 'Démarrage rapide',
+    'help.supportTitle': 'Support',
+    'profile.picture': 'Photo de profil',
+    'profile.signOut': 'Se déconnecter',
+    'search.placeholder': 'Rechercher...',
+    'search.noResults': 'Aucun résultat trouvé',
+    'search.errorFetching': 'Erreur lors de la récupération des résultats',
+    'applicationLauncher.tooltip': "Lanceur d'applications",
+    'applicationLauncher.noLinksTitle': "Aucun lien d'application configuré",
+    'applicationLauncher.noLinksSubtitle':
+      "Configurez les liens d'application dans la configuration du plugin dynamique pour un accès rapide depuis ici.",
+    'starred.title': 'Vos éléments favoris',
+    'starred.removeTooltip': 'Supprimer de la liste',
+    'starred.noItemsTitle': 'Aucun élément favori pour le moment',
+    'starred.noItemsSubtitle':
+      "Cliquez sur l'icône étoile à côté du nom d'une entité pour l'enregistrer ici pour un accès rapide.",
+    'notifications.title': 'Notifications',
+    'notifications.unsupportedDismissOption':
+      'Option de rejet non supportée "{{option}}", actuellement supporté "none", "session" ou "localstorage" !',
+    'create.title': 'Libre-service',
+    'create.registerComponent.title': 'Enregistrer un composant',
+    'create.registerComponent.subtitle': "L'importer dans la page de catalogue",
+    'create.templates.sectionTitle': 'Utiliser un modèle',
+    'create.templates.allTemplates': 'Tous les modèles',
+    'create.templates.errorFetching':
+      'Erreur lors de la récupération des modèles',
+    'create.templates.noTemplatesAvailable': 'Aucun modèle disponible',
+    'profile.settings': 'Paramètres',
+    'profile.myProfile': 'Mon profil',
+    'applicationLauncher.developerHub': 'Developer Hub',
+    'applicationLauncher.rhdhLocal': 'RHDH Local',
+    'applicationLauncher.sections.documentation': 'Documentation',
+    'applicationLauncher.sections.developerTools': 'Outils de développement',
+  },
+});
+
+export default globalHeaderTranslationFr;

--- a/workspaces/global-header/plugins/global-header/src/translations/index.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/index.ts
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
-export { useDropdownManager } from './useDropdownManager';
-export { useTranslation } from './useTranslation';
-export { useLanguage } from './useLanguage';
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+import { globalHeaderTranslationRef } from './ref';
+
+/**
+ * Translation resource for the global header plugin, providing support for multiple languages.
+ *
+ * @public
+ */
+export const globalHeaderTranslations = createTranslationResource({
+  ref: globalHeaderTranslationRef,
+  translations: {
+    de: () => import('./de'),
+    es: () => import('./es'),
+    fr: () => import('./fr'),
+    it: () => import('./it'),
+  },
+});
+
+export { globalHeaderTranslationRef };

--- a/workspaces/global-header/plugins/global-header/src/translations/it.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/it.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { globalHeaderTranslationRef } from './ref';
+
+const globalHeaderTranslationIt = createTranslationMessages({
+  ref: globalHeaderTranslationRef,
+  messages: {
+    'help.tooltip': 'Aiuto',
+    'help.noSupportLinks': 'Nessun link di supporto',
+    'help.noSupportLinksSubtitle':
+      'Il tuo amministratore deve configurare i link di supporto.',
+    'help.quickStart': 'Avvio rapido',
+    'help.supportTitle': 'Supporto',
+    'profile.picture': 'Immagine del profilo',
+    'profile.settings': 'Impostazioni',
+    'profile.myProfile': 'Il mio profilo',
+    'profile.signOut': 'Esci',
+    'search.placeholder': 'Cerca...',
+    'search.noResults': 'Nessun risultato trovato',
+    'search.errorFetching': 'Errore nel recupero dei risultati',
+    'applicationLauncher.tooltip': 'Launcher applicazioni',
+    'applicationLauncher.noLinksTitle': 'Nessun link applicazione configurato',
+    'applicationLauncher.noLinksSubtitle':
+      'Configura i link delle applicazioni nella configurazione del plugin dinamico per un accesso rapido da qui.',
+    'applicationLauncher.developerHub': 'Developer Hub',
+    'applicationLauncher.rhdhLocal': 'RHDH Local',
+    'applicationLauncher.sections.documentation': 'Documentazione',
+    'applicationLauncher.sections.developerTools': 'Strumenti per sviluppatori',
+    'starred.title': 'I tuoi elementi preferiti',
+    'starred.removeTooltip': 'Rimuovi dalla lista',
+    'starred.noItemsTitle': 'Nessun elemento preferito ancora',
+    'starred.noItemsSubtitle':
+      "Clicca sull'icona stella accanto al nome di un'entità per salvarla qui per un accesso rapido.",
+    'notifications.title': 'Notifiche',
+    'notifications.unsupportedDismissOption':
+      'Opzione di chiusura non supportata "{{option}}", attualmente supportate "none", "session" o "localstorage"!',
+    'create.title': 'Autoservizio',
+    'create.registerComponent.title': 'Registra un componente',
+    'create.registerComponent.subtitle': 'Importalo nella pagina del catalogo',
+    'create.templates.sectionTitle': 'Usa un modello',
+    'create.templates.allTemplates': 'Tutti i modelli',
+    'create.templates.errorFetching': 'Errore nel recupero dei modelli',
+    'create.templates.noTemplatesAvailable': 'Nessun modello disponibile',
+  },
+});
+
+export default globalHeaderTranslationIt;

--- a/workspaces/global-header/plugins/global-header/src/translations/ref.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/ref.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+// Export messages separately for testing
+export const globalHeaderMessages = {
+  help: {
+    tooltip: 'Help',
+    noSupportLinks: 'No support links',
+    noSupportLinksSubtitle: 'Your administrator needs to set up support links.',
+    quickStart: 'Quick start',
+    supportTitle: 'Support',
+  },
+  profile: {
+    picture: 'Profile picture',
+    settings: 'Settings',
+    myProfile: 'My profile',
+    signOut: 'Sign out',
+  },
+  search: {
+    placeholder: 'Search...',
+    noResults: 'No results found',
+    errorFetching: 'Error fetching results',
+  },
+  applicationLauncher: {
+    tooltip: 'Application launcher',
+    noLinksTitle: 'No application links configured',
+    noLinksSubtitle:
+      'Configure application links in dynamic plugin config for quick access from here.',
+    developerHub: 'Developer Hub',
+    rhdhLocal: 'RHDH Local',
+    sections: {
+      documentation: 'Documentation',
+      developerTools: 'Developer Tools',
+    },
+  },
+  starred: {
+    title: 'Your starred items',
+    removeTooltip: 'Remove from list',
+    noItemsTitle: 'No starred items yet',
+    noItemsSubtitle:
+      "Click the star icon next to an entity's name to save it here for quick access.",
+  },
+  notifications: {
+    title: 'Notifications',
+    unsupportedDismissOption:
+      'Unsupported dismiss option "{{option}}", currently supported "none", "session" or "localstorage"!',
+  },
+  create: {
+    title: 'Self-service',
+    registerComponent: {
+      title: 'Register a component',
+      subtitle: 'Import it to the catalog page',
+    },
+    templates: {
+      sectionTitle: 'Use a template',
+      allTemplates: 'All templates',
+      errorFetching: 'Error fetching templates',
+      noTemplatesAvailable: 'No templates available',
+    },
+  },
+};
+
+/**
+ * Translation reference for the global header plugin.
+ *
+ * @public
+ */
+export const globalHeaderTranslationRef = createTranslationRef({
+  id: 'plugin.global-header',
+  messages: globalHeaderMessages,
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Fixes - https://issues.redhat.com/browse/RHIDP-8777

### Added internationalization (i18n) support to Global Header plugin

- ✅ **Multi-language support**: English (default), German, French, Italian, and Spanish
- ✅ **Translation infrastructure**: Built with Backstage's `@backstage/core-plugin-api/alpha` using `createTranslationRef`, translation resources, and semantic key structures with parameter interpolation
- ✅ **Unit test mocking**: Created reusable translation test utilities (`mockTranslations.ts`) that use actual English strings as single source of truth - can be copied to other plugins

The plugin now supports multiple languages with proper fallbacks and maintains all existing functionality. The translation infrastructure and test patterns established here can be reused across other Backstage plugins.

**Languages added:**

- 🇩🇪 German (de)
- 🇫🇷 French (fr)
- 🇮🇹 Italian (it)
- 🇪🇸 Spanish (es)
- 🇺🇸 English (en) - default

https://github.com/user-attachments/assets/06e26d5d-fed3-4cfe-98a1-d14173528848


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
