### PR TITLE
fix(theme): resolve changeset issue

### DIFF
--- a/workspaces/theme/.changeset/version-bump-1-41-1-p1.md
+++ b/workspaces/theme/.changeset/version-bump-1-41-1-p1.md
@@ -1,5 +1,0 @@
----
-'@red-hat-developer-hub/backstage-plugin-theme': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/theme/.changeset/version-bump-1-41-1-p2.md
+++ b/workspaces/theme/.changeset/version-bump-1-41-1-p2.md
@@ -1,8 +1,0 @@
----
-'@red-hat-developer-hub/backstage-plugin-bc-test': minor
-'@red-hat-developer-hub/backstage-plugin-mui4-test': minor
-'@red-hat-developer-hub/backstage-plugin-mui5-test': minor
-'@red-hat-developer-hub/backstage-plugin-qe-theme': minor
----
-
-Backstage version bump to v1.41.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hopefully fix the theme release process because of this conflicting files.

From failing job https://github.com/redhat-developer/rhdh-plugins/actions/runs/17640707554/job/50126893808:

```
Package "backend" must depend on the current version of "app": "0.0.0" vs "link:../app"
🦋  error Error: Found mixed changeset version-bump-1-41-1-p2
🦋  error Found ignored packages: @red-hat-developer-hub/backstage-plugin-bc-test @red-hat-developer-hub/backstage-plugin-mui4-test @red-hat-developer-hub/backstage-plugin-mui5-test
🦋  error Found not ignored packages: @red-hat-developer-hub/backstage-plugin-qe-theme
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
```