### PR TITLE
fix(lightspeed): update model dropdown styles

### DIFF
--- a/workspaces/lightspeed/.changeset/swift-bikes-brake.md
+++ b/workspaces/lightspeed/.changeset/swift-bikes-brake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+update lightspeed model dropdown styles

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
@@ -24,6 +24,7 @@ import {
   ChatbotHeaderOptionsDropdown,
 } from '@patternfly/chatbot';
 import {
+  Divider,
   Dropdown,
   DropdownGroup,
   DropdownItem,
@@ -54,6 +55,9 @@ const useStyles = makeStyles(() =>
       '& svg': {
         transform: 'none !important',
       },
+    },
+    groupTitle: {
+      fontWeight: 'bold',
     },
   }),
 );
@@ -119,15 +123,27 @@ export const LightspeedChatBoxHeader = ({
         toggle={toggle}
       >
         <DropdownList>
-          {Object.entries(groupedModels).map(([provider, providerModels]) => (
-            <DropdownGroup key={provider} label={provider}>
-              {providerModels.map(model => (
-                <DropdownItem value={model.value} key={model.value}>
-                  {model.label}
-                </DropdownItem>
-              ))}
-            </DropdownGroup>
-          ))}
+          {Object.entries(groupedModels).map(
+            ([provider, providerModels], index) => (
+              <>
+                <DropdownGroup
+                  className={styles.groupTitle}
+                  key={provider}
+                  label={provider}
+                  labelHeadingLevel="h1"
+                >
+                  {providerModels.map(model => (
+                    <DropdownItem value={model.value} key={model.value}>
+                      {model.label}
+                    </DropdownItem>
+                  ))}
+                </DropdownGroup>
+                {index < Object.entries(groupedModels).length - 1 && (
+                  <Divider component="li" />
+                )}
+              </>
+            ),
+          )}
         </DropdownList>
       </Dropdown>
       <ChatbotHeaderOptionsDropdown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHDHBUGS-2268

Update Lightspeed model dropdown styles to make the Group heading more prominent.

- Made group heading bolder
- Added divider between the model groups

<img width="273" height="597" alt="image" src="https://github.com/user-attachments/assets/78983fd7-d168-431b-a3bf-c72170a3dff6" />


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
