### PR TITLE
fix(global-floating-action-button): fix test package release

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/bump-fab-button.md
+++ b/workspaces/global-floating-action-button/.changeset/bump-fab-button.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-application-listener-test': patch
+'@red-hat-developer-hub/backstage-plugin-application-provider-test': patch
+'@red-hat-developer-hub/backstage-plugin-global-floating-action-button': patch
+---
+
+Fix the test package build and rebuild all packages to have a consistant commit for them.

--- a/workspaces/global-floating-action-button/plugins/application-listener-test/package.json
+++ b/workspaces/global-floating-action-button/plugins/application-listener-test/package.json
@@ -24,11 +24,11 @@
   "sideEffects": false,
   "scripts": {
     "start": "backstage-cli package start",
-    "build": "backstage-cli package build && yarn export-dynamic",
+    "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
-    "clean": "backstage-cli package clean && rm -rf dist-scalprum",
-    "prepack": "backstage-cli package prepack && yarn export-dynamic",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {

--- a/workspaces/global-floating-action-button/plugins/application-provider-test/package.json
+++ b/workspaces/global-floating-action-button/plugins/application-provider-test/package.json
@@ -24,11 +24,11 @@
   "sideEffects": false,
   "scripts": {
     "start": "backstage-cli package start",
-    "build": "backstage-cli package build && yarn export-dynamic",
+    "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
-    "clean": "backstage-cli package clean && rm -rf dist-scalprum",
-    "prepack": "backstage-cli package prepack && yarn export-dynamic",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR solves a problem that the npm (test) package wasn't released successfully

This Version PR: https://github.com/redhat-developer/rhdh-plugins/pull/1427

Triggers this job: https://github.com/redhat-developer/rhdh-plugins/actions/runs/17640848315/job/50127538013

which failed then:

```
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-application-listener-test]: Process started
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-application-listener-test]: ➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: [@red-hat-developer-hub/backstage-plugin-application-listener-test]: ➤ YN0000: @red-hat-developer-hub/backstage-plugin-application-listener-test@workspace:plugins/application-listener-test STDOUT Usage Error: Couldn't find a script named "export-dynamic".
```

This PR removes the left overs "export-dynamic" calls from the package.json.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
