### PR TITLE
fix(extensions): keep info bar closed by default

### DIFF
--- a/workspaces/marketplace/.changeset/thirty-bananas-buy.md
+++ b/workspaces/marketplace/.changeset/thirty-bananas-buy.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+keep plugin installation alert closed by default

--- a/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/MarketplaceCatalogContent.tsx
@@ -176,7 +176,6 @@ export const MarketplaceCatalogContent = () => {
             <>
               <WarningPanel
                 title="Plugin installation is disabled."
-                defaultExpanded
                 severity="info"
                 message={
                   <>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves: https://issues.redhat.com/browse/RHDHBUGS-1972

Keeping the plugin installation info alert bar closed by default

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
