### PR TITLE
RHIDP-9663: Upgrade translations dependencies

### DIFF
--- a/workspaces/translations/package.json
+++ b/workspaces/translations/package.json
@@ -237,7 +237,8 @@
     "@backstage/plugin-user-settings-backend": "0.3.2",
     "@backstage/plugin-user-settings-common": "0.0.1",
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "refractor@npm:3.6.0/prismjs": "^1.30.0"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/translations/yarn.lock
+++ b/workspaces/translations/yarn.lock
@@ -29799,13 +29799,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^4.1.0, proc-log@npm:^4.2.0":
   version: 4.2.0
   resolution: "proc-log@npm:4.2.0"


### PR DESCRIPTION
1. Upgraded tar-fs dependencies CVE-2025-59343
2. Upgraded prismjs dependencies CVE-2024-53382