### PR TITLE
feat(orchestrator): improve permission denied error handling for workflow instances

### DIFF
--- a/workspaces/orchestrator/.changeset/rbac-permission-denied-panel.md
+++ b/workspaces/orchestrator/.changeset/rbac-permission-denied-panel.md
@@ -1,0 +1,12 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+feat: Improve permission denied error handling for workflow instances
+
+- Add PermissionDeniedPanel component for clean access denied UI
+- Improve backend error messages when user lacks instanceAdminView permission
+- Provide detailed error messages explaining why access is denied:
+  - When instance has no ownership info (external/legacy runs)
+  - When instance was created by another user

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/router.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/router.ts
@@ -25,6 +25,7 @@ import {
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 import type { Config } from '@backstage/config';
+import { NotAllowedError } from '@backstage/errors';
 import {
   AuthorizePermissionRequest,
   AuthorizePermissionResponse,
@@ -928,9 +929,29 @@ function setupInternalRoutes(
         // If not an admin, enforce initiatorEntity check
         if (!isUserAuthorizedForInstanceAdminView) {
           const instanceInitiatorEntity = instance.initiatorEntity;
+
+          // If the instance has no initiatorEntity recorded, we cannot determine ownership.
+          // This can happen for:
+          // 1. Workflow instances created before the initiatorEntity feature was added
+          // 2. Workflow instances started externally (not through Backstage)
+          // 3. Workflows that transform/overwrite their input variables
+          if (!instanceInitiatorEntity) {
+            throw new NotAllowedError(
+              `Access denied for instance ${instanceId}. ` +
+                `You have permission to view workflow '${workflowId}', but this workflow run ` +
+                `does not have ownership information recorded. Since we cannot verify you ` +
+                `initiated this run, the 'orchestrator.instanceAdminView' permission is required. ` +
+                `Contact your administrator to grant this permission.`,
+            );
+          }
+
           if (instanceInitiatorEntity !== initiatorEntity) {
-            throw new Error(
-              `Unauthorized to access instance ${instanceId} not initiated by user.`,
+            throw new NotAllowedError(
+              `Access denied for instance ${instanceId}. ` +
+                `This workflow run was initiated by '${instanceInitiatorEntity}', not by you ('${initiatorEntity}'). ` +
+                `With 'orchestrator.workflow' or 'orchestrator.workflow.${workflowId}' permissions, ` +
+                `you can only view instances you created. To view all instances, you need the ` +
+                `'orchestrator.instanceAdminView' permission.`,
             );
           }
         }

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -75,6 +75,7 @@ readonly "common.links": string;
 readonly "common.back": string;
 readonly "common.next": string;
 readonly "common.review": string;
+readonly "common.goBack": string;
 readonly "duration.aFewSeconds": string;
 readonly "duration.aSecond": string;
 readonly "duration.seconds": string;
@@ -163,6 +164,12 @@ readonly "tooltips.workflowDown": string;
 readonly "tooltips.suspended": string;
 readonly "tooltips.userNotAuthorizedAbort": string;
 readonly "reviewStep.hiddenFieldsNote": string;
+readonly "permissions.accessDenied": string;
+readonly "permissions.accessDeniedDescription": string;
+readonly "permissions.requiredPermission": string;
+readonly "permissions.contactAdmin": string;
+readonly "permissions.missingOwnership": string;
+readonly "permissions.notYourRun": string;
 readonly "stepperObjectField.error": string;
 readonly "formDecorator.error": string;
 readonly "aria.close": string;
@@ -178,7 +185,7 @@ export const orchestratorTranslations: TranslationResource<"plugin.orchestrator"
 // src/components/catalogComponents/CatalogTab.d.ts:1:22 - (ae-undocumented) Missing documentation for "IsOrchestratorCatalogTabAvailable".
 // src/components/catalogComponents/CatalogTab.d.ts:2:22 - (ae-undocumented) Missing documentation for "OrchestratorCatalogTab".
 // src/translations/index.d.ts:2:22 - (ae-undocumented) Missing documentation for "orchestratorTranslations".
-// src/translations/ref.d.ts:191:22 - (ae-undocumented) Missing documentation for "orchestratorTranslationRef".
+// src/translations/ref.d.ts:200:22 - (ae-undocumented) Missing documentation for "orchestratorTranslationRef".
 
 // (No @packageDocumentation comment for this package)
 

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
@@ -77,6 +77,11 @@ import { isNonNullable } from '../../utils/TypeGuards';
 import { buildUrl } from '../../utils/UrlUtils';
 import { BaseOrchestratorPage } from '../ui/BaseOrchestratorPage';
 import { InfoDialog } from '../ui/InfoDialog';
+import {
+  extractRequiredPermission,
+  isAccessDeniedError,
+  PermissionDeniedPanel,
+} from '../ui/PermissionDeniedPanel';
 import { WorkflowInstancePageContent } from './WorkflowInstancePageContent';
 
 const useStyles = makeStyles()(theme => ({
@@ -394,10 +399,31 @@ export const WorkflowInstancePage = () => {
     processName: value?.processName ?? '',
   });
 
+  // Check if this is a permission/access denied error
+  const isPermissionError = isAccessDeniedError(combinedError);
+  const requiredPermission = extractRequiredPermission(combinedError);
+
+  // Render permission denied panel or regular error panel
+  const renderError = () => {
+    if (!combinedError) return null;
+
+    if (isPermissionError) {
+      return (
+        <PermissionDeniedPanel
+          description={combinedError.message}
+          requiredPermission={requiredPermission}
+          onGoBack={() => navigate('/orchestrator')}
+        />
+      );
+    }
+
+    return <ResponseErrorPanel error={combinedError} />;
+  };
+
   return (
     <BaseOrchestratorPage title={title}>
       {loading ? <Progress /> : null}
-      {combinedError ? <ResponseErrorPanel error={combinedError} /> : null}
+      {renderError()}
       {!loading && isNonNullable(value) ? (
         <>
           <ContentHeader title="">

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/PermissionDeniedPanel.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/PermissionDeniedPanel.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { EmptyState } from '@backstage/core-components';
+
+import LockOutlined from '@mui/icons-material/LockOutlined';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
+
+import { useTranslation } from '../../hooks/useTranslation';
+
+const useStyles = makeStyles()(theme => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(4),
+  },
+  icon: {
+    fontSize: '4rem',
+    color: theme.palette.warning.main,
+    marginBottom: theme.spacing(2),
+  },
+  title: {
+    marginBottom: theme.spacing(1),
+    fontWeight: 500,
+  },
+  description: {
+    color: theme.palette.text.secondary,
+    textAlign: 'center',
+    maxWidth: '600px',
+    marginBottom: theme.spacing(3),
+  },
+  permissionBox: {
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(2),
+    marginBottom: theme.spacing(3),
+    fontFamily: 'monospace',
+    fontSize: '0.875rem',
+  },
+  actionButton: {
+    marginTop: theme.spacing(1),
+  },
+}));
+
+export interface PermissionDeniedPanelProps {
+  /** The title to display */
+  title?: string;
+  /** The description explaining why access is denied */
+  description?: string;
+  /** The permission(s) needed to access this resource */
+  requiredPermission?: string;
+  /** Optional action to go back */
+  onGoBack?: () => void;
+}
+
+/**
+ * A clean UI panel to display when a user doesn't have permission to access a resource.
+ * Similar to the Argo CD plugin's permission denied screen.
+ */
+export const PermissionDeniedPanel: React.FC<PermissionDeniedPanelProps> = ({
+  title,
+  description,
+  requiredPermission,
+  onGoBack,
+}) => {
+  const { t } = useTranslation();
+  const { classes } = useStyles();
+
+  const defaultTitle = t('permissions.accessDenied');
+  const defaultDescription = t('permissions.accessDeniedDescription');
+
+  return (
+    <EmptyState
+      missing="info"
+      title={title || defaultTitle}
+      description={
+        <Box className={classes.container}>
+          <LockOutlined className={classes.icon} />
+          <Typography variant="body1" className={classes.description}>
+            {description || defaultDescription}
+          </Typography>
+          {requiredPermission && (
+            <Box className={classes.permissionBox}>
+              <Typography variant="caption" color="textSecondary">
+                {t('permissions.requiredPermission')}:
+              </Typography>
+              <Typography variant="body2" component="code">
+                {requiredPermission}
+              </Typography>
+            </Box>
+          )}
+          <Typography variant="body2" color="textSecondary">
+            {t('permissions.contactAdmin')}
+          </Typography>
+          {onGoBack && (
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={onGoBack}
+              className={classes.actionButton}
+            >
+              {t('common.goBack')}
+            </Button>
+          )}
+        </Box>
+      }
+    />
+  );
+};
+
+PermissionDeniedPanel.displayName = 'PermissionDeniedPanel';
+
+/**
+ * Helper function to check if an error is an access denied error
+ */
+export const isAccessDeniedError = (error: Error | undefined): boolean => {
+  if (!error) return false;
+  const message = error.message?.toLowerCase() || '';
+  return (
+    message.includes('access denied') ||
+    message.includes('unauthorized') ||
+    message.includes('not allowed') ||
+    message.includes('permission')
+  );
+};
+
+/**
+ * Helper function to extract the required permission from an error message
+ */
+export const extractRequiredPermission = (
+  error: Error | undefined,
+): string | undefined => {
+  if (!error?.message) return undefined;
+  // Look for permission names in single quotes
+  const match = error.message.match(/'([^']*permission[^']*)'/i);
+  return match?.[1];
+};

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -78,6 +78,10 @@ const orchestratorTranslationDe = createTranslationMessages({
       'Details für die Workflow-ID {{id}} konnten nicht geladen werden.',
     'workflow.messages.areYouSureYouWantToRunThisWorkflow':
       'Sind Sie sicher, dass Sie diesen Workflow ausführen möchten?',
+    'workflow.messages.userNotAuthorizedExecute':
+      'Benutzer nicht berechtigt, den Workflow auszuführen.',
+    'workflow.messages.workflowDown':
+      'Der Workflow ist derzeit nicht verfügbar oder befindet sich in einem Fehlerzustand. Eine Ausführung kann fehlschlagen oder zu unerwarteten Ergebnissen führen.',
     'workflow.buttons.run': 'Ausführen',
     'workflow.buttons.runWorkflow': 'Workflow ausführen',
     'workflow.buttons.runAgain': 'Erneut ausführen',
@@ -102,6 +106,7 @@ const orchestratorTranslationDe = createTranslationMessages({
       'Es ist nicht möglich, die Ausführung abzubrechen, da sie bereits abgeschlossen wurde.',
     'run.status.completed': 'Ausführung abgeschlossen',
     'run.status.failed': 'Ausführung fehlgeschlagen {{time}}',
+    'run.status.failedAt': 'Ausführung fehlgeschlagen {{time}}',
     'run.status.aborted': 'Ausführung abgebrochen',
     'run.status.completedWithMessage':
       'Ausführung abgeschlossen {{time}} mit Nachricht',
@@ -155,6 +160,17 @@ const orchestratorTranslationDe = createTranslationMessages({
     'common.run': 'Ausführen',
     'common.next': 'Weiter',
     'common.review': 'Überprüfen',
+    'common.goBack': 'Zurück',
+    'permissions.accessDenied': 'Zugriff verweigert',
+    'permissions.accessDeniedDescription':
+      'Sie haben keine Berechtigung, diesen Workflow-Lauf anzuzeigen.',
+    'permissions.requiredPermission': 'Erforderliche Berechtigung',
+    'permissions.contactAdmin':
+      'Bitte kontaktieren Sie Ihren Administrator, um die erforderlichen Berechtigungen anzufordern.',
+    'permissions.missingOwnership':
+      'Für diesen Workflow-Lauf sind keine Eigentümerinformationen aufgezeichnet.',
+    'permissions.notYourRun':
+      'Dieser Workflow-Lauf wurde von einem anderen Benutzer initiiert.',
     'duration.aFewSeconds': 'ein paar Sekunden',
     'duration.aSecond': 'eine Sekunde',
     'duration.seconds': '{{count}} Sekunden',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -77,6 +77,10 @@ const orchestratorTranslationEs = createTranslationMessages({
       'Error al cargar los detalles para el ID de flujo de trabajo: {{id}}',
     'workflow.messages.areYouSureYouWantToRunThisWorkflow':
       '¿Estás seguro de que quieres ejecutar este flujo de trabajo?',
+    'workflow.messages.userNotAuthorizedExecute':
+      'Usuario no autorizado para ejecutar el flujo de trabajo.',
+    'workflow.messages.workflowDown':
+      'El flujo de trabajo está actualmente inactivo o en estado de error. Ejecutarlo ahora puede fallar o producir resultados inesperados.',
     'workflow.buttons.run': 'Ejecutar',
     'workflow.buttons.runWorkflow': 'Ejecutar flujo de trabajo',
     'workflow.buttons.runAgain': 'Ejecutar de nuevo',
@@ -101,6 +105,7 @@ const orchestratorTranslationEs = createTranslationMessages({
       'No es posible abortar la ejecución ya que ha sido completada.',
     'run.status.completed': 'Ejecución completada',
     'run.status.failed': 'La ejecución ha fallado {{time}}',
+    'run.status.failedAt': 'La ejecución ha fallado {{time}}',
     'run.status.aborted': 'La ejecución ha sido abortada',
     'run.status.completedWithMessage':
       'Ejecución completada {{time}} con mensaje',
@@ -156,6 +161,17 @@ const orchestratorTranslationEs = createTranslationMessages({
     'common.run': 'Ejecutar',
     'common.next': 'Siguiente',
     'common.review': 'Revisar',
+    'common.goBack': 'Volver',
+    'permissions.accessDenied': 'Acceso denegado',
+    'permissions.accessDeniedDescription':
+      'No tiene permiso para ver esta ejecución del flujo de trabajo.',
+    'permissions.requiredPermission': 'Permiso requerido',
+    'permissions.contactAdmin':
+      'Por favor, contacte a su administrador para solicitar los permisos necesarios.',
+    'permissions.missingOwnership':
+      'Esta ejecución del flujo de trabajo no tiene información de propiedad registrada.',
+    'permissions.notYourRun':
+      'Esta ejecución del flujo de trabajo fue iniciada por otro usuario.',
     'duration.aFewSeconds': 'unos segundos',
     'duration.aSecond': 'un segundo',
     'duration.seconds': '{{count}} segundos',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -72,14 +72,14 @@ const orchestratorTranslationFr = createTranslationMessages({
     'workflow.fields.workflowId': "ID d'exécution",
     'workflow.fields.workflowIdCopied':
       "ID d'exécution copié dans le presse-papiers",
-    'workflow.errors.retriggerFailed': 'Échec du re-déclenchement : {{reason}}',
+    'workflow.errors.retriggerFailed': 'Échec du re-déclenchement : {{reason}}',
     'workflow.errors.abortFailed':
-      "Échec de l'abandon : l'exécution a déjà été terminée.",
-    'workflow.errors.abortFailedWithReason': "Échec de l'abandon : {{reason}}",
+      "Échec de l'abandon : l'exécution a déjà été terminée.",
+    'workflow.errors.abortFailedWithReason': "Échec de l'abandon : {{reason}}",
     'workflow.errors.failedToLoadDetails':
-      "Échec du chargement des détails de l'ID de workflow : {{id}}",
+      "Échec du chargement des détails de l'ID de workflow : {{id}}",
     'workflow.messages.areYouSureYouWantToRunThisWorkflow':
-      'Êtes-vous sûr de vouloir exécuter ce workflow ?',
+      'Êtes-vous sûr de vouloir exécuter ce workflow ?',
     'workflow.messages.userNotAuthorizedExecute':
       "L'utilisateur n'est pas autorisé à exécuter le workflow.",
     'workflow.messages.workflowDown':
@@ -108,21 +108,21 @@ const orchestratorTranslationFr = createTranslationMessages({
       "Il n'est pas possible d'interrompre l'exécution car elle est déjà terminée.",
     'run.status.completed': 'Exécution terminée',
     'run.status.failed': "L'exécution a échoué {{time}}",
+    'run.status.failedAt': "L'exécution a échoué {{time}}",
     'run.status.aborted': "L'exécution a été interrompue",
     'run.status.completedWithMessage':
       'Exécution terminée {{time}} avec message',
-    'run.status.failedAt': "L'exécution a échoué {{time}}",
     'run.status.completedAt': 'Exécution terminée {{time}}',
     'run.status.running':
       "Le flux de travail est en cours d'exécution. Démarré {{time}}",
     'run.status.runningWaitingAtNode':
-      "Le workflow est en cours d'exécution – en attente au nœud {{node}} depuis {{formattedTime}}",
+      "Le workflow est en cours d'exécution – en attente au nœud {{node}} depuis {{formattedTime}}",
     'run.status.workflowIsRunning':
       "Le flux de travail est en cours d'exécution. Démarré {{time}}",
     'run.status.noAdditionalInfo':
       "Le flux de travail n'a fourni aucune information supplémentaire sur le statut.",
     'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete':
-      'Les résultats seront affichés ici une fois l’exécution terminée.',
+      "Les résultats seront affichés ici une fois l'exécution terminée.",
     'run.retrigger': 'Re-déclencher',
     'run.viewVariables': 'Afficher les variables',
     'run.suggestedNextWorkflow': 'Prochain flux de travail suggéré',
@@ -162,6 +162,30 @@ const orchestratorTranslationFr = createTranslationMessages({
     'common.next': 'Suivant',
     'common.review': 'Revue',
     'common.unavailable': '---',
+    'common.goBack': 'Retour',
+    'permissions.accessDenied': 'Accès refusé',
+    'permissions.accessDeniedDescription':
+      "Vous n'avez pas la permission de visualiser cette exécution de workflow.",
+    'permissions.requiredPermission': 'Permission requise',
+    'permissions.contactAdmin':
+      'Veuillez contacter votre administrateur pour demander les permissions nécessaires.',
+    'permissions.missingOwnership':
+      "Cette exécution de workflow n'a pas d'informations de propriété enregistrées.",
+    'permissions.notYourRun':
+      'Cette exécution de workflow a été initiée par un autre utilisateur.',
+    'duration.aFewSeconds': 'quelques secondes',
+    'duration.aSecond': 'une seconde',
+    'duration.seconds': '{{count}} secondes',
+    'duration.aMinute': 'une minute',
+    'duration.minutes': '{{count}} minutes',
+    'duration.anHour': 'une heure',
+    'duration.hours': '{{count}} heures',
+    'duration.aDay': 'un jour',
+    'duration.days': '{{count}} jours',
+    'duration.aMonth': 'un mois',
+    'duration.months': '{{count}} mois',
+    'duration.aYear': 'un an',
+    'duration.years': '{{count}} ans',
     'stepperObjectField.error':
       "Le champ d'objet Stepper n'est pas pris en charge pour les schémas qui ne contiennent pas de propriétés",
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -109,10 +109,10 @@ const orchestratorTranslationIt = createTranslationMessages({
       "Non è possibile interrompere l'esecuzione poiché è già stata completata.",
     'run.status.completed': 'Esecuzione completata',
     'run.status.failed': 'Esecuzione non riuscita {{time}}',
+    'run.status.failedAt': 'Esecuzione non riuscita {{time}}',
     'run.status.aborted': 'Esecuzione interrotta',
     'run.status.completedWithMessage':
       'Esecuzione completata {{time}} con messaggio',
-    'run.status.failedAt': 'Esecuzione non riuscita {{time}}',
     'run.status.completedAt': 'Esecuzione completata {{time}}',
     'run.status.running':
       'Flusso di lavoro in esecuzione. Avviato alle {{time}}',
@@ -163,6 +163,30 @@ const orchestratorTranslationIt = createTranslationMessages({
     'common.next': 'Successivo',
     'common.review': 'Revisione',
     'common.unavailable': '---',
+    'common.goBack': 'Torna indietro',
+    'permissions.accessDenied': 'Accesso negato',
+    'permissions.accessDeniedDescription':
+      'Non hai il permesso di visualizzare questa esecuzione del workflow.',
+    'permissions.requiredPermission': 'Permesso richiesto',
+    'permissions.contactAdmin':
+      'Contatta il tuo amministratore per richiedere i permessi necessari.',
+    'permissions.missingOwnership':
+      'Questa esecuzione del workflow non ha informazioni di proprietà registrate.',
+    'permissions.notYourRun':
+      'Questa esecuzione del workflow è stata avviata da un altro utente.',
+    'duration.aFewSeconds': 'alcuni secondi',
+    'duration.aSecond': 'un secondo',
+    'duration.seconds': '{{count}} secondi',
+    'duration.aMinute': 'un minuto',
+    'duration.minutes': '{{count}} minuti',
+    'duration.anHour': "un'ora",
+    'duration.hours': '{{count}} ore',
+    'duration.aDay': 'un giorno',
+    'duration.days': '{{count}} giorni',
+    'duration.aMonth': 'un mese',
+    'duration.months': '{{count}} mesi',
+    'duration.aYear': 'un anno',
+    'duration.years': '{{count}} anni',
     'stepperObjectField.error':
       "Il campo dell'oggetto Stepper non è supportato per lo schema che non contiene proprietà",
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -191,6 +191,18 @@ export const orchestratorMessages = {
     next: 'Next',
     review: 'Review',
     unavailable: '---',
+    goBack: 'Go back',
+  },
+  permissions: {
+    accessDenied: 'Access Denied',
+    accessDeniedDescription:
+      'You do not have permission to view this workflow run.',
+    requiredPermission: 'Required permission',
+    contactAdmin:
+      'Please contact your administrator to request the necessary permissions.',
+    missingOwnership:
+      'This workflow run does not have ownership information recorded.',
+    notYourRun: 'This workflow run was initiated by another user.',
   },
   duration: {
     aFewSeconds: 'a few seconds',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR improves the user experience when a user lacks permission to view a workflow instance. Instead of showing a generic error, users now see a clean "Access Denied" panel with actionable information.

**Problem**

When RBAC is enabled and a user tries to view a workflow instance without the orchestrator.instanceAdminView permission, they would see a confusing generic error. This was particularly problematic for:

- Workflow instances created externally (not through Backstage)
- Legacy workflow instances created before the initiatorEntity feature was added
- Instances created by other users

**Solution**:

**Backend (orchestrator-backend):**

- Improved error messages when access is denied due to missing ownership info or different initiator
- Error messages now explain:
          1. Which permission the user has (orchestrator.workflow or orchestrator.workflow.[workflowId])
          2. Why access is denied (missing ownership info or different initiator)
          3. What permission is needed (orchestrator.instanceAdminView)

**Frontend (orchestrator):**

- Added new PermissionDeniedPanel component for clean access denied UI
- Shows a lock icon, detailed description, required permission, and "Go back" button

Screenshot:

Access Denied (without instanceAdminView):

User has orchestrator.workflow.yamlgreet permission but lacks instanceAdminView. When accessing a workflow instance created externally (without initiatorEntity ownership info), the new PermissionDeniedPanel is displayed 

<img width="1728" height="1044" alt="Screenshot 2026-01-12 at 2 39 54 PM" src="https://github.com/user-attachments/assets/c1c5dabc-d676-43e2-a0c7-1f2d7f8b3cfc" />

----------

After adding orchestrator.instanceAdminView permission to the user's role, they can now successfully view all workflow instance details - including those created externally or by other users.

<img width="1704" height="1044" alt="Screenshot 2026-01-12 at 2 40 42 PM" src="https://github.com/user-attachments/assets/06fa07f1-90e0-4d1e-ae48-a73845bf99e1" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
