### PR TITLE
fix(marketplace): fixed installStatus value on Installed packages tab

### DIFF
--- a/workspaces/marketplace/.changeset/few-comics-unite.md
+++ b/workspaces/marketplace/.changeset/few-comics-unite.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-marketplace': patch
+---
+
+Fixed `installStatus` value on the `Installed packages` tab.

--- a/workspaces/marketplace/plugins/marketplace/src/components/InstalledPackages/InstalledPackagesTable.tsx
+++ b/workspaces/marketplace/plugins/marketplace/src/components/InstalledPackages/InstalledPackagesTable.tsx
@@ -31,7 +31,10 @@ import Typography from '@mui/material/Typography';
 import AlertTitle from '@mui/material/AlertTitle';
 import Link from '@mui/material/Link';
 import Alert from '@mui/material/Alert';
-import { MarketplacePackage } from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
+import {
+  MarketplacePackage,
+  MarketplacePackageInstallStatus,
+} from '@red-hat-developer-hub/backstage-plugin-marketplace-common';
 
 import { useMarketplaceApi } from '../../hooks/useMarketplaceApi';
 import { getReadableName } from '../../utils/pluginProcessing';
@@ -224,7 +227,11 @@ export const InstalledPackagesTable = () => {
             // Show the npm package name directly from dynamic-plugins-info record
             packageName: p.name,
             parentPlugin: entity?.spec?.partOf?.[0] ?? '',
-            installStatus: entity?.spec?.installStatus,
+            // If entity exists, use its installStatus; otherwise, since the package is installed,
+            // set installStatus to Installed (matching the Catalog tab behavior)
+            installStatus:
+              entity?.spec?.installStatus ??
+              MarketplacePackageInstallStatus.Installed,
             // Humanized role from dynamic-plugins-info
             role: (p as any).role
               ? (() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For [RHDHBUGS-2213](https://issues.redhat.com/browse/RHDHBUGS-2213)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

Screen recording:
(all rows in Installed packages tab should display "installed" on the toggle button at the initial state)

https://github.com/user-attachments/assets/b5df7fc5-052b-4c13-9ed6-3d619cf17aeb

