### PR TITLE
chore(bulk-import): migrate rhdh-theme

### DIFF
--- a/workspaces/bulk-import/.changeset/ninety-pens-shout.md
+++ b/workspaces/bulk-import/.changeset/ninety-pens-shout.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Migrate from rhdh-theme to the theme within rhdh-plugins repo.

--- a/workspaces/bulk-import/packages/app/package.json
+++ b/workspaces/bulk-import/packages/app/package.json
@@ -47,7 +47,7 @@
     "@mui/material": "5.18.0",
     "@mui/styles": "5.18.0",
     "@red-hat-developer-hub/backstage-plugin-bulk-import": "workspace:^",
-    "@redhat-developer/red-hat-developer-hub-theme": "^0.5.0",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.10.0",
     "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",

--- a/workspaces/bulk-import/packages/app/src/App.tsx
+++ b/workspaces/bulk-import/packages/app/src/App.tsx
@@ -49,7 +49,7 @@ import { UserSettingsPage } from '@backstage/plugin-user-settings';
 import { BulkImportPage } from '@red-hat-developer-hub/backstage-plugin-bulk-import';
 import { bulkImportTranslations } from '@red-hat-developer-hub/backstage-plugin-bulk-import/alpha';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { getThemes } from '@redhat-developer/red-hat-developer-hub-theme';
+import { getThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
 import { Navigate, Route } from 'react-router-dom';
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';

--- a/workspaces/bulk-import/plugins/bulk-import/dev/index.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/dev/index.tsx
@@ -24,7 +24,7 @@ import {
   TestApiProvider,
 } from '@backstage/test-utils';
 
-import { getAllThemes } from '@redhat-developer/red-hat-developer-hub-theme';
+import { getAllThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
 
 import {
   BulkImportAPI,

--- a/workspaces/bulk-import/plugins/bulk-import/package.json
+++ b/workspaces/bulk-import/plugins/bulk-import/package.json
@@ -77,7 +77,7 @@
     "@backstage/dev-utils": "^1.1.13",
     "@backstage/test-utils": "^1.7.11",
     "@playwright/test": "1.55.1",
-    "@redhat-developer/red-hat-developer-hub-theme": "^0.5.0",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.10.0",
     "@spotify/prettier-config": "^15.0.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -6901,7 +6901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/icons-material@npm:5.18.0, @mui/icons-material@npm:^5.15.17":
+"@mui/icons-material@npm:5.18.0, @mui/icons-material@npm:^5.15.17, @mui/icons-material@npm:^5.17.1":
   version: 5.18.0
   resolution: "@mui/icons-material@npm:5.18.0"
   dependencies:
@@ -9170,7 +9170,7 @@ __metadata:
     "@mui/styles": 5.18.0
     "@playwright/test": 1.55.1
     "@red-hat-developer-hub/backstage-plugin-bulk-import-common": "workspace:^"
-    "@redhat-developer/red-hat-developer-hub-theme": ^0.5.0
+    "@red-hat-developer-hub/backstage-plugin-theme": ^0.10.0
     "@spotify/prettier-config": ^15.0.0
     "@tanstack/react-query": ^4.29.21
     "@testing-library/dom": ^10.0.0
@@ -9195,18 +9195,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@redhat-developer/red-hat-developer-hub-theme@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.5.0"
+"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.10.0"
+  dependencies:
+    "@mui/icons-material": ^5.17.1
   peerDependencies:
-    "@backstage/theme": ^0.5.2
-    "@emotion/react": ^11.11.1
-    "@emotion/styled": ^11.11.0
-    "@material-ui/core": ^4.12.4
+    "@backstage/core-plugin-api": ^1.10.9
+    "@backstage/theme": ^0.6.8
     "@material-ui/icons": ^4.11.3
-    "@mui/icons-material": ^5.14.19
-    "@mui/material": ^5.14.20
-  checksum: 158667ac33e7b926fec2c7ed9d26c3bd81deafe8b0026316ab171e66dd2f3a36474225e42b7ac8527d0e357c1c11432fe767f0cd46b2cd86464e53e4c146a09c
+    "@mui/icons-material": ^5.17.1
+    "@mui/material": ^5.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  checksum: a5626d864def2e255d026d1620d370ada033f11ee357b145a9f5bd95185cbb9392cae1c83d2dbdcafde8747feb95d79f7067f645d5c6086628d5910a216cf34e
   languageName: node
   linkType: hard
 
@@ -13466,7 +13467,7 @@ __metadata:
     "@mui/styles": 5.18.0
     "@playwright/test": 1.55.1
     "@red-hat-developer-hub/backstage-plugin-bulk-import": "workspace:^"
-    "@redhat-developer/red-hat-developer-hub-theme": ^0.5.0
+    "@red-hat-developer-hub/backstage-plugin-theme": ^0.10.0
     "@testing-library/dom": ^9.0.0
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrate from rhdh-theme to the theme within rhdh-plugins repo.

`yarn start` before:

<img width="2048" height="899" alt="Screenshot From 2025-09-18 21-21-55" src="https://github.com/user-attachments/assets/858e49b0-d412-4547-bd1d-641ad5c766ca" />

<img width="2048" height="899" alt="Screenshot From 2025-09-18 21-22-05" src="https://github.com/user-attachments/assets/757b1f0e-99da-4d45-a9d1-85a2b4f862c1" />

With this PR:

<img width="2038" height="899" alt="Screenshot From 2025-09-18 21-08-56" src="https://github.com/user-attachments/assets/d13e5caa-04d1-4911-a93f-ee7488b9b1cc" />

<img width="2038" height="899" alt="Screenshot From 2025-09-18 21-09-09" src="https://github.com/user-attachments/assets/31c38b7f-45ea-4ccd-bed3-e9797dad526f" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
