### PR TITLE
fix(fab): allow custom fab component

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/unlucky-grapes-perform.md
+++ b/workspaces/global-floating-action-button/.changeset/unlucky-grapes-perform.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-floating-action-button': patch
+---
+
+allow custom fab component

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/README.md
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/README.md
@@ -247,22 +247,146 @@ The sections below are relevant for static plugins. If the plugin is expected to
 
 #### Floating Action Button Parameters
 
-| Name               | Type                                                                                                              | Description                                                                                                                                                                                                       | Notes                                          |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| **slot**           | `enum`                                                                                                            | The position where the fab will be placed. Valid values: `PAGE_END`, `BOTTOM_LEFT`.                                                                                                                               | [optional] default to `PAGE_END`.              |
-| **label**          | `String`                                                                                                          | A name for your action button.                                                                                                                                                                                    | required                                       |
-| **labelKey**       | `String`                                                                                                          | Translation key for the label. If provided, will be used instead of label when translations are available.                                                                                                        | optional                                       |
-| **icon**           | `String`<br>`React.ReactElement`<br>`SVG image icon`<br>`HTML image icon`                                         | An icon for your floating button. Recommended to use **filled** icons from the [Material Design library](https://fonts.google.com/icons)                                                                          | optional                                       |
-| **showLabel**      | `Boolean`                                                                                                         | To display the label next to your icon.                                                                                                                                                                           | optional                                       |
-| **size**           | `'small'`<br>`'medium'`<br>`'large'`                                                                              | A name for your action button.                                                                                                                                                                                    | [optional] default to `'medium'`               |
-| **color**          | `'default'`<br>`'error'`<br>`'info'`<br>`'inherit'`<br>`'primary'`<br>`'secondary'`<br>`'success'`<br>`'warning'` | The color of the component. It supports both default and custom theme colors, which can be added as shown in the [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors). | [optional] default to `'default'`.             |
-| **onClick**        | `React.MouseEventHandler`                                                                                         | the action to be performed on `onClick`.                                                                                                                                                                          | optional                                       |
-| **to**             | `String`                                                                                                          | Specify an href if the action button should open a internal/external link.                                                                                                                                        | optional                                       |
-| **toolTip**        | `String`                                                                                                          | The text to appear on hover.                                                                                                                                                                                      | optional                                       |
-| **toolTipKey**     | `String`                                                                                                          | Translation key for the tooltip. If provided, will be used instead of toolTip when translations are available.                                                                                                    | optional                                       |
-| **priority**       | `number`                                                                                                          | When multiple sub-menu actions are displayed, the button can be prioritized to position either at the top or the bottom.                                                                                          | optional                                       |
-| **visibleOnPaths** | `string[]`                                                                                                        | The action button will appear only on the specified paths and will remain hidden on all other paths.                                                                                                              | [optional] default to displaying on all paths. |
-| **excludeOnPaths** | `string[]`                                                                                                        | The action button will be hidden only on the specified paths and will appear on all other paths.                                                                                                                  | [optional] default to displaying on all paths. |
+| Name                   | Type                                                                                                              | Description                                                                                                                                                                                                       | Notes                                          |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **slot**               | `enum`                                                                                                            | The position where the fab will be placed. Valid values: `PAGE_END`, `BOTTOM_LEFT`.                                                                                                                               | [optional] default to `PAGE_END`.              |
+| **label**              | `String`                                                                                                          | A name for your action button.                                                                                                                                                                                    | required                                       |
+| **labelKey**           | `String`                                                                                                          | Translation key for the label. If provided, will be used instead of label when translations are available.                                                                                                        | optional                                       |
+| **icon**               | `String`<br>`React.ReactElement`<br>`SVG image icon`<br>`HTML image icon`                                         | An icon for your floating button. Recommended to use **filled** icons from the [Material Design library](https://fonts.google.com/icons)                                                                          | optional                                       |
+| **showLabel**          | `Boolean`                                                                                                         | To display the label next to your icon.                                                                                                                                                                           | optional                                       |
+| **size**               | `'small'`<br>`'medium'`<br>`'large'`                                                                              | A name for your action button.                                                                                                                                                                                    | [optional] default to `'medium'`               |
+| **color**              | `'default'`<br>`'error'`<br>`'info'`<br>`'inherit'`<br>`'primary'`<br>`'secondary'`<br>`'success'`<br>`'warning'` | The color of the component. It supports both default and custom theme colors, which can be added as shown in the [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors). | [optional] default to `'default'`.             |
+| **onClick**            | `React.MouseEventHandler`                                                                                         | the action to be performed on `onClick`.                                                                                                                                                                          | optional                                       |
+| **to**                 | `String`                                                                                                          | Specify an href if the action button should open a internal/external link.                                                                                                                                        | optional                                       |
+| **toolTip**            | `String`                                                                                                          | The text to appear on hover.                                                                                                                                                                                      | optional                                       |
+| **toolTipKey**         | `String`                                                                                                          | Translation key for the tooltip. If provided, will be used instead of toolTip when translations are available.                                                                                                    | optional                                       |
+| **priority**           | `number`                                                                                                          | When multiple sub-menu actions are displayed, the button can be prioritized to position either at the top or the bottom.                                                                                          | optional                                       |
+| **visibleOnPaths**     | `string[]`                                                                                                        | The action button will appear only on the specified paths and will remain hidden on all other paths.                                                                                                              | [optional] default to displaying on all paths. |
+| **excludeOnPaths**     | `string[]`                                                                                                        | The action button will be hidden only on the specified paths and will appear on all other paths.                                                                                                                  | [optional] default to displaying on all paths. |
+| **isDisabled**         | `Boolean`                                                                                                         | Whether the FAB is disabled.                                                                                                                                                                                      | optional                                       |
+| **disabledToolTip**    | `String`                                                                                                          | Tooltip to display when the FAB is disabled.                                                                                                                                                                      | optional                                       |
+| **disabledToolTipKey** | `String`                                                                                                          | Translation key for the disabled tooltip.                                                                                                                                                                         | optional                                       |
+| **Component**          | `ComponentType<any>`                                                                                              | Custom component to render as the FAB item. When provided, this takes priority over icon, tooltip, and onClick.                                                                                                   | optional                                       |
+
+### Custom FAB Components
+
+You can provide a custom React component to render as a FAB item. This is useful when you need full control over the FAB's behavior, such as managing state through context or implementing complex interactions.
+
+#### Using Custom Components in Static Configuration
+
+```tsx title="packages/app/src/components/Root/Root.tsx"
+import { useState, createContext, useContext, useCallback, PropsWithChildren } from 'react';
+import Fab from '@mui/material/Fab';
+import Tooltip from '@mui/material/Tooltip';
+import ChatIcon from '@mui/icons-material/Chat';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  GlobalFloatingActionButton,
+} from '@red-hat-developer-hub/backstage-plugin-global-floating-action-button';
+
+// Create a context for managing state
+interface ChatPanelContextType {
+  isOpen: boolean;
+  togglePanel: () => void;
+}
+
+const ChatPanelContext = createContext<ChatPanelContextType | undefined>(undefined);
+
+const useChatPanel = () => {
+  const context = useContext(ChatPanelContext);
+  if (!context) {
+    throw new Error('useChatPanel must be used within ChatPanelProvider');
+  }
+  return context;
+};
+
+// Provider component to wrap your app
+const ChatPanelProvider = ({ children }: PropsWithChildren<{}>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const togglePanel = useCallback(() => setIsOpen(prev => !prev), []);
+
+  return (
+    <ChatPanelContext.Provider value={{ isOpen, togglePanel }}>
+      {children}
+      {isOpen && (
+        <div style={{ position: 'fixed', bottom: '80px', right: '24px', /* ... */ }}>
+          {/* Your panel content */}
+        </div>
+      )}
+    </ChatPanelContext.Provider>
+  );
+};
+
+// Custom FAB Component
+const ChatFABComponent = () => {
+  const { isOpen, togglePanel } = useChatPanel();
+
+  return (
+    <Tooltip title={isOpen ? 'Close Chat' : 'Open Chat'} placement="left">
+      <Fab
+        size="small"
+        color={isOpen ? 'default' : 'primary'}
+        onClick={togglePanel}
+        aria-label={isOpen ? 'Close chat' : 'Open chat'}
+      >
+        {isOpen ? <CloseIcon /> : <ChatIcon />}
+      </Fab>
+    </Tooltip>
+  );
+};
+
+// Use the custom component in Root
+export const Root = ({ children }: PropsWithChildren<{}>) => (
+  <ChatPanelProvider>
+    <SidebarPage>
+      <GlobalFloatingActionButton
+        floatingButtons={[
+          {
+            label: 'Chat',
+            toolTip: 'Chat Panel',
+            Component: ChatFABComponent
+            priority: -1,
+          },
+          // ... other FABs
+        ]}
+      />
+      {children}
+    </SidebarPage>
+  </ChatPanelProvider>
+);
+```
+
+**Key Points:**
+
+- The `Component` can have it's own `icon`, `toolTip`, and `onClick` action. The Custom components have full control over their rendering, state, and behavior
+- Use a context provider pattern when the FAB needs to manage shared state (e.g., opening panels, modals)
+- The custom component should render its own `Fab` element from MUI
+
+### Disabled FAB State
+
+You can disable a FAB and show a custom tooltip when it's disabled:
+
+```tsx title="packages/app/src/components/Root/Root.tsx"
+<GlobalFloatingActionButton
+  floatingButtons={[
+    {
+      icon: <CreateComponentIcon />,
+      label: 'Create',
+      toolTip: 'Create entity',
+      to: '/create',
+      isDisabled: true,
+      disabledToolTip: 'Creation is currently unavailable',
+      disabledToolTipKey: 'fab.create.disabled.tooltip',
+    },
+  ]}
+/>
+```
+
+When `isDisabled` is `true`:
+
+- The FAB will be visually disabled and non-interactive
+- The `disabledToolTip` (or `disabledToolTipKey` translation) will be shown instead of the regular tooltip
+- The `onClick` handler will not be triggered
 
 ### Translation Support
 

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/dev/ChatbotComponent.tsx
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/dev/ChatbotComponent.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+
+import ChatIcon from '@mui/icons-material/Chat';
+import CloseIcon from '@mui/icons-material/Close';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Fab from '@mui/material/Fab';
+import Tooltip from '@mui/material/Tooltip';
+
+interface ChatPanelContextType {
+  isOpen: boolean;
+  togglePanel: () => void;
+}
+
+const ChatPanelContext = createContext<ChatPanelContextType | undefined>(
+  undefined,
+);
+
+const useChatPanel = () => {
+  const context = useContext(ChatPanelContext);
+  if (!context) {
+    throw new Error('useChatPanel must be used within ChatPanelProvider');
+  }
+  return context;
+};
+
+export const ChatPanelProvider = ({ children }: PropsWithChildren<{}>) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const togglePanel = useCallback(() => {
+    setIsOpen(prev => !prev);
+  }, []);
+
+  return (
+    <ChatPanelContext.Provider value={{ isOpen, togglePanel }}>
+      {children}
+      {isOpen && (
+        <Typography
+          component="div"
+          style={{
+            position: 'fixed',
+            bottom: '80px',
+            right: '24px',
+            width: '350px',
+            height: '400px',
+            backgroundColor: 'white',
+            borderRadius: '8px',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+            zIndex: 1000,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Typography
+            component="div"
+            style={{
+              padding: '16px',
+              borderBottom: '1px solid #eee',
+              fontWeight: 'bold',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Typography component="span">Chat Panel</Typography>
+            <Button size="small" onClick={togglePanel}>
+              Close
+            </Button>
+          </Typography>
+          <Typography
+            component="div"
+            style={{ flex: 1, padding: '16px', overflowY: 'auto' }}
+          >
+            <Typography component="p">This is a custom chat panel!</Typography>
+            <Typography component="p">
+              It demonstrates how a custom FAB component can manage its own
+              state through context.
+            </Typography>
+            <Typography
+              component="p"
+              style={{ color: '#666', fontSize: '14px' }}
+            >
+              Have a nice day !!
+            </Typography>
+          </Typography>
+        </Typography>
+      )}
+    </ChatPanelContext.Provider>
+  );
+};
+
+// Custom FAB Component
+export const ChatFABComponent = () => {
+  const { isOpen, togglePanel } = useChatPanel();
+
+  return (
+    <Tooltip title={isOpen ? 'Close Chat' : 'Open Chat'} placement="left">
+      <Fab
+        size="small"
+        color={isOpen ? 'default' : 'primary'}
+        onClick={togglePanel}
+        aria-label={isOpen ? 'Close chat' : 'Open chat'}
+        sx={{
+          transition: 'all 0.3s ease',
+        }}
+      >
+        {isOpen ? <CloseIcon /> : <ChatIcon />}
+      </Fab>
+    </Tooltip>
+  );
+};

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/dev/index.tsx
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/dev/index.tsx
@@ -31,6 +31,7 @@ import {
   globalFloatingActionButtonPlugin,
   globalFloatingActionButtonTranslations,
 } from '../src';
+import { ChatFABComponent, ChatPanelProvider } from './ChatbotComponent';
 
 const mockFloatingButtons: FloatingActionButton[] = [
   {
@@ -88,6 +89,14 @@ const mockFloatingButtons: FloatingActionButton[] = [
     to: 'https://github.com/xyz',
     priority: 200,
     excludeOnPaths: ['/test-global-floating-action'],
+  },
+];
+
+const mockFloatingButtonsWithCustomComponent: FloatingActionButton[] = [
+  {
+    label: 'Chat',
+    Component: ChatFABComponent,
+    priority: -1,
   },
 ];
 
@@ -200,4 +209,15 @@ createDevApp()
       component: <ExampleComponent />,
     }),
   )
+  .addPage({
+    element: (
+      <ChatPanelProvider>
+        <ExampleComponent
+          floatingButtons={mockFloatingButtonsWithCustomComponent}
+        />
+      </ChatPanelProvider>
+    ),
+    title: 'Custom FAB Component',
+    path: '/test-custom-component-fab',
+  })
   .render();

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/report.api.md
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/report.api.md
@@ -6,6 +6,7 @@
 /// <reference types="react" />
 
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { ComponentType } from 'react';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 import { TranslationResource } from '@backstage/core-plugin-api/alpha';
@@ -50,6 +51,10 @@ export type FloatingActionButton = {
   priority?: number;
   visibleOnPaths?: string[];
   excludeOnPaths?: string[];
+  isDisabled?: boolean;
+  disabledToolTip?: string;
+  disabledToolTipKey?: string;
+  Component?: ComponentType<any>;
 };
 
 // @public

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/FABWithSubmenu.tsx
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/FABWithSubmenu.tsx
@@ -74,7 +74,7 @@ export const FABWithSubmenu = ({
     };
   }, [pathname]);
 
-  const handleClick = () => {
+  const handleToggle = () => {
     if (isMenuOpen) {
       setTimeout(() => {
         setIsMenuOpen(false);
@@ -104,7 +104,7 @@ export const FABWithSubmenu = ({
           <Fab
             size="medium"
             color="info"
-            onClick={handleClick}
+            onClick={handleToggle}
             aria-label="Menu"
             variant="circular"
             sx={{ zIndex: 1000 }}
@@ -118,6 +118,8 @@ export const FABWithSubmenu = ({
         </Typography>
       </Tooltip>
       {fabs?.map(fb => {
+        const FabComponent = fb.Component;
+
         return (
           <Slide
             key={fb.label}
@@ -129,13 +131,17 @@ export const FABWithSubmenu = ({
             timeout={500}
           >
             <Box>
-              <CustomFab
-                actionButton={fb}
-                t={t}
-                size="medium"
-                key={fb.label}
-                className={styles.button}
-              />
+              {FabComponent ? (
+                <FabComponent slot={slot} config={fb} />
+              ) : (
+                <CustomFab
+                  actionButton={fb}
+                  t={t}
+                  size="medium"
+                  key={fb.label}
+                  className={styles.button}
+                />
+              )}
             </Box>
           </Slide>
         );

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/FloatingButton.tsx
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/components/FloatingButton.tsx
@@ -89,6 +89,10 @@ export const FloatingButton = ({
       <FABWithSubmenu className={fabButton[slot]} fabs={fabs} slot={slot} />
     );
   } else {
+    const singleFab = fabs[0];
+    const FabComponent = singleFab.Component;
+
+    // If a custom FAB component is provided, render it instead of CustomFab
     fabDiv = (
       <div
         style={{
@@ -100,10 +104,14 @@ export const FloatingButton = ({
         id="floating-button"
         data-testid="floating-button"
       >
-        <CustomFab
-          actionButton={{ color: 'info', iconColor: 'white', ...fabs[0] }}
-          t={t}
-        />
+        {FabComponent ? (
+          <FabComponent slot={slot} config={singleFab} />
+        ) : (
+          <CustomFab
+            actionButton={{ color: 'info', iconColor: 'white', ...singleFab }}
+            t={t}
+          />
+        )}
       </div>
     );
   }

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/types.ts
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/src/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { ComponentType } from 'react';
+
 /**
  * Slot
  *
@@ -56,9 +58,26 @@ export type FloatingActionButton = {
   to?: string;
   toolTip?: string;
   toolTipKey?: string;
+  /**
+   * Priority for ordering buttons (lower number = higher priority)
+   * The FAB action with the lowest priority will be displayed on top of other FAB actions in the sub-menu
+   */
   priority?: number;
   visibleOnPaths?: string[];
   excludeOnPaths?: string[];
+  /**
+   * Whether the FAB is disabled
+   */
+  isDisabled?: boolean;
+  /**
+   * Tooltip to display when the FAB is disabled
+   */
+  disabledToolTip?: string;
+  disabledToolTipKey?: string;
+  /**
+   * Custom FAB component
+   */
+  Component?: ComponentType<any>;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHDHBUGS-1215

Solution description:

With this change, users can provide their custom FAB component while still being able to configure properties such as priority and slot. When a custom FAB is provided, users only need to configure the slot and priority in the config, the custom fab can encapsulate it's own tooltip and onClick actions 


Config for custom Component:
```
- mountPoint: global.floatingactionbutton/config
  importName: NullComponent
  config:
    Component: Chatbot
    priority: -1
```    
    
Chatbot
```
export const Chatbot = () => {
  const { isOpen, togglePanel } = useChatPanel();

  return (
    <Tooltip title={isOpen ? 'Close Chat' : 'Open Chat'} placement="left">
      <Fab
        size="small"
        color={isOpen ? 'default' : 'primary'}
        onClick={togglePanel}
        aria-label={isOpen ? 'Close chat' : 'Open chat'}
        sx={{
          transition: 'all 0.3s ease',
        }}
      >
        {isOpen ? <CloseIcon /> : <ChatIcon />}
      </Fab>
    </Tooltip>
  );
};
```


https://github.com/user-attachments/assets/933fac14-2ebc-48d4-8693-8a4dcee4a096


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
