### PR TITLE
RHIDP-9656: Update global headers dependencies

### DIFF
--- a/workspaces/global-header/package.json
+++ b/workspaces/global-header/package.json
@@ -53,7 +53,8 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "refractor@npm:3.6.0/prismjs": "^1.30.0"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/global-header/yarn.lock
+++ b/workspaces/global-header/yarn.lock
@@ -29168,13 +29168,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^4.1.0, proc-log@npm:^4.2.0":
   version: 4.2.0
   resolution: "proc-log@npm:4.2.0"


### PR DESCRIPTION
1. Upgrade form-data dependencies CVE-2025-7783
2. Upgrade prismjs dependencies CVE-2024-53382
3. Upgrade @octokit/plugin-paginate-rest dependencies CVE-2025-25288
