### PR TITLE
[orchestrator-1.8] feat(orchestrator): add ui:hidden property for hiding fields

### DIFF
--- a/workspaces/orchestrator/.changeset/ui-hidden-feature.md
+++ b/workspaces/orchestrator/.changeset/ui-hidden-feature.md
@@ -1,0 +1,25 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+---
+
+Add ui:hidden property to hide fields while preserving functionality
+
+**Hidden Fields Feature:**
+
+- Add `ui:hidden` property to hide fields while preserving widget functionality
+- Implement `HiddenFieldTemplate` to render hidden fields with `display: none`
+- Hidden fields remain active, participate in validation, and are submitted with form data
+- Hidden fields are automatically excluded from the review page
+- Update `getSortedStepEntries` to filter out steps marked with `ui:hidden: true`
+- Automatically hide entire steps when all inputs within the step are hidden
+
+**Review Page Improvements:**
+
+- Add `NestedReviewTable` component for improved hierarchical display of nested objects
+- Update `generateReviewTableData` to skip hidden fields in review page
+- Update `generateReviewTableData` to skip entire steps when all fields are hidden
+- Simplified value rendering for better readability
+
+**Documentation:**
+
+- Update `orchestratorFormWidgets.md` with `ui:hidden` property documentation and usage examples

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -53,6 +53,8 @@ Implementation of the HTTP endpoints is out of the scope of this library, they a
   - [Templating and Backstage API Exposed Parts](#templating-and-backstage-api-exposed-parts)
     - [Example](#example)
   - [Retrieving Data from Backstage Catalog](#retrieving-data-from-backstage-catalog)
+  - [Hiding Fields](#hiding-fields)
+    - [Example Usage](#example-usage)
   - [Customization](#customization)
 
 ## Context
@@ -682,6 +684,53 @@ That’s the reason for listing the exposed keys explicitly.
 Integration with the Backstage Catalog can be achieved via calling the Catalog REST API, leveraging the fetch:response:\* selectors and the use of the `$${{...}}` templates.
 
 In the future, new widgets wrapping such explicit use case can be added.
+
+## Hiding Fields
+
+Fields can be hidden from the form display while still maintaining their widget functionality and participating in form submission using the `"ui:hidden": true` property.
+
+This is different from `"ui:widget": "hidden"` which changes the widget type itself. With `"ui:hidden": true`, the field keeps its original widget type (like `ActiveText`, `ActiveTextInput`, etc.) but is visually hidden from the user.
+
+### Example Usage
+
+```json
+{
+  "hiddenField": {
+    "type": "string",
+    "title": "Hidden ActiveText",
+    "ui:widget": "ActiveText",
+    "ui:hidden": true,
+    "ui:props": {
+      "ui:text": "This text is hidden but still rendered"
+    }
+  },
+  "hiddenInput": {
+    "type": "string",
+    "title": "Hidden Input",
+    "ui:hidden": true,
+    "default": "secret-value"
+  }
+}
+```
+
+**Key differences:**
+
+| Property                | Behavior                                    | Use Case                                                                               |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `"ui:widget": "hidden"` | Changes widget type to hidden input         | Simple hidden form values                                                              |
+| `"ui:hidden": true`     | Keeps original widget but hides it visually | Hide widgets while preserving their functionality (e.g., ActiveText that fetches data) |
+
+Hidden fields:
+
+- Are not displayed in the form
+- Are not shown in the wizard stepper navigation (multi-step forms)
+- Still participate in form validation
+- Are included in form submission
+- Are excluded from the review page
+- Maintain their widget functionality (fetching, validation, etc.)
+
+**Automatic Step Hiding:**
+If all inputs within a multi-step form's step are marked with `"ui:hidden": true`, the entire step will be automatically hidden from the stepper navigation. The step and its hidden fields will still be processed during form submission.
 
 ## Customization
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
@@ -43,6 +43,7 @@
     "@rjsf/material-ui": "^5.21.2",
     "@rjsf/utils": "^5.21.2",
     "@rjsf/validator-ajv8": "^5.21.2",
+    "json-schema": "^0.4.0",
     "json-schema-library": "^9.0.0",
     "lodash": "^4.17.21",
     "tss-react": "^4.9.18"
@@ -55,7 +56,6 @@
     "@types/json-schema": "7.0.15",
     "@types/lodash": "^4.14.151",
     "@types/react": "^18.2.58",
-    "json-schema": "^0.4.0",
     "prettier": "3.6.2",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/HiddenFieldTemplate.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/HiddenFieldTemplate.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import { FieldTemplateProps } from '@rjsf/utils';
+import type { JSONSchema7 } from 'json-schema';
+
+import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+
+/**
+ * Higher-order function that wraps a FieldTemplate to support ui:hidden.
+ * When ui:hidden is true, the field is rendered but hidden from view using CSS.
+ * The field still participates in form submission and validation.
+ */
+export const createHiddenFieldTemplate = (
+  DefaultFieldTemplate: React.ComponentType<
+    FieldTemplateProps<JsonObject, JSONSchema7, OrchestratorFormContextProps>
+  >,
+) => {
+  return (
+    props: FieldTemplateProps<
+      JsonObject,
+      JSONSchema7,
+      OrchestratorFormContextProps
+    >,
+  ) => {
+    const { uiSchema } = props;
+    const isHidden = uiSchema?.['ui:hidden'];
+
+    if (isHidden) {
+      return (
+        <div style={{ display: 'none' }} data-hidden-field="true">
+          <DefaultFieldTemplate {...props} />
+        </div>
+      );
+    }
+
+    // Use default template for non-hidden fields
+    return <DefaultFieldTemplate {...props} />;
+  };
+};
+
+export default createHiddenFieldTemplate;

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/NestedReviewTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/NestedReviewTable.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { JsonObject, JsonValue } from '@backstage/types';
+
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
+
+const useStyles = makeStyles()(theme => ({
+  section: {
+    marginBottom: theme.spacing(3),
+  },
+  sectionTitle: {
+    fontWeight: 600,
+    marginBottom: theme.spacing(1.5),
+    color: theme.palette.text.primary,
+  },
+  row: {
+    display: 'flex',
+    padding: theme.spacing(1, 0),
+    '&:not(:last-child)': {
+      borderBottom: `1px solid ${theme.palette.divider}`,
+    },
+  },
+  label: {
+    minWidth: '200px',
+    fontWeight: 500,
+    color: theme.palette.text.secondary,
+  },
+  value: {
+    flex: 1,
+    color: theme.palette.text.primary,
+    wordBreak: 'break-word',
+  },
+  nestedSection: {
+    marginLeft: theme.spacing(2),
+    marginTop: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+    borderLeft: `3px solid ${theme.palette.divider}`,
+  },
+}));
+
+interface NestedReviewTableProps {
+  data: JsonObject;
+}
+
+const isObject = (value: any): value is JsonObject => {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+};
+
+const renderValue = (value: JsonValue | undefined): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+};
+
+const RenderNestedData: React.FC<{ data: JsonObject; classes: any }> = ({
+  data,
+  classes,
+}) => {
+  return (
+    <>
+      {Object.entries(data).map(([key, value]) => {
+        if (isObject(value)) {
+          // Render nested section with title
+          return (
+            <Box key={key} className={classes.nestedSection}>
+              <Typography variant="subtitle2" className={classes.sectionTitle}>
+                {key}
+              </Typography>
+              <RenderNestedData data={value} classes={classes} />
+            </Box>
+          );
+        }
+
+        // Render simple key-value pair
+        return (
+          <Box key={key} className={classes.row}>
+            <Typography className={classes.label}>{key}:</Typography>
+            <Typography className={classes.value}>
+              {renderValue(value)}
+            </Typography>
+          </Box>
+        );
+      })}
+    </>
+  );
+};
+
+export const NestedReviewTable: React.FC<NestedReviewTableProps> = ({
+  data,
+}) => {
+  const { classes } = useStyles();
+
+  // Group top-level sections
+  const sections: [string, JsonValue][] = Object.entries(data).filter(
+    ([_, value]) => value !== undefined,
+  ) as [string, JsonValue][];
+
+  return (
+    <Box>
+      {sections.map(([sectionKey, sectionValue]) => {
+        if (isObject(sectionValue)) {
+          // Render as a section with title
+          return (
+            <Box key={sectionKey} className={classes.section}>
+              <Typography variant="h6" className={classes.sectionTitle}>
+                {sectionKey}
+              </Typography>
+              <Divider style={{ marginBottom: '12px' }} />
+              <RenderNestedData data={sectionValue} classes={classes} />
+            </Box>
+          );
+        }
+
+        // Simple value at top level
+        return (
+          <Box key={sectionKey} className={classes.row}>
+            <Typography className={classes.label}>{sectionKey}:</Typography>
+            <Typography className={classes.value}>
+              {renderValue(sectionValue)}
+            </Typography>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default NestedReviewTable;

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -37,6 +37,7 @@ import { getActiveStepKey } from '../utils/getSortedStepEntries';
 import { useStepperContext } from '../utils/StepperContext';
 import useValidator from '../utils/useValidator';
 import { AuthRequester } from './AuthRequester';
+import { createHiddenFieldTemplate } from './HiddenFieldTemplate';
 import StepperObjectField from './StepperObjectField';
 
 const MuiForm = withTheme<
@@ -44,6 +45,12 @@ const MuiForm = withTheme<
   JSONSchema7,
   OrchestratorFormContextProps
 >(MuiTheme);
+
+// Get the default FieldTemplate from Material-UI theme and wrap it with hidden field support
+const DefaultFieldTemplate = MuiTheme.templates?.FieldTemplate;
+const HiddenFieldTemplate = DefaultFieldTemplate
+  ? createHiddenFieldTemplate(DefaultFieldTemplate as any)
+  : undefined;
 
 const FormComponent = (decoratorProps: FormDecoratorProps) => {
   const formContext = decoratorProps.formContext;
@@ -131,6 +138,9 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
           {...omit(decoratorProps, 'getExtraErrors')}
           widgets={{ AuthRequester, ...decoratorProps.widgets }}
           fields={isMultiStep ? { ObjectField: StepperObjectField } : {}}
+          templates={
+            HiddenFieldTemplate ? { FieldTemplate: HiddenFieldTemplate } : {}
+          }
           uiSchema={uiSchema}
           validator={validator}
           schema={schema}

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
@@ -16,7 +16,7 @@
 
 import { useMemo } from 'react';
 
-import { Content, StructuredMetadataTable } from '@backstage/core-components';
+import { Content } from '@backstage/core-components';
 import { JsonObject } from '@backstage/types';
 
 import Box from '@mui/material/Box';
@@ -28,6 +28,7 @@ import { makeStyles } from 'tss-react/mui';
 import { useTranslation } from '../hooks/useTranslation';
 import generateReviewTableData from '../utils/generateReviewTableData';
 import { useStepperContext } from '../utils/StepperContext';
+import NestedReviewTable from './NestedReviewTable';
 import SubmitButton from './SubmitButton';
 
 const useStyles = makeStyles()(theme => ({
@@ -78,7 +79,7 @@ const ReviewStep = ({
   return (
     <Content noPadding>
       <Paper square elevation={0} className={classes.paper}>
-        <StructuredMetadataTable dense metadata={displayData} />
+        <NestedReviewTable data={displayData} />
         <Box mb={4} />
         <div className={classes.footer}>
           <Button

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
@@ -38,6 +38,11 @@ export function processSchema(
 
   const name = definitionInSchema?.title ?? key;
   if (definitionInSchema) {
+    // Skip hidden fields in the review table
+    if (definitionInSchema['ui:hidden'] === true) {
+      return {};
+    }
+
     if (definitionInSchema['ui:widget'] === 'password') {
       return { [name]: '******' };
     }
@@ -54,6 +59,11 @@ export function processSchema(
         },
         {},
       );
+
+      // Skip if all nested fields are hidden (resulting in empty object)
+      if (Object.keys(nestedValue).length === 0) {
+        return {};
+      }
 
       return { [name]: nestedValue };
     }


### PR DESCRIPTION
Manual cherrypick of PR - https://github.com/redhat-developer/rhdh-plugins/pull/1878

## Hey, I just made a Pull Request!

Story: https://issues.redhat.com/browse/RHIDP-10944


**Hidden Fields Feature:**

- Add `ui:hidden` property to hide fields while preserving widget functionality
- Implement `HiddenFieldTemplate` to render hidden fields with `display: none`
- Hidden fields remain active, participate in validation, and are submitted with form data
- Hidden fields are automatically excluded from the review page
- Update `getSortedStepEntries` to filter out steps marked with `ui:hidden: true`
- Automatically hide entire steps when all inputs within the step are hidden

**Review Page Improvements:**

- Add `NestedReviewTable` component for improved hierarchical display of nested objects
- Update `generateReviewTableData` to skip hidden fields in review page
- Update `generateReviewTableData` to skip entire steps when all fields are hidden



**Documentation:**

- Update `orchestratorFormWidgets.md` with `ui:hidden` property documentation and usage examples


------Hidden widget----

https://github.com/user-attachments/assets/ccf40458-22cc-4c0b-bb0e-87daaea17a51

------------------

------Nested formatting------

https://github.com/user-attachments/assets/1e864a64-b521-4c75-88b2-e830a6e528a8

--------------------

-----complete step is hidden-----

https://github.com/user-attachments/assets/f2435528-34ba-46b8-ac59-2504f5ae620e




--------------------
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
