### PR TITLE
fix: send contact sales and verification as cta events 

### DIFF
--- a/workspaces/sandbox/make/sandbox.mk
+++ b/workspaces/sandbox/make/sandbox.mk
@@ -16,8 +16,9 @@ RHDH_LOCAL_DIR := "$(TMPDIR)rhdh-local"
 .PHONY: clone-rhdh-local
 clone-rhdh-local:
 	rm -rf ${RHDH_LOCAL_DIR}; \
-	git clone https://github.com/redhat-developer/rhdh-local $(RHDH_LOCAL_DIR) && \
+	git clone --depth 1 https://github.com/redhat-developer/rhdh-local $(RHDH_LOCAL_DIR) && \
 	cd $(RHDH_LOCAL_DIR) && \
+	git fetch --unshallow && \
 	git checkout 37be302480b1458c3dfd3270c25726d65f0ffe75 && \
 	echo "cloned to $(RHDH_LOCAL_DIR)"
 

--- a/workspaces/sandbox/plugins/sandbox/segment-events.html
+++ b/workspaces/sandbox/plugins/sandbox/segment-events.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Developer Sandbox - Segment Events</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif; color: #222; margin: 24px; }
+      h1 { font-size: 22px; margin-bottom: 8px; }
+      h2 { font-size: 18px; margin-top: 24px; margin-bottom: 8px; }
+      p { color: #444; }
+      table { border-collapse: collapse; width: 100%; margin-top: 12px; }
+      th, td { border: 1px solid #ddd; padding: 8px; vertical-align: top; }
+      th { background: #f7f7f7; text-align: left; }
+      code { background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    </style>
+  </head>
+  <body>
+    <h1>Developer Sandbox - Segment Events</h1>
+    <p>This document lists all Segment calls made by the Sandbox plugin, including tracked events and their properties, plus Identify and Group calls.</p>
+
+    <h2>Track Events</h2>
+    <p>Event names follow the pattern: <code>&lt;What&gt; &lt;past-tense-verb&gt;</code> where the verb is <code>launched</code> for CTAs and <code>clicked</code> otherwise.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Event Name</th>
+          <th>Section</th>
+          <th>Link Type</th>
+          <th>Properties (payload)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Removed generic CTA pattern; listing explicit CTAs below -->
+        <!-- Explicit CTA events from the Catalog card -->
+        <tr>
+          <td class="mono">OpenShift launched</td>
+          <td>Catalog</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Catalog</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-catalog</span></div>
+            <div><code>text</code>: OpenShift</div>
+            <div><code>href</code>: product link (varies)</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+            <div><code>internalCampaign</code>: <span class="mono">701Pe00000dnCEYIA2</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">OpenShift AI launched</td>
+          <td>Catalog</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Catalog</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-catalog</span></div>
+            <div><code>text</code>: OpenShift AI</div>
+            <div><code>href</code>: product link (varies)</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+            <div><code>internalCampaign</code>: <span class="mono">701Pe00000do2uiIAA</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Dev Spaces launched</td>
+          <td>Catalog</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Catalog</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-catalog</span></div>
+            <div><code>text</code>: Dev Spaces</div>
+            <div><code>href</code>: product link (varies)</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+            <div><code>internalCampaign</code>: <span class="mono">701Pe00000doTQCIA2</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Ansible Automation Platform launched</td>
+          <td>Catalog</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Catalog</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-catalog</span></div>
+            <div><code>text</code>: Ansible Automation Platform</div>
+            <div><code>href</code>: product link (may be empty initially)</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+            <div><code>internalCampaign</code>: <span class="mono">701Pe00000dowQXIAY</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">OpenShift Virtualization launched</td>
+          <td>Catalog</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Catalog</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-catalog</span></div>
+            <div><code>text</code>: OpenShift Virtualization</div>
+            <div><code>href</code>: product link (varies)</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+            <div><code>internalCampaign</code>: <span class="mono">701Pe00000dov6IIAQ</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Get Started - Ansible launched</td>
+          <td>Catalog</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Catalog</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-catalog</span></div>
+            <div><code>text</code>: Get Started - Ansible</div>
+            <div><code>href</code>: Ansible UI link</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+            <div><code>internalCampaign</code>: set to AAP intcmp</div>
+          </td>
+          
+        </tr>
+        <!-- Activities: explicit list -->
+        <tr>
+          <td class="mono">Get started with your Developer Sandbox clicked</td>
+          <td>Activities</td>
+          <td>default</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Activities</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-activities</span></div>
+            <div><code>text</code>: Get started with your Developer Sandbox</div>
+            <div><code>href</code>: https://developers.redhat.com/learn/openshift/get-started-your-developer-sandbox</div>
+            <div><code>linkType</code>: <span class="mono">default</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Streamline automation in OpenShift Dev Spaces with Ansible clicked</td>
+          <td>Activities</td>
+          <td>default</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Activities</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-activities</span></div>
+            <div><code>text</code>: Streamline automation in OpenShift Dev Spaces with Ansible</div>
+            <div><code>href</code>: https://developers.redhat.com/learn/openshift/streamline-automation-openshift-dev-spaces-ansible</div>
+            <div><code>linkType</code>: <span class="mono">default</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">How to deploy a Java application on Kubernetes in minutes clicked</td>
+          <td>Activities</td>
+          <td>default</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Activities</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-activities</span></div>
+            <div><code>text</code>: How to deploy a Java application on Kubernetes in minutes</div>
+            <div><code>href</code>: https://developers.redhat.com/learn/java/how-deploy-java-application-kubernetes-minutes</div>
+            <div><code>linkType</code>: <span class="mono">default</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Foundations of OpenShift clicked</td>
+          <td>Activities</td>
+          <td>default</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Activities</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-activities</span></div>
+            <div><code>text</code>: Foundations of OpenShift</div>
+            <div><code>href</code>: https://developers.redhat.com/learn/openshift/foundations-openshift</div>
+            <div><code>linkType</code>: <span class="mono">default</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Using OpenShift Pipelines clicked</td>
+          <td>Activities</td>
+          <td>default</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Activities</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-activities</span></div>
+            <div><code>text</code>: Using OpenShift Pipelines</div>
+            <div><code>href</code>: https://developers.redhat.com/learn/openshift/using-openshift-pipelines</div>
+            <div><code>linkType</code>: <span class="mono">default</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">OpenShift virtualization and application modernization using the Developer Sandbox clicked</td>
+          <td>Activities</td>
+          <td>default</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Activities</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-activities</span></div>
+            <div><code>text</code>: OpenShift virtualization and application modernization using the Developer Sandbox</div>
+            <div><code>href</code>: https://developers.redhat.com/learn/openshift/openshift-virtualization-and-application-modernization-using-developer-sandbox</div>
+            <div><code>linkType</code>: <span class="mono">default</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Contact Red Hat Sales launched</td>
+          <td>Support</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Support</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-support</span></div>
+            <div><code>text</code>: Contact Red Hat Sales</div>
+            <div><code>href</code>: https://www.redhat.com/en/contact</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Send Code launched</td>
+          <td>Verification</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Verification</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-verification</span></div>
+            <div><code>text</code>: Send Code</div>
+            <div><code>href</code>: current page URL</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Cancel Verification launched</td>
+          <td>Verification</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Verification</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-verification</span></div>
+            <div><code>text</code>: Cancel Verification</div>
+            <div><code>href</code>: current page URL</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Start Trial launched</td>
+          <td>Verification</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Verification</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-verification</span></div>
+            <div><code>text</code>: Start Trial</div>
+            <div><code>href</code>: current page URL</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+          </td>
+          
+        </tr>
+        <tr>
+          <td class="mono">Resend Code launched</td>
+          <td>Verification</td>
+          <td>cta</td>
+          <td>
+            <div><code>category</code>: <span class="mono">Developer Sandbox|Verification</span></div>
+            <div><code>regions</code>: <span class="mono">sandbox-verification</span></div>
+            <div><code>text</code>: Resend Code</div>
+            <div><code>href</code>: current page URL</div>
+            <div><code>linkType</code>: <span class="mono">cta</span></div>
+          </td>
+          
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Identify / Group Calls</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Call</th>
+          <th>Triggered When</th>
+          <th>ID Used</th>
+          <th>Traits</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="mono">identify</td>
+          <td>First time user data with <code>userID</code> is available in session</td>
+          <td><code>userID</code></td>
+          <td>
+            <div><code>company</code></div>
+          </td>
+          <td>Runs once per session per user</td>
+        </tr>
+        <tr>
+          <td class="mono">group</td>
+          <td>First time user data with <code>accountID</code> is available</td>
+          <td><code>accountID</code> (as <code>groupId</code>)</td>
+          <td>
+            <div><code>ebs</code>: account number string (when present)</div>
+          </td>
+          <td>Runs once per session per account</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Common Properties</h2>
+    <p>Every track call includes the following properties:</p>
+    <ul>
+      <li><code>category</code>: <span class="mono">Developer Sandbox|&lt;Section&gt;</span></li>
+      <li><code>regions</code>: <span class="mono">sandbox-&lt;section-lowercase&gt;</span></li>
+      <li><code>text</code>: the item name</li>
+      <li><code>href</code>: destination URL (may be empty for some CTAs)</li>
+      <li><code>linkType</code>: <span class="mono">cta</span> or <span class="mono">default</span></li>
+      <li><code>internalCampaign</code>: present for some Catalog CTAs (e.g., Ansible, OpenShift)</li>
+    </ul>
+  </body>
+  </html>
+
+

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/PhoneNumberStep.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/PhoneNumberStep.tsx
@@ -32,10 +32,7 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 
 import CircularProgress from '@mui/material/CircularProgress';
-import {
-  getEddlDataAttributes,
-  useTrackAnalytics,
-} from '../../../utils/eddl-utils';
+import { useTrackAnalytics } from '../../../utils/eddl-utils';
 
 const FLAG_FETCH_URL =
   'https://catamphetamine.github.io/country-flag-icons/3x2';
@@ -69,27 +66,37 @@ export const PhoneNumberStep: React.FC<PhoneNumberFormProps> = ({
 }) => {
   const theme = useTheme();
   const trackAnalytics = useTrackAnalytics();
-  const sendCodeEddlAttributes = getEddlDataAttributes(
-    'Send Code',
-    'Verification',
-  );
-  const cancelEddlAttributes = getEddlDataAttributes(
-    'Cancel Verification',
-    'Verification',
-  );
 
   // Handle Send Code click for analytics tracking
-  const handleSendCodeClick = async () => {
-    await trackAnalytics('Send Code', 'Verification', window.location.href);
+  const handleSendCodeClick = async (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    await trackAnalytics(
+      'Send Code',
+      'Verification',
+      window.location.href,
+      undefined,
+      'cta',
+    );
     handlePhoneNumberSubmit();
   };
 
   // Handle Cancel click for analytics tracking
-  const handleCancelClick = async () => {
+  const handleCancelClick = async (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
     await trackAnalytics(
       'Cancel Verification',
       'Verification',
       window.location.href,
+      undefined,
+      'cta',
     );
     handleClose();
   };
@@ -239,7 +246,6 @@ export const PhoneNumberStep: React.FC<PhoneNumberFormProps> = ({
           endIcon={
             loading && <CircularProgress size={20} sx={{ color: '#AFAFAF' }} />
           }
-          {...sendCodeEddlAttributes}
         >
           Send code
         </Button>
@@ -254,7 +260,6 @@ export const PhoneNumberStep: React.FC<PhoneNumberFormProps> = ({
               borderColor: '#1976d2',
             },
           }}
-          {...cancelEddlAttributes}
         >
           Cancel
         </Button>

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/VerificationCodeStep.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/VerificationCodeStep.tsx
@@ -39,10 +39,7 @@ import { useSandboxContext } from '../../../hooks/useSandboxContext';
 import { Country, getCountryCallingCode } from 'react-phone-number-input';
 import { useApi } from '@backstage/core-plugin-api';
 import { registerApiRef } from '../../../api';
-import {
-  getEddlDataAttributes,
-  useTrackAnalytics,
-} from '../../../utils/eddl-utils';
+import { useTrackAnalytics } from '../../../utils/eddl-utils';
 
 type VerificationCodeProps = {
   id: Product;
@@ -73,18 +70,6 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
 }) => {
   const theme = useTheme();
   const trackAnalytics = useTrackAnalytics();
-  const startTrialEddlAttributes = getEddlDataAttributes(
-    'Start Trial',
-    'Verification',
-  );
-  const resendCodeEddlAttributes = getEddlDataAttributes(
-    'Resend Code',
-    'Verification',
-  );
-  const cancelVerificationEddlAttributes = getEddlDataAttributes(
-    'Cancel Verification',
-    'Verification',
-  );
 
   const inputRefs = useRef<any>([]);
   const { refetchUserData, handleAAPInstance } = useSandboxContext();
@@ -221,23 +206,53 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
   };
 
   // Handle Start Trial click for analytics tracking
-  const handleStartTrialClickWithTracking = async (pdt: Product) => {
-    await trackAnalytics('Start Trial', 'Verification', window.location.href);
+  const handleStartTrialClickWithTracking = async (
+    event: React.MouseEvent<HTMLButtonElement>,
+    pdt: Product,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    await trackAnalytics(
+      'Start Trial',
+      'Verification',
+      window.location.href,
+      undefined,
+      'cta',
+    );
     handleStartTrialClick(pdt);
   };
 
   // Handle Resend Code click for analytics tracking
-  const handleResendCodeClickWithTracking = async () => {
-    await trackAnalytics('Resend Code', 'Verification', window.location.href);
+  const handleResendCodeClickWithTracking = async (
+    event: React.MouseEvent<HTMLElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    await trackAnalytics(
+      'Resend Code',
+      'Verification',
+      window.location.href,
+      undefined,
+      'cta',
+    );
     handleResendCode();
   };
 
   // Handle Cancel click for analytics tracking
-  const handleCancelVerificationClick = async () => {
+  const handleCancelVerificationClick = async (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
     await trackAnalytics(
       'Cancel Verification',
       'Verification',
       window.location.href,
+      undefined,
+      'cta',
     );
     handleClose();
   };
@@ -322,11 +337,10 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
             fontWeight: 400,
             backgroundColor: 'transparent !important',
           }}
-          onClick={() => {
-            handleResendCodeClickWithTracking();
+          onClick={event => {
+            handleResendCodeClickWithTracking(event);
             inputRefs.current[0]?.focus();
           }}
-          {...resendCodeEddlAttributes}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
             {codeResent ? (
@@ -357,12 +371,11 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
           data-testid="submit-opt-button"
           variant="contained"
           type="submit"
-          onClick={() => handleStartTrialClickWithTracking(id)}
+          onClick={event => handleStartTrialClickWithTracking(event, id)}
           disabled={otp.some(digit => !digit) || loading}
           endIcon={
             loading && <CircularProgress size={20} sx={{ color: '#AFAFAF' }} />
           }
-          {...startTrialEddlAttributes}
         >
           Start trial
         </Button>
@@ -377,7 +390,6 @@ export const VerificationCodeStep: React.FC<VerificationCodeProps> = ({
               borderColor: '#1976d2',
             },
           }}
-          {...cancelVerificationEddlAttributes}
         >
           Cancel
         </Button>

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/__tests__/PhoneNumberStep.test.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/PhoneVerificationSteps/__tests__/PhoneNumberStep.test.tsx
@@ -46,11 +46,11 @@ declare module '../PhoneNumberStep' {
 }
 
 describe('PhoneNumberStep', () => {
+  const mockTrackAnalytics = jest.fn();
   const mockSetPhoneNumber = jest.fn();
   const mockHandleClose = jest.fn();
   const mockHandlePhoneNumberSubmit = jest.fn();
   const mockSetCountry = jest.fn();
-  const mockTrackAnalytics = jest.fn();
   const phoneNumber = parsePhoneNumber(' 8 (800) 555-35-35 ', 'RU');
 
   beforeEach(() => {
@@ -190,43 +190,43 @@ describe('PhoneNumberStep', () => {
     expect(inputValue).toBe('+1 737 307 2270');
   });
 
-  describe('EDDL data attributes', () => {
-    test('should have correct EDDL data attributes on Send Code button', () => {
+  describe('Analytics tracking', () => {
+    test('calls trackAnalytics with correct parameters when Send Code is clicked', async () => {
       renderComponent(phoneNumber);
-
       const sendCodeButton = screen.getByRole('button', { name: /Send code/i });
 
-      expect(sendCodeButton).toHaveAttribute(
-        'data-analytics-category',
-        'Developer Sandbox|Verification',
-      );
-      expect(sendCodeButton).toHaveAttribute(
-        'data-analytics-text',
-        'Send Code',
-      );
-      expect(sendCodeButton).toHaveAttribute(
-        'data-analytics-region',
-        'sandbox-verification',
-      );
+      const clickEvent = fireEvent.click(sendCodeButton);
+
+      await waitFor(() => {
+        expect(mockTrackAnalytics).toHaveBeenCalledWith(
+          'Send Code',
+          'Verification',
+          window.location.href,
+          undefined,
+          'cta',
+        );
+      });
+      expect(mockHandlePhoneNumberSubmit).toHaveBeenCalled();
+      expect(clickEvent).toBe(false); // Event was prevented
     });
 
-    test('should have correct EDDL data attributes on Cancel button', () => {
+    test('calls trackAnalytics with correct parameters when Cancel is clicked', async () => {
       renderComponent(phoneNumber);
-
       const cancelButton = screen.getByRole('button', { name: /Cancel/i });
 
-      expect(cancelButton).toHaveAttribute(
-        'data-analytics-category',
-        'Developer Sandbox|Verification',
-      );
-      expect(cancelButton).toHaveAttribute(
-        'data-analytics-text',
-        'Cancel Verification',
-      );
-      expect(cancelButton).toHaveAttribute(
-        'data-analytics-region',
-        'sandbox-verification',
-      );
+      const clickEvent = fireEvent.click(cancelButton);
+
+      await waitFor(() => {
+        expect(mockTrackAnalytics).toHaveBeenCalledWith(
+          'Cancel Verification',
+          'Verification',
+          window.location.href,
+          undefined,
+          'cta',
+        );
+      });
+      expect(mockHandleClose).toHaveBeenCalled();
+      expect(clickEvent).toBe(false); // Event was prevented
     });
   });
 });

--- a/workspaces/sandbox/plugins/sandbox/src/components/Modals/__tests__/AccessCodeInputModal.test.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/Modals/__tests__/AccessCodeInputModal.test.tsx
@@ -202,12 +202,12 @@ describe('AccessCodeInputModal', () => {
 
     // Fill all inputs by typing once in the first input - auto-focus will handle the rest
     await user.click(inputs[0]);
-    await user.type(inputs[0], 'ABCDEF'); // Type enough characters to fill all inputs
+    await user.type(inputs[0], 'ABCDE'); // Type 5 characters to fill all 5 inputs
 
     // Wait for all inputs to be filled
     await waitFor(() => {
       inputs.forEach((input, index) => {
-        expect(input).toHaveValue(String.fromCharCode(65 + index)); // A, B, C, D, E, F
+        expect(input).toHaveValue(String.fromCharCode(65 + index)); // A, B, C, D, E
       });
     });
 

--- a/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/SandboxHeader.tsx
@@ -21,7 +21,7 @@ import { useTheme } from '@mui/material/styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SupportAgentIcon from '@mui/icons-material/SupportAgent';
 import { Header, Link } from '@backstage/core-components';
-import { getEddlDataAttributes, useTrackAnalytics } from '../utils/eddl-utils';
+import { useTrackAnalytics } from '../utils/eddl-utils';
 
 interface SandboxHeaderProps {
   pageTitle: string;
@@ -52,18 +52,24 @@ export const SandboxHeader: React.FC<SandboxHeaderProps> = ({ pageTitle }) => {
   }, []);
 
   const theme = useTheme();
-  const contactSalesEddlAttributes = getEddlDataAttributes(
-    'Contact Red Hat Sales',
-    'Support',
-  );
 
   // Handle Contact Sales click for analytics tracking
-  const handleContactSalesClick = async () => {
+  const handleContactSalesClick = async (
+    event: React.MouseEvent<HTMLAnchorElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
     await trackAnalytics(
       'Contact Red Hat Sales',
       'Support',
       'https://www.redhat.com/en/contact',
+      undefined,
+      'cta',
     );
+
+    // Navigate after tracking completes
+    window.open('https://www.redhat.com/en/contact', '_blank');
   };
 
   return (
@@ -112,7 +118,6 @@ export const SandboxHeader: React.FC<SandboxHeaderProps> = ({ pageTitle }) => {
           underline="none"
           target="_blank"
           onClick={handleContactSalesClick}
-          {...contactSalesEddlAttributes}
         >
           <Button
             variant="outlined"

--- a/workspaces/sandbox/plugins/sandbox/src/components/__tests__/SandboxHeader.test.tsx
+++ b/workspaces/sandbox/plugins/sandbox/src/components/__tests__/SandboxHeader.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { SandboxHeader } from '../SandboxHeader';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -93,19 +93,29 @@ describe('SandboxHeader', () => {
     expect(subtitle?.querySelector('svg')).toBeInTheDocument();
   });
 
-  test('has correct EDDL data attributes on Contact Red Hat Sales link', () => {
+  test('calls trackAnalytics with correct parameters when Contact Sales is clicked', async () => {
+    const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation();
+
     renderComponent();
     const button = screen.getByText('Contact Red Hat Sales');
     const link = button.closest('a');
 
-    expect(link).toHaveAttribute(
-      'data-analytics-category',
-      'Developer Sandbox|Support',
-    );
-    expect(link).toHaveAttribute(
-      'data-analytics-text',
-      'Contact Red Hat Sales',
-    );
-    expect(link).toHaveAttribute('data-analytics-region', 'sandbox-support');
+    fireEvent.click(link!);
+
+    await waitFor(() => {
+      expect(mockTrackAnalytics).toHaveBeenCalledWith(
+        'Contact Red Hat Sales',
+        'Support',
+        'https://www.redhat.com/en/contact',
+        undefined,
+        'cta',
+      );
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        'https://www.redhat.com/en/contact',
+        '_blank',
+      );
+    });
+
+    windowOpenSpy.mockRestore();
   });
 });

--- a/workspaces/sandbox/plugins/sandbox/src/utils/eddl-utils.ts
+++ b/workspaces/sandbox/plugins/sandbox/src/utils/eddl-utils.ts
@@ -61,6 +61,7 @@ export const pushCtaEvent = (
         text: itemName,
         href: href,
         linkType: 'cta',
+        linkTypeName: 'cross property link',
         ...(internalCampaign && { internalCampaign }),
       },
     };


### PR DESCRIPTION
For https://issues.redhat.com/browse/PCA-289

**Important fix:** 

Looks like the events for Contact Sales and Phone Verification as well need to be sent as `cta` and not regular Master Link click.

**Minor changes** 
- add segment events overview html
- fix flaky test
- fix cloning rhdh-local that sometimes fails 
