### PR TITLE
fix(scorecard): change the default api version from latest to 3 for the jira api/module

### DIFF
--- a/workspaces/scorecard/.changeset/odd-baboons-drum.md
+++ b/workspaces/scorecard/.changeset/odd-baboons-drum.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira': patch
+---
+
+Change the default API version from latest to version 3.

--- a/workspaces/scorecard/app-config.local.EXAMPLE.yaml
+++ b/workspaces/scorecard/app-config.local.EXAMPLE.yaml
@@ -42,7 +42,7 @@ proxy:
       Accept: 'application/json'
       Content-Type: 'application/json'
       X-Atlassian-Token: 'nocheck'
-      User-Agent: 'MY-UA-STRING'
+      User-Agent: RHDH-SCORECARD-PLUGIN
 
 integrations:
   github:
@@ -54,7 +54,6 @@ jira:
   product: cloud
   baseUrl: ${JIRA_URL}
   token: ${JIRA_TOKEN}
-  #apiVersion: 3
 
 scorecard:
   plugins:

--- a/workspaces/scorecard/app-config.yaml
+++ b/workspaces/scorecard/app-config.yaml
@@ -51,7 +51,7 @@ proxy:
       Accept: 'application/json'
       Content-Type: 'application/json'
       X-Atlassian-Token: 'nocheck'
-      User-Agent: 'MY-UA-STRING'
+      User-Agent: RHDH-SCORECARD-PLUGIN
 
 # Jira plugin and scorecard configuration
 jira:
@@ -64,8 +64,12 @@ jira:
   token: ${JIRA_TOKEN}
   # Required: Supported products: `cloud` or `datacenter`
   product: cloud
-  # By default, the latest version is used. You can omit this prop when using the latest version.
-  apiVersion: 2
+  # By default, the scorecard jira module is using a stable/tested version of the Jira API.
+  # See `API_VERSION_DEFAULT` in `plugins/scorecard-backend-module-jira/src/constants/jiraOpenIssues.ts`.
+  # Admins, customers, or we can override this api version to test other api versions.
+  # Using "latest" works for our scorecard jira module but not the Roadie Jira plugin.
+  # To use "latest" you might need to disable that plugin temporarily.
+  # apiVersion: latest
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/workspaces/scorecard/plugins/scorecard-backend-module-jira/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-jira/README.md
@@ -46,7 +46,11 @@ jira:
   token: ${JIRA_TOKEN}
   # Required: Supported products: `cloud` or `datacenter`
   product: cloud
-  # Optional: By default, the latest version is used. You can omit this prop when using the latest version.
+
+  # Optional and not recommended
+  # The scorecard jira module is using a stable and tested api version by default.
+  # You can override this and use another api version (or latest) of the Jira API if you notice issues with the default.
+  # This is not recommended in production environments.
   apiVersion: 3
 ```
 
@@ -60,7 +64,11 @@ jira:
   proxyPath: /jira/api
   # Required: Supported products: `cloud` or `datacenter`
   product: cloud
-  # Optional: By default, the latest version is used. You can omit this prop when using the latest version.
+
+  # Optional and not recommended
+  # The scorecard jira module is using a stable and tested api version by default.
+  # You can override this and use another api version (or latest) of the Jira API if you notice issues with the default.
+  # This is not recommended in production environments.
   apiVersion: 3
 
 # This proxy configuration presented only as an example

--- a/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/clients/base.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/clients/base.test.ts
@@ -17,6 +17,7 @@
 import type { Config } from '@backstage/config';
 import { JiraClient } from './base';
 import { ScorecardJiraAnnotations } from '../annotations';
+import { API_VERSION_DEFAULT } from '../constants';
 import { ConnectionStrategy } from '../strategies/ConnectionStrategy';
 import {
   newEntityComponent,
@@ -67,7 +68,9 @@ describe('JiraClient', () => {
     mockConnectionStrategy = {
       getBaseUrl: jest
         .fn()
-        .mockReturnValue('https://example.com/api/rest/api/latest'),
+        .mockReturnValue(
+          `https://example.com/api/rest/api/${API_VERSION_DEFAULT}`,
+        ),
       getAuthHeaders: jest
         .fn()
         .mockResolvedValue({ Authorization: 'Basic Fds31dsF32' }),
@@ -82,7 +85,7 @@ describe('JiraClient', () => {
 
   describe('constructor', () => {
     it('should create api version', () => {
-      expect((testJiraClient as any).apiVersion).toEqual('latest');
+      expect((testJiraClient as any).apiVersion).toEqual(3);
     });
 
     it('should create correct options', () => {
@@ -350,7 +353,7 @@ describe('JiraClient', () => {
   describe('getBaseUrl', () => {
     it('should return URL', async () => {
       const baseUrl = await (testJiraClient as any).getBaseUrl();
-      expect(baseUrl).toEqual('https://example.com/api/rest/api/latest');
+      expect(baseUrl).toEqual('https://example.com/api/rest/api/3');
     });
   });
 

--- a/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/constants/jiraOpenIssues.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/constants/jiraOpenIssues.ts
@@ -34,7 +34,7 @@ export const JIRA_CONFIG_PATH = 'jira' as const;
 export const JIRA_OPTIONS_PATH =
   'scorecard.plugins.jira.open_issues.options' as const;
 
-export const API_VERSION_DEFAULT = 'latest' as const;
+export const API_VERSION_DEFAULT = 3 as const;
 
 export const JIRA_MANDATORY_FILTER =
   'type = Bug AND resolution = Unresolved' as const;

--- a/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/strategies/JiraDataCenterClientStrategy.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/strategies/JiraDataCenterClientStrategy.test.ts
@@ -42,7 +42,6 @@ describe('JiraDataCenterClient', () => {
       customFilter: 'priority in ("Critical", "Blocker")',
     };
     const config = newMockRootConfig({
-      jiraConfig: { apiVersion: 2 },
       options,
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

@dzemanov @imykhno, this is an "opinionated" change, please take a look and let me know if you're fine with this in general, and how I've done the change in "your" backend... :)

I've changed the `API_VERSION_DEFAULT` version from `latest` to 3, just for the case that Atlassion publishes a new, incompatible API. With this change, the plugin will still work until we have updated and tested it with the new API.

If needed a customer can still change/configure the api version but I made a "strong opinionated" comment to the README that we don't recommend.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
