### PR TITLE
chore: fix/pin package versions between frontend and backend

### DIFF
--- a/workspaces/adoption-insights/.changeset/config.json
+++ b/workspaces/adoption-insights/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/bulk-import/.changeset/config.json
+++ b/workspaces/bulk-import/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/lightspeed/.changeset/config.json
+++ b/workspaces/lightspeed/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/marketplace/.changeset/config.json
+++ b/workspaces/marketplace/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/redhat-resource-optimization/.changeset/config.json
+++ b/workspaces/redhat-resource-optimization/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/scorecard/.changeset/config.json
+++ b/workspaces/scorecard/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/translations/.changeset/config.json
+++ b/workspaces/translations/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@red-hat-developer-hub/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Set `fixed` (see [changeset documentation](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md)) for these workspaces that ships backend plugins, frontend plugins and sometimes common or node packages:

1. adoption-insights
2. bulk-import
3. lightspeed
4. marketplace
5. redhat-resource-optimization
6. scorecard
7. translations

I looked into the other workspaces and wasn't sure if we want this now. So let us start with this 7 workspaces...

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
