### PR TITLE
fix(lightspeed): show only llm models in the model dropdown

### DIFF
--- a/workspaces/lightspeed/.changeset/many-masks-sin.md
+++ b/workspaces/lightspeed/.changeset/many-masks-sin.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+use only llm models in the model dropdown

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
@@ -53,6 +53,7 @@ const LightspeedPageInner = () => {
   const identityApi = useApi(identityApiRef);
 
   const { data: models } = useAllModels();
+
   const { allowed: hasViewAccess, loading } = useLightspeedViewPermission();
 
   const { value: profile, loading: profileLoading } = useAsync(
@@ -67,11 +68,13 @@ const LightspeedPageInner = () => {
   const modelsItems = useMemo(
     () =>
       models
-        ? models.map(m => ({
-            label: m.provider_resource_id,
-            value: m.provider_resource_id,
-            provider: m.provider_id,
-          }))
+        ? models
+            .filter(model => model.model_type === 'llm')
+            .map(m => ({
+              label: m.provider_resource_id,
+              value: m.provider_resource_id,
+              provider: m.provider_id,
+            }))
         : [],
     [models],
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

**Fixes**:

https://issues.redhat.com/browse/RHDHBUGS-2138


| Before fix    | After fix |
| -------- | ------- |
| <img width="214" height="495" alt="image" src="https://github.com/user-attachments/assets/0336ac4e-46f5-4946-80c1-01f0bfafec2d" />  |<img width="264" height="391" alt="image" src="https://github.com/user-attachments/assets/424237f0-bb7f-4f8b-abd3-01afaea12c9b" />    |




**Description:**

Use only models that are of type `llm` to avoid showing embedding models in the list.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
