### PR TITLE
fix(global-header): add ability to use custom star icons

### DIFF
--- a/workspaces/global-header/.changeset/lovely-pianos-pay.md
+++ b/workspaces/global-header/.changeset/lovely-pianos-pay.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+fix: add ability to use custom star icons

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
@@ -19,7 +19,7 @@ import {
   useEntityPresentation,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
-import { Link } from '@backstage/core-components';
+import { Link, AppIcon } from '@backstage/core-components';
 import {
   CompoundEntityRef,
   Entity,
@@ -107,7 +107,7 @@ const StarredItem: FC<SectionComponentProps> = ({
             color: rhdhPalette?.general?.starredItemsColor ?? '#F3BA37',
           }}
         >
-          <Star />
+          <AppIcon id="star" Fallback={Star} />
         </IconButton>
       </Tooltip>
     </MenuItem>
@@ -123,7 +123,7 @@ export const StarredDropdown = () => {
 
   return (
     <HeaderDropdownComponent
-      buttonContent={<StarBorderIcon />}
+      buttonContent={<AppIcon id="unstarred" Fallback={StarBorderIcon} />}
       onOpen={handleOpen}
       onClose={handleClose}
       anchorEl={anchorEl}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use backstage AppIcon to render star icons in `StarredDropdown` component, this will allow overriding default icon with custom icons

Icon id `star` and `unstarred` are default icons for starred entities in Backstage

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

### Screenshots

This is how it looks with custom icons

```tsx title="App.tsx"
// In App.tsx
import BookmarkTwoTone from '@mui/icons-material/BookmarkTwoTone';
import BookmarkBorderTwoTone from '@mui/icons-material/BookmarkBorderTwoTone';

const app = createApp({
  icons: {
    ...
    star: BookmarkTwoTone,
    unstarred: BookmarkBorderTwoTone,
  }  
```

<img width="2015" height="1315" alt="image" src="https://github.com/user-attachments/assets/07faacf5-9136-414d-80b5-f31c863b9fc8" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
