### PR TITLE
chore(scorecard): exclude openssf module for now from the linked plugins

### DIFF
--- a/workspaces/scorecard/.changeset/config.json
+++ b/workspaces/scorecard/.changeset/config.json
@@ -2,7 +2,16 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@red-hat-developer-hub/*"]],
+  "fixed": [
+    [
+      "@red-hat-developer-hub/backstage-plugin-scorecard",
+      "@red-hat-developer-hub/backstage-plugin-scorecard-backend",
+      "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-github",
+      "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira",
+      "@red-hat-developer-hub/backstage-plugin-scorecard-common",
+      "@red-hat-developer-hub/backstage-plugin-scorecard-node"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The goal is to release scorecard frontend and backend and core modules (GitHub and Jira) together and release an openssf 0.1 for now. See #1956

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
