### PR TITLE
chore(openshift-image-registry): add missing BUI dependency

### DIFF
--- a/workspaces/openshift-image-registry/packages/app/package.json
+++ b/workspaces/openshift-image-registry/packages/app/package.json
@@ -42,6 +42,7 @@
     "@backstage/plugin-techdocs-react": "^1.3.5",
     "@backstage/plugin-user-settings": "^0.8.29",
     "@backstage/theme": "^0.7.0",
+    "@backstage/ui": "^0.9.1",
     "@mui/icons-material": "5.18.0",
     "@mui/lab": "5.0.0-alpha.177",
     "@mui/material": "5.18.0",

--- a/workspaces/openshift-image-registry/packages/app/src/index.tsx
+++ b/workspaces/openshift-image-registry/packages/app/src/index.tsx
@@ -17,5 +17,6 @@
 import '@backstage/cli/asset-types';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import '@backstage/ui/css/styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/dev/index.tsx
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/dev/index.tsx
@@ -17,6 +17,9 @@
 import { createDevApp } from '@backstage/dev-utils';
 import { TestApiProvider } from '@backstage/test-utils';
 
+// eslint-disable-next-line @backstage/no-ui-css-imports-in-non-frontend
+import '@backstage/ui/css/styles.css';
+
 import ExtensionIcon from '@mui/icons-material/Extension';
 
 import { getAllThemes } from '@red-hat-developer-hub/backstage-plugin-theme';

--- a/workspaces/openshift-image-registry/plugins/openshift-image-registry/package.json
+++ b/workspaces/openshift-image-registry/plugins/openshift-image-registry/package.json
@@ -55,6 +55,7 @@
     "@backstage/core-app-api": "^1.19.2",
     "@backstage/dev-utils": "^1.1.17",
     "@backstage/test-utils": "^1.7.13",
+    "@backstage/ui": "^0.9.1",
     "@mui/icons-material": "^6.1.6",
     "@red-hat-developer-hub/backstage-plugin-theme": "^0.11.0",
     "@spotify/prettier-config": "^15.0.0",

--- a/workspaces/openshift-image-registry/yarn.lock
+++ b/workspaces/openshift-image-registry/yarn.lock
@@ -1640,9 +1640,9 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 934b0a0460f7d06637d93fcd1a44ac49adc33518d17253b5a0b55ff4cb90a45d8fe78bf034b448911dbec7aff2a90b918697559f78d21c99ff8dbadae9565b55
+  version: 7.28.6
+  resolution: "@babel/runtime@npm:7.28.6"
+  checksum: 42d8a868c2fc2e9a77927945a6daa7ec03c7ea49e611e0d15442933cdabb12f20e3a6849c729259076c10a4247adec229331d1f94c2d0073ea0979d7853e29fd
   languageName: node
   linkType: hard
 
@@ -3908,7 +3908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.9.0":
+"@backstage/ui@npm:^0.9.0, @backstage/ui@npm:^0.9.1":
   version: 0.9.1
   resolution: "@backstage/ui@npm:0.9.1"
   dependencies:
@@ -4837,41 +4837,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.6.0":
-  version: 1.6.8
-  resolution: "@floating-ui/core@npm:1.6.8"
+"@floating-ui/core@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@floating-ui/core@npm:1.7.3"
   dependencies:
-    "@floating-ui/utils": ^0.2.8
-  checksum: 82faa6ea9d57e466779324e51308d6d49c098fb9d184a08d9bb7f4fad83f08cc070fc491f8d56f0cad44a16215fb43f9f829524288413e6c33afcb17303698de
+    "@floating-ui/utils": ^0.2.10
+  checksum: 5adfb28ddfa1776ec83516439256b9026e5d62b5413f62ae51e50a870cf0df4bea9abf72aacc0610ee84bc00e85883d0d32f2a0976ee7fa89728a717a7494f27
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.0":
-  version: 1.6.12
-  resolution: "@floating-ui/dom@npm:1.6.12"
+"@floating-ui/dom@npm:^1.7.4":
+  version: 1.7.4
+  resolution: "@floating-ui/dom@npm:1.7.4"
   dependencies:
-    "@floating-ui/core": ^1.6.0
-    "@floating-ui/utils": ^0.2.8
-  checksum: 956514ed100c0c853e73ace9e3c877b7e535444d7c31326f687a7690d49cb1e59ef457e9c93b76141aea0d280e83ed5a983bb852718b62eea581f755454660f6
+    "@floating-ui/core": ^1.7.3
+    "@floating-ui/utils": ^0.2.10
+  checksum: 806923e6f5b09e024c366070f2115a4db6e8ad28462bac29cd075170a6f7d900497da3ee542439bd0770b8e2fff12b636cc30873d1c82e9ec4a487870b080643
   languageName: node
   linkType: hard
 
 "@floating-ui/react-dom@npm:^2.0.0, @floating-ui/react-dom@npm:^2.0.8":
-  version: 2.1.2
-  resolution: "@floating-ui/react-dom@npm:2.1.2"
+  version: 2.1.6
+  resolution: "@floating-ui/react-dom@npm:2.1.6"
   dependencies:
-    "@floating-ui/dom": ^1.0.0
+    "@floating-ui/dom": ^1.7.4
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 25bb031686e23062ed4222a8946e76b3f9021d40a48437bd747233c4964a766204b8a55f34fa8b259839af96e60db7c6e3714d81f1de06914294f90e86ffbc48
+  checksum: 24ff266806cd4cba6ad066f0eda7b99583f68af877f41df0b2a8d10a392692e3a1c1d666ebb75571a060818ede940bae59d833aa517ed538f7dba9dddd9991ae
   languageName: node
   linkType: hard
 
-"@floating-ui/utils@npm:^0.2.8":
-  version: 0.2.8
-  resolution: "@floating-ui/utils@npm:0.2.8"
-  checksum: deb98bba017c4e073c7ad5740d4dec33a4d3e0942d412e677ac0504f3dade15a68fc6fd164d43c93c0bb0bcc5dc5015c1f4080dfb1a6161140fe660624f7c875
+"@floating-ui/utils@npm:^0.2.10":
+  version: 0.2.10
+  resolution: "@floating-ui/utils@npm:0.2.10"
+  checksum: ffc4c24a46a665cfd0337e9aaf7de8415b572f8a0f323af39175e4b575582aed13d172e7f049eedeece9eaf022bad019c140a2d192580451984ae529bdf1285c
   languageName: node
   linkType: hard
 
@@ -5520,12 +5520,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@internationalized/date@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "@internationalized/date@npm:3.10.0"
+"@internationalized/date@npm:^3.10.0, @internationalized/date@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "@internationalized/date@npm:3.10.1"
   dependencies:
     "@swc/helpers": ^0.5.0
-  checksum: cb6a33622ad368e42fd2d05f9c9111644d0861ea6c9305d7d73b85ddb0cd9259c5af37087d8ed05a2a07d76b798b386c89fb85a2dd567b0f4b0cc19770e0d42b
+  checksum: ed71692398ec9dbb33a93e2f6c0952627f1af838078af471f6e982769ad33dbe19faf4ce659bb086ca442be5e7777d300398f076fecd93d1c32a4d4a8f1d7667
   languageName: node
   linkType: hard
 
@@ -8753,19 +8753,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/focus@npm:^3.21.2":
-  version: 3.21.2
-  resolution: "@react-aria/focus@npm:3.21.2"
+"@react-aria/focus@npm:^3.21.2, @react-aria/focus@npm:^3.21.3":
+  version: 3.21.3
+  resolution: "@react-aria/focus@npm:3.21.3"
   dependencies:
-    "@react-aria/interactions": ^3.25.6
-    "@react-aria/utils": ^3.31.0
+    "@react-aria/interactions": ^3.26.0
+    "@react-aria/utils": ^3.32.0
     "@react-types/shared": ^3.32.1
     "@swc/helpers": ^0.5.0
     clsx: ^2.0.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: c6a773f2add800cafabae654dcb4aee51a7d205911de0fc7b0c9417cab5644ca7c8358749d92abe0295be2aa199f864b06071547def4c975e79fbc0dc1aec9da
+  checksum: 1b9c0d3ca82f3e3e74caa121a596da4f967a84bce8a12a9ecf3e5a4279948cf856cf7cd8932d3098a80664de35ef27d0e091624d5c5659e79b8f30fd4f14933e
   languageName: node
   linkType: hard
 
@@ -8830,38 +8830,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/i18n@npm:^3.12.13":
-  version: 3.12.13
-  resolution: "@react-aria/i18n@npm:3.12.13"
+"@react-aria/i18n@npm:^3.12.13, @react-aria/i18n@npm:^3.12.14":
+  version: 3.12.14
+  resolution: "@react-aria/i18n@npm:3.12.14"
   dependencies:
-    "@internationalized/date": ^3.10.0
+    "@internationalized/date": ^3.10.1
     "@internationalized/message": ^3.1.8
     "@internationalized/number": ^3.6.5
     "@internationalized/string": ^3.2.7
     "@react-aria/ssr": ^3.9.10
-    "@react-aria/utils": ^3.31.0
+    "@react-aria/utils": ^3.32.0
     "@react-types/shared": ^3.32.1
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 4b0d8dd0f62702bc1e55793ef60825c6c1ad8d7fe33d6bd979ad50b47441ba98b2599565df997b5665092c3858d3e40a72e4dc74fb087a49b70593e72a7bf9e4
+  checksum: 42794577654660e2ce0e14590313d7b8bab409557ce7edb8631a29f790f70cb0d283bc0e350145e6309263af39858e5d081135f5f7f4da7c3fd52b72c96e0c47
   languageName: node
   linkType: hard
 
-"@react-aria/interactions@npm:^3.25.6":
-  version: 3.25.6
-  resolution: "@react-aria/interactions@npm:3.25.6"
+"@react-aria/interactions@npm:^3.25.6, @react-aria/interactions@npm:^3.26.0":
+  version: 3.26.0
+  resolution: "@react-aria/interactions@npm:3.26.0"
   dependencies:
     "@react-aria/ssr": ^3.9.10
-    "@react-aria/utils": ^3.31.0
+    "@react-aria/utils": ^3.32.0
     "@react-stately/flags": ^3.1.2
     "@react-types/shared": ^3.32.1
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: e3965a550b6e2caf7b4e0c7375fe93ca75ffd836e1c69130cdc234376f40ed91da963381e5a28b815f1d1be5901edb63e6eb80c31c8af8a0b3239b243c65a9bf
+  checksum: 3e174fc3eb332195bfa4904334aaad1253a0573dee8901a4170cb019b6ca00c90675dd86e3960f63cee3f7bfdddf5ae4864f24eb02ce5f88d08bbf1d6b53c518
   languageName: node
   linkType: hard
 
@@ -9002,16 +9002,16 @@ __metadata:
   linkType: hard
 
 "@react-aria/overlays@npm:^3.30.0":
-  version: 3.30.0
-  resolution: "@react-aria/overlays@npm:3.30.0"
+  version: 3.31.0
+  resolution: "@react-aria/overlays@npm:3.31.0"
   dependencies:
-    "@react-aria/focus": ^3.21.2
-    "@react-aria/i18n": ^3.12.13
-    "@react-aria/interactions": ^3.25.6
+    "@react-aria/focus": ^3.21.3
+    "@react-aria/i18n": ^3.12.14
+    "@react-aria/interactions": ^3.26.0
     "@react-aria/ssr": ^3.9.10
-    "@react-aria/utils": ^3.31.0
-    "@react-aria/visually-hidden": ^3.8.28
-    "@react-stately/overlays": ^3.6.20
+    "@react-aria/utils": ^3.32.0
+    "@react-aria/visually-hidden": ^3.8.29
+    "@react-stately/overlays": ^3.6.21
     "@react-types/button": ^3.14.1
     "@react-types/overlays": ^3.9.2
     "@react-types/shared": ^3.32.1
@@ -9019,7 +9019,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 93d5eae156ba0b52ca4ff52283290fb4e9f56ca7f4afe9914e0bd1471a13aa3ebce3d74c8a357c04c72119100e3045ae9bfbb09ac9a7452901c055d66610028f
+  checksum: 5dbda76594f5cc4b7a79ca7b3da28f7971cfe12c33e325f6195eeadc6f13c5709b563799098ac50ba1bd76c1eb9277e459e814b93381b379e9065360fe17572f
   languageName: node
   linkType: hard
 
@@ -9374,20 +9374,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/utils@npm:^3.31.0":
-  version: 3.31.0
-  resolution: "@react-aria/utils@npm:3.31.0"
+"@react-aria/utils@npm:^3.31.0, @react-aria/utils@npm:^3.32.0":
+  version: 3.32.0
+  resolution: "@react-aria/utils@npm:3.32.0"
   dependencies:
     "@react-aria/ssr": ^3.9.10
     "@react-stately/flags": ^3.1.2
-    "@react-stately/utils": ^3.10.8
+    "@react-stately/utils": ^3.11.0
     "@react-types/shared": ^3.32.1
     "@swc/helpers": ^0.5.0
     clsx: ^2.0.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 21cdda60eb60509f943302972cd573a88c2ac968447b2bf6508aa392abca1ad5a21e2c826e1d68b3c991e328b8456d6d8d87a75f6c22a539e47c1441ba0e4bbe
+  checksum: f631012b146b428bca75377310e6d2e06a700da9c3325e82ad2ce8cc12b44bcada53840baf4b9782bd6f19bacf9d7fa5cebb9af66d7ad32a6d0b2c9b01a6f42f
   languageName: node
   linkType: hard
 
@@ -9408,18 +9408,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/visually-hidden@npm:^3.8.28":
-  version: 3.8.28
-  resolution: "@react-aria/visually-hidden@npm:3.8.28"
+"@react-aria/visually-hidden@npm:^3.8.28, @react-aria/visually-hidden@npm:^3.8.29":
+  version: 3.8.29
+  resolution: "@react-aria/visually-hidden@npm:3.8.29"
   dependencies:
-    "@react-aria/interactions": ^3.25.6
-    "@react-aria/utils": ^3.31.0
+    "@react-aria/interactions": ^3.26.0
+    "@react-aria/utils": ^3.32.0
     "@react-types/shared": ^3.32.1
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 053d1950a8eb75bc3fb1a4b3e11c3db8ecdb23888d1053dafe6fbacc390200cec47a966522786c24889eae9aa273f8ff6ecf317e7a67b13fb494384069fb75dd
+  checksum: 5fe5efd37421c63787da8aab2ec93d65a77f47069f3feab06b802a0e5ccad7b6bbf00ab80cdd1527bf88701e687297602a1c73072b3051023db39cb87592c02c
   languageName: node
   linkType: hard
 
@@ -9691,16 +9691,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/overlays@npm:^3.6.20":
-  version: 3.6.20
-  resolution: "@react-stately/overlays@npm:3.6.20"
+"@react-stately/overlays@npm:^3.6.20, @react-stately/overlays@npm:^3.6.21":
+  version: 3.6.21
+  resolution: "@react-stately/overlays@npm:3.6.21"
   dependencies:
-    "@react-stately/utils": ^3.10.8
+    "@react-stately/utils": ^3.11.0
     "@react-types/overlays": ^3.9.2
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 652a5d3207631e63acd4b9f1a093f7570cbdc33924a02bea4bea2ff3b5e3c3497e92b4b2a3a2fb52136fa06ddfb890db8580ec509387043e0243d801f5e911a8
+  checksum: 2edd3e5b63b628472c7d8ebe1b8ed3db204d678f0d5980018c3b388ee6469c7d1147e920ada1365623fc82147b2b9f46008ce7baee1b1f2796332a7baf5dd6bc
   languageName: node
   linkType: hard
 
@@ -9864,14 +9864,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/utils@npm:^3.10.8":
-  version: 3.10.8
-  resolution: "@react-stately/utils@npm:3.10.8"
+"@react-stately/utils@npm:^3.10.8, @react-stately/utils@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "@react-stately/utils@npm:3.11.0"
   dependencies:
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 3d0ed0c1a73c06e50775a7037a4f88f12505313f6caa431d87c8ef20cfec63fedb60be294e6986d1ef5f5d85e5e7b1e2794f5971988561dc1ae78fc40e432c5c
+  checksum: a5232b6ad60f5171254fab1ca4e3f51328766d8c2868bc37fb052458580491dd466cfc71d88fb0c55c879d2621bd6d93543c6e361e2829e5fcb305bcb463ca2f
   languageName: node
   linkType: hard
 
@@ -10218,6 +10218,7 @@ __metadata:
     "@backstage/dev-utils": ^1.1.17
     "@backstage/test-utils": ^1.7.13
     "@backstage/theme": ^0.7.0
+    "@backstage/ui": ^0.9.1
     "@emotion/styled": ^11.13.0
     "@ianvs/prettier-plugin-sort-imports": ^4.3.1
     "@material-ui/core": ^4.9.13
@@ -14264,6 +14265,7 @@ __metadata:
     "@backstage/plugin-user-settings": ^0.8.29
     "@backstage/test-utils": ^1.7.13
     "@backstage/theme": ^0.7.0
+    "@backstage/ui": ^0.9.1
     "@mui/icons-material": 5.18.0
     "@mui/lab": 5.0.0-alpha.177
     "@mui/material": 5.18.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When testing the global-header workspace I noticed this white background behind the app in the dark theme and checked openshift-image-registry as well:

Before:

<img width="1722" height="1307" alt="Screenshot From 2026-01-13 00-35-43" src="https://github.com/user-attachments/assets/7e7a8b7c-b853-4f60-bf9f-ff7a7992ff87" />

With this PR:

<img width="1722" height="1307" alt="Screenshot From 2026-01-13 00-35-30" src="https://github.com/user-attachments/assets/29a9c799-1acd-4ca9-bead-20474027ff62" />

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
