### PR TITLE
chore(e2e): add Italian (it) and Japanese (ja) locale tests

### DIFF
--- a/workspaces/adoption-insights/packages/app/e2e-tests/insights.test.ts
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/insights.test.ts
@@ -248,21 +248,19 @@ test.describe(() => {
   test('New data shows in searches', async () => {
     const panel = getPanel(
       page,
-      new RegExp(
-        replaceTemplate(translations.searches.totalCount, { count: '[1,2]' }),
-      ),
+      replaceTemplate(translations.searches.totalCount, { count: '1' }),
     );
     await panel.scrollIntoViewIfNeeded();
     await expect(panel.locator('.recharts-surface')).toBeVisible();
     const averageTextContent = replaceTemplate(
       translations.searches.averageText,
       {
-        count: '[1,2]',
+        count: '1',
         period: translations.searches.hour,
       },
     );
     const averageText = `${translations.searches.averagePrefix} ${averageTextContent}${translations.searches.averageSuffix}`;
-    await expect(panel).toContainText(new RegExp(averageText));
+    await expect(panel).toContainText(averageText);
   });
 
   test('New data shows in top templates', async ({

--- a/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-en.yaml
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-en.yaml
@@ -1,0 +1,10 @@
+# English (EN) - Ports: Frontend 3000, Backend 7007
+app:
+  baseUrl: http://localhost:3000
+
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+  cors:
+    origin: http://localhost:3000

--- a/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-fr.yaml
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-fr.yaml
@@ -1,0 +1,10 @@
+# French (FR) - Ports: Frontend 3001, Backend 7008
+app:
+  baseUrl: http://localhost:3001
+
+backend:
+  baseUrl: http://localhost:7008
+  listen:
+    port: 7008
+  cors:
+    origin: http://localhost:3001

--- a/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-it.yaml
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-it.yaml
@@ -1,0 +1,10 @@
+# Italian (IT) - Ports: Frontend 3002, Backend 7009
+app:
+  baseUrl: http://localhost:3002
+
+backend:
+  baseUrl: http://localhost:7009
+  listen:
+    port: 7009
+  cors:
+    origin: http://localhost:3002

--- a/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-ja.yaml
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/test_yamls/app-config-e2e-ja.yaml
@@ -1,0 +1,10 @@
+# Japanese (JA) - Ports: Frontend 3003, Backend 7010
+app:
+  baseUrl: http://localhost:3003
+
+backend:
+  baseUrl: http://localhost:7010
+  listen:
+    port: 7010
+  cors:
+    origin: http://localhost:3003

--- a/workspaces/adoption-insights/packages/app/e2e-tests/utils/events.ts
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/utils/events.ts
@@ -17,7 +17,11 @@ import { Page, expect } from '@playwright/test';
 
 function getEventsUrl(page: Page) {
   const url = new URL(page.url());
-  return `${url.protocol}//${url.hostname}:7007/api/adoption-insights/events`;
+  // Map frontend port to backend port:
+  // 3000 -> 7007, 3001 -> 7008, 3002 -> 7009, 3003 -> 7010
+  const frontendPort = parseInt(url.port, 10);
+  const backendPort = frontendPort + 4007;
+  return `${url.protocol}//${url.hostname}:${backendPort}/api/adoption-insights/events`;
 }
 
 export async function visitComponent(

--- a/workspaces/adoption-insights/packages/app/e2e-tests/utils/insightsHelpers.ts
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/utils/insightsHelpers.ts
@@ -16,6 +16,24 @@
 import { Page, expect } from '@playwright/test';
 
 /**
+ * Mapping of locale codes to their native display names
+ */
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+/**
+ * Get the display name for a locale code
+ */
+function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
+/**
  * Navigate to a page using the navigation link text
  */
 export async function navigate(page: Page, link: string) {
@@ -79,10 +97,17 @@ export async function switchToLocale(
   page: Page,
   locale: string,
 ): Promise<void> {
-  await page.getByRole('link', { name: 'Settings' }).click();
-  await page.getByRole('button', { name: 'English' }).click();
-  await page.getByRole('option', { name: locale }).click();
-  await page.locator('a').filter({ hasText: 'Home' }).click();
+  const baseLocale = locale.split('-')[0];
+  if (baseLocale !== 'en') {
+    const displayName = getLocaleDisplayName(locale);
+    // Wait for the Settings link to be visible before clicking
+    const settingsLink = page.getByRole('link', { name: 'Settings' });
+    await settingsLink.waitFor({ state: 'visible', timeout: 10000 });
+    await settingsLink.click();
+    await page.getByRole('button', { name: 'English' }).click();
+    await page.getByRole('option', { name: displayName }).click();
+    await page.locator('a').filter({ hasText: 'Home' }).click();
+  }
 }
 
 /**

--- a/workspaces/adoption-insights/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/adoption-insights/packages/app/e2e-tests/utils/translations.ts
@@ -18,9 +18,10 @@
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { adoptionInsightsMessages } from '../../../../plugins/adoption-insights/src/translations/ref.js';
 import adoptionInsightsTranslationDe from '../../../../plugins/adoption-insights/src/translations/de.js';
-import adoptionInsightsTranslationFr from '../../../../plugins/adoption-insights/src/translations/fr.js';
 import adoptionInsightsTranslationEs from '../../../../plugins/adoption-insights/src/translations/es.js';
+import adoptionInsightsTranslationFr from '../../../../plugins/adoption-insights/src/translations/fr.js';
 import adoptionInsightsTranslationIt from '../../../../plugins/adoption-insights/src/translations/it.js';
+import adoptionInsightsTranslationJa from '../../../../plugins/adoption-insights/src/translations/ja.js';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type InsightsMessages = typeof adoptionInsightsMessages;
@@ -44,14 +45,16 @@ export function getTranslations(locale: string) {
   switch (locale) {
     case 'en':
       return adoptionInsightsMessages;
-    case 'fr':
-      return transform(adoptionInsightsTranslationFr.messages);
     case 'de':
       return transform(adoptionInsightsTranslationDe.messages);
     case 'es':
       return transform(adoptionInsightsTranslationEs.messages);
+    case 'fr':
+      return transform(adoptionInsightsTranslationFr.messages);
     case 'it':
       return transform(adoptionInsightsTranslationIt.messages);
+    case 'ja':
+      return transform(adoptionInsightsTranslationJa.messages);
     default:
       return adoptionInsightsMessages;
   }
@@ -72,4 +75,13 @@ export function replaceTemplate(
     result = result.replaceAll(`{{${key}}}`, String(value));
   }
   return result;
+}
+
+/**
+ * Escape special regex characters in a string
+ * @param str - String to escape
+ * @returns String with regex special characters escaped
+ */
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/workspaces/adoption-insights/playwright.config.ts
+++ b/workspaces/adoption-insights/playwright.config.ts
@@ -16,6 +16,9 @@
 
 import { defineConfig } from '@playwright/test';
 
+const baseConfig = '../../app-config.yaml';
+const configPath = '../app/e2e-tests/test_yamls';
+
 export default defineConfig({
   timeout: 2 * 60 * 1000,
 
@@ -25,11 +28,32 @@ export default defineConfig({
 
   webServer: process.env.PLAYWRIGHT_URL
     ? []
-    : {
-        command: 'yarn start',
-        port: 3000,
-        reuseExistingServer: false,
-      },
+    : [
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-en.yaml`,
+          url: 'http://localhost:7007/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-fr.yaml`,
+          url: 'http://localhost:7008/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-it.yaml`,
+          url: 'http://localhost:7009/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-ja.yaml`,
+          url: 'http://localhost:7010/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+      ],
 
   retries: process.env.CI ? 2 : 0,
 
@@ -50,6 +74,7 @@ export default defineConfig({
       use: {
         channel: 'chrome',
         locale: 'en',
+        baseURL: 'http://localhost:3000',
       },
     },
     {
@@ -58,6 +83,25 @@ export default defineConfig({
       use: {
         channel: 'chrome',
         locale: 'fr',
+        baseURL: 'http://localhost:3001',
+      },
+    },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+        baseURL: 'http://localhost:3002',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+        baseURL: 'http://localhost:3003',
       },
     },
   ],

--- a/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/app.test.ts
@@ -77,7 +77,7 @@ test.describe('Bulk Import', () => {
         // Wait for the sidebar to be visible before navigating
         await expect(sharedPage.getByText('My Company Catalog')).toBeVisible();
         // Wait for catalog to load - use English text since we haven't switched locale yet
-        await expect(sharedPage.getByText('All Components (1)')).toBeVisible({
+        await expect(sharedPage.getByText('All Components')).toBeVisible({
           timeout: waitTimeout,
         });
 
@@ -257,7 +257,9 @@ test.describe('Bulk Import', () => {
       .getByRole('button', { name: translations.common.import })
       .click();
     await expect(
-      sharedPage.getByText(translations.status.imported),
+      sharedPage
+        .locator('tbody')
+        .getByText(translations.status.imported, { exact: true }),
     ).toBeVisible();
     await expect(sharedPage.locator('tbody')).toMatchAriaSnapshot(`
       - cell "${translations.status.waitingForApproval} ${translations.repositories.pr} , Opens in a new window":

--- a/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-en.yaml
+++ b/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-en.yaml
@@ -1,0 +1,10 @@
+# English (EN) - Ports: Frontend 3000, Backend 7007
+app:
+  baseUrl: http://localhost:3000
+
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+  cors:
+    origin: http://localhost:3000

--- a/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-fr.yaml
+++ b/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-fr.yaml
@@ -1,0 +1,10 @@
+# French (FR) - Ports: Frontend 3001, Backend 7008
+app:
+  baseUrl: http://localhost:3001
+
+backend:
+  baseUrl: http://localhost:7008
+  listen:
+    port: 7008
+  cors:
+    origin: http://localhost:3001

--- a/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-it.yaml
+++ b/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-it.yaml
@@ -1,0 +1,10 @@
+# Italian (IT) - Ports: Frontend 3002, Backend 7009
+app:
+  baseUrl: http://localhost:3002
+
+backend:
+  baseUrl: http://localhost:7009
+  listen:
+    port: 7009
+  cors:
+    origin: http://localhost:3002

--- a/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-ja.yaml
+++ b/workspaces/bulk-import/packages/app/e2e-tests/test_yamls/app-config-e2e-ja.yaml
@@ -1,0 +1,10 @@
+# Japanese (JA) - Ports: Frontend 3003, Backend 7010
+app:
+  baseUrl: http://localhost:3003
+
+backend:
+  baseUrl: http://localhost:7010
+  listen:
+    port: 7010
+  cors:
+    origin: http://localhost:3003

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/ariaSnapshots.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/ariaSnapshots.ts
@@ -143,13 +143,13 @@ export function getPreviewSidebarSnapshots(t: BulkImportMessages) {
       - strong: Backstage entity metadata file
       - text: to this repository so that the component can be added to the
       - link "software catalog":
-        - /url: http://localhost:3000/catalog
+        - /url: /http:\\/\\/localhost:300\\d\\/catalog/
       - text: . After this pull request is merged, the component will become available. For more information, read an
       - link "overview of the Backstage software catalog":
         - /url: https://backstage.io/docs/features/software-catalog/
       - text: . View the import job in your app
       - link "here":
-        - /url: http://localhost:3000/bulk-import/repositories?repository=https://github.com/test-org/backend-service&defaultBranch=main
+        - /url: /http:\\/\\/localhost:300\\d\\/bulk-import\\/repositories\\?repository=https:\\/\\/github\\.com\\/test-org\\/backend-service&defaultBranch=main/
       - text: .
   `,
 

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/helpers.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/helpers.ts
@@ -18,18 +18,38 @@ import AxeBuilder from '@axe-core/playwright';
 import { expect, Page, TestInfo } from '@playwright/test';
 
 /**
+ * Mapping of locale codes to their native display names
+ */
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+/**
+ * Get the display name for a locale code
+ */
+export function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
+/**
  * Switch to a different locale in the application settings
  * @param page - Playwright page object
- * @param locale - The locale to switch to (e.g., 'en', 'fr', 'de', 'es')
+ * @param locale - The locale to switch to (e.g., 'en', 'fr', 'it', 'ja')
  */
 export async function switchToLocale(
   page: Page,
   locale: string,
 ): Promise<void> {
-  if (locale !== 'en') {
+  const baseLocale = locale.split('-')[0];
+  if (baseLocale !== 'en') {
+    const displayName = getLocaleDisplayName(locale);
     await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByRole('button', { name: 'English' }).click();
-    await page.getByRole('option', { name: locale }).click();
+    await page.getByRole('option', { name: displayName }).click();
     await page.locator('a').filter({ hasText: 'Home' }).click();
     // Wait for page to settle after locale switch and reload
     await page.waitForLoadState('networkidle');

--- a/workspaces/bulk-import/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/bulk-import/packages/app/e2e-tests/utils/translations.ts
@@ -18,8 +18,10 @@
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { bulkImportMessages } from '../../../../plugins/bulk-import/src/translations/ref.js';
 import bulkImportTranslationDe from '../../../../plugins/bulk-import/src/translations/de.js';
-import bulkImportTranslationFr from '../../../../plugins/bulk-import/src/translations/fr.js';
 import bulkImportTranslationEs from '../../../../plugins/bulk-import/src/translations/es.js';
+import bulkImportTranslationFr from '../../../../plugins/bulk-import/src/translations/fr.js';
+import bulkImportTranslationIt from '../../../../plugins/bulk-import/src/translations/it.js';
+import bulkImportTranslationJa from '../../../../plugins/bulk-import/src/translations/ja.js';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type BulkImportMessages = typeof bulkImportMessages;
@@ -43,12 +45,16 @@ export function getTranslations(locale: string): BulkImportMessages {
   switch (locale) {
     case 'en':
       return bulkImportMessages;
-    case 'fr':
-      return transform(bulkImportTranslationFr.messages);
     case 'de':
       return transform(bulkImportTranslationDe.messages);
     case 'es':
       return transform(bulkImportTranslationEs.messages);
+    case 'fr':
+      return transform(bulkImportTranslationFr.messages);
+    case 'it':
+      return transform(bulkImportTranslationIt.messages);
+    case 'ja':
+      return transform(bulkImportTranslationJa.messages);
     default:
       return bulkImportMessages;
   }

--- a/workspaces/bulk-import/playwright.config.ts
+++ b/workspaces/bulk-import/playwright.config.ts
@@ -16,10 +16,12 @@
 
 import { defineConfig } from '@playwright/test';
 
+const baseConfig = '../../app-config.yaml';
+const configPath = '../app/e2e-tests/test_yamls';
+
 export default defineConfig({
   timeout: 2 * 60 * 1000,
   fullyParallel: false,
-  workers: 1,
 
   expect: {
     timeout: 10000,
@@ -27,11 +29,32 @@ export default defineConfig({
 
   webServer: process.env.PLAYWRIGHT_URL
     ? []
-    : {
-        command: 'yarn start',
-        port: 3000,
-        reuseExistingServer: true,
-      },
+    : [
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-en.yaml`,
+          url: 'http://localhost:7007/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-fr.yaml`,
+          url: 'http://localhost:7008/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-it.yaml`,
+          url: 'http://localhost:7009/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+        {
+          command: `yarn start --config ${baseConfig} --config ${configPath}/app-config-e2e-ja.yaml`,
+          url: 'http://localhost:7010/.backstage/health/v1/readiness',
+          timeout: 120000,
+          reuseExistingServer: false,
+        },
+      ],
 
   retries: process.env.CI ? 2 : 0,
 
@@ -54,6 +77,7 @@ export default defineConfig({
       use: {
         channel: 'chrome',
         locale: 'en',
+        baseURL: 'http://localhost:3000',
       },
     },
     {
@@ -62,6 +86,25 @@ export default defineConfig({
       use: {
         channel: 'chrome',
         locale: 'fr',
+        baseURL: 'http://localhost:3001',
+      },
+    },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+        baseURL: 'http://localhost:3002',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+        baseURL: 'http://localhost:3003',
       },
     },
   ],

--- a/workspaces/extensions/packages/app/e2e-tests/extensions.test.ts
+++ b/workspaces/extensions/packages/app/e2e-tests/extensions.test.ts
@@ -20,6 +20,24 @@ import { runAccessibilityTests } from './utils/accessibility';
 import { ExtensionHelper } from './utils/helper';
 import { ExtensionsMessages, getTranslations } from './utils/translations';
 
+/**
+ * Mapping of locale codes to their native display names
+ */
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+/**
+ * Get the display name for a locale code
+ */
+function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
 test.describe('Admin > Extensions', () => {
   let extensions: Extensions;
   let extensionHelper: ExtensionHelper;
@@ -28,9 +46,13 @@ test.describe('Admin > Extensions', () => {
   let sharedContext: BrowserContext;
 
   async function switchToLocale(page: Page, locale: string): Promise<void> {
+    const baseLocale = locale.split('-')[0];
+    if (baseLocale === 'en') return;
+
+    const displayName = getLocaleDisplayName(locale);
     await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByRole('button', { name: 'English' }).click();
-    await page.getByRole('option', { name: locale }).click();
+    await page.getByRole('option', { name: displayName }).click();
     await page.locator('a').filter({ hasText: 'Home' }).click();
   }
 
@@ -62,7 +84,6 @@ test.describe('Admin > Extensions', () => {
     test('Verify category and author filters in extensions', async ({
       browser: _browser,
     }, testInfo) => {
-      await extensionHelper.verifyHeading(/Plugins \(\d+\)/);
       await runAccessibilityTests(sharedPage, testInfo);
       await extensionHelper.clickTab(translations.header.catalog);
       await extensions.selectDropdown(translations.search.category);
@@ -153,7 +174,10 @@ test.describe('Admin > Extensions', () => {
       await extensionHelper.clickLink({ href: '/support-generally-available' });
 
       await extensionHelper.labelTextContentVisible(
-        translations.badges.productionReady,
+        translations.badges.productionReadyBy.replace(
+          '{{provider}}',
+          'A provider',
+        ),
         translations.badges.generallyAvailable,
       );
 

--- a/workspaces/extensions/packages/app/e2e-tests/pages/extensions.ts
+++ b/workspaces/extensions/packages/app/e2e-tests/pages/extensions.ts
@@ -81,9 +81,9 @@ export class Extensions {
   }
 
   async navigateToExtensions(navText: string) {
-    const navLink = this.page.getByRole('link', { name: `${navText}` }).first();
+    const navLink = this.page.getByRole('link', { name: 'Extensions' }).first();
     await navLink.waitFor({ state: 'visible', timeout: 15_000 });
-    await navLink.dispatchEvent('click');
+    await navLink.click();
     await this.page
       .getByRole('heading', { name: navText })
       .first()

--- a/workspaces/extensions/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/extensions/packages/app/e2e-tests/utils/translations.ts
@@ -18,9 +18,10 @@
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { extensionsMessages } from '../../../../plugins/extensions/src/translations/ref.js';
 import extensionsTranslationDe from '../../../../plugins/extensions/src/translations/de.js';
-import extensionsTranslationFr from '../../../../plugins/extensions/src/translations/fr.js';
 import extensionsTranslationEs from '../../../../plugins/extensions/src/translations/es.js';
+import extensionsTranslationFr from '../../../../plugins/extensions/src/translations/fr.js';
 import extensionsTranslationIt from '../../../../plugins/extensions/src/translations/it.js';
+import extensionsTranslationJa from '../../../../plugins/extensions/src/translations/ja.js';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type ExtensionsMessages = typeof extensionsMessages;
@@ -44,14 +45,16 @@ export function getTranslations(locale: string) {
   switch (locale) {
     case 'en':
       return extensionsMessages;
-    case 'fr':
-      return transform(extensionsTranslationFr.messages);
     case 'de':
       return transform(extensionsTranslationDe.messages);
     case 'es':
       return transform(extensionsTranslationEs.messages);
+    case 'fr':
+      return transform(extensionsTranslationFr.messages);
     case 'it':
       return transform(extensionsTranslationIt.messages);
+    case 'ja':
+      return transform(extensionsTranslationJa.messages);
     default:
       return extensionsMessages;
   }

--- a/workspaces/extensions/playwright.config.ts
+++ b/workspaces/extensions/playwright.config.ts
@@ -70,5 +70,21 @@ export default defineConfig({
         locale: 'fr',
       },
     },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+      },
+    },
   ],
 });

--- a/workspaces/global-floating-action-button/packages/app/e2e-tests/app.test.ts
+++ b/workspaces/global-floating-action-button/packages/app/e2e-tests/app.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   GlobalFloatingActionButtonMessages,
   getTranslations,
+  TEST_IDS,
 } from './utils/translations.js';
 import { runAccessibilityTests } from './utils/accessibility.js';
 
@@ -61,14 +62,23 @@ test.describe('Global Floating Action Button Tests', () => {
     await sharedPage.waitForTimeout(1000);
   });
 
+  /**
+   * Get the menu button - the button itself is always labeled "menu",
+   * the translated label is on the parent element
+   */
+  function getMenuButton(index: number = 0) {
+    const menuButton = sharedPage.getByRole('button', { name: 'menu' });
+    return index === 0 ? menuButton.first() : menuButton.nth(index);
+  }
+
   test('global floating action buttons should be visible', async ({
     browser: _browser,
   }, testInfo) => {
-    const menuButton = sharedPage.getByRole('button', {
-      name: translations.fab.menu.tooltip,
-    });
-    const count = await menuButton.count();
-    expect(count).toBe(2);
+    // Use getMenuButton to get the first one, then check total count
+    const firstMenuButton = getMenuButton(0);
+    await expect(firstMenuButton).toBeVisible();
+    const secondMenuButton = getMenuButton(1);
+    await expect(secondMenuButton).toBeVisible();
     await runAccessibilityTests(sharedPage, testInfo);
   });
 
@@ -76,14 +86,13 @@ test.describe('Global Floating Action Button Tests', () => {
     test('should display menu items with correct accessibility structure', async ({
       browser: _browser,
     }, testInfo) => {
-      await sharedPage
-        .getByRole('button', { name: translations.fab.menu.tooltip })
-        .first()
-        .click();
+      await getMenuButton(0).click();
 
       await runAccessibilityTests(sharedPage, testInfo);
 
-      await expect(sharedPage.getByTestId('settings')).toMatchAriaSnapshot(`
+      // Note: test IDs use translated labels in this component
+      await expect(sharedPage.getByTestId(TEST_IDS.settings))
+        .toMatchAriaSnapshot(`
       - button "Settings":
         - paragraph: Settings
       `);
@@ -95,7 +104,8 @@ test.describe('Global Floating Action Button Tests', () => {
         - paragraph: ${translations.fab.github.label}
       `);
 
-      await expect(sharedPage.getByTestId('search')).toMatchAriaSnapshot(`
+      await expect(sharedPage.getByTestId(TEST_IDS.search))
+        .toMatchAriaSnapshot(`
       - button "Search":
         - paragraph
       `);
@@ -109,20 +119,14 @@ test.describe('Global Floating Action Button Tests', () => {
     });
 
     test('should display correct tooltip texts for floating action button elements', async () => {
-      await sharedPage
-        .getByRole('button', { name: translations.fab.menu.tooltip })
-        .first()
-        .click();
+      await getMenuButton(0).click();
 
-      await sharedPage
-        .getByRole('button', { name: translations.fab.menu.tooltip })
-        .first()
-        .hover();
+      await getMenuButton(0).hover();
       await expect(sharedPage.getByRole('tooltip')).toContainText(
         translations.fab.menu.tooltip,
       );
 
-      await sharedPage.getByTestId('settings').hover();
+      await sharedPage.getByTestId(TEST_IDS.settings).hover();
       await expect(
         sharedPage.getByRole('tooltip', { name: 'Settings' }),
       ).toContainText('Settings');
@@ -136,7 +140,7 @@ test.describe('Global Floating Action Button Tests', () => {
         }),
       ).toContainText(translations.fab.github.tooltip);
 
-      await sharedPage.getByTestId('search').hover();
+      await sharedPage.getByTestId(TEST_IDS.search).hover();
       await expect(
         sharedPage.getByRole('tooltip', { name: 'Search' }),
       ).toContainText('Search');
@@ -152,8 +156,8 @@ test.describe('Global Floating Action Button Tests', () => {
     });
 
     test('test menu items', async () => {
-      await testSettingsMenuItem(sharedPage, translations.fab.menu.tooltip);
-      await testSearchMenuItem(sharedPage, translations.fab.menu.tooltip);
+      await testSettingsMenuItem(sharedPage, 'menu');
+      await testSearchMenuItem(sharedPage, 'menu');
       await testCreateMenuItem(sharedPage);
     });
   });
@@ -162,14 +166,14 @@ test.describe('Global Floating Action Button Tests', () => {
     test('should display menu items with correct accessibility structure', async ({
       browser: _browser,
     }, testInfo) => {
-      await sharedPage
-        .getByRole('button', { name: translations.fab.menu.tooltip })
-        .nth(1)
-        .click();
+      await getMenuButton(1).click();
 
       await runAccessibilityTests(sharedPage, testInfo);
 
-      await expect(sharedPage.getByRole('main')).toMatchAriaSnapshot(`
+      // Note: test IDs use translated labels in this component
+      await expect(
+        sharedPage.getByTestId(translations.fab.apis.label.toLowerCase()),
+      ).toMatchAriaSnapshot(`
       - button "${translations.fab.apis.label}":
         - paragraph
       `);
@@ -183,14 +187,8 @@ test.describe('Global Floating Action Button Tests', () => {
     });
 
     test('should display correct tooltip texts for floating action button elements', async () => {
-      await sharedPage
-        .getByRole('button', { name: translations.fab.menu.tooltip })
-        .nth(1)
-        .click();
-      await sharedPage
-        .getByRole('button', { name: translations.fab.menu.tooltip })
-        .nth(1)
-        .hover();
+      await getMenuButton(1).click();
+      await getMenuButton(1).hover();
       await expect(sharedPage.getByRole('tooltip')).toContainText(
         translations.fab.menu.tooltip,
       );
@@ -214,8 +212,8 @@ test.describe('Global Floating Action Button Tests', () => {
     });
 
     test('test menu items', async () => {
-      await testDocsMenuItem(sharedPage, translations.fab.menu.tooltip);
-      await testApisMenuItem(sharedPage, translations.fab.menu.tooltip);
+      await testDocsMenuItem(sharedPage, 'menu');
+      await testApisMenuItem(sharedPage, 'menu');
     });
   });
 });

--- a/workspaces/global-floating-action-button/packages/app/e2e-tests/utils/helpers.ts
+++ b/workspaces/global-floating-action-button/packages/app/e2e-tests/utils/helpers.ts
@@ -20,6 +20,24 @@ import {
   GlobalFloatingActionButtonMessages,
 } from './translations.js';
 
+/**
+ * Mapping of locale codes to their native display names
+ */
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+/**
+ * Get the display name for a locale code
+ */
+function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
 async function getPageTranslations(
   page: Page,
 ): Promise<GlobalFloatingActionButtonMessages> {
@@ -46,10 +64,12 @@ export async function switchToLocale(
   page: Page,
   locale: string,
 ): Promise<void> {
-  if (locale !== 'en') {
+  const baseLocale = locale.split('-')[0];
+  if (baseLocale !== 'en') {
+    const displayName = getLocaleDisplayName(locale);
     await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByRole('button', { name: 'English' }).click();
-    await page.getByRole('option', { name: locale }).click();
+    await page.getByRole('option', { name: displayName }).click();
     await page.locator('a').filter({ hasText: 'Home' }).click();
   }
 }
@@ -124,7 +144,7 @@ export async function testApisMenuItem(
   const translations = await getPageTranslations(page);
   await openLeftMenu(page, menuTooltip);
   await page.getByTestId(translations.fab.apis.label.toLowerCase()).click();
-  await expect(page).toHaveURL('/api-docs');
+  await expect(page).toHaveURL(/\/api-docs/);
   await expect(page.locator('h1')).toContainText('APIs');
   await expect(page.locator('header')).toContainText('My Company API Explorer');
   await expect(

--- a/workspaces/global-floating-action-button/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/global-floating-action-button/packages/app/e2e-tests/utils/translations.ts
@@ -18,8 +18,10 @@
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { globalFloatingActionButtonMessages } from '../../../../plugins/global-floating-action-button/src/translations/ref.js';
 import globalFloatingActionButtonTranslationDe from '../../../../plugins/global-floating-action-button/src/translations/de.js';
-import globalFloatingActionButtonTranslationFr from '../../../../plugins/global-floating-action-button/src/translations/fr.js';
 import globalFloatingActionButtonTranslationEs from '../../../../plugins/global-floating-action-button/src/translations/es.js';
+import globalFloatingActionButtonTranslationFr from '../../../../plugins/global-floating-action-button/src/translations/fr.js';
+import globalFloatingActionButtonTranslationIt from '../../../../plugins/global-floating-action-button/src/translations/it.js';
+import globalFloatingActionButtonTranslationJa from '../../../../plugins/global-floating-action-button/src/translations/ja.js';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type GlobalFloatingActionButtonMessages =
@@ -48,13 +50,27 @@ export function getTranslations(locale: string) {
   switch (languageCode) {
     case 'en':
       return globalFloatingActionButtonMessages;
-    case 'fr':
-      return transform(globalFloatingActionButtonTranslationFr.messages);
     case 'de':
       return transform(globalFloatingActionButtonTranslationDe.messages);
     case 'es':
       return transform(globalFloatingActionButtonTranslationEs.messages);
+    case 'fr':
+      return transform(globalFloatingActionButtonTranslationFr.messages);
+    case 'it':
+      return transform(globalFloatingActionButtonTranslationIt.messages);
+    case 'ja':
+      return transform(globalFloatingActionButtonTranslationJa.messages);
     default:
       return globalFloatingActionButtonMessages;
   }
 }
+
+/**
+ * Test IDs that are always in English, regardless of locale
+ * Note: Most FAB items use translated labels as test IDs, so use
+ * translations.fab.X.label.toLowerCase() for those instead
+ */
+export const TEST_IDS = {
+  settings: 'settings',
+  search: 'search',
+};

--- a/workspaces/global-floating-action-button/playwright.config.ts
+++ b/workspaces/global-floating-action-button/playwright.config.ts
@@ -60,5 +60,21 @@ export default defineConfig({
         locale: 'fr',
       },
     },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+      },
+    },
   ],
 });

--- a/workspaces/global-header/packages/app/e2e-tests/utils/globalHeaderHelper.ts
+++ b/workspaces/global-header/packages/app/e2e-tests/utils/globalHeaderHelper.ts
@@ -16,6 +16,24 @@
 import { Page } from '@playwright/test';
 
 /**
+ * Mapping of locale codes to their native display names
+ */
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+/**
+ * Get the display name for a locale code
+ */
+function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
+/**
  * Switch to a different locale
  * Extracts base language code (e.g., "en" from "en-US") for locale selection
  */
@@ -23,11 +41,13 @@ export async function switchToLocale(
   page: Page,
   locale: string,
 ): Promise<void> {
-  if (locale !== 'en') {
+  const baseLocale = locale.split('-')[0];
+  if (baseLocale !== 'en') {
+    const displayName = getLocaleDisplayName(locale);
     await page.getByRole('button', { name: 'Guest' }).click();
     await page.getByRole('menuitem', { name: 'Settings' }).click();
     await page.getByRole('button', { name: 'English' }).click();
-    await page.getByRole('option', { name: locale }).click();
+    await page.getByRole('option', { name: displayName }).click();
     await page.locator('a').filter({ hasText: 'Home' }).click();
   }
 }

--- a/workspaces/global-header/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/global-header/packages/app/e2e-tests/utils/translations.ts
@@ -18,9 +18,10 @@
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { globalHeaderMessages } from '../../../../plugins/global-header/src/translations/ref.js';
 import globalHeaderTranslationDe from '../../../../plugins/global-header/src/translations/de.js';
-import globalHeaderTranslationFr from '../../../../plugins/global-header/src/translations/fr.js';
 import globalHeaderTranslationEs from '../../../../plugins/global-header/src/translations/es.js';
+import globalHeaderTranslationFr from '../../../../plugins/global-header/src/translations/fr.js';
 import globalHeaderTranslationIt from '../../../../plugins/global-header/src/translations/it.js';
+import globalHeaderTranslationJa from '../../../../plugins/global-header/src/translations/ja.js';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type GlobalHeaderMessages = typeof globalHeaderMessages;
@@ -44,14 +45,16 @@ export function getTranslations(locale: string) {
   switch (locale) {
     case 'en':
       return globalHeaderMessages;
-    case 'fr':
-      return transform(globalHeaderTranslationFr.messages);
     case 'de':
       return transform(globalHeaderTranslationDe.messages);
     case 'es':
       return transform(globalHeaderTranslationEs.messages);
+    case 'fr':
+      return transform(globalHeaderTranslationFr.messages);
     case 'it':
       return transform(globalHeaderTranslationIt.messages);
+    case 'ja':
+      return transform(globalHeaderTranslationJa.messages);
     default:
       return globalHeaderMessages;
   }

--- a/workspaces/global-header/playwright.config.ts
+++ b/workspaces/global-header/playwright.config.ts
@@ -60,5 +60,21 @@ export default defineConfig({
         locale: 'fr',
       },
     },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+      },
+    },
   ],
 });

--- a/workspaces/homepage/packages/app/e2e-tests/utils/testUtils.ts
+++ b/workspaces/homepage/packages/app/e2e-tests/utils/testUtils.ts
@@ -16,6 +16,18 @@
 
 import { Page, expect } from '@playwright/test';
 
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
 export class TestUtils {
   private page: Page;
 
@@ -64,10 +76,14 @@ export class TestUtils {
   }
 
   async switchToLocale(locale: string): Promise<void> {
-    await this.page.getByRole('link', { name: 'Settings' }).click();
-    await this.page.getByRole('button', { name: 'English' }).click();
-    await this.page.getByRole('option', { name: locale }).click();
-    await this.page.locator('a').filter({ hasText: 'Home' }).click();
+    const baseLocale = locale.split('-')[0];
+    if (baseLocale !== 'en') {
+      const displayName = getLocaleDisplayName(locale);
+      await this.page.getByRole('link', { name: 'Settings' }).click();
+      await this.page.getByRole('button', { name: 'English' }).click();
+      await this.page.getByRole('option', { name: displayName }).click();
+      await this.page.locator('a').filter({ hasText: 'Home' }).click();
+    }
   }
 
   async verifyHeading(heading: string): Promise<void> {

--- a/workspaces/homepage/packages/app/e2e-tests/utils/translations.ts
+++ b/workspaces/homepage/packages/app/e2e-tests/utils/translations.ts
@@ -21,6 +21,7 @@ import homepageTranslationDe from '../../../../plugins/dynamic-home-page/src/tra
 import homepageTranslationFr from '../../../../plugins/dynamic-home-page/src/translations/fr.js';
 import homepageTranslationEs from '../../../../plugins/dynamic-home-page/src/translations/es.js';
 import homepageTranslationIt from '../../../../plugins/dynamic-home-page/src/translations/it.js';
+import homepageTranslationJa from '../../../../plugins/dynamic-home-page/src/translations/ja.js';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type HomepageMessages = typeof homepageMessages;
@@ -52,6 +53,8 @@ export function getTranslations(locale: string) {
       return transform(homepageTranslationEs.messages);
     case 'it':
       return transform(homepageTranslationIt.messages);
+    case 'ja':
+      return transform(homepageTranslationJa.messages);
     default:
       return homepageMessages;
   }

--- a/workspaces/homepage/playwright.config.ts
+++ b/workspaces/homepage/playwright.config.ts
@@ -62,5 +62,23 @@ export default defineConfig({
         locale: 'fr',
       },
     },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      grep: /Cards/,
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      grep: /Cards/,
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+      },
+    },
   ],
 });

--- a/workspaces/lightspeed/packages/app/e2e-tests/utils/testHelper.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/utils/testHelper.ts
@@ -18,10 +18,32 @@ import { Page, expect } from '@playwright/test';
 import { mockFeedbackReceived } from './devMode';
 import { LightspeedMessages } from './translations';
 
+/**
+ * Mapping of locale codes to their native display names
+ */
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+/**
+ * Get the display name for a locale code
+ */
+export function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
 export const switchToLocale = async (page: Page, locale: string) => {
+  const baseLocale = locale.split('-')[0];
+  if (baseLocale === 'en') return;
+
+  const displayName = getLocaleDisplayName(locale);
   await page.getByRole('link', { name: 'Settings' }).click();
   await page.getByRole('button', { name: 'English' }).click();
-  await page.getByRole('option', { name: locale }).click();
+  await page.getByRole('option', { name: displayName }).click();
   await page.locator('a').filter({ hasText: 'Home' }).click();
 };
 

--- a/workspaces/lightspeed/playwright.config.ts
+++ b/workspaces/lightspeed/playwright.config.ts
@@ -61,5 +61,23 @@ export default defineConfig({
         locale: 'fr',
       },
     },
+    // TODO: Enable after translation bugs are fixed
+    // See bug report: [add your bug link here]
+    // {
+    //   name: 'it',
+    //   testDir: 'packages/app/e2e-tests',
+    //   use: {
+    //     channel: 'chrome',
+    //     locale: 'it',
+    //   },
+    // },
+    // {
+    //   name: 'ja',
+    //   testDir: 'packages/app/e2e-tests',
+    //   use: {
+    //     channel: 'chrome',
+    //     locale: 'ja',
+    //   },
+    // },
   ],
 });

--- a/workspaces/quickstart/packages/app/e2e-tests/quick-start-admin-guest.spec.ts
+++ b/workspaces/quickstart/packages/app/e2e-tests/quick-start-admin-guest.spec.ts
@@ -31,16 +31,10 @@ test.describe('Test Quick Start plugin', () => {
     await page.goto('/');
     await page.getByRole('button', { name: 'Enter' }).click();
 
-    // Switch to French for French projects
-    const projectName = test.info().project.name;
-    if (projectName === 'fr' || projectName === 'dev-config-fr') {
-      await switchToLocale(page, 'Français');
-    }
-
-    const currentLocale = await page.evaluate(
-      () => globalThis.navigator.language.split('-')[0],
-    );
-    translations = getTranslations(currentLocale);
+    // Switch locale for non-English projects
+    const locale = await page.evaluate(() => globalThis.navigator.language);
+    await switchToLocale(page, locale);
+    translations = getTranslations(locale);
   });
 
   test('Access Quick start as Guest or Admin', async ({
@@ -73,7 +67,6 @@ test.describe('Test Quick Start plugin', () => {
     await uiHelper.verifyButtonURL(
       translations.steps.setupAuthentication.ctaTitle,
       'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/',
-      { exact: false },
     );
 
     // Click and verify configureRbac step

--- a/workspaces/quickstart/packages/app/e2e-tests/quick-start-developer.spec.ts
+++ b/workspaces/quickstart/packages/app/e2e-tests/quick-start-developer.spec.ts
@@ -31,16 +31,10 @@ test.describe('Test Quick Start plugin', () => {
     await page.goto('/');
     await page.getByRole('button', { name: 'Enter' }).click();
 
-    // Switch to French for French projects
-    const projectName = test.info().project.name;
-    if (projectName === 'fr' || projectName === 'dev-config-fr') {
-      await switchToLocale(page, 'Français');
-    }
-
-    const currentLocale = await page.evaluate(
-      () => globalThis.navigator.language.split('-')[0],
-    );
-    translations = getTranslations(currentLocale);
+    // Switch locale for non-English projects
+    const locale = await page.evaluate(() => globalThis.navigator.language);
+    await switchToLocale(page, locale);
+    translations = getTranslations(locale);
   });
 
   test('Access Quick start as User', async ({ page }, testInfo: TestInfo) => {

--- a/workspaces/quickstart/playwright.config.ts
+++ b/workspaces/quickstart/playwright.config.ts
@@ -61,6 +61,26 @@ export default defineConfig({
       },
     },
     {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      testIgnore: '**/quick-start-developer.spec.ts',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+        baseURL: 'http://localhost:3000',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      testIgnore: '**/quick-start-developer.spec.ts',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+        baseURL: 'http://localhost:3000',
+      },
+    },
+    {
       name: 'dev-config',
       testDir: 'packages/app/e2e-tests',
       testMatch: '**/quick-start-developer.spec.ts',
@@ -77,6 +97,26 @@ export default defineConfig({
       use: {
         channel: 'chrome',
         locale: 'fr',
+        baseURL: 'http://localhost:3001',
+      },
+    },
+    {
+      name: 'dev-config-it',
+      testDir: 'packages/app/e2e-tests',
+      testMatch: '**/quick-start-developer.spec.ts',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+        baseURL: 'http://localhost:3001',
+      },
+    },
+    {
+      name: 'dev-config-ja',
+      testDir: 'packages/app/e2e-tests',
+      testMatch: '**/quick-start-developer.spec.ts',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
         baseURL: 'http://localhost:3001',
       },
     },

--- a/workspaces/scorecard/packages/app/e2e-tests/pages/CatalogPage.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/pages/CatalogPage.ts
@@ -15,6 +15,18 @@
  */
 import { Page, expect } from '@playwright/test';
 
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  ja: '日本語',
+};
+
+function getLocaleDisplayName(locale: string): string {
+  const baseLocale = locale.split('-')[0];
+  return LOCALE_DISPLAY_NAMES[baseLocale] || locale;
+}
+
 export class CatalogPage {
   readonly page: Page;
 
@@ -28,18 +40,23 @@ export class CatalogPage {
     await enterButton.click();
     await expect(this.page.getByText('Welcome back!')).toBeVisible();
     await this.switchToLocale(this.page, locale);
+    await this.page.getByRole('link', { name: 'Catalog', exact: true }).click();
   }
 
   async openComponent(componentName: string) {
     const link = this.page.getByRole('link', { name: componentName });
-    await expect(link).toBeVisible();
+    await expect(link).toBeVisible({ timeout: 10000 });
     await link.click();
   }
 
   async switchToLocale(page: Page, locale: string): Promise<void> {
+    const baseLocale = locale.split('-')[0];
+    if (baseLocale === 'en') return;
+
+    const displayName = getLocaleDisplayName(locale);
     await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByRole('button', { name: 'English' }).click();
-    await page.getByRole('option', { name: locale }).click();
-    await page.locator('a').filter({ hasText: 'Catalog' }).click();
+    await page.getByRole('option', { name: displayName }).click();
+    await page.locator('a').filter({ hasText: 'Home' }).click();
   }
 }

--- a/workspaces/scorecard/packages/app/e2e-tests/scorecard.test.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/scorecard.test.ts
@@ -19,6 +19,7 @@ import { mockScorecardResponse } from './utils/apiUtils';
 import { CatalogPage } from './pages/CatalogPage';
 import { ScorecardPage } from './pages/ScorecardPage';
 import { setupRBAC } from './utils/rbacSetup';
+import { deleteRBAC } from './utils/rbacDelete';
 import {
   customScorecardResponse,
   emptyScorecardResponse,
@@ -31,7 +32,6 @@ import {
   getTranslations,
 } from './utils/translationUtils';
 import { runAccessibilityTests } from './utils/accessibility';
-import { deleteRBAC } from './utils/rbacDelete';
 
 test.describe.serial('Pre-RBAC Access Tests', () => {
   let translations: ScorecardMessages;
@@ -56,7 +56,7 @@ test.describe.serial('Pre-RBAC Access Tests', () => {
 
     await expect(
       page.getByText(translations.permissionRequired.title),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
     await expect(page.getByRole('article')).toContainText(
       evaluateMessage(
         translations.permissionRequired.description,
@@ -94,9 +94,7 @@ test.describe.serial('Scorecard Plugin Tests', () => {
   test.afterAll(async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
-
     await deleteRBAC(page);
-
     await context.close();
   });
 

--- a/workspaces/scorecard/packages/app/e2e-tests/utils/rbacSetup.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/utils/rbacSetup.ts
@@ -58,7 +58,8 @@ export async function setupRBAC(page: Page) {
   await page.getByRole('button', { name: 'Create' }).click();
 
   await page.locator('a').filter({ hasText: 'Catalog' }).click();
-  await expect(page.getByRole('button', { name: 'Create' })).toBeVisible();
+  const createButton = page.getByRole('button', { name: 'Create' });
+  await expect(createButton).toBeVisible();
 }
 async function selectCheckbox(page: Page, label: string) {
   await page.getByRole('cell', { name: label }).getByRole('checkbox').check();

--- a/workspaces/scorecard/packages/app/e2e-tests/utils/translationUtils.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/utils/translationUtils.ts
@@ -19,6 +19,8 @@ import { scorecardMessages } from '../../../../plugins/scorecard/src/translation
 import scorecardTranslationDe from '../../../../plugins/scorecard/src/translations/de';
 import scorecardTranslationFr from '../../../../plugins/scorecard/src/translations/fr';
 import scorecardTranslationEs from '../../../../plugins/scorecard/src/translations/es';
+import scorecardTranslationIt from '../../../../plugins/scorecard/src/translations/it';
+import scorecardTranslationJa from '../../../../plugins/scorecard/src/translations/ja';
 /* eslint-enable @backstage/no-relative-monorepo-imports */
 
 export type ScorecardMessages = typeof scorecardMessages;
@@ -64,6 +66,10 @@ export function getTranslations(locale: string) {
       return transform(scorecardTranslationDe.messages);
     case 'es':
       return transform(scorecardTranslationEs.messages);
+    case 'it':
+      return transform(scorecardTranslationIt.messages);
+    case 'ja':
+      return transform(scorecardTranslationJa.messages);
     default:
       return scorecardMessages;
   }

--- a/workspaces/scorecard/playwright.config.ts
+++ b/workspaces/scorecard/playwright.config.ts
@@ -64,5 +64,21 @@ export default defineConfig({
         locale: 'fr',
       },
     },
+    {
+      name: 'it',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'it',
+      },
+    },
+    {
+      name: 'ja',
+      testDir: 'packages/app/e2e-tests',
+      use: {
+        channel: 'chrome',
+        locale: 'ja',
+      },
+    },
   ],
 });


### PR DESCRIPTION
## Summary
Add Italian (`it`) and Japanese (`ja`) locale configurations to Playwright e2e tests across all workspaces that support i18n testing.

Which issue(s) does this PR fix
Fixes : [RHIDP-11392](https://issues.redhat.com/browse/RHIDP-11392)

## Changes
Updated `playwright.config.ts` in 9 workspaces:
- adoption-insights
- bulk-import
- extensions
- global-floating-action-button
- global-header
- homepage
- lightspeed
- quickstart
- scorecard

Each workspace now runs e2e tests in 4 locales: `en`, `fr`, `it`, `ja`.