### PR TITLE
fix(bulk-import): use git provider host from configuration

### DIFF
--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/handlers/import/bulkImports.ts
@@ -131,6 +131,7 @@ export async function findAllImports(
   // It can be 'main' or something more convoluted like 'our/awesome/main'.
   const defaultBranchByRepoUrl = await resolveReposDefaultBranches(
     deps.logger,
+    deps.config,
     deps.gitlabApiService,
     deps.githubApiService,
     allLocations.keys(),
@@ -149,14 +150,14 @@ export async function findAllImports(
   const importsReachableFromGHIntegrations =
     await deps.githubApiService.filterLocationsAccessibleFromIntegrations(
       importCandidates.filter(val => {
-        return parseGitURLForApprovalTool(val) === 'GIT';
+        return parseGitURLForApprovalTool(val, deps.config) === 'GIT';
       }),
     );
 
   const importsReachableFromGLIntegrations =
     await deps.gitlabApiService.filterLocationsAccessibleFromIntegrations(
       importCandidates.filter(val => {
-        return parseGitURLForApprovalTool(val) === 'GITLAB';
+        return parseGitURLForApprovalTool(val, deps.config) === 'GITLAB';
       }),
     );
 
@@ -245,6 +246,7 @@ export async function findAllImports(
 
 async function resolveReposDefaultBranches(
   logger: LoggerService,
+  config: Config,
   gitlabApiService: GitlabApiService,
   githubApiService: GithubApiService,
   allLocations: Iterable<string>,
@@ -271,7 +273,7 @@ async function resolveReposDefaultBranches(
     // Have to do this for Both the gitlab/github, possibly a better way?
     // Should probably parse the URL to figure out which to use?
     defaultBranchByRepoUrlPromises.push(
-      (parseGitURLForApprovalTool(repoUrl) === 'GITLAB'
+      (parseGitURLForApprovalTool(repoUrl, config) === 'GITLAB'
         ? gitlabApiService
         : githubApiService
       )

--- a/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.ts
+++ b/workspaces/bulk-import/plugins/bulk-import-backend/src/service/router.ts
@@ -518,7 +518,7 @@ export async function createRouter(
           logger,
           config,
           gitApiService:
-            parseGitURLForApprovalTool(q.repo) === 'GITLAB'
+            parseGitURLForApprovalTool(q.repo, config) === 'GITLAB'
               ? gitlabApiService
               : githubApiService,
           catalogHttpClient,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Prefer to use use configuration integration to determine approval tool, instead of hard-coded "gitlab" host.

### What does this pull request fix

Fix issue: https://issues.redhat.com/browse/RHIDP-9359

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
