### PR TITLE
fix(adoption-insights): "catalog entities" filter default option reverts to english after clicking

### DIFF
--- a/workspaces/adoption-insights/.changeset/fix-filter-dropdown-translation.md
+++ b/workspaces/adoption-insights/.changeset/fix-filter-dropdown-translation.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Fix FilterDropdown to show translated "All" option. When "All" is selected in the catalog entities filter dropdown, it now displays the translated text (e.g., "Tous" in French) instead of always showing "All" in English.

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/CatalogEntities/FilterDropdown.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/CatalogEntities/FilterDropdown.tsx
@@ -36,9 +36,11 @@ const FilterDropdown = ({
         <InputLabel id="kind-select">{t('filter.selectKind')}</InputLabel>
         <Select
           labelId="kind-select"
-          renderValue={(selected: string) =>
-            selected.length === 0 ? t('filter.selectKind') : selected
-          }
+          renderValue={(selected: string) => {
+            if (selected.length === 0) return t('filter.selectKind');
+            if (selected === 'All') return t('filter.all');
+            return selected;
+          }}
           value={selectedOption}
           onChange={handleChange}
           label={t('filter.selectKind')}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2218


https://github.com/user-attachments/assets/2bd7883e-6037-402a-bb76-8191e0fe2e9f



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
