### PR TITLE
fix(theme): techdocs addon subheader bg-color

### DIFF
--- a/workspaces/theme/.changeset/big-stingrays-heal.md
+++ b/workspaces/theme/.changeset/big-stingrays-heal.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Scope TechDocs subheader toolbar to use `background.paper`, fixing the gray strip under the page header. Adds a `MuiCssBaseline` rule targeting `[class*="BackstageHeader-header-"] + [class*="MuiToolbar-root"]` so other toolbars remain unaffected.

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -88,6 +88,9 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
         'pre, code': {
           fontFamily: redHatFonts.monospace,
         },
+        "[class*='BackstagePage-root-'] > [class*='MuiToolbar-root']": {
+          backgroundColor: theme.palette.background.paper,
+        },
       };
     },
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
For [RHDHBUGS-2075](https://issues.redhat.com/browse/RHDHBUGS-2075)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

Steps to test changes on RHDH
1. Pull changes from this PR to your local rhdh-plugins path
2. Update theme package version in your local `rhdh/packages/app/package.json`:
```
    "@red-hat-developer-hub/backstage-plugin-theme": "portal:<path_to_your>/rhdh-plugins/workspaces/theme/plugins/theme",
```
3. Run `yarn install` in your local RHDH root
4. Start rhdh by `yarn dev`

Steps to register a demo subHeader addon on techdocs
1. Add this to your `<your_local>/rhdh/dynamic-plugins/wrappers/backstage-plugin-techdocs-module-addons-contrib/src/addons.tsx`
```
const SubheaderDemoImpl = () => {
  return (
    <div
      style={{
        display: 'flex',
        gap: 8,
        alignItems: 'center',
        padding: '6px 8px',
      }}
    >
      <button
        type="button"
        onClick={() =>
          console.log('Subheader addon clicked')
        }
        style={{
          cursor: 'pointer',
          border: '1px solid var(--backstage-divider, #e0e0e0)',
          borderRadius: 6,
          padding: '6px 10px',
          background: 'var(--backstage-background, #fff)',
          fontSize: 13,
        }}
      >
        Subheader Demo
      </button>
    </div>
  );
};

export const SubheaderDemo = techdocsModuleAddonsContribPlugin.provide(
  createTechDocsAddonExtension<{}>({
    name: 'SubheaderDemo',
    location: TechDocsAddonLocations.Subheader, // 👈 the important bit
    component: SubheaderDemoImpl,
  }),
);
```
2. Add this to your `<your_local>/rhdh/dynamic-plugins/wrappers/backstage-plugin-techdocs-module-addons-contrib/src/index.tx` to export the added`SubheaderDemo`
```
export { ReportIssue, SubheaderDemo } from "./addons";
```
3. Add this to your `app-config.local.yaml` to register the `SubheaderDemo`
```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
  frontend:
    backstage.plugin-techdocs:
    ... # default techdocs configuration
    backstage.plugin-techdocs-module-addons-contrib:
      techdocsAddons:
        - importName: SubheaderDemo
```

<img width="3024" height="1648" alt="image" src="https://github.com/user-attachments/assets/6fade948-1d0d-4792-8598-4282433109dc" />

<img width="3024" height="1650" alt="image" src="https://github.com/user-attachments/assets/b9c59c9e-af51-4a55-b3c6-f35f24d40d0b" />
