### PR TITLE
Improve card styling consistency with Backstage design system

### DIFF
--- a/workspaces/adoption-insights/.changeset/improve-card-styling-consistency.md
+++ b/workspaces/adoption-insights/.changeset/improve-card-styling-consistency.md
@@ -1,0 +1,9 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Improve card styling consistency with Backstage design system
+
+- Remove explicit borders from CardWrapper component to match standard Backstage card styling
+- Replace custom border styling with Material-UI Paper elevation system for consistent visual appearance
+- Update Divider component to use default styling without custom borders

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/CardWrapper/CardWrapper.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/CardWrapper/CardWrapper.tsx
@@ -32,10 +32,7 @@ const CardWrapper: FC<CardWrapperProps> = ({
   filter,
 }: CardWrapperProps) => {
   return (
-    <Box
-      component={Paper}
-      sx={{ border: theme => `1px solid ${theme.palette.grey[300]}` }}
-    >
+    <Paper elevation={1}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
         <Typography
           variant="h5"
@@ -51,11 +48,9 @@ const CardWrapper: FC<CardWrapperProps> = ({
 
         {filter && <Box>{filter}</Box>}
       </Box>
-      <Divider
-        sx={{ border: theme => `1px solid ${theme.palette.grey[300]}` }}
-      />
+      <Divider />
       <Box>{children}</Box>
-    </Box>
+    </Paper>
   );
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2023

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

------BEFORE-----

<img width="1475" height="871" alt="Screenshot 2025-10-08 at 2 59 33 PM" src="https://github.com/user-attachments/assets/db87a5b9-1575-4f0f-858d-b56d98fa311d" />

<img width="1461" height="886" alt="Screenshot 2025-10-08 at 3 05 58 PM" src="https://github.com/user-attachments/assets/084a7d11-5134-44d1-8811-f898879a0efc" />


-------AFTER-----

<img width="1468" height="925" alt="Screenshot 2025-10-08 at 2 56 23 PM" src="https://github.com/user-attachments/assets/e9cde7a7-f8e3-42a3-8476-b19ac4af2503" />

<img width="1468" height="835" alt="Screenshot 2025-10-08 at 3 07 32 PM" src="https://github.com/user-attachments/assets/d1b7c973-e5f6-4854-8c57-aac5c1fd9b5b" />


Improve card styling consistency with Backstage design system

- Remove explicit borders from CardWrapper component to match standard Backstage card styling
- Replace custom border styling with Material-UI Paper elevation system for consistent visual appearance
- Update Divider component to use default styling without custom borders

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
