### PR TITLE
chore(ci): update 'test changed packages' step in ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: prettier
         run: yarn prettier:check
-      
+
       - name: read knip-reports flag from bcp.json
         id: bcp
         run: |
@@ -106,7 +106,7 @@ jobs:
             echo "bcp.json not found. Defaulting knip_reports to false."
             echo "knip_reports=false" >> $GITHUB_OUTPUT
           fi
-          
+
       - name: check knip reports
         if: ${{ steps.bcp.outputs.knip_reports == 'true' }}
         run: yarn build:knip-reports --ci
@@ -124,7 +124,7 @@ jobs:
         run: yarn backstage-cli repo fix --check --publish
 
       - name: test changed packages
-        run: yarn backstage-cli repo test --coverage --maxWorkers=3
+        run: yarn test:all --maxWorkers=3
 
       - name: install playwright
         if: ${{ hashFiles(format('workspaces/{0}/playwright.config.ts', matrix.workspace)) != '' }}

--- a/workspaces/noop/package.json
+++ b/workspaces/noop/package.json
@@ -11,6 +11,7 @@
     "fix": "exit 0",
     "postinstall": "cd ../../ && yarn install",
     "prettier:check": "exit 0",
-    "tsc:full": "exit 0"
+    "tsc:full": "exit 0",
+    "test:all": "exit 0"
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR keeps in sync `ci.yaml` with this [change](https://github.com/backstage/community-plugins/pull/3272) in community-plugins.
There are cases where a workspace might require extra options supplied to their test command, for example the changes made in https://github.com/redhat-developer/rhdh-plugins/pull/1372 require that the test command in the scorecard workspace be supplied with NODE_OPTIONS='--experimental-vm-modules'

This PR:
- Modifies test changed packages step in ci.yaml to run yarn test:all --maxWorkers=3
- Adds a test:all script to the noop workspace

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
