### PR TITLE
feat(orchestrator): add custom review page API support

### DIFF
--- a/workspaces/orchestrator/.changeset/custom-review-page-api.md
+++ b/workspaces/orchestrator/.changeset/custom-review-page-api.md
@@ -1,0 +1,20 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-api': minor
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': minor
+---
+
+Add custom review page API support
+
+**Custom Review Page API:**
+
+- Add `ReviewComponentProps` type to define props for custom review components
+- Add optional `getReviewComponent()` method to `OrchestratorFormApi` interface
+- Update `OrchestratorForm` to support custom review page components from plugins
+- Add `CustomReviewPage` example component in orchestrator-form-widgets plugin
+- Falls back to default review page when `getReviewComponent()` returns `undefined`
+
+**Documentation:**
+
+- Update `extensibleForm.md` with custom review page implementation guide
+- Add example showing how to implement and use custom review components

--- a/workspaces/orchestrator/docs/extensibleForm.md
+++ b/workspaces/orchestrator/docs/extensibleForm.md
@@ -9,6 +9,7 @@ This decorator supports overriding a selected set of [react-json-schema-form pro
   - **Asynchronous Validation** via the `getExtraErrors` property, for validations requiring backend calls.
 - **Custom Components:** Replace default form components by overriding the `widgets` property.
 - **Interdependent Field Values:** Manage complex inter-field dependencies using the `onChange` and `formData` properties.
+- **Custom Review Page:** Replace the default review page with a custom component via the `getReviewComponent` method.
 
 The custom decorator is delivered via a factory method that leverages a [Backstage utility API](https://backstage.io/docs/api/utility-apis) provided by the orchestrator.
 To trigger the desired behavior, the workflow schema should include custom UI properties.
@@ -57,6 +58,62 @@ The most simple implementation of the API is the default one - adds no extra log
 See [its sources](../plugins/orchestrator-form-api/src/DefaultFormApi.tsx).
 
 More complex example is [the FormWidgetsApi provided by orchestrator-form-widgets plugin](../plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx).
+
+### Custom Review Page Component
+
+You can provide a custom review page component to replace the default review step. This is useful when you want to customize how the form data is displayed before submission.
+
+#### Review Component Props
+
+The custom review component receives the following props:
+
+```typescript
+export type ReviewComponentProps = {
+  /** Whether the workflow execution is in progress */
+  busy: boolean;
+  /** The JSON Schema for the workflow form */
+  schema: JSONSchema7;
+  /** The form data to be reviewed before submission */
+  data: JsonObject;
+  /** Callback to execute the workflow */
+  handleExecute: () => void;
+};
+```
+
+#### Example Implementation
+
+A complete example implementation is available at:
+[`plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx`](../plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx)
+
+This example shows:
+
+- How to structure a custom review component
+- Handling of form data display with proper formatting
+- Integration with Material-UI components
+- Flattening nested objects for better readability
+- Proper button states during execution
+
+#### How to Use in Your Plugin
+
+```typescript
+import { CustomReviewPage } from './components/CustomReviewPage';
+
+class MyFormApi implements OrchestratorFormApi {
+  getFormDecorator(): OrchestratorFormDecorator {
+    // ... your decorator implementation
+  }
+
+  getReviewComponent() {
+    // Return your custom component
+    return CustomReviewPage;
+
+    // Or return undefined to use the default review page
+    // return undefined;
+  }
+}
+```
+
+**Note:** By default, `getReviewComponent()` returns `undefined`, which uses the built-in default review page. To enable a custom review page, return your custom component from this method.
 
 ### Plugin Creation Example
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -20,6 +20,7 @@ export type FormDecoratorProps = Pick<FormProps<JsonObject, JSONSchema7, Orchest
 // @public
 export interface OrchestratorFormApi {
     getFormDecorator(): OrchestratorFormDecorator;
+    getReviewComponent?(): React.ComponentType<ReviewComponentProps> | undefined;
 }
 
 // @public
@@ -49,6 +50,14 @@ export type OrchestratorFormDecorator = (FormComponent: React.ComponentType<Form
 export type OrchestratorFormSchemaUpdater = (chunks: SchemaChunksResponse) => void;
 
 // @public
+export type ReviewComponentProps = {
+    busy: boolean;
+    schema: JSONSchema7;
+    data: JsonObject;
+    handleExecute: () => void;
+};
+
+// @public
 export type SchemaChunksResponse = {
     [key: string]: JsonObject;
 };
@@ -60,7 +69,7 @@ export const useOrchestratorFormApiOrDefault: () => OrchestratorFormApi;
 
 // Warnings were encountered during analysis:
 //
-// src/api.d.ts:100:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
+// src/api.d.ts:123:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
 
 // (No @packageDocumentation comment for this package)
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
@@ -117,6 +117,23 @@ export type OrchestratorFormSchemaUpdater = (
 
 /**
  * @public
+ * ReviewComponentProps
+ *
+ * Type definition for properties passed to a custom review page component.
+ */
+export type ReviewComponentProps = {
+  /** Whether the workflow execution is in progress */
+  busy: boolean;
+  /** The JSON Schema for the workflow form */
+  schema: JSONSchema7;
+  /** The form data to be reviewed before submission */
+  data: JsonObject;
+  /** Callback to execute the workflow */
+  handleExecute: () => void;
+};
+
+/**
+ * @public
  * OrchestratorFormApi
  * API to be implemented by factory in a custom plugin
  */
@@ -136,6 +153,14 @@ export interface OrchestratorFormApi {
    * return the form decorator
    */
   getFormDecorator(): OrchestratorFormDecorator;
+
+  /**
+   * @public
+   * getReviewComponent
+   * return a custom review page component to replace the default review step
+   * @returns A React component that accepts ReviewComponentProps, or undefined to use the default review page
+   */
+  getReviewComponent?(): React.ComponentType<ReviewComponentProps> | undefined;
 }
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/index.ts
@@ -22,4 +22,5 @@ export type {
   OrchestratorFormSchemaUpdater,
   SchemaChunksResponse,
   OrchestratorFormContextProps,
+  ReviewComponentProps,
 } from './api';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -23,7 +23,10 @@ import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 
-import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import {
+  OrchestratorFormContextProps,
+  useOrchestratorFormApiOrDefault,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
 import { TranslationFunction } from '../hooks/useTranslation';
 import generateUiSchema from '../utils/generateUiSchema';
@@ -159,17 +162,30 @@ const OrchestratorForm = ({
     return generateUiSchema(schema, isMultiStep);
   }, [schema, isMultiStep]);
 
+  // Get custom review component from API if available
+  const orchestratorFormApi = useOrchestratorFormApiOrDefault();
+  const CustomReviewComponent = useMemo(() => {
+    return orchestratorFormApi.getReviewComponent?.();
+  }, [orchestratorFormApi]);
+
   const reviewStep = useMemo(() => {
+    // Use custom review component if provided, otherwise use default
+    const ReviewComponent = CustomReviewComponent || ReviewStep;
     return (
-      <ReviewStep
+      <ReviewComponent
         data={prunedFormData}
         schema={schema}
         busy={isExecuting}
         handleExecute={_handleExecute}
-        // no schema update here
       />
     );
-  }, [prunedFormData, schema, isExecuting, _handleExecute]);
+  }, [
+    CustomReviewComponent,
+    prunedFormData,
+    schema,
+    isExecuting,
+    _handleExecute,
+  ]);
 
   return (
     <StepperContextProvider reviewStep={reviewStep} t={t}>

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx
@@ -68,4 +68,12 @@ export class FormWidgetsApi implements OrchestratorFormApi {
       };
     };
   };
+
+  getReviewComponent: OrchestratorFormApi['getReviewComponent'] = () => {
+    // Return undefined to use the default review page
+    // To use a custom review page, return your custom component here
+    // Example: return CustomReviewPage;
+    // See: plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
+    return undefined;
+  };
 }

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * EXAMPLE: Custom Review Page Component
+ *
+ * This is a reference implementation showing how to create a custom review page.
+ * It is NOT actively used by default - the default review page is used instead.
+ *
+ * To use this custom review page:
+ * 1. Import this component in FormWidgetsApi.tsx
+ * 2. Return it from the getReviewComponent() method:
+ *
+ *    getReviewComponent() {
+ *      return CustomReviewPage;
+ *    }
+ *
+ * Or create your own custom review component following this pattern.
+ *
+ * See docs/extensibleForm.md for more details.
+ */
+
+import React, { useMemo } from 'react';
+import { Content } from '@backstage/core-components';
+import { ReviewComponentProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import { makeStyles } from 'tss-react/mui';
+
+const useStyles = makeStyles()(theme => ({
+  paper: {
+    padding: theme.spacing(3),
+  },
+  header: {
+    marginBottom: theme.spacing(3),
+    paddingBottom: theme.spacing(2),
+    borderBottom: `2px solid ${theme.palette.primary.main}`,
+  },
+  section: {
+    marginBottom: theme.spacing(2),
+  },
+  label: {
+    fontWeight: 600,
+    color: theme.palette.text.secondary,
+    marginRight: theme.spacing(1),
+  },
+  value: {
+    color: theme.palette.text.primary,
+  },
+  row: {
+    display: 'flex',
+    padding: theme.spacing(1.5, 0),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(4),
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  customBadge: {
+    marginLeft: theme.spacing(1),
+  },
+}));
+
+const renderValue = (value: any): React.ReactNode => {
+  if (value === null || value === undefined) {
+    return (
+      <Typography variant="body2" color="textSecondary">
+        N/A
+      </Typography>
+    );
+  }
+  if (typeof value === 'object') {
+    return (
+      <Typography
+        variant="body2"
+        component="pre"
+        sx={{ whiteSpace: 'pre-wrap' }}
+      >
+        {JSON.stringify(value, null, 2)}
+      </Typography>
+    );
+  }
+  return <Typography variant="body2">{String(value)}</Typography>;
+};
+
+/**
+ * Custom review page component with enhanced styling
+ * This demonstrates how to create a custom review page for the orchestrator form
+ */
+export const CustomReviewPage: React.FC<ReviewComponentProps> = ({
+  data,
+  schema: _schema,
+  busy,
+  handleExecute,
+}) => {
+  const { classes } = useStyles();
+
+  const flattenedData = useMemo(() => {
+    const result: Array<{ key: string; value: any; path: string }> = [];
+
+    const flatten = (obj: any, prefix = '', displayPrefix = '') => {
+      Object.entries(obj).forEach(([key, value]) => {
+        const newPath = prefix ? `${prefix}.${key}` : key;
+        const newDisplayPrefix = displayPrefix
+          ? `${displayPrefix} > ${key}`
+          : key;
+
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          flatten(value, newPath, newDisplayPrefix);
+        } else {
+          result.push({ key: newDisplayPrefix, value, path: newPath });
+        }
+      });
+    };
+
+    flatten(data);
+    return result;
+  }, [data]);
+
+  return (
+    <Content noPadding>
+      <Paper elevation={0} className={classes.paper}>
+        <Box className={classes.header}>
+          <Typography variant="h5" component="h2">
+            🎨 Custom Review Page
+            <Chip
+              label="CUSTOM"
+              color="primary"
+              size="small"
+              className={classes.customBadge}
+            />
+          </Typography>
+          <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+            This is a custom review page component provided via the
+            OrchestratorFormApi plugin system
+          </Typography>
+        </Box>
+
+        <Box className={classes.section}>
+          <Typography variant="h6" gutterBottom>
+            Review Your Information
+          </Typography>
+          <Typography variant="body2" color="textSecondary" gutterBottom>
+            Please review the information below before submitting the workflow
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 3 }}>
+          {flattenedData.map(({ key, value }) => (
+            <Box key={key} className={classes.row}>
+              <Typography className={classes.label} sx={{ minWidth: '200px' }}>
+                {key}:
+              </Typography>
+              <Box className={classes.value} sx={{ flex: 1 }}>
+                {renderValue(value)}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+
+        <Box className={classes.footer}>
+          <Button variant="outlined" disabled={busy}>
+            Back
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleExecute}
+            disabled={busy}
+          >
+            {busy ? 'Executing...' : 'Run Workflow'}
+          </Button>
+        </Box>
+      </Paper>
+    </Content>
+  );
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Story: https://issues.redhat.com/browse/RHIDP-10944


**Custom Review Page API:**

- Add `ReviewComponentProps` type to define props for custom review components
- Add optional `getReviewComponent()` method to `OrchestratorFormApi` interface
- Update `OrchestratorForm` to support custom review page components from plugins
- Add `CustomReviewPage` example component in orchestrator-form-widgets plugin
- Falls back to default review page when `getReviewComponent()` returns `undefined`

**Documentation:**

- Update `extensibleForm.md` with custom review page implementation guide



--------Custom review page-----

https://github.com/user-attachments/assets/c8d98383-5983-439f-a847-e4ed52f0a981


--------------------
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
