### PR TITLE
feat(bulk-import): Add e2e tests and playwright configuration

### DIFF
--- a/workspaces/bulk-import/app-config.yaml
+++ b/workspaces/bulk-import/app-config.yaml
@@ -72,6 +72,7 @@ techdocs:
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   providers:
+    guest: {}
     # See https://backstage.io/docs/auth/guest/provider
     github:
       development:

--- a/workspaces/bulk-import/package.json
+++ b/workspaces/bulk-import/package.json
@@ -36,11 +36,13 @@
     "directory": "workspaces/bulk-import"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.0",
     "@backstage/cli": "^0.34.5",
     "@backstage/e2e-test-utils": "^0.1.1",
     "@backstage/repo-tools": "^0.16.0",
     "@changesets/cli": "^2.27.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
+    "@playwright/test": "1.56.1",
     "@spotify/prettier-config": "^12.0.0",
     "knip": "^5.27.4",
     "node-gyp": "^9.0.0",

--- a/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
@@ -14,14 +14,238 @@
  * limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { BrowserContext, Page, expect, test, TestInfo } from '@playwright/test';
 
-test('App should render the welcome page', async ({ page }) => {
-  await page.goto('/');
+import {
+  mockBulkImportByRepoFrontendResponse,
+  mockBulkImportByRepoResponse,
+  mockBulkImportDryRunResponse,
+  mockBulkImportImportsResponse,
+  mockBulkImportRepositoriesResponse,
+  mockImportByRepoData,
+  mockImportByRepoFrontendData,
+  mockImportsData,
+  mockImportsDryRunData,
+  mockRepositoriesData,
+} from './utils/apiUtils';
+import {
+  getPreviewSidebarSnapshots,
+  PreviewSidebarSnapshotsType,
+} from './utils/ariaSnapshots';
+import { runAccessibilityTests, switchToLocale } from './utils/helpers';
+import {
+  BulkImportMessages,
+  getSelectedRepositoriesHeading,
+  getTranslations,
+} from './utils/translations';
 
-  const enterButton = page.getByRole('button', { name: 'Enter' });
-  await expect(enterButton).toBeVisible();
-  await enterButton.click();
+test.describe('Bulk Import', () => {
+  test.describe.configure({ mode: 'serial' });
 
-  await expect(page.getByText('My Company Catalog')).toBeVisible();
+  let sharedPage: Page;
+  let translations: BulkImportMessages;
+  let previewSidebarSnapshots: PreviewSidebarSnapshotsType;
+  let context: BrowserContext;
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    sharedPage = await context.newPage();
+    await mockBulkImportRepositoriesResponse(sharedPage, mockRepositoriesData);
+    await sharedPage.goto('/');
+
+    const enterButton = sharedPage.getByRole('button', { name: 'Enter' });
+    await expect(enterButton).toBeVisible();
+    await enterButton.click();
+
+    const currentLocale = await sharedPage.evaluate(
+      () => globalThis.navigator.language,
+    );
+
+    await switchToLocale(sharedPage, currentLocale);
+    translations = getTranslations(currentLocale);
+    previewSidebarSnapshots = getPreviewSidebarSnapshots(translations);
+
+    await expect(sharedPage.getByText('My Company Catalog')).toBeVisible();
+
+    await expect(
+      sharedPage.getByRole('link', { name: translations.sidebar.bulkImport }),
+    ).toBeVisible();
+    await sharedPage
+      .getByRole('link', { name: translations.sidebar.bulkImport })
+      .click();
+  });
+
+  test.afterAll(async () => {
+    await context.close();
+  });
+
+  test('should render bulk import page with source control options, search, and repositories table', async ({
+    browser,
+  }, testInfo: TestInfo) => {
+    const article = sharedPage.getByRole('article');
+
+    await expect(article).toMatchAriaSnapshot(`
+      - paragraph: ${translations.addRepositories.approvalTool.title}
+      - paragraph
+      - radiogroup:
+        - radio "${translations.addRepositories.approvalTool.github}"
+        - text: ${translations.addRepositories.approvalTool.github}
+        - radio "${translations.addRepositories.approvalTool.gitlab}"
+        - text: ${translations.addRepositories.approvalTool.gitlab}
+      `);
+
+    const selectedReposHeading = getSelectedRepositoriesHeading(
+      translations,
+      0,
+    );
+    await expect(article).toMatchAriaSnapshot(`
+      - heading "${selectedReposHeading}"
+      - textbox "search"
+      - button "${translations.addRepositories.clearSearch}" 
+      `);
+
+    await expect(article).toMatchAriaSnapshot(`
+      - table:
+        - rowgroup:
+          - row "select all repositories ${translations.table.headers.name} ${translations.table.headers.url} ${translations.table.headers.organization} ${translations.table.headers.status}":
+            - columnheader "select all repositories ${translations.table.headers.name}":
+              - checkbox "select all repositories"
+              - button "${translations.table.headers.name}"
+            - columnheader "${translations.table.headers.url}":
+              - button "${translations.table.headers.url}"
+            - columnheader "${translations.table.headers.organization}":
+              - button "${translations.table.headers.organization}"
+            - columnheader "${translations.table.headers.status}":
+              - button "${translations.table.headers.status}"
+      `);
+
+    await runAccessibilityTests(sharedPage, testInfo);
+  });
+
+  test('Verify selected repositories count change', async () => {
+    const selectAllCheckbox = sharedPage.getByRole('checkbox', {
+      name: 'select all repositories',
+    });
+    const headingId = `${translations.addRepositories.selectedLabel} ${translations.addRepositories.selectedRepositories}`;
+    const selectedReposHeading = sharedPage.locator(`[id="${headingId}"]`);
+
+    const zeroSelected = getSelectedRepositoriesHeading(translations, 0);
+    const fiveSelected = getSelectedRepositoriesHeading(translations, 5);
+
+    await expect(selectedReposHeading).toContainText(zeroSelected);
+    await selectAllCheckbox.check();
+    await expect(selectAllCheckbox).toBeChecked();
+    await expect(selectedReposHeading).toContainText(fiveSelected);
+    const readyToImport = await sharedPage
+      .getByText(translations.status.readyToImport)
+      .count();
+    expect(readyToImport).toEqual(5);
+    await selectAllCheckbox.uncheck();
+    await expect(selectAllCheckbox).not.toBeChecked();
+  });
+
+  test('Verify preview sidebar', async ({ browser }, testInfo: TestInfo) => {
+    const backendServiceCheckbox = sharedPage
+      .getByRole('rowheader', { name: 'backend-service' })
+      .getByRole('checkbox');
+    const sidebar = sharedPage.getByTestId('preview-pullrequest-sidebar');
+
+    await backendServiceCheckbox.check();
+    await expect(
+      sharedPage.getByText(translations.status.readyToImport).first(),
+    ).toBeVisible();
+    await sharedPage.getByTestId('preview-file').first().click();
+    await expect(sidebar.locator('h5')).toContainText('backend-service');
+    await expect(sidebar).toMatchAriaSnapshot(`
+      - button "${translations.common.save}"
+      - link "${translations.common.cancel}":
+        - /url: /bulk-import/repositories
+        - button "${translations.common.cancel}"
+      `);
+
+    // Validate each section individually for better readability
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.pullRequestDetails,
+    );
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.entityConfigHeader,
+    );
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.entityOwner,
+    );
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.codeownersOption,
+    );
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.annotations,
+    );
+    await expect(sidebar).toMatchAriaSnapshot(previewSidebarSnapshots.labels);
+    await expect(sidebar).toMatchAriaSnapshot(previewSidebarSnapshots.spec);
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.previewPullRequest,
+    );
+    await expect(sidebar).toMatchAriaSnapshot(
+      previewSidebarSnapshots.previewEntities,
+    );
+
+    await runAccessibilityTests(sharedPage, testInfo);
+
+    await sharedPage
+      .getByRole('button', { name: translations.common.cancel })
+      .click();
+  });
+
+  test('Verify Import flow', async () => {
+    const backendServiceCheckbox = sharedPage
+      .getByRole('rowheader', { name: 'backend-service' })
+      .getByRole('checkbox');
+    const frontendAppCheckbox = sharedPage
+      .getByRole('rowheader', { name: 'frontend-app' })
+      .getByRole('checkbox');
+    const addRepoFooter = sharedPage.getByTestId('add-repository-footer');
+
+    await mockBulkImportDryRunResponse(sharedPage, mockImportsDryRunData);
+    await mockBulkImportImportsResponse(sharedPage, mockImportsData);
+    await mockBulkImportByRepoResponse(sharedPage, mockImportByRepoData);
+    await mockBulkImportByRepoFrontendResponse(
+      sharedPage,
+      mockImportByRepoFrontendData,
+    );
+    await backendServiceCheckbox.check();
+    await frontendAppCheckbox.check();
+    await expect(addRepoFooter).toMatchAriaSnapshot(`
+      - button "${translations.common.import}"
+      - link "${translations.common.cancel}":
+        - /url: /bulk-import/repositories
+        - button "${translations.common.cancel}"
+      `);
+    await sharedPage
+      .getByTestId('add-repository-footer')
+      .getByRole('button', { name: translations.common.import })
+      .click();
+    await sharedPage.waitForTimeout(2000);
+    await expect(
+      sharedPage.getByText(translations.status.imported),
+    ).toBeVisible();
+    await expect(sharedPage.locator('tbody')).toMatchAriaSnapshot(`
+      - cell "${translations.status.waitingForApproval} ${translations.repositories.pr} , Opens in a new window":
+        - link "${translations.repositories.pr} , Opens in a new window":
+          - /url: https://github.com/test-org/frontend-app/pull/1
+      `);
+  });
+
+  test('test rows dropdown', async () => {
+    await sharedPage
+      .getByRole('combobox', { name: translations.table.pagination.rows5 })
+      .click();
+    await expect(sharedPage.getByRole('listbox')).toMatchAriaSnapshot(`
+      - listbox:
+        - option "${translations.table.pagination.rows5}"
+        - option "${translations.table.pagination.rows10}"
+        - option "${translations.table.pagination.rows20}"
+        - option "${translations.table.pagination.rows50}"
+        - option "${translations.table.pagination.rows100}"
+      `);
+    await sharedPage.keyboard.press('Escape');
+  });
 });

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/apiUtils.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/apiUtils.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Page } from '@playwright/test';
+
+/**
+ * API route patterns for bulk import endpoints
+ */
+export const ApiRoutes = {
+  repositories: '**/api/bulk-import/repositories*',
+  importsDryRun: '**/api/bulk-import/imports?dryRun=true*',
+  imports: '**/api/bulk-import/imports',
+  byRepoBackend:
+    '**/api/bulk-import/import/by-repo?repo=https://github.com/test-org/backend-service*',
+  byRepoFrontend:
+    '**/api/bulk-import/import/by-repo?repo=https://github.com/test-org/frontend-app*',
+} as const;
+
+type ApiRouteKey = keyof typeof ApiRoutes;
+
+/**
+ * Generic helper to mock any bulk import API response
+ */
+async function mockApiResponse(
+  page: Page,
+  route: string,
+  responseData: object,
+  status = 200,
+) {
+  await page.route(route, async r => {
+    await r.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(responseData),
+    });
+  });
+}
+
+/**
+ * Mock bulk import API response by route key
+ */
+export async function mockBulkImportResponse(
+  page: Page,
+  routeKey: ApiRouteKey,
+  responseData: object,
+  status = 200,
+) {
+  await mockApiResponse(page, ApiRoutes[routeKey], responseData, status);
+}
+
+// Convenience functions for specific routes (preserves backward compatibility)
+export const mockBulkImportRepositoriesResponse = (
+  page: Page,
+  responseData: object,
+  status = 200,
+) => mockApiResponse(page, ApiRoutes.repositories, responseData, status);
+
+export const mockBulkImportDryRunResponse = (
+  page: Page,
+  responseData: object,
+  status = 200,
+) => mockApiResponse(page, ApiRoutes.importsDryRun, responseData, status);
+
+export const mockBulkImportImportsResponse = (
+  page: Page,
+  responseData: object,
+  status = 200,
+) => mockApiResponse(page, ApiRoutes.imports, responseData, status);
+
+export const mockBulkImportByRepoResponse = (
+  page: Page,
+  responseData: object,
+  status = 200,
+) => mockApiResponse(page, ApiRoutes.byRepoBackend, responseData, status);
+
+export const mockBulkImportByRepoFrontendResponse = (
+  page: Page,
+  responseData: object,
+  status = 200,
+) => mockApiResponse(page, ApiRoutes.byRepoFrontend, responseData, status);
+
+// Reusable repository definitions
+const repositories = {
+  backendService: {
+    id: 'test-org/backend-service',
+    name: 'backend-service',
+    organization: 'test-org',
+    url: 'https://github.com/test-org/backend-service',
+    defaultBranch: 'main',
+    lastUpdate: '2024-12-21T15:21:03Z',
+  },
+  frontendApp: {
+    id: 'test-org/frontend-app',
+    name: 'frontend-app',
+    organization: 'test-org',
+    url: 'https://github.com/test-org/frontend-app',
+    defaultBranch: 'main',
+    lastUpdate: '2024-12-27T06:12:46Z',
+  },
+  apiGateway: {
+    id: 'sample-org/api-gateway',
+    name: 'api-gateway',
+    organization: 'sample-org',
+    url: 'https://github.com/sample-org/api-gateway',
+    defaultBranch: 'main',
+    lastUpdate: '2024-06-12T11:00:00Z',
+  },
+  sharedComponents: {
+    id: 'sample-org/shared-components',
+    name: 'shared-components',
+    organization: 'sample-org',
+    url: 'https://github.com/sample-org/shared-components',
+    defaultBranch: 'main',
+    lastUpdate: '2025-05-22T06:54:21Z',
+  },
+  exampleService: {
+    id: 'demo-org/example-service',
+    name: 'example-service',
+    organization: 'demo-org',
+    url: 'https://github.com/demo-org/example-service',
+    defaultBranch: 'master',
+    lastUpdate: '2025-05-16T18:52:04Z',
+  },
+} as const;
+
+/** Mock data for repositories list response */
+export const mockRepositoriesData = {
+  errors: [],
+  repositories: [
+    { ...repositories.backendService, errors: [] },
+    { ...repositories.frontendApp, errors: [] },
+    { ...repositories.apiGateway, errors: [] },
+    { ...repositories.sharedComponents, errors: [] },
+    { ...repositories.exampleService, errors: [] },
+  ],
+  totalCount: 325,
+  pagePerIntegration: 1,
+  sizePerIntegration: 5,
+  approvalTool: 'GIT',
+};
+
+/** Mock data for dry run import response - validation results */
+export const mockImportsDryRunData = [
+  {
+    errors: ['CATALOG_INFO_FILE_EXISTS_IN_REPO'],
+    catalogEntityName: repositories.backendService.name,
+    repository: {
+      url: repositories.backendService.url,
+      name: repositories.backendService.name,
+      organization: repositories.backendService.organization,
+    },
+  },
+];
+
+/** Mock data for import response - successful import */
+export const mockImportsData = [
+  {
+    status: 'ADDED',
+    repository: {
+      url: repositories.backendService.url,
+      name: repositories.backendService.name,
+      organization: repositories.backendService.organization,
+    },
+  },
+];
+
+/** Mock data for backend-service import by repo response */
+export const mockImportByRepoData = {
+  id: repositories.backendService.url,
+  repository: repositories.backendService,
+  approvalTool: 'GIT',
+  status: 'ADDED',
+  lastUpdate: repositories.backendService.lastUpdate,
+};
+
+/** Mock data for frontend-app import by repo response - waiting for PR approval */
+export const mockImportByRepoFrontendData = {
+  id: repositories.frontendApp.url,
+  repository: repositories.frontendApp,
+  approvalTool: 'GIT',
+  status: 'WAIT_PR_APPROVAL',
+  github: {
+    pullRequest: {
+      number: 1,
+      url: `${repositories.frontendApp.url}/pull/1`,
+      title: 'Add catalog-info.yaml config file',
+      body: `This pull request adds a **Backstage entity metadata file**
+to this repository so that the component can
+be added to the [software catalog](http://localhost:3000/catalog).
+After this pull request is merged, the component will become available.
+For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).
+View the import job in your app [here](http://localhost:3000/bulk-import/repositories?repository=${repositories.frontendApp.url}&defaultBranch=${repositories.frontendApp.defaultBranch}).`,
+      catalogInfoContent: `apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${repositories.frontendApp.name}
+  annotations:
+    github.com/project-slug: ${repositories.frontendApp.id}
+spec:
+  type: other
+  lifecycle: unknown
+  owner: user:development/guest
+`,
+    },
+  },
+  lastUpdate: repositories.frontendApp.lastUpdate,
+};

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/ariaSnapshots.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/ariaSnapshots.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BulkImportMessages, replaceTemplate } from './translations';
+
+/**
+ * Creates aria snapshot chunks for the Preview Pull Request Sidebar.
+ * Each chunk represents a logical section of the sidebar for better readability and maintainability.
+ *
+ * @param t - Translation messages object
+ * @returns Object containing aria snapshot strings for each section
+ */
+export function getPreviewSidebarSnapshots(t: BulkImportMessages) {
+  const prDetails = replaceTemplate(t.previewFile.pullRequest.details, {
+    tool: t.previewFile.pullRequest.title,
+  });
+  const prTitleLabel = replaceTemplate(t.previewFile.pullRequest.titleLabel, {
+    tool: t.previewFile.pullRequest.title,
+  });
+  const prBodyLabel = replaceTemplate(t.previewFile.pullRequest.bodyLabel, {
+    tool: t.previewFile.pullRequest.title,
+  });
+  const annotationsSeparator = replaceTemplate(
+    t.previewFile.useSemicolonSeparator,
+    { label: t.previewFile.pullRequest.annotations.toLowerCase() },
+  );
+  const labelsSeparator = replaceTemplate(t.previewFile.useSemicolonSeparator, {
+    label: t.previewFile.pullRequest.labels.toLowerCase(),
+  });
+  const specSeparator = replaceTemplate(t.previewFile.useSemicolonSeparator, {
+    label: t.previewFile.pullRequest.spec.toLowerCase(),
+  });
+
+  // Parse the useCodeOwnersFile translation: "Use *CODEOWNERS* file as Entity Owner"
+  // The asterisks mark emphasis around CODEOWNERS
+  const codeOwnersText = t.previewFile.pullRequest.useCodeOwnersFile;
+  const codeOwnersCheckboxName = codeOwnersText.replace(/\*/g, '');
+  const codeOwnersParts = codeOwnersText.split('*CODEOWNERS*');
+  const codeOwnersBeforeText = codeOwnersParts[0].trim();
+  const codeOwnersAfterText = codeOwnersParts[1].trim();
+
+  return {
+    /**
+     * Pull request details section - contains title and body textboxes
+     */
+    pullRequestDetails: `
+    - heading "${prDetails}" [level=6]
+    - text: ${prTitleLabel}
+    - textbox "${prTitleLabel}":
+      - /placeholder: ${t.previewFile.pullRequest.titlePlaceholder}
+      - text: Add catalog-info.yaml config file
+    - text: ${prBodyLabel}
+    - textbox "${prBodyLabel}":
+      - /placeholder: ${t.previewFile.pullRequest.bodyPlaceholder}
+      - text: /This pull request adds a \\*\\*Backstage entity metadata file\\*\\* to this repository so that the component can be added to the \\[software catalog\\]\\(http:\\/\\/localhost:\\d+\\/catalog\\)\\. After this pull request is merged, the component will become available\\. For more information, read an \\[overview of the Backstage software catalog\\]\\(https:\\/\\/backstage\\.io\\/docs\\/features\\/software-catalog\\/\\)\\. View the import job in your app \\[here\\]\\(http:\\/\\/localhost:\\d+\\/bulk-import\\/repositories\\?repository=https:\\/\\/github\\.com\\/test-org\\/backend-service&defaultBranch=main\\)\\./
+  `,
+
+    /**
+     * Entity configuration heading and component name field
+     */
+    entityConfigHeader: `
+    - heading "${t.previewFile.pullRequest.entityConfiguration}" [level=6]
+    - text: ${t.previewFile.pullRequest.componentNameLabel}
+    - textbox "${t.previewFile.pullRequest.componentNameLabel}":
+      - /placeholder: ${t.previewFile.pullRequest.componentNamePlaceholder}
+  `,
+
+    /**
+     * Entity owner selection field
+     */
+    entityOwner: `
+    - text: ${t.previewFile.pullRequest.entityOwnerLabel}
+    - combobox "${t.previewFile.pullRequest.entityOwnerLabel}": user:development/guest
+    - button "Open"
+    - paragraph: ${t.previewFile.pullRequest.entityOwnerHelper}
+  `,
+
+    /**
+     * CODEOWNERS checkbox option
+     */
+    codeownersOption: `
+    - checkbox "${codeOwnersCheckboxName}"
+    - paragraph:
+      - text: ${codeOwnersBeforeText}
+      - emphasis: CODEOWNERS
+      - text: ${codeOwnersAfterText}
+    - paragraph: "${t.previewFile.pullRequest.codeOwnersWarning}"
+  `,
+
+    /**
+     * Annotations field
+     */
+    annotations: `
+    - text: ${t.previewFile.pullRequest.annotations}
+    - textbox "${t.previewFile.pullRequest.annotations}":
+      - /placeholder: "${t.previewFile.keyValuePlaceholder}"
+      - text: "github.com/project-slug: test-org/backend-service"
+    - paragraph: ${annotationsSeparator}
+  `,
+
+    /**
+     * Labels field
+     */
+    labels: `
+    - text: ${t.previewFile.pullRequest.labels}
+    - textbox "${t.previewFile.pullRequest.labels}":
+      - /placeholder: "${t.previewFile.keyValuePlaceholder}"
+    - paragraph: ${labelsSeparator}
+  `,
+
+    /**
+     * Spec field
+     */
+    spec: `
+    - text: ${t.previewFile.pullRequest.spec}
+    - textbox "${t.previewFile.pullRequest.spec}":
+      - /placeholder: "${t.previewFile.keyValuePlaceholder}"
+      - text: "type: other; lifecycle: unknown; owner: user:development/guest"
+    - paragraph: ${specSeparator}
+  `,
+
+    /**
+     * Preview pull request section - shows the PR preview with links
+     */
+    previewPullRequest: `
+    - heading "${t.previewFile.preview} ${t.previewFile.pullRequest.title.toLowerCase()}" [level=6]
+    - text: Add catalog-info.yaml config file Create a new Pull Request
+    - paragraph:
+      - text: This pull request adds a
+      - strong: Backstage entity metadata file
+      - text: to this repository so that the component can be added to the
+      - link "software catalog":
+        - /url: http://localhost:3000/catalog
+      - text: . After this pull request is merged, the component will become available. For more information, read an
+      - link "overview of the Backstage software catalog":
+        - /url: https://backstage.io/docs/features/software-catalog/
+      - text: . View the import job in your app
+      - link "here":
+        - /url: http://localhost:3000/bulk-import/repositories?repository=https://github.com/test-org/backend-service&defaultBranch=main
+      - text: .
+  `,
+
+    /**
+     * Preview entities section - shows the generated catalog-info.yaml content
+     */
+    previewEntities: `
+    - heading "${t.previewFile.pullRequest.previewEntities}" [level=6]
+    - code: https://github.com/test-org/backend-service/catalog-info.yaml
+    - code: "apiVersion: backstage.io/v1alpha1 kind: Component metadata: name: backend-service annotations: github.com/project-slug: test-org/backend-service spec: type: other lifecycle: unknown owner: user:development/guest"
+  `,
+  };
+}
+
+/**
+ * Type for the preview sidebar snapshots object
+ */
+export type PreviewSidebarSnapshotsType = ReturnType<
+  typeof getPreviewSidebarSnapshots
+>;
+
+/**
+ * Helper function to get all preview sidebar snapshots combined.
+ * Use this when you need to validate the entire sidebar at once.
+ *
+ * @param t - Translation messages object
+ * @returns Combined aria snapshot string for the entire sidebar
+ */
+export function getFullPreviewSidebarSnapshot(t: BulkImportMessages): string {
+  const snapshots = getPreviewSidebarSnapshots(t);
+  return `
+    ${snapshots.pullRequestDetails}
+    ${snapshots.entityConfigHeader}
+    ${snapshots.entityOwner}
+    ${snapshots.codeownersOption}
+    ${snapshots.annotations}
+    ${snapshots.labels}
+    ${snapshots.spec}
+    ${snapshots.previewPullRequest}
+    ${snapshots.previewEntities}
+  `;
+}

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/helpers.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/helpers.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import AxeBuilder from '@axe-core/playwright';
+import { expect, Page, TestInfo } from '@playwright/test';
+
+/**
+ * Switch to a different locale in the application settings
+ * @param page - Playwright page object
+ * @param locale - The locale to switch to (e.g., 'en', 'fr', 'de', 'es')
+ */
+export async function switchToLocale(
+  page: Page,
+  locale: string,
+): Promise<void> {
+  if (locale !== 'en') {
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await page.getByRole('button', { name: 'English' }).click();
+    await page.getByRole('option', { name: locale }).click();
+    await page.locator('a').filter({ hasText: 'Home' }).click();
+  }
+}
+
+/**
+ * Run accessibility tests using axe-core
+ * @param page - Playwright page object
+ * @param testInfo - Playwright test info for attaching results
+ * @param attachName - Name of the attachment file
+ */
+export async function runAccessibilityTests(
+  page: Page,
+  testInfo: TestInfo,
+  attachName = 'accessibility-scan-results.json',
+) {
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+
+  await testInfo.attach(attachName, {
+    body: JSON.stringify(accessibilityScanResults, null, 2),
+    contentType: 'application/json',
+  });
+}

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/translations.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These translation files are not exported by the package, so relative imports are necessary for e2e tests
+/* eslint-disable @backstage/no-relative-monorepo-imports */
+import { bulkImportMessages } from '../../../../plugins/bulk-import/src/translations/ref.js';
+import bulkImportTranslationDe from '../../../../plugins/bulk-import/src/translations/de.js';
+import bulkImportTranslationFr from '../../../../plugins/bulk-import/src/translations/fr.js';
+import bulkImportTranslationEs from '../../../../plugins/bulk-import/src/translations/es.js';
+/* eslint-enable @backstage/no-relative-monorepo-imports */
+
+export type BulkImportMessages = typeof bulkImportMessages;
+
+function transform(messages: typeof bulkImportTranslationDe.messages) {
+  const result = Object.keys(messages).reduce((res, key) => {
+    const path = key.split('.');
+    const lastIndex = path.length - 1;
+    path.reduce((acc, currentPath, i) => {
+      acc[currentPath] =
+        lastIndex === i ? messages[key] : acc[currentPath] || {};
+      return acc[currentPath];
+    }, res);
+    return res;
+  }, {});
+
+  return result as BulkImportMessages;
+}
+
+export function getTranslations(locale: string): BulkImportMessages {
+  switch (locale) {
+    case 'en':
+      return bulkImportMessages;
+    case 'fr':
+      return transform(bulkImportTranslationFr.messages);
+    case 'de':
+      return transform(bulkImportTranslationDe.messages);
+    case 'es':
+      return transform(bulkImportTranslationEs.messages);
+    default:
+      return bulkImportMessages;
+  }
+}
+
+/**
+ * Replace multiple placeholders in a template string
+ * @param template - Template string with placeholders like {{key}}
+ * @param replacements - Object with key-value pairs for replacement
+ * @returns String with all placeholders replaced
+ */
+export function replaceTemplate(
+  template: string,
+  replacements: Record<string, string | number>,
+): string {
+  let result = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    result = result.replaceAll(`{{${key}}}`, String(value));
+  }
+  return result;
+}
+
+/**
+ * Get the "Selected repositories (count)" heading text
+ * Built from selectedLabel + selectedRepositories + count
+ * @param translations - Translation messages object
+ * @param count - Number of selected repositories
+ * @returns Formatted heading string like "Selected repositories (5)"
+ */
+export function getSelectedRepositoriesHeading(
+  translations: BulkImportMessages,
+  count: number,
+): string {
+  return `${translations.addRepositories.selectedLabel} ${translations.addRepositories.selectedRepositories} (${count})`;
+}

--- a/workspaces/bulk-import/packages/app/package.json
+++ b/workspaces/bulk-import/packages/app/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@backstage/test-utils": "^1.7.13",
-    "@playwright/test": "1.57.0",
     "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/workspaces/bulk-import/playwright.config.ts
+++ b/workspaces/bulk-import/playwright.config.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  timeout: 2 * 60 * 1000,
+  fullyParallel: false,
+  workers: 1,
+
+  expect: {
+    timeout: 10000,
+  },
+
+  webServer: process.env.PLAYWRIGHT_URL
+    ? []
+    : {
+        command: 'yarn start',
+        port: 3000,
+        reuseExistingServer: true,
+      },
+
+  retries: process.env.CI ? 2 : 0,
+
+  reporter: [['html', { open: 'never', outputFolder: 'e2e-test-report' }]],
+
+  use: {
+    baseURL: process.env.PLAYWRIGHT_URL ?? 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+
+  outputDir: 'node_modules/.cache/e2e-test-results',
+
+  projects: [
+    {
+      name: 'en',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'en',
+      },
+    },
+    {
+      name: 'fr',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'fr',
+      },
+    },
+  ],
+});

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -1104,6 +1104,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@axe-core/playwright@npm:^4.11.0":
+  version: 4.11.0
+  resolution: "@axe-core/playwright@npm:4.11.0"
+  dependencies:
+    axe-core: ~4.11.0
+  peerDependencies:
+    playwright-core: ">= 1.0.0"
+  checksum: 036d13cb73f9c3bdcff039caa8a3f4ae9c2fffeb41855053dd78f72d98d1635b0d7eec38ff5087beaa5e15c99e060a771d1b449f08df58694f02781d54aa155c
+  languageName: node
+  linkType: hard
+
 "@azure/abort-controller@npm:^2.0.0, @azure/abort-controller@npm:^2.1.2":
   version: 2.1.2
   resolution: "@azure/abort-controller@npm:2.1.2"
@@ -5605,11 +5616,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/bulk-import@workspace:."
   dependencies:
+    "@axe-core/playwright": ^4.11.0
     "@backstage/cli": ^0.34.5
     "@backstage/e2e-test-utils": ^0.1.1
     "@backstage/repo-tools": ^0.16.0
     "@changesets/cli": ^2.27.1
     "@ianvs/prettier-plugin-sort-imports": ^4.3.1
+    "@playwright/test": 1.56.1
     "@spotify/prettier-config": ^12.0.0
     knip: ^5.27.4
     node-gyp: ^9.0.0
@@ -8447,6 +8460,17 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 6ad6a00fc4f2f2cfc6bff76fb1d88b8ee20bc0601e18ebb01b6d4be583733a860239a521a7fbca73b612e66705078809483549d2b18f370eb346c5155c8e4a0f
+  languageName: node
+  linkType: hard
+
+"@playwright/test@npm:1.56.1":
+  version: 1.56.1
+  resolution: "@playwright/test@npm:1.56.1"
+  dependencies:
+    playwright: 1.56.1
+  bin:
+    playwright: cli.js
+  checksum: 109544665800de973987893adffa17d1e563fb99d3485d6399784e8c8a9269081cae9a00e09ca308aa140e932a4e862dca0b3de07a21e2dfbf8cfcc3b2b6b4f3
   languageName: node
   linkType: hard
 
@@ -15263,7 +15287,6 @@ __metadata:
     "@mui/lab": 5.0.0-alpha.177
     "@mui/material": 5.18.0
     "@mui/styles": 5.18.0
-    "@playwright/test": 1.57.0
     "@red-hat-developer-hub/backstage-plugin-bulk-import": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-theme": ^0.11.0
     "@testing-library/dom": ^9.0.0
@@ -15750,10 +15773,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.10.0":
-  version: 4.10.2
-  resolution: "axe-core@npm:4.10.2"
-  checksum: 2b9b1c93ea73ea9f206604e4e17bd771d2d835f077bde54517d73028b8865c69b209460e73d5b109968cbdb39ab3d28943efa5695189bd79e16421ce1706719e
+"axe-core@npm:^4.10.0, axe-core@npm:~4.11.0":
+  version: 4.11.0
+  resolution: "axe-core@npm:4.11.0"
+  checksum: 57b0d7206d4dd63a1127b8ad6e173417857a3de43717cbb03561e75e2ff85765a228a7588fde4c828dbf179ef25f263ad98535656701e78def8f29a9524be866
   languageName: node
   linkType: hard
 
@@ -29541,12 +29564,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.56.1":
+  version: 1.56.1
+  resolution: "playwright-core@npm:1.56.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 170dff398b47da140182631ae025190248dabde7a5264335f54e238546a478f522ac9a620b31462e6e31c883273223bff8e883b502a699da490abe9741fb3b71
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.57.0":
   version: 1.57.0
   resolution: "playwright-core@npm:1.57.0"
   bin:
     playwright-core: cli.js
   checksum: 960e80d6ec06305b11a3ca9e78e8e4201cc17f37dd37279cb6fece4df43d74bf589833f4f94535fadd284b427f98c5f1cf09368e22f0f00b6a9477571ce6b03b
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.56.1":
+  version: 1.56.1
+  resolution: "playwright@npm:1.56.1"
+  dependencies:
+    fsevents: 2.3.2
+    playwright-core: 1.56.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: e7537e7d5048a1a8544d7675b005196ba9db919edc3b6d46b92273ee6f20e37ada8991774c5df9ef5123ea4610978d582feb141c8a02f4cf256a6c0b224b8793
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Add E2E Tests to Bulk Import with i18n & Accessibility
### Which issue(s) does this PR fix
Fixes : [RHIDP-9432](https://issues.redhat.com/browse/RHIDP-9432)

### Summary
Add bulk-import e2e test suite with internationalization support and WCAG accessibility checks.

### Changes
- **i18n Support**: Tests now use plugin translations instead of hardcoded strings, enabling multi-locale test execution
- **Accessibility Testing**: Integrated `@axe-core/playwright` for WCAG 2.0/2.1 AA compliance validation
- **Multi-locale Testing**: Added French (`fr`) locale project to Playwright config

### Files Changed
- `packages/app/e2e-tests/app.test.ts`
- `packages/app/e2e-tests/utils/ariaSnapshots.ts`
- `packages/app/e2e-tests/utils/helpers.ts` 
- `packages/app/e2e-tests/utils/translations.ts`
- `playwright.config.ts`
- `packages/app/package.json`