### PR TITLE
[orchestrator-1.8] Fix: Resolve [object Object] displaying in browser tab title on workflow instance page

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-workflow-instance-browser-title.md
+++ b/workspaces/orchestrator/.changeset/fix-workflow-instance-browser-title.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix browser tab showing `[object Object]` on workflow instance page
+
+Replace `<Trans>` component with `t()` function for page title to ensure a string is returned instead of an element, which was causing `[object Object]` to appear in the browser tab title.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
@@ -75,7 +75,6 @@ import { orchestratorTranslationRef } from '../../translations';
 import { deepSearchObject } from '../../utils/deepSearchObject';
 import { isNonNullable } from '../../utils/TypeGuards';
 import { buildUrl } from '../../utils/UrlUtils';
-import { Trans } from '../Trans';
 import { BaseOrchestratorPage } from '../ui/BaseOrchestratorPage';
 import { InfoDialog } from '../ui/InfoDialog';
 import { WorkflowInstancePageContent } from './WorkflowInstancePageContent';
@@ -391,12 +390,9 @@ export const WorkflowInstancePage = () => {
 
   const combinedError: Error | undefined = error || inputSchemaError;
 
-  const title = (
-    <Trans
-      message="run.pageTitle"
-      params={{ processName: value?.processName }}
-    />
-  ) as unknown as string;
+  const title = t('run.pageTitle', {
+    processName: value?.processName ?? '',
+  });
 
   return (
     <BaseOrchestratorPage title={title}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Problem**
When viewing a workflow instance page, the browser tab title shows [object Object] instead of the expected workflow name

**Root cause**
The page title was using <Trans> component, which can return an element. When passed to the Backstage Header, this element gets converted to [object Object] for the browser tab title.

**Solution**
Use the t() function directly instead of the <Trans> component, consistent with how all other translations in this file are handled.

<img width="888" height="746" alt="image" src="https://github.com/user-attachments/assets/33037918-b12d-44b0-8396-845e253331cf" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
