### PR TITLE
feat(i18n): Add translation support for QuickStart

### DIFF
--- a/workspaces/quickstart/.changeset/add-quickstart-i18n-support.md
+++ b/workspaces/quickstart/.changeset/add-quickstart-i18n-support.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-quickstart': minor
+---
+
+Add internationalization (i18n) support with German, French and Spanish translations in quickstart.

--- a/workspaces/quickstart/packages/app/src/App.test.tsx
+++ b/workspaces/quickstart/packages/app/src/App.test.tsx
@@ -16,6 +16,63 @@
 import { render, waitFor } from '@testing-library/react';
 import App from './App';
 
+// Mock HTMLCanvasElement.getContext to avoid canvas-related errors in tests
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: jest.fn(() => ({
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    getImageData: jest.fn(() => ({
+      data: new Array(4),
+    })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(() => []),
+    setTransform: jest.fn(),
+    drawImage: jest.fn(),
+    save: jest.fn(),
+    fillText: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    stroke: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    rotate: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 })),
+    transform: jest.fn(),
+    rect: jest.fn(),
+    clip: jest.fn(),
+    createLinearGradient: jest.fn(() => ({
+      addColorStop: jest.fn(),
+    })),
+  })),
+});
+
+// eslint-disable-next-line no-console
+const originalError = console.error;
+beforeAll(() => {
+  // eslint-disable-next-line no-console
+  console.error = (...args: any[]) => {
+    if (
+      typeof args[0] === 'string' &&
+      (args[0].includes('MUI: The') ||
+        args[0].includes('Warning: findDOMNode') ||
+        args[0].includes('Not implemented: HTMLCanvasElement'))
+    ) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  // eslint-disable-next-line no-console
+  console.error = originalError;
+});
+
 describe('App', () => {
   it('should render', async () => {
     process.env = {

--- a/workspaces/quickstart/packages/app/src/App.tsx
+++ b/workspaces/quickstart/packages/app/src/App.tsx
@@ -51,9 +51,15 @@ import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { getAllThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
+import { quickstartTranslations } from '@red-hat-developer-hub/backstage-plugin-quickstart';
 
 const app = createApp({
   apis,
+  __experimentalTranslations: {
+    defaultLanguage: 'en',
+    availableLanguages: ['en', 'de', 'fr', 'es'],
+    resources: [quickstartTranslations],
+  },
   bindRoutes({ bind }) {
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,

--- a/workspaces/quickstart/plugins/quickstart/dev/index.tsx
+++ b/workspaces/quickstart/plugins/quickstart/dev/index.tsx
@@ -16,7 +16,9 @@
 
 import { createDevApp } from '@backstage/dev-utils';
 import { quickstartPlugin, QuickstartDrawerProvider } from '../src/plugin';
+import { quickstartTranslations } from '../src/translations';
 import { useQuickstartDrawerContext } from '../src/hooks/useQuickstartDrawerContext';
+import { useTranslation } from '../src/hooks/useTranslation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
@@ -27,26 +29,28 @@ import { getAllThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
 const QuickstartTestPageContent = () => {
   const { openDrawer, closeDrawer, isDrawerOpen } =
     useQuickstartDrawerContext();
+  const { t } = useTranslation();
 
   return (
     <Box sx={{ padding: 4 }}>
       <Typography variant="h3" gutterBottom>
-        Quickstart Plugin Test Page
+        {t('dev.pageTitle')}
       </Typography>
 
       <Typography variant="body1" paragraph>
-        This is a test page for the Quickstart plugin. Use the buttons below to
-        interact with the quickstart drawer.
+        {t('dev.pageDescription')}
       </Typography>
 
       <Card sx={{ maxWidth: 600, marginBottom: 2 }}>
         <CardContent>
           <Typography variant="h6" gutterBottom>
-            Drawer Controls
+            {t('dev.drawerControls')}
           </Typography>
 
           <Typography variant="body2" color="text.secondary" paragraph>
-            Current drawer state: {isDrawerOpen ? 'Open' : 'Closed'}
+            {t('dev.currentState' as any, {
+              state: isDrawerOpen ? t('dev.stateOpen') : t('dev.stateClosed'),
+            })}
           </Typography>
 
           <Box sx={{ display: 'flex', gap: 2 }}>
@@ -56,7 +60,7 @@ const QuickstartTestPageContent = () => {
               onClick={openDrawer}
               disabled={isDrawerOpen}
             >
-              Open Quickstart Guide
+              {t('button.openQuickstartGuide')}
             </Button>
 
             <Button
@@ -64,7 +68,7 @@ const QuickstartTestPageContent = () => {
               onClick={closeDrawer}
               disabled={!isDrawerOpen}
             >
-              Close Drawer
+              {t('button.closeDrawer')}
             </Button>
           </Box>
         </CardContent>
@@ -73,19 +77,18 @@ const QuickstartTestPageContent = () => {
       <Card sx={{ maxWidth: 600 }}>
         <CardContent>
           <Typography variant="h6" gutterBottom>
-            Instructions
+            {t('dev.instructions')}
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            1. Click "Open Quickstart Guide" to open the drawer
+            {t('dev.step1')}
             <br />
-            2. Navigate through the quickstart steps
+            {t('dev.step2')}
             <br />
-            3. Test the progress tracking by completing steps
+            {t('dev.step3')}
             <br />
-            4. The drawer can be closed using the close button or the drawer's
-            own controls
+            {t('dev.step4')}
             <br />
-            5. Progress is automatically saved to localStorage
+            {t('dev.step5')}
           </Typography>
         </CardContent>
       </Card>
@@ -101,6 +104,9 @@ const QuickstartTestPage = () => (
 
 createDevApp()
   .registerPlugin(quickstartPlugin)
+  .addTranslationResource(quickstartTranslations)
+  .setAvailableLanguages(['en', 'de', 'fr', 'es'])
+  .setDefaultLanguage('en')
   .addThemes(getAllThemes())
   .addPage({
     element: <QuickstartTestPage />,

--- a/workspaces/quickstart/plugins/quickstart/report.api.md
+++ b/workspaces/quickstart/plugins/quickstart/report.api.md
@@ -8,6 +8,7 @@
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CSSProperties } from 'react';
 import { PropsWithChildren } from 'react';
+import { TranslationResource } from '@backstage/core-plugin-api/alpha';
 
 // @public
 export const QuickstartButton: React.ComponentType<QuickstartButtonProps>;
@@ -34,6 +35,9 @@ export const QuickstartDrawerProvider: React.ComponentType<PropsWithChildren>;
 
 // @public
 export const quickstartPlugin: BackstagePlugin<{}, {}, {}>;
+
+// @public
+export const quickstartTranslations: TranslationResource<'plugin.quickstart'>;
 
 // @public
 export const useQuickstartDrawerContext: () => QuickstartDrawerContextType;

--- a/workspaces/quickstart/plugins/quickstart/src/alpha.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/alpha.ts
@@ -14,17 +14,4 @@
  * limitations under the License.
  */
 
-import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
-
-ClassNameGenerator.configure(componentName => {
-  return componentName.startsWith('v5-')
-    ? componentName
-    : `v5-${componentName}`;
-});
-
-export * from './plugin';
-
-export { useQuickstartDrawerContext } from './hooks/useQuickstartDrawerContext';
-export type { QuickstartDrawerContextType } from './components/QuickstartDrawerContext';
-
-export { quickstartTranslations } from './translations';
+export * from './translations';

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartButton/QuickstartButton.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartButton/QuickstartButton.tsx
@@ -22,6 +22,7 @@ import { useTheme } from '@mui/material/styles';
 import WavingHandIcon from '@mui/icons-material/WavingHandOutlined';
 import { useQuickstartPermission } from '../../hooks/useQuickstartPermission';
 import { useQuickstartDrawerContext } from '../../hooks/useQuickstartDrawerContext';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * Props for the QuickstartButton component
@@ -47,13 +48,16 @@ export interface QuickstartButtonProps {
  * @public
  */
 export const QuickstartButton = ({
-  title = 'Quick start',
+  title,
   style,
   onClick = () => {},
 }: QuickstartButtonProps) => {
+  const { t } = useTranslation();
   const isAllowed = useQuickstartPermission();
   const { toggleDrawer } = useQuickstartDrawerContext();
   const theme = useTheme();
+
+  const defaultTitle = t('button.quickstart');
 
   const handleClick = useCallback(() => {
     toggleDrawer();
@@ -102,7 +106,7 @@ export const QuickstartButton = ({
             }}
           >
             <Typography variant="body2" color={theme.palette.text.primary}>
-              {title}
+              {title || defaultTitle}
             </Typography>
           </Box>
         </Box>

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.tsx
@@ -20,6 +20,7 @@ import { QuickstartItem } from './QuickstartItem';
 import { EmptyState } from '@backstage/core-components';
 import { useState } from 'react';
 import { QuickstartItemData } from '../../types';
+import { useTranslation } from '../../hooks/useTranslation';
 
 type QuickstartContentProps = {
   quickstartItems: QuickstartItemData[];
@@ -32,6 +33,7 @@ export const QuickstartContent = ({
   setProgress,
   itemCount,
 }: QuickstartContentProps) => {
+  const { t } = useTranslation();
   const [openItems, setOpenItems] = useState<boolean[]>(
     new Array(itemCount).fill(false),
   );
@@ -62,10 +64,7 @@ export const QuickstartContent = ({
           ))}
         </List>
       ) : (
-        <EmptyState
-          title="Quickstart content not available for your role."
-          missing="data"
-        />
+        <EmptyState title={t('content.emptyState.title')} missing="data" />
       )}
     </Box>
   );

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItem.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItem.tsx
@@ -27,6 +27,7 @@ import { QuickstartItemIcon } from './QuickstartItemIcon';
 import { QuickstartCtaLink } from './QuickstartCtaLink';
 import IconButton from '@mui/material/IconButton';
 import { QuickstartItemData } from '../../types';
+import { useTranslation } from '../../hooks/useTranslation';
 
 export type QuickstartItemProps = {
   item: QuickstartItemData;
@@ -43,6 +44,7 @@ export const QuickstartItem = ({
   open,
   handleOpen,
 }: QuickstartItemProps) => {
+  const { t } = useTranslation();
   const [stepCompleted, setStepCompleted] = useState<boolean>(false);
   const itemKey = `${item.title}-${index}`;
 
@@ -70,7 +72,11 @@ export const QuickstartItem = ({
         onClick={handleOpen}
         role="button"
         aria-expanded={open}
-        aria-label={`${open ? 'Collapse' : 'Expand'} ${item.title} details`}
+        aria-label={
+          open
+            ? t('item.collapseAriaLabel' as any, { title: item.title })
+            : t('item.expandAriaLabel' as any, { title: item.title })
+        }
         tabIndex={0}
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -115,7 +121,11 @@ export const QuickstartItem = ({
           }}
         />
         <IconButton
-          aria-label={open ? 'Collapse item' : 'Expand item'}
+          aria-label={
+            open
+              ? t('item.collapseButtonAriaLabel')
+              : t('item.expandButtonAriaLabel')
+          }
           sx={{
             ...(open
               ? { color: theme => theme.palette.text.primary }

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartFooter.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartFooter.tsx
@@ -18,6 +18,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
+import { useTranslation } from '../hooks/useTranslation';
 
 export type QuickstartFooterProps = {
   handleDrawerClose: () => void;
@@ -28,6 +29,8 @@ export const QuickstartFooter = ({
   handleDrawerClose,
   progress,
 }: QuickstartFooterProps) => {
+  const { t } = useTranslation();
+
   return (
     <Box>
       <LinearProgress variant="determinate" value={progress} />
@@ -40,9 +43,11 @@ export const QuickstartFooter = ({
         }}
       >
         <Typography sx={{ fontSize: theme => theme.typography.caption }}>
-          {progress > 0 ? `${progress}% progress` : 'Not started'}
+          {progress > 0
+            ? t('footer.progress' as any, { progress: progress.toString() })
+            : t('footer.notStarted')}
         </Typography>
-        <Button onClick={() => handleDrawerClose()}>Hide</Button>
+        <Button onClick={() => handleDrawerClose()}>{t('footer.hide')}</Button>
       </Box>
     </Box>
   );

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartHeader.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartHeader.tsx
@@ -18,8 +18,11 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import quickstartImage from '../assets/quickstart-image.png';
+import { useTranslation } from '../hooks/useTranslation';
 
 export const QuickstartHeader = () => {
+  const { t } = useTranslation();
+
   return (
     <Toolbar
       sx={{
@@ -43,10 +46,10 @@ export const QuickstartHeader = () => {
         }}
       >
         <Typography sx={{ fontSize: theme => theme.typography.h6 }}>
-          Let's get you started with Developer Hub
+          {t('header.title')}
         </Typography>
         <Typography sx={{ fontSize: theme => theme.typography.caption }}>
-          We'll guide you through a few quick steps
+          {t('header.subtitle')}
         </Typography>
       </Box>
     </Toolbar>

--- a/workspaces/quickstart/plugins/quickstart/src/components/Trans.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/Trans.test.tsx
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+import { render } from '@testing-library/react';
+import { Trans } from './Trans';
 
-ClassNameGenerator.configure(componentName => {
-  return componentName.startsWith('v5-')
-    ? componentName
-    : `v5-${componentName}`;
+describe('Trans', () => {
+  it('renders translated text', () => {
+    const { getByText } = render(<Trans message="header.title" />);
+    expect(
+      getByText("Let's get you started with Developer Hub"),
+    ).toBeInTheDocument();
+  });
+
+  it('renders translated text with params', () => {
+    const { getByText } = render(
+      <Trans message="footer.progress" params={{ progress: '50' }} />,
+    );
+    expect(getByText('50% progress')).toBeInTheDocument();
+  });
 });
-
-export * from './plugin';
-
-export { useQuickstartDrawerContext } from './hooks/useQuickstartDrawerContext';
-export type { QuickstartDrawerContextType } from './components/QuickstartDrawerContext';
-
-export { quickstartTranslations } from './translations';

--- a/workspaces/quickstart/plugins/quickstart/src/components/Trans.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/Trans.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+import { useTranslation } from '../hooks/useTranslation';
+import { quickstartTranslationRef } from '../translations';
 
-ClassNameGenerator.configure(componentName => {
-  return componentName.startsWith('v5-')
-    ? componentName
-    : `v5-${componentName}`;
-});
+type Messages = typeof quickstartTranslationRef.T;
 
-export * from './plugin';
+interface TransProps<TMessages extends { [key: string]: string }> {
+  message: keyof TMessages;
+  params?: any;
+}
 
-export { useQuickstartDrawerContext } from './hooks/useQuickstartDrawerContext';
-export type { QuickstartDrawerContextType } from './components/QuickstartDrawerContext';
-
-export { quickstartTranslations } from './translations';
+export const Trans = ({ message, params }: TransProps<Messages>) => {
+  const { t } = useTranslation();
+  return t(message as any, params);
+};

--- a/workspaces/quickstart/plugins/quickstart/src/hooks/useTranslation.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/hooks/useTranslation.ts
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+import {
+  useTranslationRef,
+  TranslationFunction,
+} from '@backstage/core-plugin-api/alpha';
+import { quickstartTranslationRef } from '../translations';
 
-ClassNameGenerator.configure(componentName => {
-  return componentName.startsWith('v5-')
-    ? componentName
-    : `v5-${componentName}`;
-});
-
-export * from './plugin';
-
-export { useQuickstartDrawerContext } from './hooks/useQuickstartDrawerContext';
-export type { QuickstartDrawerContextType } from './components/QuickstartDrawerContext';
-
-export { quickstartTranslations } from './translations';
+export const useTranslation = (): {
+  t: TranslationFunction<typeof quickstartTranslationRef.T>;
+} => useTranslationRef(quickstartTranslationRef);

--- a/workspaces/quickstart/plugins/quickstart/src/plugin.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/plugin.ts
@@ -20,6 +20,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { PropsWithChildren } from 'react';
 import { QuickstartButtonProps } from './components/QuickstartButton/QuickstartButton';
+import { quickstartTranslationRef } from './translations';
 
 export type { QuickstartButtonProps } from './components/QuickstartButton/QuickstartButton';
 
@@ -30,7 +31,11 @@ export type { QuickstartButtonProps } from './components/QuickstartButton/Quicks
  */
 export const quickstartPlugin = createPlugin({
   id: 'quickstart',
-});
+  __experimentalTranslations: {
+    availableLanguages: ['en', 'de', 'fr', 'es'],
+    resources: [quickstartTranslationRef],
+  },
+} as any);
 
 /**
  * Quick start drawer provider

--- a/workspaces/quickstart/plugins/quickstart/src/setupTests.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/setupTests.ts
@@ -15,3 +15,14 @@
  */
 
 import '@testing-library/jest-dom';
+import { mockUseTranslation, MockTrans } from './test-utils/mockTranslations';
+
+// Global mock for useTranslation hook
+jest.mock('./hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+// Global mock for Trans component
+jest.mock('./components/Trans', () => ({
+  Trans: MockTrans,
+}));

--- a/workspaces/quickstart/plugins/quickstart/src/test-utils/mockTranslations.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/test-utils/mockTranslations.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { quickstartMessages } from '../translations/ref';
+
+function flattenMessages(obj: any, prefix = ''): Record<string, string> {
+  const flattened: Record<string, string> = {};
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const value = obj[key];
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (typeof value === 'object' && value !== null) {
+        Object.assign(flattened, flattenMessages(value, newKey));
+      } else {
+        flattened[newKey] = value;
+      }
+    }
+  }
+  return flattened;
+}
+
+const flattenedMessages = flattenMessages(quickstartMessages);
+
+export const mockT = (key: string, params?: any) => {
+  let message = flattenedMessages[key] || key;
+  if (params) {
+    for (const [paramKey, paramValue] of Object.entries(params)) {
+      message = message.replace(
+        new RegExp(`{{${paramKey}}}`, 'g'),
+        String(paramValue),
+      );
+    }
+  }
+  return message;
+};
+
+export const mockUseTranslation = () => ({ t: mockT });
+
+export const MockTrans = ({
+  message,
+  params,
+}: {
+  message: string;
+  params?: any;
+}) => mockT(message, params);

--- a/workspaces/quickstart/plugins/quickstart/src/translations/de.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/de.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { quickstartTranslationRef } from './ref';
+
+const quickstartTranslationDe = createTranslationMessages({
+  ref: quickstartTranslationRef,
+  messages: {
+    'header.title': 'Erste Schritte mit dem Developer Hub',
+    'header.subtitle': 'Wir führen Sie durch einige schnelle Schritte',
+    'button.quickstart': 'Schnellstart',
+    'button.openQuickstartGuide': 'Schnellstart-Leitfaden öffnen',
+    'button.closeDrawer': 'Drawer schließen',
+    'footer.progress': '{{progress}}% Fortschritt',
+    'footer.notStarted': 'Nicht begonnen',
+    'footer.hide': 'Ausblenden',
+    'content.emptyState.title':
+      'Schnellstart-Inhalte sind für Ihre Rolle nicht verfügbar.',
+    'item.expandAriaLabel': '{{title}} Details erweitern',
+    'item.collapseAriaLabel': '{{title}} Details einklappen',
+    'item.expandButtonAriaLabel': 'Element erweitern',
+    'item.collapseButtonAriaLabel': 'Element einklappen',
+    'dev.pageTitle': 'Quickstart Plugin Testseite',
+    'dev.pageDescription':
+      'Dies ist eine Testseite für das Quickstart-Plugin. Verwenden Sie die Schaltflächen unten, um mit dem Quickstart-Drawer zu interagieren.',
+    'dev.drawerControls': 'Drawer-Steuerungen',
+    'dev.currentState': 'Aktueller Drawer-Status: {{state}}',
+    'dev.stateOpen': 'Offen',
+    'dev.stateClosed': 'Geschlossen',
+    'dev.instructions': 'Anweisungen',
+    'dev.step1':
+      '1. Klicken Sie auf "Schnellstart-Leitfaden öffnen", um den Drawer zu öffnen',
+    'dev.step2': '2. Navigieren Sie durch die Schnellstart-Schritte',
+    'dev.step3':
+      '3. Testen Sie die Fortschrittsverfolgung durch Abschließen von Schritten',
+    'dev.step4':
+      '4. Der Drawer kann mit der Schließen-Schaltfläche oder den eigenen Steuerelementen des Drawers geschlossen werden',
+    'dev.step5':
+      '5. Der Fortschritt wird automatisch in localStorage gespeichert',
+  },
+});
+
+export default quickstartTranslationDe;

--- a/workspaces/quickstart/plugins/quickstart/src/translations/es.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/es.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { quickstartTranslationRef } from './ref';
+
+const quickstartTranslationEs = createTranslationMessages({
+  ref: quickstartTranslationRef,
+  messages: {
+    'header.title': 'Comencemos con el Hub del Desarrollador',
+    'header.subtitle': 'Te guiaremos a través de algunos pasos rápidos',
+    'button.quickstart': 'Inicio rápido',
+    'footer.progress': '{{progress}}% de progreso',
+    'footer.notStarted': 'No iniciado',
+    'footer.hide': 'Ocultar',
+    'content.emptyState.title':
+      'El contenido de inicio rápido no está disponible para tu rol.',
+    'item.expandAriaLabel': 'Expandir detalles de {{title}}',
+    'item.collapseAriaLabel': 'Contraer detalles de {{title}}',
+    'item.expandButtonAriaLabel': 'Expandir elemento',
+    'item.collapseButtonAriaLabel': 'Contraer elemento',
+    'button.openQuickstartGuide': 'Abrir guía de inicio rápido',
+    'button.closeDrawer': 'Cerrar cajón',
+    'dev.pageTitle': 'Página de prueba del plugin Quickstart',
+    'dev.pageDescription':
+      'Esta es una página de prueba para el plugin Quickstart. Use los botones de abajo para interactuar con el cajón de inicio rápido.',
+    'dev.drawerControls': 'Controles del cajón',
+    'dev.currentState': 'Estado actual del cajón: {{state}}',
+    'dev.stateOpen': 'Abierto',
+    'dev.stateClosed': 'Cerrado',
+    'dev.instructions': 'Instrucciones',
+    'dev.step1':
+      '1. Haga clic en "Abrir guía de inicio rápido" para abrir el cajón',
+    'dev.step2': '2. Navegue a través de los pasos de inicio rápido',
+    'dev.step3': '3. Pruebe el seguimiento del progreso completando pasos',
+    'dev.step4':
+      '4. El cajón puede cerrarse usando el botón de cerrar o los controles propios del cajón',
+    'dev.step5': '5. El progreso se guarda automáticamente en localStorage',
+  },
+});
+
+export default quickstartTranslationEs;

--- a/workspaces/quickstart/plugins/quickstart/src/translations/fr.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/fr.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { quickstartTranslationRef } from './ref';
+
+const quickstartTranslationFr = createTranslationMessages({
+  ref: quickstartTranslationRef,
+  messages: {
+    'header.title': 'Commençons avec le Hub Développeur',
+    'header.subtitle': 'Nous vous guiderons à travers quelques étapes rapides',
+    'button.quickstart': 'Démarrage rapide',
+    'footer.progress': '{{progress}}% de progression',
+    'footer.notStarted': 'Pas encore commencé',
+    'footer.hide': 'Masquer',
+    'content.emptyState.title':
+      "Le contenu de démarrage rapide n'est pas disponible pour votre rôle.",
+    'item.expandAriaLabel': 'Développer les détails de {{title}}',
+    'item.collapseAriaLabel': 'Réduire les détails de {{title}}',
+    'item.expandButtonAriaLabel': "Développer l'élément",
+    'item.collapseButtonAriaLabel': "Réduire l'élément",
+    'button.openQuickstartGuide': 'Ouvrir le guide de démarrage rapide',
+    'button.closeDrawer': 'Fermer le tiroir',
+    'dev.pageTitle': 'Page de test du plugin Quickstart',
+    'dev.pageDescription':
+      'Ceci est une page de test pour le plugin Quickstart. Utilisez les boutons ci-dessous pour interagir avec le tiroir de démarrage rapide.',
+    'dev.drawerControls': 'Contrôles du tiroir',
+    'dev.currentState': 'État actuel du tiroir : {{state}}',
+    'dev.stateOpen': 'Ouvert',
+    'dev.stateClosed': 'Fermé',
+    'dev.instructions': 'Instructions',
+    'dev.step1':
+      '1. Cliquez sur "Ouvrir le guide de démarrage rapide" pour ouvrir le tiroir',
+    'dev.step2': '2. Naviguez à travers les étapes de démarrage rapide',
+    'dev.step3': '3. Testez le suivi de progression en complétant les étapes',
+    'dev.step4':
+      '4. Le tiroir peut être fermé en utilisant le bouton de fermeture ou les contrôles propres du tiroir',
+    'dev.step5':
+      '5. La progression est automatiquement sauvegardée dans localStorage',
+  },
+});
+
+export default quickstartTranslationFr;

--- a/workspaces/quickstart/plugins/quickstart/src/translations/index.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/index.ts
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+import { quickstartTranslationRef } from './ref';
 
-ClassNameGenerator.configure(componentName => {
-  return componentName.startsWith('v5-')
-    ? componentName
-    : `v5-${componentName}`;
+/**
+ * Translation Resource for Quickstart
+ * @public
+ */
+export const quickstartTranslations = createTranslationResource({
+  ref: quickstartTranslationRef,
+  translations: {
+    de: () => import('./de'),
+    fr: () => import('./fr'),
+    es: () => import('./es'),
+  },
 });
 
-export * from './plugin';
-
-export { useQuickstartDrawerContext } from './hooks/useQuickstartDrawerContext';
-export type { QuickstartDrawerContextType } from './components/QuickstartDrawerContext';
-
-export { quickstartTranslations } from './translations';
+export { quickstartTranslationRef };

--- a/workspaces/quickstart/plugins/quickstart/src/translations/ref.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/ref.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+/**
+ * Messages object containing all English translations.
+ * This is our single source of truth for translations.
+ * @public
+ */
+export const quickstartMessages = {
+  header: {
+    title: "Let's get you started with Developer Hub",
+    subtitle: "We'll guide you through a few quick steps",
+  },
+  button: {
+    quickstart: 'Quick start',
+    openQuickstartGuide: 'Open Quickstart Guide',
+    closeDrawer: 'Close Drawer',
+  },
+  footer: {
+    progress: '{{progress}}% progress',
+    notStarted: 'Not started',
+    hide: 'Hide',
+  },
+  content: {
+    emptyState: {
+      title: 'Quickstart content not available for your role.',
+    },
+  },
+  item: {
+    expandAriaLabel: 'Expand {{title}} details',
+    collapseAriaLabel: 'Collapse {{title}} details',
+    expandButtonAriaLabel: 'Expand item',
+    collapseButtonAriaLabel: 'Collapse item',
+  },
+  dev: {
+    pageTitle: 'Quickstart Plugin Test Page',
+    pageDescription:
+      'This is a test page for the Quickstart plugin. Use the buttons below to interact with the quickstart drawer.',
+    drawerControls: 'Drawer Controls',
+    currentState: 'Current drawer state: {{state}}',
+    stateOpen: 'Open',
+    stateClosed: 'Closed',
+    instructions: 'Instructions',
+    step1: '1. Click "Open Quickstart Guide" to open the drawer',
+    step2: '2. Navigate through the quickstart steps',
+    step3: '3. Test the progress tracking by completing steps',
+    step4:
+      "4. The drawer can be closed using the close button or the drawer's own controls",
+    step5: '5. Progress is automatically saved to localStorage',
+  },
+};
+
+/**
+ * Translation reference for Quickstart plugin
+ * @public
+ */
+export const quickstartTranslationRef = createTranslationRef({
+  id: 'plugin.quickstart',
+  messages: quickstartMessages,
+});


### PR DESCRIPTION
## Translation support to QuickStart

### Fixes

https://issues.redhat.com/browse/RHIDP-8745

Added internationalization (i18n) support to QuickStart. The plugin now supports multiple languages with proper fallbacks and maintains all existing functionality. 

- Multi-language support: English (default), German, French, and Spanish

**Languages added:**

1. 🇫🇷 French (fr)
2. 🇩🇪 German (de)
3. 🇪🇸 Spanish (es)
4. 🇺🇸 English (en) - default



## Screenshots

![QuickStart plugin - translation support](https://github.com/user-attachments/assets/53aa7e3f-0ed7-4d41-844e-d7bb00f16f20)

--------

<img width="1490" height="958" alt="Screenshot 2025-09-05 at 1 45 50 PM" src="https://github.com/user-attachments/assets/fdc1d895-5849-48ab-8ce3-2b568312bee2" />

--------

<img width="1492" height="959" alt="Screenshot 2025-09-05 at 1 46 04 PM" src="https://github.com/user-attachments/assets/a6cd08bd-d8e0-4e67-9ed8-5417e103f369" />

--------

<img width="1485" height="955" alt="Screenshot 2025-09-05 at 1 46 23 PM" src="https://github.com/user-attachments/assets/f2a033cc-db6b-4613-8a15-1dcafbacd6d1" />

--------

<img width="1488" height="955" alt="Screenshot 2025-09-05 at 1 46 33 PM" src="https://github.com/user-attachments/assets/56690a7c-2a79-444a-85f6-1ca209dc36a8" />

--------



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
