### PR TITLE
fix(adoption-insights): normalize timezone strings to avoid invalid date error.

### DIFF
--- a/workspaces/adoption-insights/.changeset/clear-files-talk.md
+++ b/workspaces/adoption-insights/.changeset/clear-files-talk.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+safely parse the date so it works in different Node.js/browser environments

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/ChartTooltip.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/ChartTooltip.tsx
@@ -24,6 +24,7 @@ import {
   formatTooltipHeaderLabel,
   formatWeeklyBucket,
   formatLongDate,
+  safeDate,
 } from '../../utils/utils';
 import { useDateRange } from '../Header/DateRangeContext';
 
@@ -83,7 +84,7 @@ const ChartTooltip = ({
   }
 
   // Parse date from chart label - chart data typically provides ISO strings or timestamps
-  const date = label ? new Date(label) : new Date();
+  const date = label ? safeDate(label) : new Date();
 
   return (
     <Paper
@@ -103,14 +104,19 @@ const ChartTooltip = ({
       >
         {formatBucketLabel(date)
           .split('\n')
-          .map((line, i) => (
-            <div key={i}>{line}</div>
+          .map((line, index) => (
+            <div key={`tooltip-line-${line.substring(0, 10)}-${index}`}>
+              {line}
+            </div>
           ))}
       </Typography>
 
       <Box display="flex" justifyContent="space-between" alignItems="center">
         {payload.map(({ dataKey, value }, index) => (
-          <Box mr={index === payload.length - 1 ? 0 : 3}>
+          <Box
+            key={`tooltip-value-${dataKey}-${value}-${index}`}
+            mr={index === payload.length - 1 ? 0 : 3}
+          >
             <Typography
               sx={{
                 fontSize: '0.875rem',

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
@@ -29,6 +29,15 @@ import { TranslationFunction } from '@backstage/core-plugin-api/alpha';
 import { APIsViewOptions } from '../types';
 import { adoptionInsightsTranslationRef } from '../translations';
 
+/**
+ * Parse date string and normalize timezone format.
+ * Converts +00 timezone format to Z for better browser compatibility.
+ */
+export const safeDate = (dateString: string): Date => {
+  const normalizedDate = dateString.replace(/\+00$/, 'Z');
+  return new Date(normalizedDate);
+};
+
 // =============================================================================
 // LOCALIZATION UTILITIES
 // =============================================================================
@@ -239,11 +248,11 @@ export const getXAxisTickValues = (data: any, grouping: string): string[] => {
 
   // Apply grouping-specific logic
   if (grouping === 'hourly') {
-    processGrouping(date => new Date(date).getHours());
+    processGrouping(date => safeDate(date).getHours());
   } else if (grouping === 'daily' || grouping === 'weekly') {
-    processGrouping(date => new Date(date).getDate());
+    processGrouping(date => safeDate(date).getDate());
   } else if (grouping === 'monthly') {
-    processGrouping(date => new Date(date).getMonth());
+    processGrouping(date => safeDate(date).getMonth());
   }
 
   // Always include first and last dates, plus selected middle dates
@@ -264,11 +273,11 @@ export const getXAxisformat = (
   grouping: string,
   locale?: string,
 ) => {
-  const dateObj = new Date(date);
+  const dateObj = safeDate(date);
 
   // Handle invalid dates gracefully
   if (isNaN(dateObj.getTime())) {
-    return formatShortDate(new Date(date), locale);
+    return formatShortDate(safeDate(date), locale);
   }
 
   // Format according to grouping level
@@ -299,7 +308,7 @@ export const getLastUsedDay = (
   t?: TranslationFunction<typeof adoptionInsightsTranslationRef.T>,
   locale?: string,
 ) => {
-  const date = new Date(timestamp);
+  const date = safeDate(timestamp);
 
   if (isToday(date)) {
     return t ? t('common.today') : 'Today';


### PR DESCRIPTION
## Fixes

https://issues.redhat.com/browse/RHDHBUGS-2092

## Description:

 Parsing new Date("2025-10-01T00:00:00+00") sometimes produces "Invalid Date" depending on runtime (Node.js / browser).

This PR includes the fix which safely parses the date strings so that `new Date()` function doesn't throw errors in different runtimes (NodeJS/browser).






## How to test this fix?

1. Make the following changes in the code (Not reproducible in the local environments)

```diff
--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts

 export const safeDate = (dateString: string): Date => {
-  const normalizedDate = dateString.replace(/\+00$/, 'Z');
-  return new Date(normalizedDate);
+  return new Date(dateString);
 };

```
2. run `yarn test utils.test.ts` from `workspaces/adoptions` folder, so the newly added tests will fail.

eg: 
```
 ● getLastUsedDay › should handle +00 timezone format correctly for recent dates

    RangeError: Invalid time value
```



## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
