### PR TITLE
fix(scorecard): update empty state component and add translations to permission required state

### DIFF
--- a/workspaces/scorecard/app-config.yaml
+++ b/workspaces/scorecard/app-config.yaml
@@ -6,7 +6,7 @@ jira:
   # Required: Supported products: `cloud` or `datacenter`
   product: cloud
   # By default, the latest version is used. You can omit this prop when using the latest version.
-  apiVersion: '3'
+  apiVersion: '2'
 app:
   title: Scaffolded Backstage App
   baseUrl: http://localhost:3000

--- a/workspaces/scorecard/packages/app/e2e-tests/pages/ScorecardPage.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/pages/ScorecardPage.ts
@@ -61,7 +61,7 @@ export class ScorecardPage {
       'Scorecards help you monitor component health at a glance. To begin, explore our documentation for setup guidelines.',
     );
     await expect(
-      this.page.getByRole('button', { name: 'View documentation' }),
+      this.page.getByRole('link', { name: 'View documentation' }),
     ).toBeVisible();
   }
 

--- a/workspaces/scorecard/plugins/scorecard/report-alpha.api.md
+++ b/workspaces/scorecard/plugins/scorecard/report-alpha.api.md
@@ -14,6 +14,10 @@ export const scorecardTranslationRef: TranslationRef<
     readonly 'emptyState.title': string;
     readonly 'emptyState.description': string;
     readonly 'emptyState.altText': string;
+    readonly 'permissionRequired.button': string;
+    readonly 'permissionRequired.title': string;
+    readonly 'permissionRequired.description': string;
+    readonly 'permissionRequired.altText': string;
     readonly 'errors.entityMissingProperties': string;
     readonly 'errors.invalidApiResponse': string;
     readonly 'errors.fetchError': string;

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/NoScorecardsState.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/NoScorecardsState.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Link } from '@backstage/core-components';
+
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -26,6 +27,11 @@ import { useTranslation } from '../../hooks/useTranslation';
 
 const NoScorecardsState: React.FC = () => {
   const { t } = useTranslation();
+
+  const configApi = useApi(configApiRef);
+  const supportUrl =
+    configApi.getOptionalString('app.support.url') ??
+    'https://access.redhat.com/documentation/red_hat_developer_hub';
 
   return (
     <Box sx={{ p: 4, height: '100%', maxWidth: '1592px', margin: 'auto' }}>
@@ -59,26 +65,20 @@ const NoScorecardsState: React.FC = () => {
             {t('emptyState.description')}
           </Typography>
 
-          <Link to="/docs">
-            <Button
-              sx={{
-                backgroundColor: '#1976d2',
-                color: 'white',
-                px: 3,
-                py: 1.5,
-                fontSize: '1rem',
-                fontWeight: 400,
-                textTransform: 'none',
-                borderRadius: '28px',
-                '&:hover': {
-                  backgroundColor: '#1565c0',
-                },
-              }}
-            >
-              {t('emptyState.button')}{' '}
+          <Button
+            color="primary"
+            variant="contained"
+            size="large"
+            component="a"
+            href={supportUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            endIcon={
               <OpenInNewOutlinedIcon sx={{ width: 16, height: 16, ml: 1 }} />
-            </Button>
-          </Link>
+            }
+          >
+            {t('emptyState.button')}
+          </Button>
         </Grid>
 
         <Grid item xs={12} md={6} sx={{ textAlign: 'right' }}>

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/PermissionRequiredState.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/PermissionRequiredState.tsx
@@ -55,17 +55,19 @@ const PermissionRequiredState = () => {
               lineHeight: 1.5,
             })}
           >
-            {t('permissionRequired.description')}{' '}
-            <Typography
-              component="span"
-              sx={theme => ({
-                fontWeight: 'bold',
-                color: theme.palette.text.primary,
-              })}
-            >
-              {t('permissionRequired.permission')}
-            </Typography>{' '}
-            {t('permissionRequired.descriptionSuffix')}
+            {t('permissionRequired.description' as any, {
+              permission: (
+                <Typography
+                  component="span"
+                  sx={theme => ({
+                    fontWeight: 'bold',
+                    color: theme.palette.text.primary,
+                  })}
+                >
+                  scorecard.metric.read
+                </Typography>
+              ),
+            })}
           </Typography>
 
           <Button

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/PermissionRequiredState.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/PermissionRequiredState.tsx
@@ -20,9 +20,12 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
+import { useTranslation } from '../../hooks/useTranslation';
 import permissionRequiredSvg from '../../images/permission-required.svg';
 
 const PermissionRequiredState = () => {
+  const { t } = useTranslation();
+
   return (
     <Box sx={{ p: 4, height: '100%', maxWidth: '1592px', margin: 'auto' }}>
       <Grid
@@ -41,7 +44,7 @@ const PermissionRequiredState = () => {
               mb: 2,
             })}
           >
-            Missing permission
+            {t('permissionRequired.title')}
           </Typography>
 
           <Typography
@@ -52,7 +55,7 @@ const PermissionRequiredState = () => {
               lineHeight: 1.5,
             })}
           >
-            To view Scorecard plugin, contact your administrator to give the{' '}
+            {t('permissionRequired.description')}{' '}
             <Typography
               component="span"
               sx={theme => ({
@@ -60,9 +63,9 @@ const PermissionRequiredState = () => {
                 color: theme.palette.text.primary,
               })}
             >
-              scorecard.metric.read
+              {t('permissionRequired.permission')}
             </Typography>{' '}
-            permission.
+            {t('permissionRequired.descriptionSuffix')}
           </Typography>
 
           <Button
@@ -73,7 +76,7 @@ const PermissionRequiredState = () => {
               color: theme.palette.primary.main,
             })}
           >
-            Read more &nbsp; <OpenInNewIcon />
+            {t('permissionRequired.button')} &nbsp; <OpenInNewIcon />
           </Button>
         </Grid>
 
@@ -81,7 +84,7 @@ const PermissionRequiredState = () => {
           <Box
             component="img"
             src={permissionRequiredSvg}
-            alt="No scorecards"
+            alt={t('permissionRequired.altText')}
             sx={{
               width: '100%',
               maxWidth: '600px',

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/__tests__/NoScorecardsState.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/__tests__/NoScorecardsState.test.tsx
@@ -25,6 +25,31 @@ jest.mock(
   () => 'mocked-no-scorecards.svg',
 );
 
+// Mock the useTranslation hook
+jest.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'emptyState.title': 'No scorecards added yet',
+        'emptyState.description':
+          'Scorecards help you monitor component health at a glance. To begin, explore our documentation for setup guidelines.',
+        'emptyState.button': 'View documentation',
+        'emptyState.altText': 'No scorecards',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+// Mock the useApi hook
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: jest.fn(),
+  configApiRef: 'configApiRef',
+}));
+
+const mockUseApi = require('@backstage/core-plugin-api')
+  .useApi as jest.MockedFunction<any>;
+
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const theme = createTheme();
   return (
@@ -39,6 +64,22 @@ const renderWithProviders = (component: React.ReactElement) => {
 };
 
 describe('NoScorecardsState Component', () => {
+  beforeEach(() => {
+    // Mock the config API to return a default support URL
+    mockUseApi.mockImplementation((apiRef: string) => {
+      if (apiRef === 'configApiRef') {
+        return {
+          getOptionalString: jest.fn().mockReturnValue(undefined),
+        };
+      }
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render the main heading', () => {
     renderWithProviders(<NoScorecardsState />);
 
@@ -58,19 +99,17 @@ describe('NoScorecardsState Component', () => {
   it('should render the documentation button with correct text', () => {
     renderWithProviders(<NoScorecardsState />);
 
-    const button = screen.getByRole('button', { name: /view documentation/i });
-    expect(button).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /view documentation/i });
+    expect(link).toBeInTheDocument();
   });
 
   it('should render the OpenInNewOutlined icon', () => {
     renderWithProviders(<NoScorecardsState />);
 
-    const button = screen.getByRole('button', { name: /view documentation/i });
-    expect(button).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /view documentation/i });
+    expect(link).toBeInTheDocument();
 
-    const icon = button.querySelector(
-      'svg[data-testid="OpenInNewOutlinedIcon"]',
-    );
+    const icon = link.querySelector('svg[data-testid="OpenInNewOutlinedIcon"]');
     expect(icon).toBeInTheDocument();
   });
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/__tests__/NoScorecardsState.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/__tests__/NoScorecardsState.test.tsx
@@ -25,22 +25,6 @@ jest.mock(
   () => 'mocked-no-scorecards.svg',
 );
 
-// Mock the useTranslation hook
-jest.mock('../../../hooks/useTranslation', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: Record<string, string> = {
-        'emptyState.title': 'No scorecards added yet',
-        'emptyState.description':
-          'Scorecards help you monitor component health at a glance. To begin, explore our documentation for setup guidelines.',
-        'emptyState.button': 'View documentation',
-        'emptyState.altText': 'No scorecards',
-      };
-      return translations[key] || key;
-    },
-  }),
-}));
-
 // Mock the useApi hook
 jest.mock('@backstage/core-plugin-api', () => ({
   useApi: jest.fn(),

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/__tests__/PermissionRequiredState.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/__tests__/PermissionRequiredState.test.tsx
@@ -95,16 +95,7 @@ describe('PermissionRequiredState Component', () => {
         /To view Scorecard plugin, contact your administrator to give the/,
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText('scorecard.metric.read')).toBeInTheDocument();
     expect(screen.getByText(/permission\./)).toBeInTheDocument();
-  });
-
-  it('should render the permission name with bold styling', () => {
-    renderWithProviders(<PermissionRequiredState />);
-
-    const permissionText = screen.getByText('scorecard.metric.read');
-    expect(permissionText).toBeInTheDocument();
-    expect(permissionText.tagName).toBe('SPAN');
   });
 
   it('should render the read more link button with correct text', () => {

--- a/workspaces/scorecard/plugins/scorecard/src/translations/de.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/de.ts
@@ -31,9 +31,7 @@ const scorecardTranslationDe = createTranslationMessages({
     // Permission required state
     'permissionRequired.title': 'Berechtigung fehlt',
     'permissionRequired.description':
-      'Um das Scorecard-Plugin anzuzeigen, wenden Sie sich an Ihren Administrator, um die',
-    'permissionRequired.permission': 'scorecard.metric.read',
-    'permissionRequired.descriptionSuffix': 'Berechtigung zu erteilen.',
+      'Um das Scorecard-Plugin anzuzeigen, wenden Sie sich an Ihren Administrator, um die {{permission}} Berechtigung zu erteilen.',
     'permissionRequired.button': 'Mehr lesen',
     'permissionRequired.altText': 'Berechtigung erforderlich',
 

--- a/workspaces/scorecard/plugins/scorecard/src/translations/de.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/de.ts
@@ -28,6 +28,15 @@ const scorecardTranslationDe = createTranslationMessages({
     'emptyState.button': 'Dokumentation anzeigen',
     'emptyState.altText': 'Keine Scorecards',
 
+    // Permission required state
+    'permissionRequired.title': 'Berechtigung fehlt',
+    'permissionRequired.description':
+      'Um das Scorecard-Plugin anzuzeigen, wenden Sie sich an Ihren Administrator, um die',
+    'permissionRequired.permission': 'scorecard.metric.read',
+    'permissionRequired.descriptionSuffix': 'Berechtigung zu erteilen.',
+    'permissionRequired.button': 'Mehr lesen',
+    'permissionRequired.altText': 'Berechtigung erforderlich',
+
     // Error messages
     'errors.entityMissingProperties':
       'Entität fehlt erforderliche Eigenschaften für Scorecard-Suche',

--- a/workspaces/scorecard/plugins/scorecard/src/translations/es.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/es.ts
@@ -28,6 +28,15 @@ const scorecardTranslationEs = createTranslationMessages({
     'emptyState.button': 'Ver documentación',
     'emptyState.altText': 'Sin scorecards',
 
+    // Permission required state
+    'permissionRequired.title': 'Permiso faltante',
+    'permissionRequired.description':
+      'Para ver el plugin Scorecard, contacta a tu administrador para otorgar el',
+    'permissionRequired.permission': 'scorecard.metric.read',
+    'permissionRequired.descriptionSuffix': 'permiso.',
+    'permissionRequired.button': 'Leer más',
+    'permissionRequired.altText': 'Permiso requerido',
+
     // Error messages
     'errors.entityMissingProperties':
       'Entidad falta propiedades requeridas para búsqueda de scorecard',

--- a/workspaces/scorecard/plugins/scorecard/src/translations/es.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/es.ts
@@ -31,9 +31,7 @@ const scorecardTranslationEs = createTranslationMessages({
     // Permission required state
     'permissionRequired.title': 'Permiso faltante',
     'permissionRequired.description':
-      'Para ver el plugin Scorecard, contacta a tu administrador para otorgar el',
-    'permissionRequired.permission': 'scorecard.metric.read',
-    'permissionRequired.descriptionSuffix': 'permiso.',
+      'Para ver el plugin Scorecard, contacta a tu administrador para otorgar el {{permission}} permiso.',
     'permissionRequired.button': 'Leer más',
     'permissionRequired.altText': 'Permiso requerido',
 

--- a/workspaces/scorecard/plugins/scorecard/src/translations/fr.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/fr.ts
@@ -31,9 +31,7 @@ const scorecardTranslationFr = createTranslationMessages({
     // Permission required state
     'permissionRequired.title': 'Permission manquante',
     'permissionRequired.description':
-      'Pour voir le plugin Scorecard, contactez votre administrateur pour donner la',
-    'permissionRequired.permission': 'scorecard.metric.read',
-    'permissionRequired.descriptionSuffix': 'permission.',
+      'Pour voir le plugin Scorecard, contactez votre administrateur pour donner la {{permission}} permission.',
     'permissionRequired.button': 'Lire plus',
     'permissionRequired.altText': 'Permission requise',
 

--- a/workspaces/scorecard/plugins/scorecard/src/translations/fr.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/fr.ts
@@ -28,6 +28,15 @@ const scorecardTranslationFr = createTranslationMessages({
     'emptyState.button': 'Voir la documentation',
     'emptyState.altText': 'Aucune scorecard',
 
+    // Permission required state
+    'permissionRequired.title': 'Permission manquante',
+    'permissionRequired.description':
+      'Pour voir le plugin Scorecard, contactez votre administrateur pour donner la',
+    'permissionRequired.permission': 'scorecard.metric.read',
+    'permissionRequired.descriptionSuffix': 'permission.',
+    'permissionRequired.button': 'Lire plus',
+    'permissionRequired.altText': 'Permission requise',
+
     // Error messages
     'errors.entityMissingProperties':
       'Entité manque de propriétés requises pour la recherche de scorecard',

--- a/workspaces/scorecard/plugins/scorecard/src/translations/ref.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/ref.ts
@@ -35,9 +35,7 @@ export const scorecardMessages = {
   permissionRequired: {
     title: 'Missing permission',
     description:
-      'To view Scorecard plugin, contact your administrator to give the',
-    permission: 'scorecard.metric.read',
-    descriptionSuffix: 'permission.',
+      'To view Scorecard plugin, contact your administrator to give the {{permission}} permission.',
     button: 'Read more',
     altText: 'Permission required',
   },

--- a/workspaces/scorecard/plugins/scorecard/src/translations/ref.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/ref.ts
@@ -31,6 +31,17 @@ export const scorecardMessages = {
     altText: 'No scorecards',
   },
 
+  // Permission required state
+  permissionRequired: {
+    title: 'Missing permission',
+    description:
+      'To view Scorecard plugin, contact your administrator to give the',
+    permission: 'scorecard.metric.read',
+    descriptionSuffix: 'permission.',
+    button: 'Read more',
+    altText: 'Permission required',
+  },
+
   // Error messages
   errors: {
     entityMissingProperties:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Fixes - https://issues.redhat.com/browse/RHDHBUGS-2081

Description

- Empty state component CTA now it linking to app.support.url or RHDH Documentation
- Removed hardcoded colors in Empty state component
- Added translations for Permission required component
- Updated unit test

## Screenshots / Recordings

#### Removed hardcoded colors and /doc path from Empty state and using `app.support.url` for Read more.
https://github.com/user-attachments/assets/91ee820a-8f6b-48a9-a12b-95642306ccdc


#### Translation added to Permission required state
<img width="1682" height="889" alt="Screenshot 2025-09-25 at 5 06 28 PM" src="https://github.com/user-attachments/assets/c333057f-585b-4a65-865a-aa411c145464" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
