### PR TITLE
feat(Orchestrator): prune unused properties for the Review step

### DIFF
--- a/workspaces/orchestrator/.changeset/prune-obsolete-form-properties.md
+++ b/workspaces/orchestrator/.changeset/prune-obsolete-form-properties.md
@@ -1,0 +1,10 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+---
+
+Prune obsolete properties from form data before Review and Submit
+
+- Update `OrchestratorForm` to prune form data before passing to Review step and execution
+- Fixes issue where SchemaUpdater dynamically adds/removes fields but old values remain in form state
+- Ensures only properties that exist in the final schema version are displayed on Review page and submitted
+- Prevents stale data from previous schema versions from being included in workflow execution

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
@@ -55,6 +55,7 @@
     "@types/json-schema": "7.0.15",
     "@types/lodash": "^4.14.151",
     "@types/react": "^18.2.58",
+    "json-schema": "^0.4.0",
     "prettier": "3.6.2",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.test.ts
@@ -1,0 +1,588 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JSONSchema7 } from 'json-schema';
+
+import { pruneFormData } from './pruneFormData';
+
+describe('pruneFormData', () => {
+  describe('Basic Property Handling', () => {
+    it('should remove properties not in schema', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+      };
+
+      const formData = {
+        name: 'John',
+        age: 30,
+        obsoleteField: 'should be removed',
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        name: 'John',
+        age: 30,
+      });
+      expect(result).not.toHaveProperty('obsoleteField');
+    });
+
+    it('should keep all valid properties', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+          active: { type: 'boolean' },
+        },
+      };
+
+      const formData = {
+        name: 'Jane',
+        email: 'jane@example.com',
+        active: true,
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual(formData);
+    });
+
+    it('should skip undefined values in formData', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+      };
+
+      const formData = {
+        name: 'Alice',
+        age: undefined,
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        name: 'Alice',
+      });
+      expect(result).not.toHaveProperty('age');
+    });
+
+    it('should handle empty form data', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      };
+
+      const result = pruneFormData({}, schema);
+
+      expect(result).toEqual({});
+    });
+
+    it('should handle schema without properties', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+      };
+
+      const formData = {
+        anything: 'here',
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('Nested Objects', () => {
+    it('should handle nested objects', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          user: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              age: { type: 'number' },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        user: {
+          name: 'Bob',
+          age: 25,
+          obsoleteNested: 'remove me',
+        },
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        user: {
+          name: 'Bob',
+          age: 25,
+        },
+      });
+    });
+
+    it('should handle multi-step form schema', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          step1: {
+            type: 'object',
+            properties: {
+              field1: { type: 'string' },
+              field2: { type: 'string' },
+            },
+          },
+          step2: {
+            type: 'object',
+            properties: {
+              field3: { type: 'number' },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        step1: {
+          field1: 'value1',
+          field2: 'value2',
+          oldField: 'removed',
+        },
+        step2: {
+          field3: 123,
+          anotherOldField: 'also removed',
+        },
+        completelyObsoleteStep: {
+          data: 'removed',
+        },
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        step1: {
+          field1: 'value1',
+          field2: 'value2',
+        },
+        step2: {
+          field3: 123,
+        },
+      });
+    });
+
+    it('should handle deeply nested objects', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          level1: {
+            type: 'object',
+            properties: {
+              level2: {
+                type: 'object',
+                properties: {
+                  level3: {
+                    type: 'object',
+                    properties: {
+                      deepField: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        level1: {
+          level2: {
+            level3: {
+              deepField: 'value',
+              obsoleteDeep: 'remove',
+            },
+            obsolete2: 'remove',
+          },
+          obsolete1: 'remove',
+        },
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        level1: {
+          level2: {
+            level3: {
+              deepField: 'value',
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('Arrays', () => {
+    it('should preserve arrays', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      };
+
+      const formData = {
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        tags: ['tag1', 'tag2', 'tag3'],
+      });
+    });
+
+    it('should preserve complex arrays', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'number' },
+                name: { type: 'string' },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        items: [
+          { id: 1, name: 'First' },
+          { id: 2, name: 'Second' },
+        ],
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual(formData);
+    });
+  });
+
+  describe('JSON Schema Dependencies', () => {
+    it('should handle simple dependencies (array form)', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          creditCard: { type: 'string' },
+        },
+        dependencies: {
+          creditCard: ['billingAddress'],
+        },
+      };
+
+      const formData = {
+        name: 'John',
+        creditCard: '1234',
+        billingAddress: '123 Main St',
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual(formData);
+    });
+
+    it('should handle schema dependencies with oneOf', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          configOption: {
+            type: 'string',
+            enum: ['simple', 'advanced'],
+          },
+          name: { type: 'string' },
+          email: { type: 'string' },
+        },
+        dependencies: {
+          configOption: {
+            oneOf: [
+              {
+                properties: {
+                  configOption: { enum: ['simple'] },
+                },
+              },
+              {
+                properties: {
+                  configOption: { enum: ['advanced'] },
+                  advancedField1: { type: 'string' },
+                  advancedField2: { type: 'string' },
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      // Test with advanced mode selected
+      const formDataAdvanced = {
+        configOption: 'advanced',
+        name: 'John',
+        email: 'john@example.com',
+        advancedField1: 'extra1',
+        advancedField2: 'extra2',
+      };
+
+      const resultAdvanced = pruneFormData(formDataAdvanced, schema);
+
+      expect(resultAdvanced).toEqual(formDataAdvanced);
+      expect(resultAdvanced).toHaveProperty('advancedField1');
+      expect(resultAdvanced).toHaveProperty('advancedField2');
+    });
+
+    it('should remove conditional fields when condition not met', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          configOption: {
+            type: 'string',
+            enum: ['simple', 'advanced'],
+          },
+          name: { type: 'string' },
+        },
+        dependencies: {
+          configOption: {
+            oneOf: [
+              {
+                properties: {
+                  configOption: { enum: ['simple'] },
+                },
+              },
+              {
+                properties: {
+                  configOption: { enum: ['advanced'] },
+                  advancedField1: { type: 'string' },
+                  advancedField2: { type: 'string' },
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      // Test with simple mode but obsolete advanced fields
+      const formDataSimple = {
+        configOption: 'simple',
+        name: 'John',
+        advancedField1: 'should be removed',
+        advancedField2: 'should be removed',
+      };
+
+      const resultSimple = pruneFormData(formDataSimple, schema);
+
+      expect(resultSimple).toEqual({
+        configOption: 'simple',
+        name: 'John',
+      });
+      expect(resultSimple).not.toHaveProperty('advancedField1');
+      expect(resultSimple).not.toHaveProperty('advancedField2');
+    });
+  });
+
+  describe('Conditional Schemas (oneOf, anyOf, allOf)', () => {
+    it('should handle allOf schemas', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        allOf: [
+          {
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+          {
+            properties: {
+              email: { type: 'string' },
+            },
+          },
+        ],
+      };
+
+      const formData = {
+        name: 'John',
+        email: 'john@example.com',
+        obsolete: 'remove',
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual({
+        name: 'John',
+        email: 'john@example.com',
+      });
+    });
+  });
+
+  describe('Real-World Scenarios', () => {
+    it('should handle test-pruning-demo schema (advanced mode)', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          step1: {
+            type: 'object',
+            title: 'Step 1 - Configuration',
+            properties: {
+              configOption: {
+                type: 'string',
+                enum: ['simple', 'advanced'],
+              },
+              name: { type: 'string' },
+              email: { type: 'string' },
+            },
+            dependencies: {
+              configOption: {
+                oneOf: [
+                  {
+                    properties: {
+                      configOption: { enum: ['simple'] },
+                    },
+                  },
+                  {
+                    properties: {
+                      configOption: { enum: ['advanced'] },
+                      advancedField1: { type: 'string' },
+                      advancedField2: { type: 'string' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          step2: {
+            type: 'object',
+            title: 'Step 2',
+            properties: {
+              notes: { type: 'string' },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        step1: {
+          configOption: 'advanced',
+          name: 'John Doe',
+          email: 'john@example.com',
+          advancedField1: 'Extra data 1',
+          advancedField2: 'Extra data 2',
+        },
+        step2: {
+          notes: 'test',
+        },
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result).toEqual(formData);
+      expect(result.step1).toHaveProperty('advancedField1');
+      expect(result.step1).toHaveProperty('advancedField2');
+    });
+
+    it('should handle test-pruning-demo schema (simple mode)', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          step1: {
+            type: 'object',
+            title: 'Step 1 - Configuration',
+            properties: {
+              configOption: {
+                type: 'string',
+                enum: ['simple', 'advanced'],
+              },
+              name: { type: 'string' },
+              email: { type: 'string' },
+            },
+            dependencies: {
+              configOption: {
+                oneOf: [
+                  {
+                    properties: {
+                      configOption: { enum: ['simple'] },
+                    },
+                  },
+                  {
+                    properties: {
+                      configOption: { enum: ['advanced'] },
+                      advancedField1: { type: 'string' },
+                      advancedField2: { type: 'string' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          step2: {
+            type: 'object',
+            title: 'Step 2',
+            properties: {
+              notes: { type: 'string' },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        step1: {
+          configOption: 'simple',
+          name: 'John Doe',
+          email: 'john@example.com',
+          advancedField1: 'Should be removed',
+          advancedField2: 'Should be removed',
+        },
+        step2: {
+          notes: 'test',
+        },
+      };
+
+      const result = pruneFormData(formData, schema);
+
+      expect(result.step1).toEqual({
+        configOption: 'simple',
+        name: 'John Doe',
+        email: 'john@example.com',
+      });
+      expect(result.step1).not.toHaveProperty('advancedField1');
+      expect(result.step1).not.toHaveProperty('advancedField2');
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject, JsonValue } from '@backstage/types';
+
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * Resolves $ref references in a schema by looking in $defs
+ */
+function resolveSchema(
+  schema: JSONSchema7,
+  rootSchema: JSONSchema7,
+): JSONSchema7 {
+  if (!schema.$ref) return schema;
+
+  // Handle #/$defs/name references
+  const refPath = schema.$ref;
+  if (refPath.startsWith('#/$defs/')) {
+    const defName = refPath.replace('#/$defs/', '');
+    const resolved = rootSchema.$defs?.[defName];
+    if (resolved && typeof resolved === 'object') {
+      return resolved as JSONSchema7;
+    }
+  }
+
+  return schema;
+}
+
+/**
+ * Checks if a property's enum value matches the form data
+ */
+function matchesEnum(propSchema: JSONSchema7, value: any): boolean {
+  if (!propSchema.enum) return true;
+  return propSchema.enum.includes(value);
+}
+
+/**
+ * Checks if a property's const value matches the form data
+ */
+function matchesConst(propSchema: JSONSchema7, value: any): boolean {
+  if (propSchema.const === undefined) return true;
+  return propSchema.const === value;
+}
+
+/**
+ * Collects valid property names from schema based on current form data
+ */
+function getValidProperties(
+  schema: JSONSchema7,
+  formData: JsonObject,
+): Set<string> {
+  const valid = new Set<string>();
+
+  // Add base properties
+  if (schema.properties) {
+    Object.keys(schema.properties).forEach(key => valid.add(key));
+  }
+
+  // Handle dependencies with oneOf (common pattern for conditional fields)
+  if (schema.dependencies) {
+    Object.entries(schema.dependencies).forEach(([depKey, depValue]) => {
+      // Only process if dependency key exists
+      if (formData[depKey] === undefined) return;
+
+      // Array form: ['prop1', 'prop2']
+      if (Array.isArray(depValue)) {
+        depValue.forEach(prop => valid.add(prop));
+        return;
+      }
+
+      // Schema form with oneOf
+      const depSchema = depValue as JSONSchema7;
+      if (depSchema.oneOf) {
+        // Find matching branch
+        for (const branch of depSchema.oneOf) {
+          if (typeof branch !== 'object' || !branch.properties) continue;
+
+          const branchSchema = branch as JSONSchema7;
+          const branchProps = branchSchema.properties;
+          if (!branchProps) continue;
+
+          let matches = true;
+
+          // Check if this branch matches current data
+          for (const [key, propDef] of Object.entries(branchProps)) {
+            if (typeof propDef === 'boolean') continue;
+            const propSchema = propDef as JSONSchema7;
+            const value = formData[key];
+
+            if (
+              !matchesEnum(propSchema, value) ||
+              !matchesConst(propSchema, value)
+            ) {
+              matches = false;
+              break;
+            }
+          }
+
+          // If branch matches, add its properties
+          if (matches) {
+            Object.keys(branchProps).forEach(key => valid.add(key));
+          }
+        }
+      }
+
+      // Add properties from dependency schema itself
+      if (depSchema.properties) {
+        Object.keys(depSchema.properties).forEach(key => valid.add(key));
+      }
+    });
+  }
+
+  // Handle allOf with if/then/else conditionals
+  if (schema.allOf) {
+    schema.allOf.forEach(subSchema => {
+      if (typeof subSchema !== 'object') return;
+
+      const subSchemaObj = subSchema as JSONSchema7;
+
+      // Check for if/then/else pattern
+      if (subSchemaObj.if && typeof subSchemaObj.if === 'object') {
+        const ifSchema = subSchemaObj.if as JSONSchema7;
+        const conditionMatches = checkIfCondition(ifSchema, formData);
+
+        if (conditionMatches && subSchemaObj.then) {
+          // Condition matches, add properties from 'then'
+          const thenSchema = subSchemaObj.then as JSONSchema7;
+          if (thenSchema.properties) {
+            Object.keys(thenSchema.properties).forEach(key => valid.add(key));
+          }
+        } else if (!conditionMatches && subSchemaObj.else) {
+          // Condition doesn't match, add properties from 'else'
+          const elseSchema = subSchemaObj.else as JSONSchema7;
+          if (elseSchema.properties) {
+            Object.keys(elseSchema.properties).forEach(key => valid.add(key));
+          }
+        }
+      } else {
+        // No if/then/else, just add properties from this allOf branch
+        if (subSchemaObj.properties) {
+          Object.keys(subSchemaObj.properties).forEach(key => valid.add(key));
+        }
+      }
+    });
+  }
+
+  return valid;
+}
+
+/**
+ * Checks if the 'if' condition in a schema matches the form data
+ */
+function checkIfCondition(
+  ifSchema: JSONSchema7,
+  formData: JsonObject,
+): boolean {
+  if (!ifSchema.properties) return true;
+
+  // Check all constraints in the 'if' schema
+  for (const [key, propDef] of Object.entries(ifSchema.properties)) {
+    if (typeof propDef === 'boolean') continue;
+
+    const propSchema = propDef as JSONSchema7;
+    const value = formData[key];
+
+    // Check const constraint
+    if (propSchema.const !== undefined) {
+      if (value !== propSchema.const) {
+        return false;
+      }
+    }
+
+    // Check enum constraint
+    if (propSchema.enum && value !== undefined) {
+      if (!propSchema.enum.includes(value as any)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Recursively prunes form data to only include properties that exist in the schema.
+ * This removes stale properties that were added by SchemaUpdater but later removed
+ * when the schema was updated again.
+ *
+ * @param formData - The form data to prune
+ * @param schema - The current JSON schema
+ * @param rootSchema - The root schema (for resolving $ref)
+ * @returns Pruned form data containing only properties that exist in the schema
+ */
+export function pruneFormData(
+  formData: JsonObject,
+  schema: JSONSchema7,
+  rootSchema?: JSONSchema7,
+): JsonObject {
+  const root = rootSchema || schema;
+  const validProps = getValidProperties(schema, formData);
+  const pruned: JsonObject = {};
+
+  for (const [key, value] of Object.entries(formData)) {
+    // Skip undefined values
+    if (value === undefined) continue;
+
+    // Skip if property is not valid
+    if (!validProps.has(key)) continue;
+
+    // Get property schema for recursion
+    let propSchema = schema.properties?.[key];
+    if (typeof propSchema === 'boolean' || !propSchema) {
+      pruned[key] = value as JsonValue;
+      continue;
+    }
+
+    // Resolve $ref if present
+    propSchema = resolveSchema(propSchema as JSONSchema7, root);
+
+    // Recursively prune nested objects
+    if (
+      propSchema.type === 'object' &&
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      // Only prune if schema has validation rules (properties, dependencies, or allOf)
+      // Otherwise keep data as-is (handles $ref and other schema patterns)
+      if (
+        propSchema.properties ||
+        propSchema.dependencies ||
+        propSchema.allOf
+      ) {
+        pruned[key] = pruneFormData(
+          value as JsonObject,
+          propSchema as JSONSchema7,
+          root,
+        );
+      } else {
+        // No validation rules, keep the data as-is
+        pruned[key] = value as JsonValue;
+      }
+    } else {
+      pruned[key] = value as JsonValue;
+    }
+  }
+
+  return pruned;
+}

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -11135,6 +11135,7 @@ __metadata:
     "@types/json-schema": 7.0.15
     "@types/lodash": ^4.14.151
     "@types/react": ^18.2.58
+    json-schema: ^0.4.0
     json-schema-library: ^9.0.0
     lodash: ^4.17.21
     prettier: 3.6.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Story - https://issues.redhat.com/browse/FLPATH-2791

#### Videos:

-----BEFORE----

![Orchestrator - pruning form data - before](https://github.com/user-attachments/assets/7eb59bc3-6e16-489f-bc95-0ea1161bc86a)

----------

----AFTER-----

![Orchestrator - pruning form data - after](https://github.com/user-attachments/assets/a7582a6b-697e-478a-99a6-671af70d109e)

----------


Prune obsolete properties from form data before Review and Submit

- Update `OrchestratorForm` to prune form data before passing to Review step and execution
- Fixes issue where SchemaUpdater dynamically adds/removes fields but old values remain in form state
- Ensures only properties that exist in the final schema version are displayed on Review page and submitted
- Prevents stale data from previous schema versions from being included in workflow execution

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
