### PR TITLE
fix(orchestrator): Starting time is not displayed correctly in Results pane when workflows are started

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-workflow-start-time-display.md
+++ b/workspaces/orchestrator/.changeset/fix-workflow-start-time-display.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix workflow start time displaying `{{ time }}` placeholder instead of actual time

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -137,7 +137,7 @@ const ResultMessage = ({
           &nbsp;
           <Trans
             message="run.status.workflowIsRunning"
-            params={{ startedTime }}
+            params={{ time: startedTime }}
           />
         </>
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes: https://issues.redhat.com/browse/RHDHBUGS-2220

--------

----BEFORE----

<img width="1680" height="918" alt="Screenshot 2025-11-17 at 3 03 46 PM" src="https://github.com/user-attachments/assets/a21c3d96-1f3d-4cd4-b4f8-9ca7750c76bd" />

--------

----AFTER----

<img width="1719" height="930" alt="Screenshot 2025-11-17 at 3 17 05 PM" src="https://github.com/user-attachments/assets/9596b7d8-00be-47a5-a6aa-29f40687c7bb" />

--------

Steps to Reproduce the Bug (Before Fix)

1. Create a test workflow with a sleep/delay state to keep it in "Running" status:

```
id: test-workflow
name: Test Time Display
start: DelayState
states:
  - name: DelayState
    type: sleep
    duration: PT30S  # 30 second delay
    end: true
```

2. Execute the workflow from the Orchestrator UI
3. Immediately view the workflow instance page and check the "Results" pane
Observe the bug:
It shows "Workflow is running. Started {{ time }}"


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
