### PR TITLE
fix(orchestrator): prevent form submission on Enter in ActiveMultiSelect

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-multiselect-enter-key.md
+++ b/workspaces/orchestrator/.changeset/fix-multiselect-enter-key.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Fixed ActiveMultiSelect Enter key behavior when `ui:allowNewItems` is enabled. Pressing Enter now adds a new chip instead of submitting the form to the next step.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://issues.redhat.com/browse/RHDHBUGS-2506


## Problem

When a user types a custom value in an `ActiveMultiSelect` widget (with `ui:allowNewItems: true`) and presses Enter, the Enter key event bubbles up to the form and triggers form submission, causing the form to advance to the next step.

## Solution

- Added `freeSolo` prop to Autocomplete when `allowNewItems` is enabled, allowing custom values
- Added controlled `inputValue` with `onInputChange` handler for proper input state management
- Added `onKeyDown` handler that intercepts the Enter key when there's typed input:
  - Calls `event.preventDefault()` and `event.stopPropagation()` to prevent form submission
  - Adds the typed value as a new chip
  - Clears the input field
  
----------BEFORE-----------


https://github.com/user-attachments/assets/4ebcb34c-c771-4037-983e-b6dc89b571e4


----------AFTER------------


https://github.com/user-attachments/assets/60d4851f-3e88-4953-b04d-c7f3cdc56408



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
