### PR TITLE
chore(e2e): add e2e test to verify AI disclaimer visibility

### DIFF
--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -97,12 +97,6 @@ test('Lightspeed is available', async ({ page }) => {
 });
 
 test('Verify disclaimer to be visible', async ({ page }) => {
-  await expect(
-    page.getByRole('heading', { name: 'Info alert: Important' }),
-  ).toBeVisible();
-  await expect(page.getByLabel('Scrollable message log')).toContainText(
-    "This feature uses AI technology. Do not include any personal information or any other sensitive information in your input. Interactions may be used to improve Red Hat's products or services.",
-  );
   await expect(page.getByLabel('Scrollable message log')).toMatchAriaSnapshot(`
     - 'heading "Info alert: Important" [level=4]'
     - text: This feature uses AI technology. Do not include any personal information or any other sensitive information in your input. Interactions may be used to improve Red Hat's products or services.


### PR DESCRIPTION
### Which issue(s) does this PR fix
Fixes : https://issues.redhat.com/browse/RHIDP-9478
## Summary
Adds a test to the existing e2e to verify the AI technology disclaimer is properly displayed in the Lightspeed interface.

## Changes
Added a test which validates:
- Disclaimer heading visibility
- Complete disclaimer message text
- ARIA snapshot structure