### PR TITLE
fix(orchestrator): clear ActiveTextInput when API returns empty string

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-active-text-input-empty-string.md
+++ b/workspaces/orchestrator/.changeset/fix-active-text-input-empty-string.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Fix ActiveTextInput not clearing field when API returns empty string

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
@@ -129,10 +129,8 @@ export const ActiveTextInput: Widget<
             defaultValueSelector,
           );
 
-          // Only override if fetch returns a non-empty value
-          // This ensures static default remains as fallback when fetch returns empty
           if (
-            fetchedValue &&
+            typeof fetchedValue === 'string' &&
             fetchedValue !== 'null' &&
             value !== fetchedValue
           ) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The ActiveTextInput widget does not clear the field when the API returns an empty string "". It retains the previous/stale value instead of clearing. Fixed it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
