### PR TITLE
fix(global-header): make the myProfile check backward compatible for customers with a custom header configuration

### DIFF
--- a/workspaces/global-header/.changeset/dirty-dancers-appear.md
+++ b/workspaces/global-header/.changeset/dirty-dancers-appear.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Make the myProfile check backward compatible for customers with a custom header configuration

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/ProfileDropdown.tsx
@@ -126,7 +126,12 @@ export const ProfileDropdown = ({ layout }: ProfileDropdownProps) => {
           link: staticLink = '',
           type = '',
         } = mp.config?.props ?? {};
-        const isMyProfile = type === 'myProfile';
+        // The title fallbacks are to be backward compatibility with older versions
+        // of the global-header configuration if a customer has customized it.
+        const isMyProfile =
+          type === 'myProfile' ||
+          title === 'profile.myProfile' ||
+          title === 'My profile';
         const link = isMyProfile ? profileLink ?? '' : staticLink;
 
         // Hide "My Profile" for guest users or when user doesn't exist in catalog


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related to https://redhat-internal.slack.com/archives/C05KGRQLPLG/p1759992575803099?thread_ts=1759990155.526029&cid=C05KGRQLPLG and the next comments :)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
