### PR TITLE
feat(orchestrator): Backport - ActiveTextInput ignores default value if it is null

### DIFF
--- a/workspaces/orchestrator/.changeset/rare-apricots-suffer.md
+++ b/workspaces/orchestrator/.changeset/rare-apricots-suffer.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+ActiveTextInput ignores default value if it is null

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
@@ -101,7 +101,10 @@ export const ActiveTextInput: Widget<
           data,
           defaultValueSelector,
         );
-        handleChange(defaultValue);
+
+        if (defaultValue && defaultValue !== null && defaultValue !== 'null') {
+          handleChange(defaultValue);
+        }
       }
 
       if (autocompleteSelector) {


### PR DESCRIPTION
Backport #1633