### PR TITLE
fix(adoption-insights): test flakes

### DIFF
--- a/workspaces/adoption-insights/packages/app/e2e-tests/utils/events.ts
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/utils/events.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Page, expect } from '@playwright/test';
+
+function getEventsUrl(page: Page) {
+  const url = new URL(page.url());
+  return `${url.protocol}//${url.hostname}:7007/api/adoption-insights/events`;
+}
+
+export async function visitComponent(
+  page: Page,
+  auth: string,
+  component: string,
+) {
+  const date = new Date().toISOString();
+  const resp = await page.request.post(getEventsUrl(page), {
+    headers: {
+      authorization: auth,
+    },
+    data: [
+      {
+        action: 'click',
+        subject: `/catalog/default/component/${component}`,
+        attributes: {
+          to: `/catalog/default/component/${component}`,
+        },
+        context: {
+          routeRef: 'catalog',
+          pluginId: 'catalog',
+          extension: 'CatalogIndexPage',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+      {
+        action: 'navigate',
+        subject: `/catalog/default/component/${component}`,
+        attributes: {
+          namespace: 'default',
+          kind: 'component',
+          name: component,
+        },
+        context: {
+          routeRef: 'catalog:entity',
+          pluginId: 'catalog',
+          extension: 'App',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+    ],
+  });
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function runTemplate(page: Page, auth: string) {
+  const date = new Date().toISOString();
+  const resp = await page.request.post(getEventsUrl(page), {
+    headers: {
+      authorization: auth,
+    },
+    data: [
+      {
+        action: 'click',
+        subject: 'Create',
+        context: {
+          routeRef: 'scaffolder',
+          pluginId: 'scaffolder',
+          extension: 'ScaffolderPage',
+          entityRef: 'template:default/example-nodejs-template',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+      {
+        action: 'create',
+        subject: 'Task has been created',
+        attributes: {
+          templateSteps: 2,
+        },
+        context: {
+          routeRef: 'scaffolder',
+          pluginId: 'scaffolder',
+          extension: 'ScaffolderPage',
+          entityRef: 'template:default/example-nodejs-template',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+      {
+        action: 'navigate',
+        subject: '/create/tasks/b12e470a-7a5d-46c8-a148-811cd05d558d',
+        attributes: {},
+        context: {
+          routeRef: 'scaffolder',
+          pluginId: 'scaffolder',
+          extension: 'App',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+    ],
+  });
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function visitDocs(page: Page, auth: string) {
+  const date = new Date().toISOString();
+  const resp = await page.request.post(getEventsUrl(page), {
+    headers: {
+      authorization: auth,
+    },
+    data: [
+      {
+        action: 'click',
+        subject: 'Docs',
+        attributes: { to: '/docs' },
+        context: {
+          routeRef: 'unknown',
+          pluginId: 'root',
+          extension: 'App',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+      {
+        action: 'navigate',
+        subject: '/docs',
+        attributes: {},
+        context: {
+          routeRef: 'techdocs:index-page',
+          pluginId: 'techdocs',
+          extension: 'App',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+    ],
+  });
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function performSearch(
+  page: Page,
+  auth: string,
+  searchPhrase: string,
+) {
+  const date = new Date().toISOString();
+  const resp = await page.request.post(getEventsUrl(page), {
+    headers: {
+      authorization: auth,
+    },
+    data: [
+      {
+        action: 'click',
+        subject: 'Search',
+        attributes: { to: '/' },
+        context: {
+          routeRef: 'unknown',
+          pluginId: 'search',
+          extension: 'SidebarSearchModal',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+      {
+        action: 'search',
+        subject: searchPhrase,
+        value: 0,
+        context: {
+          routeRef: 'unknown',
+          pluginId: 'search',
+          extension: 'SidebarSearchModal',
+          userName: 'user:development/guest',
+          userId:
+            'edf9b585cd547bd4d13e21375202ef43adaa479c4627d70db6d64e0407e11087',
+          timestamp: date,
+        },
+      },
+    ],
+  });
+  expect(resp.ok()).toBeTruthy();
+}

--- a/workspaces/adoption-insights/packages/app/e2e-tests/utils/insightsHelpers.ts
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/utils/insightsHelpers.ts
@@ -34,7 +34,7 @@ export async function navigateToInsights(page: Page, insightsTitle?: string) {
 /**
  * Get a panel locator by its title
  */
-export function getPanel(page: Page, panelTitle: string) {
+export function getPanel(page: Page, panelTitle: string | RegExp) {
   return page.locator('.v5-MuiPaper-root', { hasText: panelTitle });
 }
 
@@ -70,61 +70,6 @@ export async function closeDateRangePicker(
   await datePicker
     .getByRole('button', { name: cancelText || 'Cancel' })
     .click();
-}
-
-/**
- * Visit a catalog entity by name
- */
-export async function visitCatalogEntity(page: Page, entityName: string) {
-  await navigate(page, 'home');
-  await page.getByRole('link', { name: entityName }).click();
-  await page
-    .getByRole('heading', { name: entityName })
-    .waitFor({ state: 'visible' });
-}
-
-/**
- * Run a template with the given parameters
- */
-export async function runTemplate(
-  page: Page,
-  runName: string,
-  org: string,
-  repo: string,
-) {
-  await navigate(page, 'create...');
-  await page.getByTestId('template-card-actions--create').click();
-  await page.getByRole('textbox').fill(runName);
-  await page.getByRole('button', { name: 'next' }).click();
-  await page.getByRole('textbox').first().fill(org);
-  await page.getByRole('textbox').last().fill(repo);
-  await page.getByRole('button', { name: 'review' }).click();
-  await page.getByRole('button', { name: 'create' }).click();
-  await page
-    .getByText('Run of Example Node.js Template')
-    .waitFor({ state: 'visible' });
-}
-
-/**
- * Visit the docs page
- */
-export async function visitDocs(page: Page) {
-  await navigate(page, 'docs');
-  await page.getByText('No documents to show').waitFor({ state: 'visible' });
-}
-
-/**
- * Perform a search query
- */
-export async function performSearch(page: Page, searchQuery: string) {
-  await page.getByRole('button', { name: 'search' }).click();
-  await page.getByRole('textbox').fill(searchQuery);
-
-  const noSearchResults = page.getByRole('heading', {
-    name: 'Sorry, no results were found',
-  });
-  await noSearchResults.waitFor({ state: 'visible' });
-  await page.getByRole('button', { name: 'close' }).click();
 }
 
 /**


### PR DESCRIPTION
Fixing 2 intermittent issues with tests:

- 2 projects performing actions at the same time, yet tests only expect one of the actions to be visible - made to accept either one or both
- sometimes actions could spill into 2 event flushes and some data would not be available - post events directly through api