### PR TITLE
chore(repo): update better-sqlite3 to Backstage 1.42+ aligned version

### DIFF
--- a/workspaces/adoption-insights/packages/backend/package.json
+++ b/workspaces/adoption-insights/packages/backend/package.json
@@ -47,7 +47,7 @@
     "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/adoption-insights/yarn.lock
+++ b/workspaces/adoption-insights/yarn.lock
@@ -15984,7 +15984,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "workspace:^"
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16157,17 +16157,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/ai-integrations/packages/backend/package.json
+++ b/workspaces/ai-integrations/packages/backend/package.json
@@ -49,7 +49,7 @@
     "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-catalog-techdoc-url-reader-backend": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/ai-integrations/yarn.lock
+++ b/workspaces/ai-integrations/yarn.lock
@@ -16319,7 +16319,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-model-catalog": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-catalog-techdoc-url-reader-backend": "workspace:^"
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16492,17 +16492,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/extensions/packages/backend/package.json
+++ b/workspaces/extensions/packages/backend/package.json
@@ -49,7 +49,7 @@
     "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-extensions-backend": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/extensions/yarn.lock
+++ b/workspaces/extensions/yarn.lock
@@ -16616,7 +16616,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-extensions-backend": "workspace:^"
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16790,17 +16790,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/global-header/packages/backend/package.json
+++ b/workspaces/global-header/packages/backend/package.json
@@ -50,7 +50,7 @@
     "@backstage/plugin-signals-backend": "^0.3.10",
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/global-header/yarn.lock
+++ b/workspaces/global-header/yarn.lock
@@ -16383,7 +16383,7 @@ __metadata:
     "@backstage/plugin-signals-backend": ^0.3.10
     "@backstage/plugin-techdocs-backend": ^2.1.2
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16557,17 +16557,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/homepage/packages/backend/package.json
+++ b/workspaces/homepage/packages/backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.17",
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/homepage/yarn.lock
+++ b/workspaces/homepage/yarn.lock
@@ -15372,7 +15372,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": ^1.3.17
     "@backstage/plugin-techdocs-backend": ^2.1.2
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -15546,17 +15546,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/lightspeed/packages/backend/package.json
+++ b/workspaces/lightspeed/packages/backend/package.json
@@ -46,7 +46,7 @@
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "@red-hat-developer-hub/backstage-plugin-lightspeed-backend": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -16173,7 +16173,7 @@ __metadata:
     "@backstage/plugin-techdocs-backend": ^2.1.2
     "@red-hat-developer-hub/backstage-plugin-lightspeed-backend": "workspace:^"
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16367,17 +16367,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/mcp-integrations/packages/backend/package.json
+++ b/workspaces/mcp-integrations/packages/backend/package.json
@@ -49,7 +49,7 @@
     "@red-hat-developer-hub/backstage-plugin-software-catalog-mcp-tool": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-techdocs-mcp-tool": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/mcp-integrations/yarn.lock
+++ b/workspaces/mcp-integrations/yarn.lock
@@ -15815,7 +15815,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-software-catalog-mcp-tool": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-techdocs-mcp-tool": "workspace:^"
     app: "link:../app"
-    better-sqlite3: "npm:^9.0.0"
+    better-sqlite3: "npm:^12.0.0"
     node-gyp: "npm:^10.0.0"
     pg: "npm:^8.11.3"
   languageName: unknown
@@ -15993,17 +15993,6 @@ __metadata:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
   checksum: 10/2662e321237624d5813a7b97528dfc11fc5110b068d57f4096de82d7136e7e4a4b722a2a4266ddfb5095070712fd3d2542f6212ccb68e2d3eb2042498269e1cf
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10/06b3d95221071a06c2e22a9746d9b7049c0bce7962e5e3290ccf088fffbf4d4d52868f0d98b8ae2565fe33b1adab89823145f23c6f6eb63ecc4fc1b883f9082c
   languageName: node
   linkType: hard
 

--- a/workspaces/openshift-image-registry/packages/backend/package.json
+++ b/workspaces/openshift-image-registry/packages/backend/package.json
@@ -44,7 +44,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.17",
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3",
     "winston": "^3.2.1"

--- a/workspaces/openshift-image-registry/yarn.lock
+++ b/workspaces/openshift-image-registry/yarn.lock
@@ -14910,7 +14910,7 @@ __metadata:
     "@types/express-serve-static-core": ^4.17.5
     "@types/luxon": ^2.0.4
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
     winston: ^3.2.1
@@ -15020,17 +15020,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/orchestrator/packages/backend/package.json
+++ b/workspaces/orchestrator/packages/backend/package.json
@@ -53,7 +53,7 @@
     "@red-hat-developer-hub/backstage-plugin-orchestrator-backend": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "custom-authentication-provider-module-backend": "workspace:^",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3",

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -18265,7 +18265,7 @@ __metadata:
     "@types/express-serve-static-core": ^4.17.5
     "@types/luxon": ^2.0.4
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     custom-authentication-provider-module-backend: "workspace:^"
     node-gyp: ^10.0.0
     pg: ^8.11.3
@@ -18468,17 +18468,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: 39141f425a661fcb6ad413c791132c58463026f30d652a672ed9e0fa9fd286021826c0d2c3700762d6bafcccef8de5af1f0fb79eb8c2f31f005f7f0b47069292
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/quickstart/packages/backend/package.json
+++ b/workspaces/quickstart/packages/backend/package.json
@@ -47,7 +47,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.17",
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/quickstart/yarn.lock
+++ b/workspaces/quickstart/yarn.lock
@@ -15973,7 +15973,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": ^1.3.17
     "@backstage/plugin-techdocs-backend": ^2.1.2
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16147,17 +16147,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/scorecard/packages/backend/package.json
+++ b/workspaces/scorecard/packages/backend/package.json
@@ -50,7 +50,7 @@
     "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-openssf": "workspace:^",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/scorecard/yarn.lock
+++ b/workspaces/scorecard/yarn.lock
@@ -16470,7 +16470,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-openssf": "workspace:^"
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -16623,17 +16623,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 

--- a/workspaces/theme/packages/backend/package.json
+++ b/workspaces/theme/packages/backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.17",
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/theme/yarn.lock
+++ b/workspaces/theme/yarn.lock
@@ -15465,7 +15465,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": ^1.3.17
     "@backstage/plugin-techdocs-backend": ^2.1.2
     app: "link:../app"
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^12.0.0
     node-gyp: ^10.0.0
     pg: ^8.11.3
   languageName: unknown
@@ -15639,17 +15639,6 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update multiple workspaces to the better-sqlite3 version that was used since Backstage 1.42, see https://backstage.github.io/upgrade-helper/?from=1.41.0&to=1.42.0&yarnPlugin=0

This will also help with the Backstage 1.46 upgrade because this outdated better-sqlite3 version doesn't work with Node 24 anymore.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
