### PR TITLE
[orchestrator-1.8] fix: Validation errors incorrectly shown on wrong step when navigating back

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-extra-errors-wrong-step.md
+++ b/workspaces/orchestrator/.changeset/fix-extra-errors-wrong-step.md
@@ -1,0 +1,12 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+---
+
+Fix validation errors incorrectly shown on wrong step when navigating back.
+
+When using widgets with `validate:url`, the `getExtraErrors` callback validates all fields across all steps and returns a nested error object. The previous logic had full error object when the current step had no errors, causing validation errors from other steps to appear on the wrong step.
+
+This fix:
+
+- Sets `extraErrors` to `undefined` when current step has no errors
+- Updates step navigation to only check current step's errors before proceeding

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -90,16 +90,22 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
     setExtraErrors(undefined);
     let _extraErrors: ErrorSchema<JsonObject> | undefined = undefined;
     let _validationError: Error | undefined = undefined;
+    const activeKey = getActiveKey();
+
     if (decoratorProps.getExtraErrors) {
       try {
         handleValidateStarted();
         _extraErrors = await decoratorProps.getExtraErrors(formData, uiSchema);
-        const activeKey = getActiveKey();
-        setExtraErrors(
-          activeKey && _extraErrors?.[activeKey]
-            ? (_extraErrors[activeKey] as ErrorSchema<JsonObject>)
-            : _extraErrors,
-        );
+
+        if (activeKey) {
+          setExtraErrors(
+            _extraErrors?.[activeKey]
+              ? (_extraErrors[activeKey] as ErrorSchema<JsonObject>)
+              : undefined,
+          );
+        } else {
+          setExtraErrors(_extraErrors);
+        }
       } catch (err) {
         _validationError = err as Error;
       } finally {
@@ -107,8 +113,15 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
       }
     }
     setValidationError(_validationError);
+
+    const currentStepErrors = activeKey
+      ? _extraErrors?.[activeKey]
+      : _extraErrors;
+    const hasCurrentStepErrors =
+      currentStepErrors && Object.keys(currentStepErrors).length > 0;
+
     if (
-      (!_extraErrors || Object.keys(_extraErrors).length === 0) &&
+      !hasCurrentStepErrors &&
       !_validationError &&
       activeStep < (numStepsInMultiStepSchema ?? 1)
     ) {


### PR DESCRIPTION
Cherrypick of PR - https://github.com/redhat-developer/rhdh-plugins/pull/1958