### PR TITLE
fix(scorecard): Fix github app integration

### DIFF
--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GitHubClient.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GitHubClient.test.ts
@@ -18,7 +18,6 @@ import { ConfigReader } from '@backstage/config';
 import { DefaultGithubCredentialsProvider } from '@backstage/integration';
 import { GithubClient } from './GithubClient';
 import { GithubRepository } from './types';
-import { DEFAULT_GITHUB_HOSTNAME } from './constants';
 
 describe('GithubClient', () => {
   let githubClient: GithubClient;
@@ -50,7 +49,7 @@ describe('GithubClient', () => {
       integrations: {
         github: [
           {
-            host: DEFAULT_GITHUB_HOSTNAME,
+            host: 'github.com',
             token: 'dummy-token',
           },
         ],
@@ -61,6 +60,7 @@ describe('GithubClient', () => {
 
   describe('getOpenPullRequestsCount', () => {
     it('should return the count of open pull requests', async () => {
+      const url = `https://github.com/owner/repo`;
       const response = {
         repository: {
           pullRequests: {
@@ -71,8 +71,8 @@ describe('GithubClient', () => {
       mockedGraphqlClient.mockResolvedValue(response);
 
       const result = await githubClient.getOpenPullRequestsCount(
+        url,
         repository,
-        DEFAULT_GITHUB_HOSTNAME,
       );
 
       expect(result).toBe(42);
@@ -82,14 +82,15 @@ describe('GithubClient', () => {
         repository,
       );
       expect(getCredentialsSpy).toHaveBeenCalledWith({
-        url: `https://${DEFAULT_GITHUB_HOSTNAME}/owner`,
+        url,
       });
     });
 
-    it('should throw error when GitHub integration for hostname is missing', async () => {
+    it('should throw error when GitHub integration for URL is missing', async () => {
+      const unknownUrl = 'https://unknown-host/owner/repo';
       await expect(
-        githubClient.getOpenPullRequestsCount(repository, 'unknown-host'),
-      ).rejects.toThrow("Missing GitHub integration for 'unknown-host'");
+        githubClient.getOpenPullRequestsCount(unknownUrl, repository),
+      ).rejects.toThrow(`Missing GitHub integration for '${unknownUrl}'`);
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GitHubClient.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GitHubClient.test.ts
@@ -28,7 +28,7 @@ describe('GithubClient', () => {
     repo: 'repo',
   };
 
-  jest
+  const getCredentialsSpy = jest
     .spyOn(DefaultGithubCredentialsProvider.prototype, 'getCredentials')
     .mockResolvedValue({
       type: 'token',
@@ -81,6 +81,9 @@ describe('GithubClient', () => {
         expect.stringContaining('query getOpenPRsCount'),
         repository,
       );
+      expect(getCredentialsSpy).toHaveBeenCalledWith({
+        url: `https://${DEFAULT_GITHUB_HOSTNAME}/owner`,
+      });
     });
 
     it('should throw error when GitHub integration for hostname is missing', async () => {

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GithubClient.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GithubClient.ts
@@ -20,7 +20,6 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import { GithubRepository } from './types';
-import { DEFAULT_GITHUB_HOSTNAME } from './constants';
 
 export class GithubClient {
   private readonly integrations: ScmIntegrations;
@@ -29,20 +28,17 @@ export class GithubClient {
     this.integrations = ScmIntegrations.fromConfig(config);
   }
 
-  private async getOctokitClient(
-    hostname: string = DEFAULT_GITHUB_HOSTNAME,
-    owner: string,
-  ): Promise<typeof graphql> {
-    const githubIntegration = this.integrations.github.byHost(hostname);
+  private async getOctokitClient(url: string): Promise<typeof graphql> {
+    const githubIntegration = this.integrations.github.byUrl(url);
     if (!githubIntegration) {
-      throw new Error(`Missing GitHub integration for '${hostname}'`);
+      throw new Error(`Missing GitHub integration for '${url}'`);
     }
 
     const credentialsProvider =
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
 
     const { headers } = await credentialsProvider.getCredentials({
-      url: `https://${hostname}/${owner}`,
+      url,
     });
 
     const { graphql } = await import('@octokit/graphql');
@@ -53,10 +49,10 @@ export class GithubClient {
   }
 
   async getOpenPullRequestsCount(
+    url: string,
     repository: GithubRepository,
-    hostname: string,
   ): Promise<number> {
-    const octokit = await this.getOctokitClient(hostname, repository.owner);
+    const octokit = await this.getOctokitClient(url);
 
     const query = `
       query getOpenPRsCount($owner: String!, $repo: String!) {

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GithubClient.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GithubClient.ts
@@ -31,6 +31,7 @@ export class GithubClient {
 
   private async getOctokitClient(
     hostname: string = DEFAULT_GITHUB_HOSTNAME,
+    owner: string,
   ): Promise<typeof graphql> {
     const githubIntegration = this.integrations.github.byHost(hostname);
     if (!githubIntegration) {
@@ -41,7 +42,7 @@ export class GithubClient {
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
 
     const { headers } = await credentialsProvider.getCredentials({
-      url: `https://${hostname}`,
+      url: `https://${hostname}/${owner}`,
     });
 
     const { graphql } = await import('@octokit/graphql');
@@ -55,7 +56,7 @@ export class GithubClient {
     repository: GithubRepository,
     hostname: string,
   ): Promise<number> {
-    const octokit = await this.getOctokitClient(hostname);
+    const octokit = await this.getOctokitClient(hostname, repository.owner);
 
     const query = `
       query getOpenPRsCount($owner: String!, $repo: String!) {

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/constants.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/constants.ts
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export const DEFAULT_GITHUB_HOSTNAME = 'github.com';
 export const GITHUB_PROJECT_ANNOTATION = 'github.com/project-slug';

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/utils.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/utils.test.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import { type Entity, getEntitySourceLocation } from '@backstage/catalog-model';
-import {
-  getHostnameFromEntity,
-  getRepositoryInformationFromEntity,
-} from './utils';
+import { type Entity } from '@backstage/catalog-model';
+import { getRepositoryInformationFromEntity } from './utils';
 
 jest.mock('@backstage/catalog-model', () => ({
   ...jest.requireActual('@backstage/catalog-model'),
@@ -33,27 +30,6 @@ describe('utils', () => {
       name: 'test-component',
     },
   };
-
-  describe('getHostnameFromEntity', () => {
-    it('should extract hostname', () => {
-      (getEntitySourceLocation as jest.Mock).mockReturnValue({
-        type: 'url',
-        target: 'https://github.com/org/test/tree/main/',
-      });
-
-      const result = getHostnameFromEntity(mockEntity);
-      expect(result).toBe('github.com');
-    });
-
-    it('should throw error for invalid URL', () => {
-      (getEntitySourceLocation as jest.Mock).mockReturnValue({
-        type: 'file',
-        target: 'file-path',
-      });
-
-      expect(() => getHostnameFromEntity(mockEntity)).toThrow();
-    });
-  });
 
   describe('getRepositoryInformationFromEntity', () => {
     it('should extract owner and repo from github.com/project-slug annotation', () => {

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/utils.ts
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  type Entity,
-  getEntitySourceLocation,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
+import { type Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { GithubRepository } from './types';
 import { GITHUB_PROJECT_ANNOTATION } from './constants';
-
-export const getHostnameFromEntity = (entity: Entity): string => {
-  const { target } = getEntitySourceLocation(entity);
-  return new URL(target).hostname;
-};
 
 export const getRepositoryInformationFromEntity = (
   entity: Entity,

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/metricProviders/GithubOpenPRsProvider.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/metricProviders/GithubOpenPRsProvider.test.ts
@@ -152,13 +152,10 @@ describe('GithubOpenPRsProvider', () => {
       expect(result).toBe(42);
       expect(
         mockedGithubClientInstance.getOpenPullRequestsCount,
-      ).toHaveBeenCalledWith(
-        {
-          owner: 'org',
-          repo: 'orgRepo',
-        },
-        'github.com',
-      );
+      ).toHaveBeenCalledWith('https://github.com/org/orgRepo/tree/main/', {
+        owner: 'org',
+        repo: 'orgRepo',
+      });
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/metricProviders/GithubOpenPRsProvider.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/metricProviders/GithubOpenPRsProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Config } from '@backstage/config';
-import type { Entity } from '@backstage/catalog-model';
+import { getEntitySourceLocation, type Entity } from '@backstage/catalog-model';
 import {
   DEFAULT_NUMBER_THRESHOLDS,
   Metric,
@@ -26,10 +26,7 @@ import {
   validateThresholds,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-node';
 import { GithubClient } from '../github/GithubClient';
-import {
-  getHostnameFromEntity,
-  getRepositoryInformationFromEntity,
-} from '../github/utils';
+import { getRepositoryInformationFromEntity } from '../github/utils';
 import { GITHUB_PROJECT_ANNOTATION } from '../github/constants';
 
 export class GithubOpenPRsProvider implements MetricProvider<'number'> {
@@ -82,11 +79,11 @@ export class GithubOpenPRsProvider implements MetricProvider<'number'> {
 
   async calculateMetric(entity: Entity): Promise<number> {
     const repository = getRepositoryInformationFromEntity(entity);
-    const hostname = getHostnameFromEntity(entity);
+    const { target } = getEntitySourceLocation(entity);
 
     const result = await this.githubClient.getOpenPullRequestsCount(
+      target,
       repository,
-      hostname,
     );
 
     return result;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Make Github app integration work for scorecard.

#### Fixes
Fixes https://issues.redhat.com/browse/RHDHBUGS-2078

#### How to test
Update `github-scorecard-only.yaml`: github.com/project-slug and backstage.io/source-location to some repo that is in the organization/user for which you have installed Github app.
1. First try out that your token integration still works:
```
integrations:
  github:
    - host: github.com
      token: XXX
```
2. Try out Github app:
```
integrations:
  github:
    - host: github.com
      apps:
        - appId: XXX
          clientId: XXX
          clientSecret: XXX
          webhookSecret: XXX
          privateKey: |
            XXX
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Note: This uses the first available integration for a host, currently there is no easy way to switch to a different one if there are multiple intergrations for the same host and the first matched one doesn't have access to concrete repo. Planning to improve this in the future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
