### PR TITLE
feat(homepage): update quickaccess card icon rendering logic

### DIFF
--- a/workspaces/homepage/.changeset/loud-weeks-tie.md
+++ b/workspaces/homepage/.changeset/loud-weeks-tie.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dynamic-home-page': patch
+---
+
+update quickaccess card's icon rendering logic

--- a/workspaces/homepage/packages/app/src/App.tsx
+++ b/workspaces/homepage/packages/app/src/App.tsx
@@ -60,6 +60,7 @@ import {
   DynamicCustomizableHomePage,
   VisitListener,
   OnboardingSection,
+  QuickAccessCard,
   EntitySection,
   TemplateSection,
   defaultLayouts,
@@ -113,6 +114,12 @@ const mountPoints: HomePageCardMountPoint[] = [
     Component: OnboardingSection,
     config: {
       layouts: defaultLayouts.onboarding,
+    },
+  },
+  {
+    Component: QuickAccessCard,
+    config: {
+      layouts: defaultLayouts.quickAccessCard,
     },
   },
   {

--- a/workspaces/homepage/plugins/dynamic-home-page/report.api.md
+++ b/workspaces/homepage/plugins/dynamic-home-page/report.api.md
@@ -114,6 +114,38 @@ export const defaultLayouts: {
             h: number;
         };
     };
+    quickAccessCard: {
+        xl: {
+            w: number;
+            h: number;
+            x: number;
+        };
+        lg: {
+            w: number;
+            h: number;
+            x: number;
+        };
+        md: {
+            w: number;
+            h: number;
+            x: number;
+        };
+        sm: {
+            w: number;
+            h: number;
+            x: number;
+        };
+        xs: {
+            w: number;
+            h: number;
+            x: number;
+        };
+        xxs: {
+            w: number;
+            h: number;
+            x: number;
+        };
+    };
 };
 
 // @public

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessCard.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessCard.tsx
@@ -28,6 +28,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import { useQuickAccessLinks } from '../hooks/useQuickAccessLinks';
 import { useTranslation } from '../hooks/useTranslation';
+import { QuickAccessIcon } from './QuickAccessIcon';
 
 const useStyles = makeStyles()({
   center: {
@@ -35,10 +36,6 @@ const useStyles = makeStyles()({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  img: {
-    height: '40px',
-    width: 'auto',
   },
   title: {
     '& div > div > div > div > p': {
@@ -89,13 +86,7 @@ export const QuickAccessCard = (props: QuickAccessCardProps) => {
             title={item.title}
             tools={item.links.map(link => ({
               ...link,
-              icon: (
-                <img
-                  className={classes.img}
-                  src={link.iconUrl}
-                  alt={link.label}
-                />
-              ),
+              icon: <QuickAccessIcon icon={link.iconUrl} alt={link.label} />,
             }))}
             // Component creation is allowed inside component props only
             // if prop name starts with `render`.

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessIcon.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessIcon.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactElement } from 'react';
+import { makeStyles } from 'tss-react/mui';
+
+import { isValidElement } from 'react';
+import { useApp } from '@backstage/core-plugin-api';
+
+import MuiIcon from '@mui/material/Icon';
+
+const useStyles = makeStyles()({
+  img: {
+    height: '40px',
+    width: 'auto',
+  },
+});
+
+export const QuickAccessIcon = ({
+  icon,
+  alt,
+}: {
+  icon: string | ReactElement;
+  alt: string;
+}) => {
+  const { classes } = useStyles();
+  const app = useApp();
+
+  if (!icon) {
+    return null;
+  }
+
+  if (isValidElement(icon)) {
+    return icon;
+  }
+
+  const strIcon = icon as string;
+
+  const SystemIcon = app.getSystemIcon(strIcon);
+
+  if (SystemIcon) {
+    return <SystemIcon fontSize="large" />;
+  }
+
+  if (strIcon.startsWith('<svg')) {
+    const svgDataUri = `data:image/svg+xml;base64,${btoa(strIcon)}`;
+    return <img src={svgDataUri} className={classes.img} alt={alt} />;
+  }
+
+  if (
+    strIcon.startsWith('https://') ||
+    strIcon.startsWith('http://') ||
+    strIcon.startsWith('/')
+  ) {
+    return <img src={strIcon} className={classes.img} alt={alt} />;
+  }
+
+  return <MuiIcon baseClassName="material-icons-outlined">{strIcon}</MuiIcon>;
+};

--- a/workspaces/homepage/plugins/dynamic-home-page/src/defaults.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/defaults.ts
@@ -65,4 +65,12 @@ export const defaultLayouts = {
     xs: { w: 12, h: 7.5 },
     xxs: { w: 12, h: 13.5 },
   },
+  quickAccessCard: {
+    xl: { w: 6, h: 8, x: 6 },
+    lg: { w: 6, h: 8, x: 6 },
+    md: { w: 6, h: 8, x: 6 },
+    sm: { w: 12, h: 8, x: 6 },
+    xs: { w: 12, h: 8, x: 6 },
+    xxs: { w: 12, h: 8, x: 6 },
+  },
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://issues.redhat.com/browse/RHIDP-9035

The PR updates the current QuickAccess card icon rendering logic to support `<svg>..</svg>`, `Backstage system icon`, along with `image url` and `relative path`

**Test setup:**

Update `app-config.yaml` to add proxy:

```
proxy:
  endpoints:
    # Other Proxies
    # customize developer hub instance
    '/developer-hub':
      target: https://raw.githubusercontent.com/ # i.e https://raw.githubusercontent.com/
      pathRewrite:
        '^/api/proxy/developer-hub': /debsmita1/test-homepage/refs/heads/main/data-homepage.json # i.e /redhat-developer/rhdh/main/packages/app/public/homepage/data.json
      changeOrigin: true
      secure: true
```

PS: I have the `calendar.svg` icon downloaded and saved under `packages/app/public`


**Screenshots:**
<img width="1018" height="593" alt="Screenshot 2025-10-06 at 7 00 58 PM" src="https://github.com/user-attachments/assets/b8557cc6-b81f-4406-a3cf-0776b7588aa9" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
