### PR TITLE
fix(bulk-import): use a single react-query QueryClient instance for all pages and remove the need to have one in the app

### DIFF
--- a/workspaces/bulk-import/.changeset/silly-donuts-refuse.md
+++ b/workspaces/bulk-import/.changeset/silly-donuts-refuse.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Use a single react-query QueryClient instance for all pages and remove the need to have one in the app.

--- a/workspaces/bulk-import/packages/app/src/App.tsx
+++ b/workspaces/bulk-import/packages/app/src/App.tsx
@@ -48,7 +48,6 @@ import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import { UserSettingsPage } from '@backstage/plugin-user-settings';
 import { BulkImportPage } from '@red-hat-developer-hub/backstage-plugin-bulk-import';
 import { bulkImportTranslations } from '@red-hat-developer-hub/backstage-plugin-bulk-import/alpha';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { getThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
 import { Navigate, Route } from 'react-router-dom';
 import { apis } from './apis';
@@ -99,8 +98,6 @@ const app = createApp({
   themes: getThemes(),
 });
 
-const queryClient = new QueryClient();
-
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
@@ -136,14 +133,7 @@ const routes = (
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
     <Route path="/bulk-import" element={<Navigate to="repositories" />} />
-    <Route
-      path="/bulk-import/repositories"
-      element={
-        <QueryClientProvider client={queryClient}>
-          <BulkImportPage />
-        </QueryClientProvider>
-      }
-    />
+    <Route path="/bulk-import/repositories" element={<BulkImportPage />} />
   </FlatRoutes>
 );
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react';
-
 import { Content, Header, Page, Progress } from '@backstage/core-components';
 import { usePermission } from '@backstage/plugin-permission-react';
 
@@ -27,7 +25,6 @@ import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { bulkImportPermission } from '@red-hat-developer-hub/backstage-plugin-bulk-import-common';
 
@@ -37,13 +34,8 @@ import { AddRepositoriesForm } from './AddRepositoriesForm';
 import { Illustrations } from './Illustrations';
 
 export const AddRepositoriesPage = () => {
-  const queryClientRef = useRef<QueryClient>();
   const theme = useTheme();
   const { t } = useTranslation();
-
-  if (!queryClientRef.current) {
-    queryClientRef.current = new QueryClient();
-  }
 
   const bulkImportViewPermissionResult = usePermission({
     permission: bulkImportPermission,
@@ -130,9 +122,7 @@ export const AddRepositoriesPage = () => {
               </AccordionDetails>
             </Accordion>
           </div>
-          <QueryClientProvider client={queryClientRef.current as QueryClient}>
-            <AddRepositoriesForm />
-          </QueryClientProvider>
+          <AddRepositoriesForm />
         </>
       );
     }

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportPage.tsx
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react';
-
 import { Content, Header, Page, Progress } from '@backstage/core-components';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import FormControl from '@mui/material/FormControl';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Formik } from 'formik';
 
 import { bulkImportPermission } from '@red-hat-developer-hub/backstage-plugin-bulk-import-common';
@@ -38,8 +35,6 @@ import { DrawerContextProvider } from './DrawerContext';
 import { RepositoriesList } from './Repositories/RepositoriesList';
 
 export const BulkImportPage = () => {
-  // to store the queryClient instance
-  const queryClientRef = useRef<QueryClient>();
   const { t } = useTranslation();
   const initialValues: AddRepositoriesFormValues = {
     repositoryType: RepositorySelection.Repository,
@@ -53,27 +48,21 @@ export const BulkImportPage = () => {
     resourceRef: bulkImportPermission.resourceType,
   });
 
-  if (!queryClientRef.current) {
-    queryClientRef.current = new QueryClient();
-  }
-
   const showContent = () => {
     if (bulkImportViewPermissionResult.loading) {
       return <Progress />;
     }
     if (bulkImportViewPermissionResult.allowed) {
       return (
-        <QueryClientProvider client={queryClientRef.current!}>
-          <Formik
-            initialValues={initialValues}
-            enableReinitialize
-            onSubmit={async (_values: AddRepositoriesFormValues) => {}}
-          >
-            <FormControl fullWidth>
-              <RepositoriesList />
-            </FormControl>
-          </Formik>
-        </QueryClientProvider>
+        <Formik
+          initialValues={initialValues}
+          enableReinitialize
+          onSubmit={async (_values: AddRepositoriesFormValues) => {}}
+        >
+          <FormControl fullWidth>
+            <RepositoriesList />
+          </FormControl>
+        </Formik>
       );
     }
     return (

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
@@ -16,22 +16,28 @@
 
 import { Route, Routes } from 'react-router-dom';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import { addRepositoriesRouteRef, tasksRouteRef } from '../routes';
 import { AddRepositoriesPage } from './AddRepositories/AddRepositoriesPage';
 import { BulkImportPage } from './BulkImportPage';
 import { TasksPage } from './Repositories/TasksPage';
+
+const queryClient = new QueryClient();
 
 /**
  *
  * @public
  */
 export const Router = () => (
-  <Routes>
-    <Route path="*" element={<BulkImportPage />} />
-    <Route
-      path={addRepositoriesRouteRef.path}
-      element={<AddRepositoriesPage />}
-    />
-    <Route path={tasksRouteRef.path} element={<TasksPage />} />
-  </Routes>
+  <QueryClientProvider client={queryClient}>
+    <Routes>
+      <Route path="*" element={<BulkImportPage />} />
+      <Route
+        path={addRepositoriesRouteRef.path}
+        element={<AddRepositoriesPage />}
+      />
+      <Route path={tasksRouteRef.path} element={<TasksPage />} />
+    </Routes>
+  </QueryClientProvider>
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHDHBUGS-2108

Before it was necessary to have a QueryClient in the app which would not work in rhdh.

I saw that two other "pages" has their own QueryClient instance and it was "missed" on the new `TasksPage`. Instead of adding it there I removed all instances and added one around all pages in the `Router` component.

Yes, the instance is now shared also if a user leave the bulk import and opens it again. For me, this is a feature that the second time some cached (and automatically refetched!) result was displayed. 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
