### PR TITLE
Fix lightspeed chat streaming

### DIFF
--- a/workspaces/lightspeed/.changeset/serious-bobcats-fail.md
+++ b/workspaces/lightspeed/.changeset/serious-bobcats-fail.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+fix streaming response in lightspeed UI

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
@@ -246,7 +246,7 @@ export const useConversationMessages = (
                 }
               }
 
-              if (event === 'token' && data?.role === 'inference') {
+              if (event === 'token') {
                 const content = data?.token || '';
 
                 finalMessages.push(content);


### PR DESCRIPTION
### Fixes
https://issues.redhat.com/browse/RHDHBUGS-2248

## Lightspeed chat streaming 



Fix chat streaming in the lightspeed UI. Recent changes in LCS response structure caused the lightspeed UI to lose its streaming effect. `data.role` is removed int he LCS response structure.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->



https://github.com/user-attachments/assets/741b52eb-9a33-4882-aac8-312ebe12477b

**How to test:**
1. Checkout this Lightspeed stack PR - https://github.com/lightspeed-core/lightspeed-stack/pull/737 and run lightspeed-stack
2. Run lightspeed plugins using `yarn dev`


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
