### PR TITLE
RHIDP-8300: Plugin card UX improvements

### DIFF
--- a/workspaces/marketplace/.changeset/plugin-card-ux-improvements.md
+++ b/workspaces/marketplace/.changeset/plugin-card-ux-improvements.md
@@ -1,0 +1,11 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+Plugin card UX improvements:
+
+- Added visual install status indicators (Installed, Disabled) on plugin cards
+- Enhanced hover interaction on category tags with visual feedback
+- Implemented long tag name truncation with ellipsis and full-name tooltips for better layout
+- Fixed alignment for plugin cards without tags to maintain consistent layout
+- Ensured plugin description text always starts at the same horizontal point for better readability

--- a/workspaces/marketplace/plugins/marketplace/src/components/CategoryLinkButton.test.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/CategoryLinkButton.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MouseEvent } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+import { CategoryLinkButton } from './CategoryLinkButton';
+
+const renderCategoryLinkButton = (props: {
+  categoryName: string;
+  to: string;
+  onClick?: (event: MouseEvent) => void;
+  maxLength?: number;
+}) => {
+  return render(
+    <BrowserRouter>
+      <CategoryLinkButton {...props} />
+    </BrowserRouter>,
+  );
+};
+
+describe('CategoryLinkButton', () => {
+  describe('Rendering', () => {
+    it('should render category name when within default max length', () => {
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+      });
+
+      expect(screen.getByRole('button')).toHaveTextContent('Kubernetes');
+    });
+
+    it('should truncate long category names', () => {
+      renderCategoryLinkButton({
+        categoryName: 'this-is-a-very-long-category-name-that-exceeds-limit',
+        to: '/catalog?filter=spec.categories=this-is-a-very-long-category-name-that-exceeds-limit',
+      });
+
+      expect(screen.getByRole('button')).toHaveTextContent(
+        'this-is-a-very-long-categ...',
+      );
+    });
+
+    it('should respect custom max length', () => {
+      renderCategoryLinkButton({
+        categoryName: 'medium-length-category',
+        to: '/catalog?filter=spec.categories=medium-length-category',
+        maxLength: 10,
+      });
+
+      expect(screen.getByRole('button')).toHaveTextContent('medium-len...');
+    });
+
+    it('should show tooltip for truncated names', () => {
+      renderCategoryLinkButton({
+        categoryName: 'this-is-a-very-long-category-name-that-exceeds-limit',
+        to: '/catalog?filter=spec.categories=this-is-a-very-long-category-name-that-exceeds-limit',
+      });
+
+      // The tooltip should contain the full category name as aria-label
+      expect(
+        screen.getByLabelText(
+          'this-is-a-very-long-category-name-that-exceeds-limit',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should not show tooltip for non-truncated names', () => {
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+      });
+
+      // The tooltip should be empty for non-truncated names (empty aria-label)
+      expect(screen.getByLabelText('')).toBeInTheDocument();
+    });
+  });
+
+  describe('Navigation', () => {
+    it('should have correct link target', () => {
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+      });
+
+      const linkButton = screen.getByRole('button').closest('a');
+      expect(linkButton).toHaveAttribute(
+        'href',
+        '/catalog?filter=spec.categories=Kubernetes',
+      );
+    });
+  });
+
+  describe('Click handling', () => {
+    it('should call onClick handler when provided', () => {
+      const handleClick = jest.fn();
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+        onClick: handleClick,
+      });
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should work without onClick handler', () => {
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+      });
+
+      // Should not throw error when clicking without onClick handler
+      expect(() => {
+        fireEvent.click(screen.getByRole('button'));
+      }).not.toThrow();
+    });
+  });
+
+  describe('Styling and accessibility', () => {
+    it('should have proper button variant', () => {
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+      });
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('MuiButton-outlined');
+    });
+
+    it('should have minimum height container', () => {
+      renderCategoryLinkButton({
+        categoryName: 'Kubernetes',
+        to: '/catalog?filter=spec.categories=Kubernetes',
+      });
+
+      const container = screen.getByRole('button').parentElement;
+      expect(container).toHaveStyle('min-height: 28px');
+    });
+  });
+});

--- a/workspaces/marketplace/plugins/marketplace/src/components/CategoryLinkButton.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/CategoryLinkButton.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MouseEvent } from 'react';
+
+import { LinkButton } from '@backstage/core-components';
+
+import Tooltip from '@mui/material/Tooltip';
+import { makeStyles } from '@material-ui/core';
+
+import { getCategoryTagDisplayInfo } from '../utils';
+
+const useStyles = makeStyles(() => ({
+  pluginCategoryLinkButton: {
+    fontWeight: 'normal',
+    padding: '2px 6px',
+    transition: 'border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
+    '&:hover': {
+      borderColor: '#a3a3a3',
+      boxShadow: 'inset 0 0 0 1px #a3a3a3',
+    },
+    '&:focus-visible': {
+      borderColor: '#a3a3a3',
+      boxShadow: 'inset 0 0 0 1px #a3a3a3',
+      outline: '2px solid #06c',
+      outlineOffset: '2px',
+    },
+  },
+}));
+
+export interface CategoryLinkButtonProps {
+  categoryName: string;
+  to: string;
+  onClick?: (event: MouseEvent) => void;
+  maxLength?: number;
+}
+
+export const CategoryLinkButton = ({
+  categoryName,
+  to,
+  onClick,
+  maxLength = 25,
+}: CategoryLinkButtonProps) => {
+  const classes = useStyles();
+  const { displayName, tooltipTitle } = getCategoryTagDisplayInfo(
+    categoryName,
+    {
+      maxLength,
+    },
+  );
+
+  return (
+    <Tooltip title={tooltipTitle} arrow>
+      <div style={{ display: 'inline-block', minHeight: '28px' }}>
+        <LinkButton
+          to={to}
+          variant="outlined"
+          className={classes.pluginCategoryLinkButton}
+          onClick={onClick}
+        >
+          {displayName}
+        </LinkButton>
+      </div>
+    </Tooltip>
+  );
+};

--- a/workspaces/marketplace/plugins/marketplace/src/components/PluginCard.test.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/PluginCard.test.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BrowserRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+
+import {
+  MarketplacePlugin,
+  MarketplacePluginInstallStatus,
+} from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+
+import { PluginCard } from './PluginCard';
+import { rootRouteRef, pluginRouteRef } from '../routes';
+
+// Mock the route refs
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useRouteRef: jest.fn().mockImplementation(ref => {
+    if (ref === rootRouteRef) {
+      return () => '/marketplace';
+    }
+    if (ref === pluginRouteRef) {
+      return () => '/marketplace/plugin';
+    }
+    return () => '/';
+  }),
+}));
+
+const mockPlugin: MarketplacePlugin = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Plugin',
+  metadata: {
+    name: 'test-plugin',
+    namespace: 'default',
+    title: 'Test Plugin',
+    description: 'A test plugin for testing',
+  },
+  spec: {
+    authors: [{ name: 'Test Author' }],
+    categories: ['testing'],
+  },
+};
+
+const renderPluginCard = (plugin: MarketplacePlugin) => {
+  return render(
+    <TestApiProvider apis={[]}>
+      <BrowserRouter>
+        <PluginCard plugin={plugin} />
+      </BrowserRouter>
+    </TestApiProvider>,
+  );
+};
+
+describe('PluginCard', () => {
+  describe('Install Status Indicators', () => {
+    it('should show "Installed" status for Installed plugin', () => {
+      const pluginWithStatus = {
+        ...mockPlugin,
+        spec: {
+          ...mockPlugin.spec,
+          installStatus: MarketplacePluginInstallStatus.Installed,
+        },
+      };
+
+      renderPluginCard(pluginWithStatus);
+
+      expect(screen.getByText('Installed')).toBeInTheDocument();
+      expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument();
+    });
+
+    it('should show "Installed" status for UpdateAvailable plugin', () => {
+      const pluginWithStatus = {
+        ...mockPlugin,
+        spec: {
+          ...mockPlugin.spec,
+          installStatus: MarketplacePluginInstallStatus.UpdateAvailable,
+        },
+      };
+
+      renderPluginCard(pluginWithStatus);
+
+      expect(screen.getByText('Installed')).toBeInTheDocument();
+      expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument();
+    });
+
+    it('should show "Disabled" status for Disabled plugin', () => {
+      const pluginWithStatus = {
+        ...mockPlugin,
+        spec: {
+          ...mockPlugin.spec,
+          installStatus: MarketplacePluginInstallStatus.Disabled,
+        },
+      };
+
+      renderPluginCard(pluginWithStatus);
+
+      expect(screen.getByText('Disabled')).toBeInTheDocument();
+      expect(screen.getByText('--')).toBeInTheDocument();
+    });
+
+    it('should not show any status for NotInstalled plugin', () => {
+      const pluginWithStatus = {
+        ...mockPlugin,
+        spec: {
+          ...mockPlugin.spec,
+          installStatus: MarketplacePluginInstallStatus.NotInstalled,
+        },
+      };
+
+      renderPluginCard(pluginWithStatus);
+
+      expect(screen.queryByText('Installed')).not.toBeInTheDocument();
+      expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('CheckCircleIcon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('BlockIcon')).not.toBeInTheDocument();
+    });
+
+    it('should not show any status when installStatus is undefined', () => {
+      renderPluginCard(mockPlugin);
+
+      expect(screen.queryByText('Installed')).not.toBeInTheDocument();
+      expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('CheckCircleIcon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('BlockIcon')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Plugin Card Layout', () => {
+    it('should render plugin title', () => {
+      renderPluginCard(mockPlugin);
+      expect(screen.getByText('Test Plugin')).toBeInTheDocument();
+    });
+
+    it('should render plugin author', () => {
+      renderPluginCard(mockPlugin);
+      expect(screen.getByText('by')).toBeInTheDocument();
+      expect(screen.getByText('Test Author')).toBeInTheDocument();
+    });
+
+    it('should render plugin description', () => {
+      renderPluginCard(mockPlugin);
+      expect(screen.getByText('A test plugin for testing')).toBeInTheDocument();
+    });
+
+    it('should render "no description available" when description is missing', () => {
+      const pluginWithoutDescription = {
+        ...mockPlugin,
+        metadata: {
+          ...mockPlugin.metadata,
+          description: undefined,
+        },
+      };
+
+      renderPluginCard(pluginWithoutDescription);
+      expect(screen.getByText('no description available')).toBeInTheDocument();
+    });
+
+    it('should render category tag', () => {
+      renderPluginCard(mockPlugin);
+      expect(screen.getByText('testing')).toBeInTheDocument();
+    });
+
+    it('should handle missing categories gracefully', () => {
+      const pluginWithoutCategories = {
+        ...mockPlugin,
+        spec: {
+          ...mockPlugin.spec,
+          categories: undefined,
+        },
+      };
+
+      renderPluginCard(pluginWithoutCategories);
+      expect(screen.getByText('Test Plugin')).toBeInTheDocument();
+      expect(screen.queryByText('testing')).not.toBeInTheDocument();
+    });
+
+    it('should truncate long category names', () => {
+      const pluginWithLongCategory = {
+        ...mockPlugin,
+        spec: {
+          ...mockPlugin.spec,
+          categories: [
+            'this-is-a-very-long-category-name-that-should-be-truncated',
+          ],
+        },
+      };
+
+      renderPluginCard(pluginWithLongCategory);
+      expect(
+        screen.getByText('this-is-a-very-long-categ...'),
+      ).toBeInTheDocument();
+    });
+
+    it('should render "Read more" link', () => {
+      renderPluginCard(mockPlugin);
+      expect(screen.getByText('Read more')).toBeInTheDocument();
+    });
+  });
+});

--- a/workspaces/marketplace/plugins/marketplace/src/utils.ts
+++ b/workspaces/marketplace/plugins/marketplace/src/utils.ts
@@ -167,3 +167,25 @@ export const isPluginInstalled = (
     pluginInstallStatus === MarketplacePluginInstallStatus.Disabled
   );
 };
+
+export interface CategoryTagDisplayOptions {
+  maxLength?: number;
+}
+
+export const getCategoryTagDisplayInfo = (
+  categoryName: string,
+  options: CategoryTagDisplayOptions = {},
+) => {
+  const { maxLength = 25 } = options;
+
+  const shouldTruncate = categoryName.length > maxLength;
+  const displayName = shouldTruncate
+    ? `${categoryName.substring(0, maxLength)}...`
+    : categoryName;
+
+  return {
+    displayName,
+    tooltipTitle: shouldTruncate ? categoryName : '',
+    shouldShowTooltip: shouldTruncate,
+  };
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:
https://issues.redhat.com/browse/RHIDP-8300

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

<img width="1201" height="787" alt="Screenshot 2025-09-02 at 4 06 49 PM" src="https://github.com/user-attachments/assets/89030d56-cad6-4216-9ae2-b8a90d108983" />
<img width="1167" height="820" alt="Screenshot 2025-09-02 at 4 07 06 PM" src="https://github.com/user-attachments/assets/67f88c6f-c17a-4859-83c6-58b0f849e7cd" />
<img width="1167" height="818" alt="Screenshot 2025-09-02 at 4 07 26 PM" src="https://github.com/user-attachments/assets/c14c4840-880a-4715-b1b5-bff22c1a435a" />
<img width="1193" height="756" alt="Screenshot 2025-09-02 at 4 08 19 PM" src="https://github.com/user-attachments/assets/8a136375-5f1e-44d0-9546-269b94bd9cf3" />
<img width="1220" height="757" alt="Screenshot 2025-09-02 at 4 08 31 PM" src="https://github.com/user-attachments/assets/fc79afd8-46a1-41e2-9dba-7aee6ef18519" />

- Added visual install status indicators (Installed, Disabled) on plugin cards
- Enhanced hover interaction on category tags with visual feedback
- Implemented long tag name truncation with ellipsis and full-name tooltips for better layout
- Fixed alignment for plugin cards without tags to maintain consistent layout
- Ensured plugin description text always starts at the same horizontal point for better readability

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
