### PR TITLE
fix(homepage) [release-1.8]: allow base64 images in quickaccess icons

### DIFF
--- a/workspaces/homepage/.changeset/nervous-ears-agree.md
+++ b/workspaces/homepage/.changeset/nervous-ears-agree.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dynamic-home-page': patch
+---
+
+allow base64 image in quick access icons

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessIcon.test.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessIcon.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import HomeIcon from '@mui/icons-material/Home';
+
+import { QuickAccessIcon } from './QuickAccessIcon';
+
+const mockGetSystemIcon = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApp: jest.fn(() => ({
+    getSystemIcon: mockGetSystemIcon,
+  })),
+}));
+
+describe('QuickAccessIcon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSystemIcon.mockReturnValue(null);
+  });
+
+  it('should return null when icon is not provided', () => {
+    const { container } = render(<QuickAccessIcon icon="" alt="test" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render React element directly', () => {
+    render(
+      <QuickAccessIcon
+        icon={<GitHubIcon data-testid="github-icon" />}
+        alt="GitHub"
+      />,
+    );
+    expect(screen.getByTestId('github-icon')).toBeInTheDocument();
+  });
+
+  it('should render system icon when available', () => {
+    mockGetSystemIcon.mockReturnValue(() => (
+      <HomeIcon data-testid="system-home-icon" />
+    ));
+
+    render(<QuickAccessIcon icon="home" alt="Home" />);
+    expect(screen.getByTestId('system-home-icon')).toBeInTheDocument();
+    expect(mockGetSystemIcon).toHaveBeenCalledWith('home');
+  });
+
+  it('should render SVG string as base64 data URI', () => {
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg"><circle/></svg>';
+    render(<QuickAccessIcon icon={svgString} alt="SVG Icon" />);
+
+    const img = screen.getByRole('img', { name: 'SVG Icon' });
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toMatch(/^data:image\/svg\+xml;base64,/);
+  });
+
+  it('should render HTTPS URL as image', () => {
+    const url = 'https://example.com/icon.png';
+    render(<QuickAccessIcon icon={url} alt="HTTPS Icon" />);
+
+    const img = screen.getByRole('img', { name: 'HTTPS Icon' });
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toBe(url);
+  });
+
+  it('should render HTTP URL as image', () => {
+    const url = 'http://example.com/icon.png';
+    render(<QuickAccessIcon icon={url} alt="HTTP Icon" />);
+
+    const img = screen.getByRole('img', { name: 'HTTP Icon' });
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toBe(url);
+  });
+
+  it('should render relative path as image', () => {
+    const path = '/assets/icon.png';
+    render(<QuickAccessIcon icon={path} alt="Relative Icon" />);
+
+    const img = screen.getByRole('img', { name: 'Relative Icon' });
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toBe(path);
+  });
+
+  it('should render data:image URI as image', () => {
+    const dataUri =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    render(<QuickAccessIcon icon={dataUri} alt="Data URI Icon" />);
+
+    const img = screen.getByRole('img', { name: 'Data URI Icon' });
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toBe(dataUri);
+  });
+
+  it('should render material icon for plain string', () => {
+    render(<QuickAccessIcon icon="settings" alt="Settings" />);
+
+    const icon = screen.getByText('settings');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('material-icons-outlined');
+  });
+});

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessIcon.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/QuickAccessIcon.tsx
@@ -63,7 +63,8 @@ export const QuickAccessIcon = ({
   if (
     strIcon.startsWith('https://') ||
     strIcon.startsWith('http://') ||
-    strIcon.startsWith('/')
+    strIcon.startsWith('/') ||
+    strIcon.startsWith('data:image/')
   ) {
     return <img src={strIcon} className={classes.img} alt={alt} />;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHDHBUGS-2397

Allow base64 images as a icon source  homepage plugin.




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)