### PR TITLE
Fix `metadataUrl` field generation process

### DIFF
--- a/workspaces/mcp-integrations/plugins/techdocs-mcp-tool/src/service.test.ts
+++ b/workspaces/mcp-integrations/plugins/techdocs-mcp-tool/src/service.test.ts
@@ -37,6 +37,7 @@ describe('TechDocsService', () => {
       baseUrl: 'http://localhost:3000',
     },
     backend: {
+      baseUrl: 'http://localhost:7007',
       auth: {
         externalAccess: [
           {
@@ -109,7 +110,7 @@ describe('TechDocsService', () => {
         techDocsUrl:
           'http://localhost:3000/docs/default/component/test-service',
         metadataUrl:
-          'http://localhost:7007/api/entities/by-name/component/default/test-service',
+          'http://localhost:7007/api/catalog/entities/by-name/component/default/test-service',
       });
     });
 
@@ -120,7 +121,7 @@ describe('TechDocsService', () => {
       expect(urls).toEqual({
         techDocsUrl: 'http://localhost:3000/docs/default/api/test-api',
         metadataUrl:
-          'http://localhost:7007/api/entities/by-name/api/default/test-api',
+          'http://localhost:7007/api/catalog/entities/by-name/api/default/test-api',
       });
     });
 
@@ -134,7 +135,7 @@ describe('TechDocsService', () => {
         techDocsUrl:
           'http://localhost:3000/docs/production/component/test-service',
         metadataUrl:
-          'http://localhost:7007/api/entities/by-name/component/production/test-service',
+          'http://localhost:7007/api/catalog/entities/by-name/component/production/test-service',
       });
     });
   });
@@ -302,7 +303,7 @@ describe('TechDocsService', () => {
         techDocsUrl:
           'http://localhost:3000/docs/default/component/service-with-docs',
         metadataUrl:
-          'http://localhost:7007/api/entities/by-name/component/default/service-with-docs',
+          'http://localhost:7007/api/catalog/entities/by-name/component/default/service-with-docs',
         metadata: {
           lastUpdated: '2021-01-01T00:00:00.000Z',
           buildTimestamp: 1609459200,
@@ -341,7 +342,7 @@ describe('TechDocsService', () => {
         techDocsUrl:
           'http://localhost:3000/docs/default/component/service-without-metadata',
         metadataUrl:
-          'http://localhost:7007/api/entities/by-name/component/default/service-without-metadata',
+          'http://localhost:7007/api/catalog/entities/by-name/component/default/service-without-metadata',
         metadata: undefined,
       });
     });

--- a/workspaces/mcp-integrations/plugins/techdocs-mcp-tool/src/service.ts
+++ b/workspaces/mcp-integrations/plugins/techdocs-mcp-tool/src/service.ts
@@ -171,14 +171,14 @@ export class TechDocsService {
     entity: Entity,
   ): Promise<{ techDocsUrl: string; metadataUrl: string }> {
     const appBaseUrl = this.config.getString('app.baseUrl');
-    const backendBaseUrl = await this.discovery.getBaseUrl('catalog');
+    const backendBaseUrl = this.config.getString('backend.baseUrl');
 
     const { namespace = 'default', name } = entity.metadata;
     const kind = entity.kind.toLowerCase();
 
     return {
       techDocsUrl: `${appBaseUrl}/docs/${namespace}/${kind}/${name}`,
-      metadataUrl: `${backendBaseUrl}/entities/by-name/${kind}/${namespace}/${name}`,
+      metadataUrl: `${backendBaseUrl}/api/catalog/entities/by-name/${kind}/${namespace}/${name}`,
     };
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The PR adds a small fix on the `metadataUrl` field that currently has an issue (always returned with base_url being a localhost one).

Fixes the issue RHDHPAI-1154 which was reported after the very first tests on a production env.

All tests have been updated too.

A test plugin image that includes the fix is:

```yaml
- disabled: false
  package: oci://quay.io/tpetkos/mcp-techdoc-tool:v0.1.4!red-hat-developer-hub-backstage-plugin-techdocs-mcp-tool
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
