### PR TITLE
fix(adoption-insights): mark the app-config `app.analytics.adoptionInsights` option as optional

### DIFF
--- a/workspaces/adoption-insights/.changeset/tame-clubs-chew.md
+++ b/workspaces/adoption-insights/.changeset/tame-clubs-chew.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights': patch
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+---
+
+Mark the app-config `app.analytics.adoptionInsights` option as optional. It was already read with getOptional<Number/Boolean> so there is no code change or configuration change needed, this just reflect the status quo better.

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/README.md
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/README.md
@@ -23,13 +23,15 @@ backend.add(
 
 ## Configuration
 
+The following optional configuration parameters are available to fine tune adoption analytics events:
+
 ```yaml
 app:
   analytics:
     adoptionInsights:
-      maxBufferSize: 25
-      flushInterval: 6000
-      debug: false # enable this to debug
+      maxBufferSize: 20 # Optional: Maximum buffer size for event batching (default: 20)
+      flushInterval: 5000 # Optional: Flush interval in milliseconds for event batching (default: 5000ms)
+      debug: false # Optional: Enable debug mode to log every event in the browser console (default: false)
       licensedUsers: 100 # Administrators can set this value to see the user adoption metrics.
 ```
 

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/config.d.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/config.d.ts
@@ -16,8 +16,8 @@
 
 export interface Config {
   app?: {
-    analytics: {
-      adoptionInsights: {
+    analytics?: {
+      adoptionInsights?: {
         /**
          * Maximum buffer size for event batching.
          * default 20

--- a/workspaces/adoption-insights/plugins/analytics-module-adoption-insights/README.md
+++ b/workspaces/adoption-insights/plugins/analytics-module-adoption-insights/README.md
@@ -47,9 +47,7 @@ export const apis: AnyApiFactory[] = [AdoptionInsightsAnalyticsApiFactory];
 
 ## Configuration
 
-### Available Configuration Options
-
-The following is the optional configuration required to fine tune adoption analytics events:
+The following optional configuration parameters are available to fine tune adoption analytics events:
 
 ```yaml
 # app-config.yaml

--- a/workspaces/adoption-insights/plugins/analytics-module-adoption-insights/config.d.ts
+++ b/workspaces/adoption-insights/plugins/analytics-module-adoption-insights/config.d.ts
@@ -16,8 +16,8 @@
 
 export interface Config {
   app?: {
-    analytics: {
-      adoptionInsights: {
+    analytics?: {
+      adoptionInsights?: {
         /**
          * Maximum buffer size for event batching.
          * default 20


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Mark the app-config `app.analytics.adoptionInsights` option as optional. It was already read with `getOptional<Number/Boolean>` so there is no code change or configuration change needed, this just reflect the status quo better.

I aligned also the README files from the backend and analytics module a bit.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
