### PR TITLE
fix(ai-integrations): copy model, model server annotations to resource, component annotations

### DIFF
--- a/workspaces/ai-integrations/.changeset/sixty-cows-accept.md
+++ b/workspaces/ai-integrations/.changeset/sixty-cows-accept.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog': minor
+---
+
+copy model/modelServer annotations to resource/component annotations

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.test.ts
@@ -516,4 +516,168 @@ describe('Model Catalog Generator', () => {
     // Should not have annotations if none were provided in API
     expect(modelServerComponent.metadata.annotations).toBeUndefined();
   });
+
+  it('should copy modelServer annotations to component metadata when present', () => {
+    const modelCatalog: ModelCatalog = {
+      modelServer: {
+        name: 'annotated-server',
+        owner: 'example-user',
+        description: 'Model server with annotations',
+        lifecycle: 'production',
+        annotations: {
+          'custom.io/annotation1': 'server-value1',
+          'custom.io/annotation2': 'server-value2',
+          'backstage.io/custom-tag': 'server-custom',
+        },
+      },
+      models: [
+        {
+          name: 'test-model',
+          description: 'Test model',
+          lifecycle: 'production',
+          owner: 'example-user',
+        },
+      ],
+    };
+
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+
+    const modelServerComponent = modelCatalogEntities.find(
+      entity =>
+        entity.kind === 'Component' &&
+        entity.metadata.name === 'annotated-server',
+    ) as ComponentEntity;
+
+    expect(modelServerComponent).toBeDefined();
+    expect(modelServerComponent.metadata.annotations).toBeDefined();
+    expect(modelServerComponent.metadata.annotations).toEqual({
+      'custom.io/annotation1': 'server-value1',
+      'custom.io/annotation2': 'server-value2',
+      'backstage.io/custom-tag': 'server-custom',
+    });
+  });
+
+  it('should merge modelServer annotations with API annotations when both are present', () => {
+    const modelCatalog: ModelCatalog = {
+      modelServer: {
+        name: 'fully-annotated-service',
+        owner: 'example-user',
+        description: 'Model service with both server and API annotations',
+        lifecycle: 'production',
+        annotations: {
+          'server.io/annotation1': 'from-server',
+          'server.io/annotation2': 'also-from-server',
+        },
+        API: {
+          url: 'https://api.example.com',
+          type: Type.Openapi,
+          spec: 'https://example.com/openapi.json',
+          annotations: {
+            'api.io/annotation1': 'from-api',
+            'api.io/annotation2': 'also-from-api',
+          },
+        },
+      },
+      models: [
+        {
+          name: 'test-model',
+          description: 'Test model',
+          lifecycle: 'production',
+          owner: 'example-user',
+        },
+      ],
+    };
+
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+
+    // Find the model server component entity
+    const modelServerComponent = modelCatalogEntities.find(
+      entity =>
+        entity.kind === 'Component' &&
+        entity.metadata.name === 'fully-annotated-service',
+    ) as ComponentEntity;
+
+    expect(modelServerComponent).toBeDefined();
+    expect(modelServerComponent.metadata.annotations).toBeDefined();
+    // Should contain annotations from both API and modelServer
+    expect(modelServerComponent.metadata.annotations).toEqual({
+      'api.io/annotation1': 'from-api',
+      'api.io/annotation2': 'also-from-api',
+      'server.io/annotation1': 'from-server',
+      'server.io/annotation2': 'also-from-server',
+    });
+  });
+
+  it('should copy model annotations to resource metadata when present', () => {
+    const modelCatalog: ModelCatalog = {
+      models: [
+        {
+          name: 'annotated-model',
+          description: 'Model with annotations',
+          lifecycle: 'production',
+          owner: 'example-user',
+          annotations: {
+            'custom.io/model-annotation1': 'model-value1',
+            'custom.io/model-annotation2': 'model-value2',
+            'backstage.io/custom-model-tag': 'model-custom',
+          },
+        },
+      ],
+    };
+
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+
+    // Find the model resource entity
+    const modelResource = modelCatalogEntities.find(
+      entity =>
+        entity.kind === 'Resource' &&
+        entity.metadata.name === 'annotated-model',
+    );
+
+    expect(modelResource).toBeDefined();
+    expect(modelResource!.metadata.annotations).toBeDefined();
+    expect(modelResource!.metadata.annotations).toEqual({
+      'custom.io/model-annotation1': 'model-value1',
+      'custom.io/model-annotation2': 'model-value2',
+      'backstage.io/custom-model-tag': 'model-custom',
+    });
+  });
+
+  it('should copy model annotations and preserve TechDocs special case handling', () => {
+    const modelCatalog: ModelCatalog = {
+      models: [
+        {
+          name: 'fully-annotated-model',
+          description: 'Model with multiple annotations including TechDocs',
+          lifecycle: 'production',
+          owner: 'example-user',
+          annotations: {
+            TechDocs:
+              'https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main',
+            'custom.io/model-annotation1': 'model-value1',
+            'custom.io/model-annotation2': 'model-value2',
+          },
+        },
+      ],
+    };
+
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+
+    // Find the model resource entity
+    const modelResource = modelCatalogEntities.find(
+      entity =>
+        entity.kind === 'Resource' &&
+        entity.metadata.name === 'fully-annotated-model',
+    );
+
+    expect(modelResource).toBeDefined();
+    expect(modelResource!.metadata.annotations).toBeDefined();
+    // Should have TechDocs converted to backstage.io/techdocs-ref and other annotations copied
+    expect(modelResource!.metadata.annotations).toEqual({
+      'backstage.io/techdocs-ref':
+        'url:https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main',
+      'custom.io/model-annotation1': 'model-value1',
+      'custom.io/model-annotation2': 'model-value2',
+    });
+  });
 });

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog/src/clients/ModelCatalogGenerator.ts
@@ -131,17 +131,28 @@ export function GenerateModelResourceEntities(
 
     // Handle any annotations present on the model resource
     if (model.annotations !== undefined) {
-      // Add the techdocs annotation to the resource if present
-      let techdocsUrl: string = model.annotations.TechDocs;
-      techdocsUrl = techdocsUrl.trim();
-      if (model.annotations.TechDocs !== '') {
-        if (modelResourceEntity.metadata.annotations === undefined) {
-          modelResourceEntity.metadata.annotations = {};
-        }
-        modelResourceEntity.metadata.annotations[
-          'backstage.io/techdocs-ref'
-        ] = `url:${techdocsUrl}`;
+      // Initialize annotations object if needed
+      if (modelResourceEntity.metadata.annotations === undefined) {
+        modelResourceEntity.metadata.annotations = {};
       }
+
+      // Copy all annotations from model to resource entity
+      Object.keys(model.annotations).forEach(key => {
+        // Special handling for TechDocs annotation
+        if (key === 'TechDocs') {
+          let techdocsUrl: string = model.annotations![key];
+          techdocsUrl = techdocsUrl.trim();
+          if (techdocsUrl !== '') {
+            modelResourceEntity.metadata.annotations![
+              'backstage.io/techdocs-ref'
+            ] = `url:${techdocsUrl}`;
+          }
+        } else {
+          // Copy all other annotations as-is
+          modelResourceEntity.metadata.annotations![key] =
+            model.annotations![key];
+        }
+      });
     }
     modelResourceEntities.push(modelResourceEntity);
   });
@@ -213,6 +224,19 @@ export function GenerateModelServerComponentEntity(
       url: `${modelServer.homepageURL}`,
     });
   }
+
+  // Copy annotations from modelServer to component metadata if they exist
+  if (modelServer.annotations !== undefined) {
+    if (modelServerComponent.metadata.annotations === undefined) {
+      modelServerComponent.metadata.annotations = {};
+    }
+    // Copy all key-value pairs from modelServer annotations to component annotations
+    Object.keys(modelServer.annotations).forEach(key => {
+      modelServerComponent.metadata.annotations![key] =
+        modelServer.annotations![key];
+    });
+  }
+
   return modelServerComponent;
 }
 


### PR DESCRIPTION

## Hey, I just made a Pull Request!

discovered during  the ai template and ai model catalog integration testing with @maysunfaisal that a "kserve only" AI model that @johnmcollier deployed in the rolling demo env / dev cluster was not getting the URL annotations we devised to facilitate template access to the AI model catalog entities for URL discovery

also discovered the namespace-name prefixing we employ for kserve only made model name retrieval trickly, so we added an annotations with that 

Assisted-by: claude-4-sonnet (code changes and unit tests)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [/ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [/ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
