### PR TITLE
fix(global-floating-action-button): updated the style.css import which got reverted due to git commit command

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/fix-horizontal-overflow-v1-44-2.md
+++ b/workspaces/global-floating-action-button/.changeset/fix-horizontal-overflow-v1-44-2.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-floating-action-button': patch
+---
+
+Fix horizontal page overflow issue in Backstage v1.44.2 by adding required CSS import. Added `@backstage/ui/css/styles.css` import to resolve layout issues introduced in the v1.44.2 upgrade.

--- a/workspaces/global-floating-action-button/packages/app/src/index.tsx
+++ b/workspaces/global-floating-action-button/packages/app/src/index.tsx
@@ -15,7 +15,7 @@
  */
 
 import '@backstage/cli/asset-types';
-import '@backstage/ui';
+import '@backstage/ui/css/styles.css';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On issue of git commit command, the import command got changed from `import '@backstage/ui/css/styles.css';` to `import '@backstage/ui';`
<img width="1711" height="825" alt="Screenshot 2025-11-13 at 3 49 21 PM" src="https://github.com/user-attachments/assets/8b16eef1-820c-487d-a24e-1a247a7903f7" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
