### PR TITLE
chore(translations): fix copyright author

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,7 +24,8 @@ module.exports = {
     'notice/notice': [
       'error',
       {
-        mustMatch: /Copyright (The Backstage Authors|Red Hat, Inc.)/,
+        mustMatch:
+          /Copyright (The Backstage Authors|Red Hat, Inc.|The Backstage Authors and Red Hat, Inc.)/,
         templateFile: path.resolve(
           // eslint-disable-next-line no-restricted-syntax
           __dirname,

--- a/workspaces/translations/README.md
+++ b/workspaces/translations/README.md
@@ -1,16 +1,7 @@
-# [Backstage](https://backstage.io)
+# Additional translations features for RHDH
 
-This is your newly scaffolded Backstage App, Good Luck!
+We implement this additional extensions here to move forward with translations.
 
-To start the app, run:
+Our goal is to contribute all missing feature back to Backstage Core or Backstage Community Plugins if they got accepted.
 
-```sh
-yarn install
-yarn dev
-```
-
-To generate knip reports for this app, run:
-
-```sh
-yarn backstage-repo-tools knip-reports
-```
+We might deprecate this workspace and plugin in the future when its not needed anymore.

--- a/workspaces/translations/plugins/translations/src/apis/I18nextTranslationApi.ts
+++ b/workspaces/translations/plugins/translations/src/apis/I18nextTranslationApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Red Hat, Inc.
+ * Copyright The Backstage Authors and Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/translations/plugins/translations/src/apis/TranslationRef.ts
+++ b/workspaces/translations/plugins/translations/src/apis/TranslationRef.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Red Hat, Inc.
+ * Copyright The Backstage Authors and Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/translations/plugins/translations/src/apis/TranslationResource.ts
+++ b/workspaces/translations/plugins/translations/src/apis/TranslationResource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Red Hat, Inc.
+ * Copyright The Backstage Authors and Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/translations/plugins/translations/src/apis/index.ts
+++ b/workspaces/translations/plugins/translations/src/apis/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Red Hat, Inc.
+ * Copyright The Backstage Authors and Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've modified the eslint rule that has overridden the origin authors of (opensource) code that I've copied from the backstage project. But I like to honor the origin work.

I've added also a README to the new translations workspace to make clear that this is in best case an interim solution and that we like to bring this features to Backstage Core or Backstage Community Plugins.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
