### PR TITLE
[orchestrator-1.8] feat(Orchestrator): add dynamic conditional visibility for ui:hidden

### DIFF
--- a/workspaces/orchestrator/.changeset/dynamic-ui-hidden.md
+++ b/workspaces/orchestrator/.changeset/dynamic-ui-hidden.md
@@ -1,0 +1,37 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+---
+
+Add dynamic conditional visibility for ui:hidden
+
+**Conditional Hiding Feature:**
+
+- Add `HiddenCondition` type supporting boolean and condition objects
+- Implement `evaluateHiddenCondition` utility for evaluating hide conditions
+- Support condition objects with `when`, `is`, `isNot`, and `isEmpty` operators
+- Support composite conditions with `allOf` (AND) and `anyOf` (OR) logic
+- Support nested field paths using dot notation (e.g., `config.server.port`)
+- Update `HiddenFieldTemplate` to dynamically evaluate hide conditions based on form data
+- Update `generateReviewTableData` to respect conditional hiding in review pages
+- Hidden field visibility updates in real-time when form data changes
+
+**Condition Object Patterns:**
+
+- `{ when: "field", is: "value" }` - Hide when field equals value
+- `{ when: "field", is: ["val1", "val2"] }` - Hide when field equals any value (OR)
+- `{ when: "field", isNot: "value" }` - Hide when field does NOT equal value
+- `{ when: "field", isEmpty: true }` - Hide when field is empty
+- `{ allOf: [...] }` - Hide when ALL conditions are true (AND)
+- `{ anyOf: [...] }` - Hide when ANY condition is true (OR)
+
+**Documentation:**
+
+- Update `orchestratorFormWidgets.md` with comprehensive examples of conditional hiding
+- Add examples for all condition patterns and composite conditions
+- Include complete real-world deployment configuration example
+
+**Testing:**
+
+- Add comprehensive unit tests for condition evaluation
+- Test simple conditions, composite conditions, and nested conditions
+- Test edge cases (empty values, nested paths)

--- a/workspaces/orchestrator/docs/ui-hidden-reference.md
+++ b/workspaces/orchestrator/docs/ui-hidden-reference.md
@@ -1,0 +1,241 @@
+# Dynamic ui:hidden - Quick Reference
+
+## Basic Usage
+
+### Static Hiding
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": true
+  }
+}
+```
+
+## Condition Objects
+
+### Hide when field equals value
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "when": "deploymentType",
+      "is": "simple"
+    }
+  }
+}
+```
+
+### Hide when field equals ANY value (OR)
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "when": "deploymentType",
+      "is": ["simple", "managed"]
+    }
+  }
+}
+```
+
+### Hide when field does NOT equal value
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "when": "deploymentType",
+      "isNot": "custom"
+    }
+  }
+}
+```
+
+### Hide when field is empty
+
+```json
+{
+  "childField": {
+    "type": "string",
+    "ui:hidden": {
+      "when": "parentField",
+      "isEmpty": true
+    }
+  }
+}
+```
+
+### Nested field paths
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "when": "config.server.enabled",
+      "is": false
+    }
+  }
+}
+```
+
+## Composite Conditions
+
+### AND logic (allOf) - ALL must be true
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "allOf": [
+        { "when": "environment", "is": "production" },
+        { "when": "deploymentType", "is": "custom" }
+      ]
+    }
+  }
+}
+```
+
+### OR logic (anyOf) - ANY can be true
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "anyOf": [
+        { "when": "skipValidation", "is": true },
+        { "when": "environment", "is": "development" }
+      ]
+    }
+  }
+}
+```
+
+### Nested composite
+
+```json
+{
+  "myField": {
+    "type": "string",
+    "ui:hidden": {
+      "allOf": [
+        { "when": "enabled", "is": true },
+        {
+          "anyOf": [
+            { "when": "type", "is": "A" },
+            { "when": "type", "is": "B" }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Common Patterns
+
+### Show only in production
+
+```json
+"ui:hidden": {
+  "when": "environment",
+  "isNot": "production"
+}
+```
+
+### Hide in production
+
+```json
+"ui:hidden": {
+  "when": "environment",
+  "is": "production"
+}
+```
+
+### Show when feature enabled
+
+```json
+"ui:hidden": {
+  "when": "enableFeature",
+  "isNot": true
+}
+```
+
+### Show for specific deployment types
+
+```json
+"ui:hidden": {
+  "when": "deploymentType",
+  "isNot": ["advanced", "custom"]
+}
+```
+
+### Show when checkbox is checked
+
+```json
+"ui:hidden": {
+  "when": "useCustomSettings",
+  "is": false
+}
+```
+
+## Supported Operators
+
+| Operator  | Description                           | Example                                 |
+| --------- | ------------------------------------- | --------------------------------------- |
+| `is`      | Hide if field equals value(s)         | `"is": "value"` or `"is": ["v1", "v2"]` |
+| `isNot`   | Hide if field does NOT equal value(s) | `"isNot": "value"`                      |
+| `isEmpty` | Hide if field is empty/undefined      | `"isEmpty": true`                       |
+| `allOf`   | Hide if ALL conditions true (AND)     | `"allOf": [...]`                        |
+| `anyOf`   | Hide if ANY condition true (OR)       | `"anyOf": [...]`                        |
+
+## Important Notes
+
+✅ **DO:**
+
+- Use condition objects for most use cases
+- Reference fields by their path (use dot notation for nested fields)
+- Test your conditions thoroughly
+- Consider performance with many conditional fields
+
+❌ **DON'T:**
+
+- Create circular dependencies (Field A depends on B, B depends on A)
+- Forget that hidden fields are still validated and submitted
+- Assume hidden fields are secure (they're just hidden, not encrypted)
+
+## Behavior
+
+- ✓ Hidden fields are NOT displayed
+- ✓ Hidden fields still participate in validation
+- ✓ Hidden fields ARE included in form submission
+- ✓ Hidden fields are excluded from review page
+- ✓ Visibility updates in real-time when dependencies change
+- ✓ Steps with all hidden fields are auto-hidden from stepper
+
+## TypeScript Types
+
+```typescript
+import type {
+  HiddenCondition,
+  HiddenConditionObject,
+  HiddenConditionComposite,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
+
+// Use in your schema definitions
+interface MySchema {
+  'ui:hidden'?: HiddenCondition;
+}
+```
+
+## Full Documentation
+
+See `docs/orchestratorFormWidgets.md` for complete documentation.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
@@ -6,9 +6,27 @@
 
 import { JsonObject } from '@backstage/types';
 import type { JSONSchema7 } from 'json-schema';
+import { JsonValue } from '@backstage/types';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 import { ReactNode } from 'react';
+
+// @public
+export type HiddenCondition = boolean | HiddenConditionObject | HiddenConditionComposite;
+
+// @public
+export interface HiddenConditionComposite {
+    allOf?: HiddenCondition[];
+    anyOf?: HiddenCondition[];
+}
+
+// @public
+export interface HiddenConditionObject {
+    is?: JsonValue | JsonValue[];
+    isEmpty?: boolean;
+    isNot?: JsonValue | JsonValue[];
+    when: string;
+}
 
 // @public
 export const OrchestratorForm: ({ schema: rawSchema, updateSchema, handleExecute, isExecuting, initialFormData, setAuthTokenDescriptors, t, }: OrchestratorFormProps) => JSX_2.Element;

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/index.ts
@@ -25,3 +25,8 @@
 
 export * from './components';
 export * from './hooks';
+export type {
+  HiddenCondition,
+  HiddenConditionObject,
+  HiddenConditionComposite,
+} from './types/HiddenCondition';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/types/HiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/types/HiddenCondition.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonValue } from '@backstage/types';
+
+/**
+ * Simple condition object for hiding fields based on form data
+ * @public
+ */
+export interface HiddenConditionObject {
+  /**
+   * Field path to check (e.g., "deploymentType" or "config.nested.field")
+   */
+  when: string;
+
+  /**
+   * Hide if the field value equals any of these values (OR logic)
+   * Can be a single value or an array of values
+   */
+  is?: JsonValue | JsonValue[];
+
+  /**
+   * Hide if the field value does NOT equal any of these values
+   * Can be a single value or an array of values
+   */
+  isNot?: JsonValue | JsonValue[];
+
+  /**
+   * Hide if the field is empty (undefined, null, empty string, or empty array)
+   */
+  isEmpty?: boolean;
+}
+
+/**
+ * Composite condition for complex logic
+ * @public
+ */
+export interface HiddenConditionComposite {
+  /**
+   * Hide if ALL conditions are true (AND logic)
+   */
+  allOf?: HiddenCondition[];
+
+  /**
+   * Hide if ANY condition is true (OR logic)
+   */
+  anyOf?: HiddenCondition[];
+}
+
+/**
+ * Union type for all possible ui:hidden values
+ * @public
+ */
+export type HiddenCondition =
+  | boolean // Static: true/false
+  | HiddenConditionObject // Simple condition
+  | HiddenConditionComposite; // Composite conditions

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import {
+  HiddenCondition,
+  HiddenConditionObject,
+} from '../types/HiddenCondition';
+import { evaluateHiddenCondition } from './evaluateHiddenCondition';
+
+describe('evaluateHiddenCondition', () => {
+  describe('boolean conditions', () => {
+    it('should return true for static true', () => {
+      expect(evaluateHiddenCondition(true, {})).toBe(true);
+    });
+
+    it('should return false for static false', () => {
+      expect(evaluateHiddenCondition(false, {})).toBe(false);
+    });
+  });
+
+  describe('simple conditions', () => {
+    const formData: JsonObject = {
+      deploymentType: 'advanced',
+      environment: 'production',
+      name: '',
+      tags: [],
+      count: 5,
+    };
+
+    it('should hide when field equals value (is)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'deploymentType',
+        is: 'advanced',
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should not hide when field does not equal value (is)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'deploymentType',
+        is: 'simple',
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(false);
+    });
+
+    it('should hide when field equals any value in array (is)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'deploymentType',
+        is: ['simple', 'advanced', 'custom'],
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should hide when field not in array (isNot)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'deploymentType',
+        isNot: ['simple', 'managed'],
+      };
+      // deploymentType is 'advanced', which is NOT in ['simple', 'managed'], so it should hide
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should hide when field not equals value (isNot)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'environment',
+        isNot: 'development',
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should hide when field is empty string (isEmpty)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'name',
+        isEmpty: true,
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should hide when field is empty array (isEmpty)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'tags',
+        isEmpty: true,
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should not hide when field has value (isEmpty)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'count',
+        isEmpty: true,
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(false);
+    });
+
+    it('should handle nested field paths', () => {
+      const nestedFormData: JsonObject = {
+        config: {
+          server: {
+            port: 8080,
+          },
+        },
+      };
+      const condition: HiddenConditionObject = {
+        when: 'config.server.port',
+        is: 8080,
+      };
+      expect(evaluateHiddenCondition(condition, nestedFormData)).toBe(true);
+    });
+  });
+
+  describe('composite conditions', () => {
+    const formData: JsonObject = {
+      deploymentType: 'custom',
+      environment: 'production',
+      enableFeature: true,
+    };
+
+    it('should handle allOf (AND logic) - all true', () => {
+      const condition: HiddenCondition = {
+        allOf: [
+          { when: 'deploymentType', is: 'custom' },
+          { when: 'environment', is: 'production' },
+        ],
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should handle allOf (AND logic) - one false', () => {
+      const condition: HiddenCondition = {
+        allOf: [
+          { when: 'deploymentType', is: 'custom' },
+          { when: 'environment', is: 'development' },
+        ],
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(false);
+    });
+
+    it('should handle anyOf (OR logic) - one true', () => {
+      const condition: HiddenCondition = {
+        anyOf: [
+          { when: 'deploymentType', is: 'simple' },
+          { when: 'environment', is: 'production' },
+        ],
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+
+    it('should handle anyOf (OR logic) - all false', () => {
+      const condition: HiddenCondition = {
+        anyOf: [
+          { when: 'deploymentType', is: 'simple' },
+          { when: 'environment', is: 'development' },
+        ],
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(false);
+    });
+
+    it('should handle nested composite conditions', () => {
+      const condition: HiddenCondition = {
+        allOf: [
+          { when: 'enableFeature', is: true },
+          {
+            anyOf: [
+              { when: 'deploymentType', is: 'custom' },
+              { when: 'environment', is: 'staging' },
+            ],
+          },
+        ],
+      };
+      expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject, JsonValue } from '@backstage/types';
+
+import get from 'lodash/get';
+
+import {
+  HiddenCondition,
+  HiddenConditionComposite,
+  HiddenConditionObject,
+} from '../types/HiddenCondition';
+
+/**
+ * Check if a value is considered empty
+ */
+function isEmptyValue(value: JsonValue | undefined): boolean {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return true;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check if a value matches any in a list
+ */
+function matchesAny(
+  value: JsonValue | undefined,
+  targets: JsonValue | JsonValue[],
+): boolean {
+  const targetArray = Array.isArray(targets) ? targets : [targets];
+  return targetArray.some(target => {
+    // Handle deep equality for objects and arrays
+    if (typeof value === 'object' && typeof target === 'object') {
+      return JSON.stringify(value) === JSON.stringify(target);
+    }
+    return value === target;
+  });
+}
+
+/**
+ * Evaluate a simple condition object
+ */
+function evaluateConditionObject(
+  condition: HiddenConditionObject,
+  formData: JsonObject,
+): boolean {
+  const fieldValue = get(formData, condition.when);
+
+  // Check isEmpty condition
+  if (condition.isEmpty !== undefined) {
+    const empty = isEmptyValue(fieldValue);
+    return condition.isEmpty ? empty : !empty;
+  }
+
+  // Check 'is' condition (hide if field equals any value)
+  if (condition.is !== undefined) {
+    return matchesAny(fieldValue, condition.is);
+  }
+
+  // Check 'isNot' condition (hide if field does NOT equal any value)
+  if (condition.isNot !== undefined) {
+    return !matchesAny(fieldValue, condition.isNot);
+  }
+
+  // No valid condition found, don't hide
+  return false;
+}
+
+/**
+ * Evaluate a composite condition (allOf/anyOf)
+ */
+function evaluateCompositeCondition(
+  condition: HiddenConditionComposite,
+  formData: JsonObject,
+): boolean {
+  // Evaluate 'allOf' (AND logic - all must be true)
+  if (condition.allOf) {
+    return condition.allOf.every(subCondition =>
+      evaluateHiddenCondition(subCondition, formData),
+    );
+  }
+
+  // Evaluate 'anyOf' (OR logic - at least one must be true)
+  if (condition.anyOf) {
+    return condition.anyOf.some(subCondition =>
+      evaluateHiddenCondition(subCondition, formData),
+    );
+  }
+
+  // No valid composite condition
+  return false;
+}
+
+/**
+ * Evaluate a hidden condition
+ * Returns true if the field should be hidden
+ */
+export function evaluateHiddenCondition(
+  condition: HiddenCondition,
+  formData: JsonObject,
+): boolean {
+  // Handle boolean (static)
+  if (typeof condition === 'boolean') {
+    return condition;
+  }
+
+  // Handle simple condition object
+  if ('when' in condition) {
+    return evaluateConditionObject(condition, formData);
+  }
+
+  // Handle composite condition
+  if ('allOf' in condition || 'anyOf' in condition) {
+    return evaluateCompositeCondition(condition, formData);
+  }
+
+  // Unknown condition type, don't hide
+  return false;
+}

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
@@ -21,6 +21,9 @@ import { JsonSchema, Draft07 as JSONSchema } from 'json-schema-library';
 
 import { isJsonObject } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 
+import { HiddenCondition } from '../types/HiddenCondition';
+import { evaluateHiddenCondition } from './evaluateHiddenCondition';
+
 export function processSchema(
   key: string,
   value: JsonValue | undefined,
@@ -39,8 +42,14 @@ export function processSchema(
   const name = definitionInSchema?.title ?? key;
   if (definitionInSchema) {
     // Skip hidden fields in the review table
-    if (definitionInSchema['ui:hidden'] === true) {
-      return {};
+    const uiHidden = definitionInSchema['ui:hidden'];
+    if (uiHidden !== undefined) {
+      // Handle both static boolean and condition objects
+      const hiddenCondition = uiHidden as HiddenCondition;
+      const isHidden = evaluateHiddenCondition(hiddenCondition, formState);
+      if (isHidden) {
+        return {};
+      }
     }
 
     if (definitionInSchema['ui:widget'] === 'password') {

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -146,6 +146,7 @@ readonly "tooltips.userNotAuthorizedExecute": string;
 readonly "tooltips.workflowDown": string;
 readonly "tooltips.suspended": string;
 readonly "tooltips.userNotAuthorizedAbort": string;
+readonly "reviewStep.hiddenFieldsNote": string;
 readonly "stepperObjectField.error": string;
 readonly "formDecorator.error": string;
 readonly "aria.close": string;
@@ -161,7 +162,7 @@ export const orchestratorTranslations: TranslationResource<"plugin.orchestrator"
 // src/components/catalogComponents/CatalogTab.d.ts:1:22 - (ae-undocumented) Missing documentation for "IsOrchestratorCatalogTabAvailable".
 // src/components/catalogComponents/CatalogTab.d.ts:2:22 - (ae-undocumented) Missing documentation for "OrchestratorCatalogTab".
 // src/translations/index.d.ts:2:22 - (ae-undocumented) Missing documentation for "orchestratorTranslations".
-// src/translations/ref.d.ts:168:22 - (ae-undocumented) Missing documentation for "orchestratorTranslationRef".
+// src/translations/ref.d.ts:171:22 - (ae-undocumented) Missing documentation for "orchestratorTranslationRef".
 
 // (No @packageDocumentation comment for this package)
 

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -138,6 +138,8 @@ const orchestratorTranslationDe = createTranslationMessages({
       'Dieser Workflow hat kein JSON-Schema für die Eingabevalidierung definiert. Sie können den Workflow trotzdem ausführen, aber die Eingabevalidierung wird eingeschränkt sein.',
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'Zusätzliche Informationen zu diesem Fehler sind nicht verfügbar',
+    'reviewStep.hiddenFieldsNote':
+      'Einige Felder sind auf dieser Seite ausgeblendet, werden aber in die Workflow-Ausführungsanforderung aufgenommen.',
     'common.close': 'Schließen',
     'common.cancel': 'Abbrechen',
     'common.execute': 'Ausführen',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -139,6 +139,8 @@ const orchestratorTranslationEs = createTranslationMessages({
       'Este flujo de trabajo no tiene un esquema JSON definido para la validación de entradas. Aún puedes ejecutar el flujo de trabajo, pero la validación de entradas será limitada.',
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'No hay detalles adicionales sobre este error disponibles',
+    'reviewStep.hiddenFieldsNote':
+      'Algunos campos están ocultos en esta página pero se incluirán en la solicitud de ejecución del flujo de trabajo.',
     'common.close': 'Cerrar',
     'common.cancel': 'Cancelar',
     'common.execute': 'Ejecutar',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -138,6 +138,8 @@ const orchestratorTranslationFr = createTranslationMessages({
       "Ce workflow n'a pas de schéma JSON défini pour la validation des entrées. Vous pouvez toujours exécuter le workflow, mais la validation des entrées sera limitée.",
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       "Aucune information supplémentaire sur cet erreur n'est disponible",
+    'reviewStep.hiddenFieldsNote':
+      "Certains champs sont masqués sur cette page mais seront inclus dans la demande d'exécution du workflow.",
     'common.close': 'Fermer',
     'common.cancel': 'Annuler',
     'common.execute': 'Exécuter',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -135,6 +135,8 @@ const orchestratorTranslationIt = createTranslationMessages({
       'Questo workflow non ha uno schema JSON definito per la validazione degli input. Puoi comunque eseguire il workflow, ma la validazione degli input sarà limitata.',
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'Non sono disponibili dettagli aggiuntivi su questo errore',
+    'reviewStep.hiddenFieldsNote':
+      'Alcuni campi sono nascosti in questa pagina ma verranno inclusi nella richiesta di esecuzione del workflow.',
     'common.close': 'Chiudi',
     'common.cancel': 'Annulla',
     'common.execute': 'Esegui',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -170,6 +170,10 @@ export const orchestratorMessages = {
     additionalDetailsAboutThisErrorAreNotAvailable:
       'Additional details about this error are not available',
   },
+  reviewStep: {
+    hiddenFieldsNote:
+      'Some fields are hidden on this page but will be included in the workflow execution request.',
+  },
   common: {
     close: 'Close',
     cancel: 'Cancel',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added dynamic conditional visibility for `ui:hidden` property in Orchestrator forms, allowing fields to be shown/hidden based on other form field values.

Fixes: https://issues.redhat.com/browse/RHIDP-11135

### Supported Patterns

**Static Boolean:**

"ui:hidden": true

--------------------

**Simple Conditions:**

"ui:hidden": { "when": "deploymentType", "is": "advanced" }
"ui:hidden": { "when": "environment", "isNot": ["dev", "staging"] }
"ui:hidden": { "when": "optionalField", "isEmpty": true }

--------------------

**Composite Conditions (AND/OR logic):**

```
"ui:hidden": {
  "allOf": [
    { "when": "environment", "is": "production" },
    { "when": "deploymentType", "is": "custom" }
  ]
}
```

```
"ui:hidden": {
  "anyOf": [
    { "when": "deploymentType", "is": "simple" },
    { "when": "quickDeploy", "is": true }
  ]
}
```

--------------------

**Nested Field Paths:**

"ui:hidden": { "when": "config.server.useDefaultPort", "is": true }

--------------------

#### Recordings


https://github.com/user-attachments/assets/75637b9f-0c98-44c9-8119-50854d4a007c


https://github.com/user-attachments/assets/d46a3216-6ff3-4508-8acb-839e3195e2d5

---------------

### Workflow used for testing

[Orchestrator - dyamic hiding.docx](https://github.com/user-attachments/files/24183884/Orchestrator.-.dyamic.hiding.docx)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
