### PR TITLE
Add Dark-Mode Support for Cost management

### DIFF
--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/hooks/useThemeBackgroundColor.ts
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/hooks/useThemeBackgroundColor.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTheme } from '@material-ui/core/styles';
+
+/**
+ * Hook that returns the appropriate background color based on the current theme mode.
+ * @returns Object with backgroundColor and filterTableBackgroundColor strings
+ */
+export const useThemeBackgroundColor = (): {
+  backgroundColor: string;
+  filterTableBackgroundColor: string;
+} => {
+  const theme = useTheme();
+  const isDarkMode = (theme.palette as any).mode === 'dark';
+
+  return {
+    backgroundColor: isDarkMode ? '#292929' : '#FFFFFF',
+    filterTableBackgroundColor: isDarkMode ? '#262626' : '#F2F2F2',
+  };
+};

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/AutocompleteComponent.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/AutocompleteComponent.tsx
@@ -25,12 +25,13 @@ import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,
 } from '@material-ui/lab';
+import { useThemeBackgroundColor } from '../../../hooks/useThemeBackgroundColor';
 
 const useAutocompleteStyles = makeStyles(
   {
     root: {},
     label: {},
-    input: { backgroundColor: '#ffffff' },
+    input: { backgroundColor: 'transparent' },
     fullWidth: { width: '100%' },
   },
   { name: 'AutocompleteComponent' },
@@ -77,6 +78,7 @@ type AutocompleteComponentProps = SingleProps | MultipleProps;
 export function AutocompleteComponent(props: AutocompleteComponentProps) {
   const classes = useAutocompleteStyles();
   const { label, options, placeholder, className } = props;
+  const { backgroundColor } = useThemeBackgroundColor();
 
   return (
     <Box className={className ?? classes.root} pb={1} pt={1}>
@@ -111,9 +113,9 @@ export function AutocompleteComponent(props: AutocompleteComponentProps) {
         renderInput={params => (
           <TextField
             {...params}
-            className={classes.input}
             variant="outlined"
             placeholder={placeholder}
+            style={{ backgroundColor }}
           />
         )}
         size="medium"

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/DownloadIconButton.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/DownloadIconButton.tsx
@@ -19,11 +19,18 @@ import React from 'react';
 
 type DownloadIconButtonProps = {
   label: string;
-  variant: 'gray' | 'black';
+  variant: 'gray' | 'black' | 'white';
+};
+
+const getColor = (variant: 'gray' | 'black' | 'white') => {
+  if (variant === 'gray') return '#C7C7C7';
+  if (variant === 'black') return '#000000';
+  if (variant === 'white') return '#FFFFFF';
+  return '#C7C7C7';
 };
 
 export function DownloadIconButton(props: Readonly<DownloadIconButtonProps>) {
-  const color = props.variant === 'gray' ? '#C7C7C7' : '#000000';
+  const color = getColor(props.variant);
 
   return (
     <div

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/Filters.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/Filters.tsx
@@ -25,6 +25,7 @@ import { useApi } from '@backstage/core-plugin-api';
 import { optimizationsApiRef } from '../../../apis';
 import useAsync from 'react-use/lib/useAsync';
 import debounce from 'lodash/debounce';
+import { useThemeBackgroundColor } from '../../../hooks/useThemeBackgroundColor';
 
 const useFiltersStyles = makeStyles(
   theme => ({
@@ -102,6 +103,7 @@ export function Filters(props: FiltersProps) {
   const classes = useFiltersStyles();
   const api = useApi(optimizationsApiRef);
 
+  const { filterTableBackgroundColor } = useThemeBackgroundColor();
   // State for search input and debounced search
   const [searchInput, setSearchInput] = useState<string>('');
   const [debouncedSearch, setDebouncedSearch] = useState<string>('');
@@ -351,7 +353,11 @@ export function Filters(props: FiltersProps) {
         {/* Filter table by */}
         <div className={classes.filterSection}>
           <div
-            style={{ backgroundColor: '#F2F2F2', padding: 16, borderRadius: 8 }}
+            style={{
+              backgroundColor: filterTableBackgroundColor,
+              padding: 16,
+              borderRadius: 8,
+            }}
           >
             <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>
               Filter table by

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/SelectComponent.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/SelectComponent.tsx
@@ -22,6 +22,7 @@ import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { useThemeBackgroundColor } from '../../../hooks/useThemeBackgroundColor';
 
 const useSelectStyles = makeStyles(
   {
@@ -30,7 +31,7 @@ const useSelectStyles = makeStyles(
     formControl: {
       width: '100%',
       marginTop: 5,
-      backgroundColor: '#ffffff',
+      backgroundColor: 'transparent',
     },
   },
   {
@@ -55,6 +56,7 @@ type SelectProps = {
 /** @public */
 export function SelectComponent(props: SelectProps) {
   const classes = useSelectStyles();
+  const { backgroundColor } = useThemeBackgroundColor();
   const {
     label,
     options,
@@ -73,6 +75,7 @@ export function SelectComponent(props: SelectProps) {
         className={classes.formControl}
         variant="outlined"
         hiddenLabel
+        style={{ backgroundColor }}
       >
         <Select
           displayEmpty


### PR DESCRIPTION
Support Both States:
Dark mode and Light mode.

Dark Mode:

<img width="1918" height="912" alt="image" src="https://github.com/user-attachments/assets/8a9cfe54-30f6-4322-8f74-69950e7156df" />


Light Mode:

<img width="1918" height="912" alt="image" src="https://github.com/user-attachments/assets/a0fd1390-5a07-4549-b043-27ae4674bc1a" />
