### PR TITLE
feat(orchestrator): Backport - active widgets support the 'readonly' option

### DIFF
--- a/workspaces/orchestrator/.changeset/spotty-rivers-learn.md
+++ b/workspaces/orchestrator/.changeset/spotty-rivers-learn.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Add readonly option to the active widgets

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
@@ -66,6 +66,7 @@ export const ActiveDropdown: Widget<
     () => (props.options?.props ?? {}) as UiProps,
     [props.options?.props],
   );
+  const isReadOnly = !!props.readonly;
 
   const labelSelector = uiProps['fetch:response:label']?.toString();
   const valueSelector = uiProps['fetch:response:value']?.toString();
@@ -140,6 +141,7 @@ export const ActiveDropdown: Widget<
         data-testid={id}
         value={value}
         label={label}
+        disabled={isReadOnly}
         onChange={event => handleChange(event.target.value as string)}
         MenuProps={{
           PaperProps: { sx: { maxHeight: '20rem' } },

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
@@ -63,6 +63,7 @@ export const ActiveMultiSelect: Widget<
     () => (props.options.props ?? {}) as UiProps,
     [props.options.props],
   );
+  const isReadOnly = !!props.readonly;
 
   const autocompleteSelector =
     uiProps['fetch:response:autocomplete']?.toString();
@@ -178,6 +179,7 @@ export const ActiveMultiSelect: Widget<
             multiple
             data-testid={`${id}-autocomplete`}
             options={allOptions}
+            disabled={isReadOnly}
             isOptionEqualToValue={(option, selected) => option === selected}
             value={value}
             filterSelectedOptions

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
@@ -61,6 +61,7 @@ export const ActiveTextInput: Widget<
     () => (props.options?.props ?? {}) as UiProps,
     [props.options?.props],
   );
+  const isReadOnly = !!props.readonly;
 
   const defaultValueSelector = uiProps['fetch:response:value']?.toString();
   const autocompleteSelector =
@@ -141,6 +142,7 @@ export const ActiveTextInput: Widget<
         data-testid={`${id}-textfield`}
         onChange={event => handleChange(event.target.value)}
         label={label}
+        disabled={isReadOnly}
       />
     );
 
@@ -151,6 +153,7 @@ export const ActiveTextInput: Widget<
           data-testid={`${id}-autocomplete`}
           value={value}
           onChange={(_, v) => handleChange(v)}
+          disabled={isReadOnly}
           renderInput={renderInput}
           renderOption={(liProps, item, state) => {
             return (


### PR DESCRIPTION
Backport of: #1628 