### PR TITLE
RHIDP-9661: Upgrade quickstart dependencies

### DIFF
--- a/workspaces/quickstart/package.json
+++ b/workspaces/quickstart/package.json
@@ -233,7 +233,8 @@
     "@backstage/plugin-user-settings-backend": "0.3.5",
     "@backstage/plugin-user-settings-common": "0.0.1",
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "refractor@npm:3.6.0/prismjs": "^1.30.0"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/quickstart/yarn.lock
+++ b/workspaces/quickstart/yarn.lock
@@ -28856,17 +28856,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.27.0":
+"prismjs@npm:^1.27.0, prismjs@npm:^1.30.0":
   version: 1.30.0
   resolution: "prismjs@npm:1.30.0"
   checksum: a68eddd4c5f1c506badb5434b0b28a7cc2479ed1df91bc4218e6833c7971ef40c50ec481ea49749ac964256acb78d8b66a6bd11554938e8998e46c18b5f9a580
-  languageName: node
-  linkType: hard
-
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Upgrade form-data dependencies CVE-2025-7783 CVE-2025-7783
2. Upgrade tar-fs dependencies CVE-2025-48387 CVE-2025-59343
3. Upgrade prismjs dependencies CVE-2024-53382