### PR TITLE
Revert "prevent minor updates for bulk import openapi package"

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-bulk-import-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-bulk-import-presets.json
@@ -23,13 +23,6 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Bulk Import)"
       ],
       "addLabels": ["team/rhdh", "bulk-import"]
-    },
-    {
-      "enabled": false,
-      "description": "Temporarily disable minor updates for OpenAPI package",
-      "matchFileNames": ["workspaces/bulk-import/**"],
-      "matchPackageNames": ["@openapitools/openapi-generator-cli"],
-      "matchUpdateTypes": ["minor"]
     }
   ]
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The **@octokit/oauth-app** plugin was updated in the following PR : https://github.com/redhat-developer/rhdh-plugins/pull/2055 and it's no blocker anymore to upgrade **@openapitools/openapi-generator-cli** that's why temporary disabled the updates changes was reverted 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
