### PR TITLE
fix(adoption-insights): update adoption insights page title in browser tab

### DIFF
--- a/workspaces/adoption-insights/.changeset/bumpy-stars-kneel.md
+++ b/workspaces/adoption-insights/.changeset/bumpy-stars-kneel.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Add page title to the adoption insights page

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Header/Header.tsx
@@ -130,7 +130,7 @@ const InsightsHeader: FC<InsightsHeaderProps> = () => {
   }, [startDateRange, endDateRange, t, locale]);
 
   return (
-    <Header title={t('header.title')}>
+    <Header title={t('header.title')} pageTitleOverride={t('header.title')}>
       <Select
         displayEmpty
         open={menuOpen}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHDHBUGS-2170



Add `pageTitleOverride={t('header.title')}` to explicitly set the Adoption insights page title in the browser tab.

<img width="754" height="244" alt="image" src="https://github.com/user-attachments/assets/9bd9131b-5801-46a6-b444-6328224cc4a3" />


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
