### PR TITLE
chore(translations): use caret notation for express dependency

### DIFF
--- a/workspaces/translations/.changeset/tough-friends-rest.md
+++ b/workspaces/translations/.changeset/tough-friends-rest.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-translations-backend': patch
+---
+
+Use caret notation for express dependency

--- a/workspaces/translations/plugins/translations-backend/package.json
+++ b/workspaces/translations/plugins/translations-backend/package.json
@@ -38,7 +38,7 @@
     "@backstage/config": "^1.3.6",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-catalog-node": "^1.20.0",
-    "express": "4.22.1",
+    "express": "^4.22.1",
     "express-promise-router": "^4.1.0"
   },
   "devDependencies": {

--- a/workspaces/translations/yarn.lock
+++ b/workspaces/translations/yarn.lock
@@ -10368,7 +10368,7 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.20.0
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.12
-    express: 4.22.1
+    express: ^4.22.1
     express-promise-router: ^4.1.0
     supertest: ^6.2.4
   languageName: unknown
@@ -19420,7 +19420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:4.22.1, express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.21.2":
+"express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.21.2, express@npm:^4.22.1":
   version: 4.22.1
   resolution: "express@npm:4.22.1"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Update the translation-backend to use caret notation for the express dependency.  We should avoid pinning so that we can run yarn updates in the rhdh repo without having to use resolutions

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
