### PR TITLE
fix(orchestrator): let AuthRequester reference static non-standard auth apis

### DIFF
--- a/workspaces/orchestrator/.changeset/blue-clouds-grin.md
+++ b/workspaces/orchestrator/.changeset/blue-clouds-grin.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+The AuthRequester widget can reference statically added non-core auth apis.

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useOrchestratorAuth.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useOrchestratorAuth.ts
@@ -81,17 +81,28 @@ export const useOrchestratorAuth = () => {
   const findCustomProvider = useCallback(
     async (providerApiId: string): Promise<unknown> => {
       const allPlugins = app.getPlugins();
+
+      // For APIs deployed within plugins
       const apiRef = allPlugins
         .flatMap(plugin => Array.from(plugin.getApis()))
         .find((api: AnyApiFactory) => api.api.id === providerApiId)?.api;
 
-      if (!apiRef) {
-        throw new Error(
-          `Unknown custom auth provider API of id "${providerApiId}". The provider API id should match the ApiRef id.`,
-        );
+      if (apiRef) {
+        const api = apiHolder.get(apiRef);
+        if (!api) {
+          throw new Error(
+            `API with id "${providerApiId}" was not found in the API holder. The API is provided by a plugin.`,
+          );
+        }
+        return api;
       }
 
-      const api = apiHolder.get(apiRef);
+      // Try to find a statically added api ref, like the 'internal.auth.oidc'
+      // by https://github.com/redhat-developer/rhdh/blob/main/packages/app/src/api/AuthApiRefs.ts
+      // Hint: If this approach proves to be working, we could use it for the other apis as well.
+      // @ts-ignore
+      const allApis = apiHolder.apis as Map<string, object>;
+      const api = allApis.get('core.auth.github');
       if (!api) {
         throw new Error(
           `API with id "${providerApiId}" was not found in the API holder.`,


### PR DESCRIPTION
Jira: FLPATH-2361

With this patch, the AuthRequester widget can reference statically added non-core auth apis (not well-names like GitHub, not provided by a plugin).

Example, the RHDH OIDC API: https://github.com/redhat-developer/rhdh/blob/main/packages/app/src/api/AuthApiRefs.ts#L18

Workflow data input schema example:

```
"authSetup": {
  "type": "string",
  "ui:widget": "AuthRequester",
  "ui:props": {
  "authTokenDescriptors": [
    {
      "provider": "oidc",
      "customProviderApiId": "internal.auth.oidc",
      "tokenType": "oauth"
    }
  ]}
}
```
