### PR TITLE
fix(lightspeed): preselect last used model on page load

### DIFF
--- a/workspaces/lightspeed/.changeset/brown-goats-swim.md
+++ b/workspaces/lightspeed/.changeset/brown-goats-swim.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Add localStorage persistence for last selected model
+
+The Lightspeed plugin now remembers the user's last selected model across page refreshes, automatically restoring it when available.

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
@@ -42,6 +42,7 @@ const useStyles = makeStyles(() =>
 
 const THEME_DARK = 'dark';
 const THEME_DARK_CLASS = 'pf-v6-theme-dark';
+const LAST_SELECTED_MODEL_KEY = 'lastSelectedModel';
 
 const LightspeedPageInner = () => {
   const classes = useStyles();
@@ -91,10 +92,56 @@ const LightspeedPageInner = () => {
 
   useEffect(() => {
     if (modelsItems.length > 0) {
-      setSelectedModel(modelsItems[0].value);
-      setSelectedProvider(modelsItems[0].provider);
+      try {
+        const storedData = localStorage.getItem(LAST_SELECTED_MODEL_KEY);
+        const parsedData = storedData ? JSON.parse(storedData) : null;
+
+        // Check if stored model exists in available models
+        const storedModel = parsedData?.model
+          ? modelsItems.find(m => m.value === parsedData.model)
+          : null;
+
+        if (storedModel) {
+          setSelectedModel(storedModel.value);
+          setSelectedProvider(storedModel.provider);
+        } else {
+          // Fallback to first model if stored model is not available
+          setSelectedModel(modelsItems[0].value);
+          setSelectedProvider(modelsItems[0].provider);
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Error loading last selected model from localStorage:',
+          error,
+        );
+        // Fallback to first model on error
+        setSelectedModel(modelsItems[0].value);
+        setSelectedProvider(modelsItems[0].provider);
+      }
     }
   }, [modelsItems]);
+
+  // Save to localStorage whenever model or provider changes
+  useEffect(() => {
+    if (selectedModel && selectedProvider) {
+      try {
+        localStorage.setItem(
+          LAST_SELECTED_MODEL_KEY,
+          JSON.stringify({
+            model: selectedModel,
+            provider: selectedProvider,
+          }),
+        );
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Error saving last selected model to localStorage:',
+          error,
+        );
+      }
+    }
+  }, [selectedModel, selectedProvider]);
 
   if (loading) {
     return null;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2137


The Lightspeed plugin now remembers the user's last selected model across page refreshes, automatically restoring it when available.



https://github.com/user-attachments/assets/ca351aa1-7d77-4ffc-839a-817b4e94b987




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
