### PR TITLE
feat(lightspeed): show expandable card for deep thinking responses

### DIFF
--- a/workspaces/lightspeed/.changeset/rich-spiders-pump.md
+++ b/workspaces/lightspeed/.changeset/rich-spiders-pump.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+show expandable card for deep thinking responses

--- a/workspaces/lightspeed/plugins/lightspeed/package.json
+++ b/workspaces/lightspeed/plugins/lightspeed/package.json
@@ -59,7 +59,7 @@
     "@mui/icons-material": "^6.1.8",
     "@mui/material": "^5.12.2",
     "@mui/styles": "5.18.0",
-    "@patternfly/chatbot": "6.5.0-prerelease.28",
+    "@patternfly/chatbot": "6.5.0",
     "@patternfly/react-core": "6.4.0",
     "@patternfly/react-icons": "^6.3.1",
     "@red-hat-developer-hub/backstage-plugin-lightspeed-common": "workspace:^",

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -158,6 +158,7 @@ readonly "sort.newest": string;
 readonly "sort.oldest": string;
 readonly "sort.alphabeticalAsc": string;
 readonly "sort.alphabeticalDesc": string;
+readonly "reasoning.thinking": string;
 }>;
 
 // @alpha

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
@@ -52,13 +52,16 @@ type LightspeedChatBoxHeaderProps = {
   setDisplayMode: (mode: ChatbotDisplayMode) => void;
 };
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles(theme =>
   createStyles({
     dropdown: {
       '& ul, & li': {
         padding: 0,
         margin: 0,
       },
+    },
+    header: {
+      backgroundColor: theme.palette.action.disabled,
     },
     optionsToggle: {
       '& svg': {
@@ -105,6 +108,7 @@ export const LightspeedChatBoxHeader = ({
 
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
     <MenuToggle
+      className={isModelSelectorDisabled ? styles.header : ''}
       variant="secondary"
       aria-label={t('aria.chatbotSelector')}
       ref={toggleRef}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -36,11 +36,6 @@ const useStyles = makeStyles(theme => ({
       '0 14px 20px -7px rgba(0, 0, 0, 0.22), 0 32px 50px 6px rgba(0, 0, 0, 0.16), 0 12px 60px 12px rgba(0, 0, 0, 0.14) !important',
     bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 5em)`,
     right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    // When docked drawer is open, adjust modal position
-    'body.docked-drawer-open &': {
-      transition: 'margin-right 0.3s ease',
-      marginRight: 'var(--docked-drawer-width, 500px)',
-    },
   },
 }));
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -255,6 +255,9 @@ const lightspeedTranslationDe = createTranslationMessages({
     'sort.oldest': 'Datum (älteste zuerst)',
     'sort.alphabeticalAsc': 'Name (A-Z)',
     'sort.alphabeticalDesc': 'Name (Z-A)',
+
+    // Deep thinking
+    'reasoning.thinking': 'Denkvorgang anzeigen',
   },
 });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -258,6 +258,9 @@ const lightspeedTranslationEs = createTranslationMessages({
     'sort.oldest': 'Fecha (más antiguo primero)',
     'sort.alphabeticalAsc': 'Nombre (A-Z)',
     'sort.alphabeticalDesc': 'Nombre (Z-A)',
+
+    // Deep thinking
+    'reasoning.thinking': 'Mostrar razonamiento',
   },
 });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -216,6 +216,9 @@ const lightspeedTranslationFr = createTranslationMessages({
     'sort.oldest': 'Date (plus ancien en premier)',
     'sort.alphabeticalAsc': 'Nom (A-Z)',
     'sort.alphabeticalDesc': 'Nom (Z-A)',
+
+    // Deep thinking
+    'reasoning.thinking': 'Afficher la réflexion',
   },
 });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -208,6 +208,9 @@ const lightspeedTranslationIt = createTranslationMessages({
     'sort.oldest': 'Data (meno recente prima)',
     'sort.alphabeticalAsc': 'Nome (A-Z)',
     'sort.alphabeticalDesc': 'Nome (Z-A)',
+
+    // Deep thinking
+    'reasoning.thinking': 'Mostra ragionamento',
   },
 });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -202,6 +202,9 @@ const lightspeedTranslationJa = createTranslationMessages({
     'sort.oldest': '日付（古い順）',
     'sort.alphabeticalAsc': '名前（A-Z）',
     'sort.alphabeticalDesc': '名前（Z-A）',
+
+    // Deep thinking
+    'reasoning.thinking': '思考を表示',
   },
 });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -246,6 +246,8 @@ export const lightspeedMessages = {
   'sort.oldest': 'Date (oldest first)',
   'sort.alphabeticalAsc': 'Name (A-Z)',
   'sort.alphabeticalDesc': 'Name (Z-A)',
+  // Deep thinking
+  'reasoning.thinking': 'Show thinking',
 };
 
 /**

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/reasoningParser.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/__tests__/reasoningParser.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isReasoningInProgress, parseReasoning } from '../reasoningParser';
+
+describe('reasoningParser', () => {
+  describe('isReasoningInProgress', () => {
+    it('should return false for empty content', () => {
+      expect(isReasoningInProgress('')).toBe(false);
+    });
+
+    it('should return false when no reasoning tags are present', () => {
+      expect(isReasoningInProgress('This is regular content')).toBe(false);
+    });
+
+    it('should return false when both opening and closing tags are present', () => {
+      expect(
+        isReasoningInProgress('<think>Some reasoning</think>Main content'),
+      ).toBe(false);
+    });
+
+    it('should return true when only opening tag is present', () => {
+      expect(isReasoningInProgress('<think>Some reasoning in progress')).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('parseReasoning', () => {
+    describe('empty or null content', () => {
+      it('should return empty result for empty string', () => {
+        const result = parseReasoning('');
+        expect(result).toEqual({
+          reasoning: null,
+          mainContent: '',
+          hasReasoning: false,
+          isReasoningInProgress: false,
+        });
+      });
+
+      it('should return empty result for null', () => {
+        const result = parseReasoning(null as any);
+        expect(result).toEqual({
+          reasoning: null,
+          mainContent: null,
+          hasReasoning: false,
+          isReasoningInProgress: false,
+        });
+      });
+    });
+
+    describe('content without reasoning tags', () => {
+      it('should return content as-is when no reasoning tags present', () => {
+        const content = 'This is regular content without any reasoning tags';
+        const result = parseReasoning(content);
+        expect(result).toEqual({
+          reasoning: null,
+          mainContent: content,
+          hasReasoning: false,
+          isReasoningInProgress: false,
+        });
+      });
+
+      it('should handle content with newlines', () => {
+        const content = 'Line 1\nLine 2\nLine 3';
+        const result = parseReasoning(content);
+        expect(result.mainContent).toBe(content);
+        expect(result.hasReasoning).toBe(false);
+      });
+    });
+
+    describe('complete reasoning blocks', () => {
+      it('should extract single reasoning block and clean main content', () => {
+        const content =
+          '<think>This is the reasoning content</think>This is the main response';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('This is the reasoning content');
+        expect(result.mainContent).toBe('This is the main response');
+        expect(result.hasReasoning).toBe(true);
+        expect(result.isReasoningInProgress).toBe(false);
+      });
+
+      it('should handle multiple reasoning blocks in sequence', () => {
+        const content =
+          '<think>First reasoning block</think>Some content <think>Second reasoning block</think>More content';
+        const result = parseReasoning(content);
+        // Should extract the first complete block
+        expect(result.reasoning).toBe('First reasoning block');
+        expect(result.mainContent).toContain('Some content');
+        expect(result.hasReasoning).toBe(true);
+      });
+
+      it('should handle reasoning with newlines', () => {
+        const content =
+          '<think>Line 1\nLine 2\nLine 3</think>Main content here';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Line 1\nLine 2\nLine 3');
+        expect(result.mainContent).toBe('Main content here');
+        expect(result.hasReasoning).toBe(true);
+      });
+
+      it('should trim whitespace from reasoning content', () => {
+        const content = '<think>  Reasoning with spaces  </think>Main content';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Reasoning with spaces');
+        expect(result.mainContent).toBe('Main content');
+      });
+
+      it('should handle reasoning at the start of content', () => {
+        const content = '<think>Reasoning</think>Main content follows';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Reasoning');
+        expect(result.mainContent).toBe('Main content follows');
+      });
+
+      it('should handle reasoning in the middle of content', () => {
+        const content = 'Some prefix <think>Reasoning here</think>Some suffix';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Reasoning here');
+        expect(result.mainContent).toBe('Some prefix Some suffix');
+      });
+
+      it('should handle empty reasoning block', () => {
+        const content = '<think></think>Main content';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('');
+        expect(result.mainContent).toBe('Main content');
+        expect(result.hasReasoning).toBe(true);
+      });
+    });
+
+    describe('reasoning in progress (streaming)', () => {
+      it('should detect reasoning in progress when only opening tag exists', () => {
+        const content = '<think>Reasoning that is still streaming';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe(null);
+        expect(result.mainContent).toBe('');
+        expect(result.hasReasoning).toBe(false);
+        expect(result.isReasoningInProgress).toBe(true);
+      });
+
+      it('should handle reasoning in progress with content before tag', () => {
+        const content = 'Some content <think>Reasoning in progress';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe(null);
+        expect(result.mainContent).toBe('');
+        expect(result.isReasoningInProgress).toBe(true);
+      });
+
+      it('should handle multiline reasoning in progress', () => {
+        const content = '<think>Line 1\nLine 2\nLine 3';
+        const result = parseReasoning(content);
+        expect(result.isReasoningInProgress).toBe(true);
+        expect(result.mainContent).toBe('');
+      });
+    });
+
+    describe('multiple reasoning blocks', () => {
+      it('should handle multiple complete reasoning blocks', () => {
+        const content =
+          '<think>First reasoning</think>Main content <think>Second reasoning</think>More content';
+        const result = parseReasoning(content);
+        // Should extract the first complete block
+        expect(result.reasoning).toBe('First reasoning');
+        // Should remove the first block but may leave second if not handled
+        expect(result.mainContent).toContain('Main content');
+        expect(result.hasReasoning).toBe(true);
+      });
+
+      it('should handle reasoning block followed by in-progress reasoning', () => {
+        const content =
+          '<think>Complete reasoning</think>Main content <think>In progress';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Complete reasoning');
+        expect(result.mainContent).toContain('Main content');
+        expect(result.hasReasoning).toBe(true);
+        expect(result.isReasoningInProgress).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle content with similar but not matching tags', () => {
+        const content = '<think>Not a tag</think>Regular content';
+        const result = parseReasoning(content);
+        // Should match since pattern uses </think> as closing tag
+        expect(result.hasReasoning).toBe(true);
+        expect(result.reasoning).toBe('Not a tag');
+      });
+
+      it('should handle reasoning with special characters', () => {
+        const content =
+          '<think>Reasoning with <tags> and "quotes"</think>Main content';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Reasoning with <tags> and "quotes"');
+        expect(result.mainContent).toBe('Main content');
+      });
+
+      it('should handle very long reasoning content', () => {
+        const longReasoning = 'A'.repeat(10000);
+        const content = `<think>${longReasoning}</think>Main content`;
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe(longReasoning);
+        expect(result.mainContent).toBe('Main content');
+        expect(result.hasReasoning).toBe(true);
+      });
+
+      it('should handle reasoning with markdown formatting', () => {
+        const content =
+          '<think>**Bold** reasoning with `code` and [links](url)</think>Main content';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toContain('**Bold**');
+        expect(result.reasoning).toContain('`code`');
+        expect(result.mainContent).toBe('Main content');
+      });
+    });
+
+    describe('integration with tool calling scenarios', () => {
+      it('should extract reasoning when tool calling is present', () => {
+        const content =
+          '<think>Thinking about which tool to use</think>Here is the response with tool results';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Thinking about which tool to use');
+        expect(result.mainContent).toBe(
+          'Here is the response with tool results',
+        );
+        expect(result.hasReasoning).toBe(true);
+      });
+
+      it('should handle reasoning during tool execution', () => {
+        const content = '<think>Tool is executing, waiting for results';
+        const result = parseReasoning(content);
+        expect(result.isReasoningInProgress).toBe(true);
+        expect(result.mainContent).toBe('');
+      });
+
+      it('should clean reasoning tags from main content when tool calling present', () => {
+        const content =
+          '<think>Reasoning</think>Tool response: Success\nMain content here';
+        const result = parseReasoning(content);
+        expect(result.reasoning).toBe('Reasoning');
+        expect(result.mainContent).toBe(
+          'Tool response: Success\nMain content here',
+        );
+        expect(result.mainContent).not.toContain('<think>');
+        expect(result.mainContent).not.toContain('</think>');
+      });
+    });
+  });
+});

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/reasoningParser.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/reasoningParser.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parses a message content to extract redacted reasoning and main content.
+ * Messages from models with deep thinking support may contain:
+ * <think>Some reasoning...</think>Main response
+ *
+ * @param content - The message content that may contain reasoning tags
+ * @returns An object with the extracted reasoning and cleaned main content
+ */
+export interface ParsedReasoning {
+  reasoning: string | null;
+  mainContent: string;
+  hasReasoning: boolean;
+  isReasoningInProgress: boolean;
+}
+
+export const isReasoningInProgress = (content: string): boolean => {
+  if (!content) return false;
+
+  const hasOpeningTag = content.includes('<think>');
+  const hasClosingTag = content.includes('</think>');
+
+  return hasOpeningTag && !hasClosingTag;
+};
+
+export const parseReasoning = (content: string): ParsedReasoning => {
+  if (!content) {
+    return {
+      reasoning: null,
+      mainContent: content,
+      hasReasoning: false,
+      isReasoningInProgress: false,
+    };
+  }
+
+  const reasoningInProgress = isReasoningInProgress(content);
+
+  const reasoningPattern = /<think>(.*?)<\/think>/s;
+  const match = content.match(reasoningPattern);
+
+  if (match) {
+    const reasoning = (match[1] || '').trim();
+    const mainContent = content.replace(reasoningPattern, '').trim();
+
+    return {
+      reasoning,
+      mainContent,
+      hasReasoning: true,
+      isReasoningInProgress: false,
+    };
+  }
+
+  if (reasoningInProgress) {
+    return {
+      reasoning: null,
+      mainContent: '',
+      hasReasoning: false,
+      isReasoningInProgress: true,
+    };
+  }
+
+  return {
+    reasoning: null,
+    mainContent: content,
+    hasReasoning: false,
+    isReasoningInProgress: false,
+  };
+};

--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -8608,9 +8608,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/chatbot@npm:6.5.0-prerelease.28":
-  version: 6.5.0-prerelease.28
-  resolution: "@patternfly/chatbot@npm:6.5.0-prerelease.28"
+"@patternfly/chatbot@npm:6.5.0":
+  version: 6.5.0
+  resolution: "@patternfly/chatbot@npm:6.5.0"
   dependencies:
     "@patternfly/react-code-editor": ^6.1.0
     "@patternfly/react-core": ^6.1.0
@@ -8638,7 +8638,7 @@ __metadata:
       optional: false
     monaco-editor:
       optional: false
-  checksum: 7e3c3ac13fc2a459ec93d45d448808debe3ac90879ffe889d417042fb880cf4151946dd12682441e9be1811f32c5de44705a275f711c2323c69c9fcf892391f9
+  checksum: fffce2a61555666c6b04361507bfb0dce9788a69627d22d1609cc971b76beb85275e526908b4722b47837925d0f2d3205d14b412c5a3832825749b27e2361390
   languageName: node
   linkType: hard
 
@@ -11122,7 +11122,7 @@ __metadata:
     "@mui/icons-material": ^6.1.8
     "@mui/material": ^5.12.2
     "@mui/styles": 5.18.0
-    "@patternfly/chatbot": 6.5.0-prerelease.28
+    "@patternfly/chatbot": 6.5.0
     "@patternfly/react-core": 6.4.0
     "@patternfly/react-icons": ^6.3.1
     "@red-hat-developer-hub/backstage-plugin-lightspeed-common": "workspace:^"

--- a/workspaces/quickstart/packages/app/e2e-tests/quick-start-developer.spec.ts
+++ b/workspaces/quickstart/packages/app/e2e-tests/quick-start-developer.spec.ts
@@ -57,7 +57,7 @@ test.describe('Test Quick Start plugin', () => {
       // Header not visible, try to open the drawer
       // First, check if drawer is already open via class
       const drawerOpen = await page.evaluate(() => {
-        return document.body.classList.contains('quickstart-drawer-open');
+        return document.body.classList.contains('docked-drawer-open');
       });
 
       if (!drawerOpen) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://issues.redhat.com/browse/RHIDP-11420

Adds an expandable card when the model responds with reasoning



https://github.com/user-attachments/assets/136c984f-1e0d-4d4d-88ed-1776853e5028


 
<img width="1350" height="774" alt="Screenshot 2026-01-16 at 12 45 02 PM" src="https://github.com/user-attachments/assets/50f1b7a4-8e77-457c-bac1-cf1cfe3db976" />

**Test setup:**

pull a model that supports deep thinking

```
ollama pull deepseek-r1:7b
```

replace run.yaml in lightspeed-stack.yaml with this

```
version: 2
image_name: llama-stack-examples
apis:
  - agents
  - inference
  - safety
  - tool_runtime
  - vector_io

# external_providers_dir: /Users/kjeeyar/Documents/lightspeed-providers/providers.d

providers:
  tool_runtime:
    - provider_id: model-context-protocol
      provider_type: remote::model-context-protocol
      config: {}
  inference:
    - provider_id: ollama
      provider_type: remote::vllm
      config:
        url: http://localhost:11434/v1
        api_token: dummy
    - provider_id: sentence-transformers
      provider_type: inline::sentence-transformers
      config: {}

  safety:
    - provider_id: llama-guard
      provider_type: inline::llama-guard
      config:
        model: llama3.2:3b
    - provider_id: llama-guard
      provider_type: inline::llama-guard
      config:
        model: deepseek-r1:7b
  agents:
    - provider_id: meta-reference
      provider_type: inline::meta-reference
      config:
        persistence_store:
          type: sqlite
          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/custom}/agents_store.db
        responses_store:
          type: sqlite
          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/custom}/responses_store.db
  vector_io:
    - provider_id: faiss
      provider_type: inline::faiss
      config:
        kvstore:
          type: sqlite
          namespace: null
          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/custom}/faiss_store.db

metadata_store:
  type: sqlite
  db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/custom}/registry.db
  namespace: null

inference_store:
  type: sqlite
  db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/custom}/inference_store.db

models:
  - metadata: {}
    model_id: llama3.2:3b
    provider_id: ollama
    provider_model_id: llama3.2:3b
  - metadata: {}
    model_id: deepseek-r1:7b
    provider_id: ollama
    provider_model_id: deepseek-r1:7b
  - model_id: sentence-transformers/all-mpnet-base-v2
    metadata:
      embedding_dimension: 768
    model_type: embedding
    provider_id: sentence-transformers
    provider_model_id: sentence-transformers/all-mpnet-base-v2

shields: []
  # - shield_id: lightspeed_question_validity-shield
  #   provider_id: lightspeed_question_validity

server:
  port: 8321
```

and llama_stack url in lightspeed-stack.yaml

`url: http://localhost:8321`

**Note: not all AI models support tool calling , like this deepseek model. So, ensure that you do not have mcp server configured in lightspeed-stack.yaml**

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
