### PR TITLE
fix(bulk-import): automatically select templates for bulkImport.importTemplate configuration

### DIFF
--- a/workspaces/bulk-import/.changeset/lemon-cherries-cross.md
+++ b/workspaces/bulk-import/.changeset/lemon-cherries-cross.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import-backend': patch
+---
+
+Automatically select templates from default namespace for bulkImport.importTemplate configuration.

--- a/workspaces/bulk-import/package.json
+++ b/workspaces/bulk-import/package.json
@@ -20,6 +20,7 @@
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
+    "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
     "postinstall": "cd ../../ && yarn install"
   },

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/utils.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/helpers/utils.ts
@@ -69,7 +69,10 @@ export function parseGitURLForApprovalTool(repoUrl: string) {
 
 export function getImportTemplateRef(templateRef: string): string {
   try {
-    const { name, namespace, kind } = parseEntityRef(templateRef);
+    const { name, namespace, kind } = parseEntityRef(templateRef, {
+      defaultKind: 'template',
+      defaultNamespace: 'default',
+    });
 
     if (kind !== 'template') {
       throw new InputError(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows in the `app-config.yaml`:

```yaml
bulkImport:
  importAPI: scaffolder
  importTemplate: create-pr-with-catalog-info
```

instead of

```yaml
bulkImport:
  importAPI: scaffolder
  importTemplate: template:default/create-pr-with-catalog-info
```

Other namespaces are still possible of course.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
