### PR TITLE
FLPATH-2734 | [FE] Export data

### DIFF
--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-backend/src/service/router.test.ts
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-backend/src/service/router.test.ts
@@ -33,6 +33,7 @@ describe('createRouter', () => {
         getRecommendationList: jest.fn(),
         getRecommendationById: jest.fn(),
         getCostManagementReport: jest.fn(),
+        downloadCostManagementReport: jest.fn(),
         searchOpenShiftProjects: jest.fn(),
         searchOpenShiftClusters: jest.fn(),
         searchOpenShiftNodes: jest.fn(),

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report-clients.api.md
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report-clients.api.md
@@ -146,6 +146,16 @@ export interface DistributedCost extends BasicCost {
 }
 
 // @public (undocumented)
+export interface DownloadCostManagementRequest
+  extends GetCostManagementRequest {
+  // (undocumented)
+  format: ExportFormat;
+}
+
+// @public (undocumented)
+export type ExportFormat = 'csv' | 'json';
+
+// @public (undocumented)
 export interface GetAccessResponse {
   // (undocumented)
   authorizeClusterIds: string[];
@@ -214,6 +224,9 @@ export type OptimizationsApi = Omit<
   getCostManagementReport(
     request: GetCostManagementRequest,
   ): Promise<TypedResponse<CostManagementReport>>;
+  downloadCostManagementReport(
+    request: DownloadCostManagementRequest,
+  ): Promise<void>;
   searchOpenShiftProjects(search?: string): Promise<
     TypedResponse<{
       data: Array<{
@@ -267,6 +280,10 @@ export type OptimizationsApi = Omit<
 // @public
 export class OptimizationsClient implements OptimizationsApi {
   constructor(options: { discoveryApi: DiscoveryApi; fetchApi?: FetchApi });
+  // (undocumented)
+  downloadCostManagementReport(
+    request: DownloadCostManagementRequest,
+  ): Promise<void>;
   // (undocumented)
   getCostManagementReport(
     request: GetCostManagementRequest,
@@ -414,7 +431,7 @@ export interface Tag {
 
 // Warnings were encountered during analysis:
 //
-// src/clients/optimizations/types.d.ts:27:5 - (ae-forgotten-export) The symbol "TypedResponse" needs to be exported by the entry point index.d.ts
+// src/clients/optimizations/types.d.ts:33:5 - (ae-forgotten-export) The symbol "TypedResponse" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report.api.md
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report.api.md
@@ -378,6 +378,16 @@ export interface DistributedCost extends BasicCost {
 }
 
 // @public (undocumented)
+export interface DownloadCostManagementRequest
+  extends GetCostManagementRequest {
+  // (undocumented)
+  format: ExportFormat;
+}
+
+// @public (undocumented)
+export type ExportFormat = 'csv' | 'json';
+
+// @public (undocumented)
 export interface GetAccessResponse {
   // (undocumented)
   authorizeClusterIds: string[];
@@ -544,6 +554,9 @@ export type OptimizationsApi = Omit<
   getCostManagementReport(
     request: GetCostManagementRequest,
   ): Promise<TypedResponse<CostManagementReport>>;
+  downloadCostManagementReport(
+    request: DownloadCostManagementRequest,
+  ): Promise<void>;
   searchOpenShiftProjects(search?: string): Promise<
     TypedResponse<{
       data: Array<{
@@ -597,6 +610,10 @@ export type OptimizationsApi = Omit<
 // @public
 export class OptimizationsClient implements OptimizationsApi {
   constructor(options: { discoveryApi: DiscoveryApi; fetchApi?: FetchApi });
+  // (undocumented)
+  downloadCostManagementReport(
+    request: DownloadCostManagementRequest,
+  ): Promise<void>;
   // (undocumented)
   getCostManagementReport(
     request: GetCostManagementRequest,

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/src/clients/optimizations/types.ts
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/src/clients/optimizations/types.ts
@@ -44,6 +44,15 @@ export interface GetCostManagementRequest {
 }
 
 /** @public */
+export type ExportFormat = 'csv' | 'json';
+
+/** @public */
+export interface DownloadCostManagementRequest
+  extends GetCostManagementRequest {
+  format: ExportFormat;
+}
+
+/** @public */
 export type OptimizationsApi = Omit<
   InstanceType<typeof DefaultApiClient>,
   'fetchApi' | 'discoveryApi'
@@ -51,6 +60,9 @@ export type OptimizationsApi = Omit<
   getCostManagementReport(
     request: GetCostManagementRequest,
   ): Promise<TypedResponse<CostManagementReport>>;
+  downloadCostManagementReport(
+    request: DownloadCostManagementRequest,
+  ): Promise<void>;
   searchOpenShiftProjects(
     search?: string,
   ): Promise<

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/DownloadIconButton.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/DownloadIconButton.tsx
@@ -20,9 +20,12 @@ import React from 'react';
 type DownloadIconButtonProps = {
   label: string;
   variant: 'gray' | 'black' | 'white';
+  onClick?: () => void;
+  disabled?: boolean;
 };
 
-const getColor = (variant: 'gray' | 'black' | 'white') => {
+const getColor = (variant: 'gray' | 'black' | 'white', disabled?: boolean) => {
+  if (disabled) return '#999999';
   if (variant === 'gray') return '#C7C7C7';
   if (variant === 'black') return '#000000';
   if (variant === 'white') return '#FFFFFF';
@@ -30,25 +33,40 @@ const getColor = (variant: 'gray' | 'black' | 'white') => {
 };
 
 export function DownloadIconButton(props: Readonly<DownloadIconButtonProps>) {
-  const color = getColor(props.variant);
+  const { label, variant, onClick, disabled } = props;
+  const color = getColor(variant, disabled);
 
   return (
     <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      onClick={disabled ? undefined : onClick}
+      onKeyDown={
+        disabled
+          ? undefined
+          : e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick?.();
+              }
+            }
+      }
       style={{
         border: `2px solid ${color}`,
         borderRadius: 2,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        cursor: 'pointer',
+        cursor: disabled ? 'not-allowed' : 'pointer',
         paddingTop: 2,
+        opacity: disabled ? 0.6 : 1,
       }}
     >
       <Typography
         variant="body2"
         style={{ color, fontSize: 9, fontWeight: 'bold' }}
       >
-        {props.label}
+        {label}
       </Typography>
     </div>
   );

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/TableToolbar.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/openshift/components/TableToolbar.tsx
@@ -68,6 +68,9 @@ type TableToolbarProps = {
   setShowInfrastructureCost: (show: boolean) => void;
   showSupplementaryCost: boolean;
   setShowSupplementaryCost: (show: boolean) => void;
+  onDownloadCsv?: () => void;
+  onDownloadJson?: () => void;
+  isDownloading?: boolean;
 };
 
 /** @public */
@@ -83,6 +86,9 @@ export function TableToolbar(props: TableToolbarProps) {
     setShowInfrastructureCost,
     showSupplementaryCost,
     setShowSupplementaryCost,
+    onDownloadCsv,
+    onDownloadJson,
+    isDownloading,
   } = props;
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -144,8 +150,18 @@ export function TableToolbar(props: TableToolbarProps) {
           </div>
         )}
 
-        <DownloadIconButton label="CSV" variant="gray" />
-        <DownloadIconButton label="JSON" variant="gray" />
+        <DownloadIconButton
+          label="CSV"
+          variant="gray"
+          onClick={onDownloadCsv}
+          disabled={isDownloading}
+        />
+        <DownloadIconButton
+          label="JSON"
+          variant="gray"
+          onClick={onDownloadJson}
+          disabled={isDownloading}
+        />
       </div>
       <IconButton
         aria-label="menu"


### PR DESCRIPTION
FLPATH-2734 | [FE] Export data

Allow user to export data with two supported formats: JSON / CSV.
User can export data either from header (to download all available data) or from specific row for selected project/cluster/tag or node.

<img width="1667" height="869" alt="image" src="https://github.com/user-attachments/assets/adef3d34-85a2-463e-ab31-6c26dadc65b2" />
