### PR TITLE
fix(orchestrator): Shorten ActiveDropdown list of options

### DIFF
--- a/workspaces/orchestrator/.changeset/two-balloons-happen.md
+++ b/workspaces/orchestrator/.changeset/two-balloons-happen.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Fix ActiveDropdown for long lists.

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
@@ -141,6 +141,9 @@ export const ActiveDropdown: Widget<
         value={value}
         label={label}
         onChange={event => handleChange(event.target.value as string)}
+        MenuProps={{
+          PaperProps: { sx: { maxHeight: '20rem' } },
+        }}
       >
         {labels.map((itemLabel, idx) => (
           <MenuItem


### PR DESCRIPTION
Fix ActiveDropdown for long lists.

Before (video):
https://github.com/user-attachments/assets/de3eb501-3b48-4e5d-a161-e5e1a5296ec3

After:
https://github.com/user-attachments/assets/5798f8af-3569-481e-9166-b8c05b0b1586

