### PR TITLE
chore: add gh actions to detect propose renovate presets for new workspaces

### DIFF
--- a/.github/workflows/detect-new-workspace.yml
+++ b/.github/workflows/detect-new-workspace.yml
@@ -1,0 +1,97 @@
+name: Detect and propose Renovate presets for new workspaces
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: new-workspace-presets
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Detect uncovered workspaces
+    runs-on: ubuntu-latest
+    outputs:
+      workspaces: ${{ steps.detect.outputs.workspaces }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout main
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: main
+          token: ${{ secrets.RHDH_BOT_TOKEN }}
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Detect new workspaces
+        id: detect
+        run: echo "workspaces=$(node scripts/ci/detect-new-workspaces.js --list | jq -c .)" >> $GITHUB_OUTPUT
+
+  propose:
+    name: Propose preset for workspace
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.workspaces != '[]' && needs.prepare.outputs.workspaces != ''
+    strategy:
+      matrix:
+        workspace: ${{ fromJSON(needs.prepare.outputs.workspaces) }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout main
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: main
+          token: ${{ secrets.RHDH_BOT_TOKEN }}
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Apply changes for workspace
+        id: apply
+        run: node scripts/ci/detect-new-workspaces.js --apply "${{ matrix.workspace }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
+        with:
+          token: ${{ secrets.RHDH_BOT_TOKEN }}
+          base: main
+          branch: automation/add-renovate-presets-${{ matrix.workspace }}
+          commit-message: "chore: add Renovate presets for ${{ matrix.workspace }}"
+          title: "chore: add Renovate presets for ${{ matrix.workspace }}"
+          body: |
+            This PR adds Renovate presets for the new `${{ matrix.workspace }}` workspace.
+
+            Extends: base minor/patch/devdependency presets.
+
+            Created by [Detect New Workspace ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          signoff: true
+          add-paths: |
+            .github/renovate-presets/workspace/*.json
+            .github/renovate.json

--- a/scripts/ci/detect-new-workspaces.js
+++ b/scripts/ci/detect-new-workspaces.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import path from 'path';
+import { format as prettierFormat } from 'prettier';
+
+const workspacesDir = path.resolve('workspaces');
+const presetsDir = path.resolve('.github', 'renovate-presets', 'workspace');
+const renovateJsonPath = path.resolve('.github', 'renovate.json');
+
+function listWorkspaceNames() {
+  if (!fs.existsSync(workspacesDir)) return [];
+  return fs
+    .readdirSync(workspacesDir, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name)
+    .filter(name => name !== 'noop')
+    .sort();
+}
+
+function isWorkspaceCovered(workspaceName) {
+  const presetFile = path.join(
+    presetsDir,
+    `rhdh-${workspaceName}-presets.json`,
+  );
+  return fs.existsSync(presetFile);
+}
+
+function toTitleCase(source) {
+  return source
+    .split(/[-_ ]+/)
+    .filter(Boolean)
+    .map(token => token.charAt(0).toLocaleUpperCase('en-US') + token.slice(1))
+    .join(' ');
+}
+
+async function ensureRenovateExtends(presetRef) {
+  let content = fs.readFileSync(renovateJsonPath, 'utf8');
+
+  if (content.includes(`"${presetRef}"`)) {
+    return false;
+  }
+
+  const descIndex = content.indexOf('"all RHDH Plugins workspaces"');
+  if (descIndex === -1) {
+    throw new Error('Could not find "all RHDH Plugins workspaces" rule');
+  }
+
+  const extendsIndex = content.indexOf('"extends":', descIndex);
+  const arrayStart = content.indexOf('[', extendsIndex);
+  const arrayEnd = content.indexOf(']', arrayStart);
+
+  if (extendsIndex === -1 || arrayStart === -1 || arrayEnd === -1) {
+    throw new Error('Could not find extends array');
+  }
+
+  const before = content.substring(0, arrayEnd).trimEnd();
+  const after = content.substring(arrayEnd);
+  content = `${before},\n        "${presetRef}"\n      ${after}`;
+
+  fs.writeFileSync(renovateJsonPath, content, 'utf8');
+  return true;
+}
+
+if (!fs.existsSync(presetsDir)) fs.mkdirSync(presetsDir, { recursive: true });
+
+function buildPresetJson(workspaceName) {
+  const displayName = toTitleCase(workspaceName.replace(/^rhdh-/, ''));
+  return {
+    packageRules: [
+      {
+        description: `all ${displayName} minor updates`,
+        matchFileNames: [`workspaces/${workspaceName}/**`],
+        extends: [
+          `github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(${displayName})`,
+        ],
+        addLabels: ['team/rhdh', `${workspaceName}`],
+      },
+      {
+        description: `all ${displayName} patch updates`,
+        matchFileNames: [`workspaces/${workspaceName}/**`],
+        extends: [
+          `github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(${displayName})`,
+        ],
+        addLabels: ['team/rhdh', `${workspaceName}`],
+      },
+      {
+        description: `all ${displayName} dev dependency updates`,
+        matchFileNames: [`workspaces/${workspaceName}/**`],
+        extends: [
+          `github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(${displayName})`,
+        ],
+        addLabels: ['team/rhdh', `${workspaceName}`],
+      },
+    ],
+  };
+}
+
+function findUncoveredWorkspaces() {
+  return listWorkspaceNames().filter(ws => !isWorkspaceCovered(ws));
+}
+
+const argv = process.argv.slice(2);
+switch (argv[0]) {
+  case '--apply': {
+    const ws = argv[1];
+    if (!ws) {
+      console.error('ERROR: --apply requires a workspace name');
+      process.exit(2);
+    }
+    if (isWorkspaceCovered(ws)) {
+      console.log(JSON.stringify({ workspace: ws, skipped: true }));
+      process.exit(0);
+    }
+
+    const presetFilePath = path.join(presetsDir, `rhdh-${ws}-presets.json`);
+    const presetJson = buildPresetJson(ws);
+    const formattedPreset = await prettierFormat(JSON.stringify(presetJson), {
+      parser: 'json',
+    });
+    fs.writeFileSync(presetFilePath, formattedPreset, 'utf8');
+    const presetRef = `github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-${ws}-presets`;
+    await ensureRenovateExtends(presetRef);
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, `workspace=${ws}\n`);
+    }
+    console.log(JSON.stringify({ workspace: ws }));
+    break;
+  }
+  case '--list': {
+    const queue = findUncoveredWorkspaces();
+    console.log(JSON.stringify(queue));
+    break;
+  }
+  default: {
+    console.error(
+      `Unknown command: ${argv[0]}. Use --list (default) or --apply <workspace>.`,
+    );
+    break;
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR adds a new GitHub actions workflow to detect and propose renovate presets for new workspaces
- Runs on a weekly basis every Monday at 06:00 UTC
- Assigns reviewers based on [CODEOWNERS](https://github.com/redhat-developer/rhdh-plugins/blob/main/.github/CODEOWNERS)

Preview generates PRs [here](https://github.com/JessicaJHee/rhdh-plugins/pulls).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
