### PR TITLE
chore(ci): fix publish step

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -152,7 +152,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{ secrets.RHDH_NPM_TOKEN }}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+          yarn workspaces foreach --worktree -v --no-private npm publish --access public --tolerate-republish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RHDH_NPM_TOKEN }}
 

--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -171,7 +171,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.RHDH_NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
+          yarn workspaces foreach --worktree -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RHDH_NPM_TOKEN }}
       


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing error on publish here: https://github.com/redhat-developer/rhdh-plugins/actions/runs/18462220498/job/52596360667#logs
```
Usage Error: Invalid option schema: missing at least one property from "all", "recursive", "since", or "worktree"
```

https://yarnpkg.com/advanced/changelog:
yarn [workspaces foreach](https://yarnpkg.com/cli/workspaces/foreach) now requires one of --all, --recursive, --since, or --worktree to be explicitly specified; the previous default was --worktree, but it was rarely what users expected.

Setting it to previous default.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
