### PR TITLE
RHDHPAI-1125: copy modelcatalog.api.annotations to component annotations

### DIFF
--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -194,6 +194,18 @@ export function GenerateModelServerComponentEntity(
       url: `${modelServer.API.url}`,
     });
     modelServerComponent.spec.providesApis = [modelServer.name];
+
+    // Copy annotations from API to component metadata if they exist
+    if (modelServer.API.annotations !== undefined) {
+      if (modelServerComponent.metadata.annotations === undefined) {
+        modelServerComponent.metadata.annotations = {};
+      }
+      // Copy all key-value pairs from API annotations to component annotations
+      Object.keys(modelServer.API.annotations).forEach(key => {
+        modelServerComponent.metadata.annotations![key] =
+          modelServer.API!.annotations![key];
+      });
+    }
   }
   if (modelServer.homepageURL !== undefined) {
     modelServerComponent.metadata.links.push({


### PR DESCRIPTION
Assisted-by: claude-4-sonnet (code changes and unit tests)

## Hey, I just made a Pull Request!

This copies the annotations introduced by https://github.com/redhat-ai-dev/model-catalog-bridge/pull/53 into the model catalog component's annotations map

this facilitates work for https://issues.redhat.com/browse/RHDHPAI-1009

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [n/a ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [n/a ] Added or Updated documentation
- [ /] Tests for new functionality and regression tests for bug fixes
- [ n/a] Screenshots attached (for UI changes)
