### PR TITLE
fix(quickstart): Resolve  accessibility violations

### DIFF
--- a/workspaces/quickstart/.changeset/legal-times-remain.md
+++ b/workspaces/quickstart/.changeset/legal-times-remain.md
@@ -1,0 +1,9 @@
+---
+'@red-hat-developer-hub/backstage-plugin-quickstart': patch
+---
+
+Fixed WCAG 2.1 AA accessibility violations:
+
+- Added accessible name to progress bar
+- Fixed invalid list structure (ul containing div elements)
+- Resolved nested interactive controls issue

--- a/workspaces/quickstart/plugins/quickstart/report-alpha.api.md
+++ b/workspaces/quickstart/plugins/quickstart/report-alpha.api.md
@@ -17,6 +17,7 @@ export const quickstartTranslationRef: TranslationRef<
     readonly 'footer.progress': string;
     readonly 'footer.hide': string;
     readonly 'footer.notStarted': string;
+    readonly 'footer.progressBarLabel': string;
     readonly 'header.title': string;
     readonly 'header.subtitle': string;
     readonly 'content.emptyState.title': string;

--- a/workspaces/quickstart/plugins/quickstart/report.api.md
+++ b/workspaces/quickstart/plugins/quickstart/report.api.md
@@ -103,6 +103,7 @@ export const quickstartTranslationRef: TranslationRef<
     readonly 'footer.progress': string;
     readonly 'footer.hide': string;
     readonly 'footer.notStarted': string;
+    readonly 'footer.progressBarLabel': string;
     readonly 'header.title': string;
     readonly 'header.subtitle': string;
     readonly 'content.emptyState.title': string;

--- a/workspaces/quickstart/plugins/quickstart/src/components/Quickstart.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/Quickstart.test.tsx
@@ -103,7 +103,7 @@ describe('Quickstart', () => {
 
       // Complete first admin item
       const expandButtons = screen.getAllByRole('button', {
-        name: /expand item/i,
+        name: /expand.*details/i,
       });
       fireEvent.click(expandButtons[0]);
 
@@ -131,7 +131,7 @@ describe('Quickstart', () => {
 
       // Complete first developer item
       const expandButtons = screen.getAllByRole('button', {
-        name: /expand item/i,
+        name: /expand.*details/i,
       });
       fireEvent.click(expandButtons[0]);
 

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartContent.test.tsx
@@ -117,10 +117,10 @@ describe('QuickstartContent', () => {
     );
 
     const expandIcon1 = screen.getAllByRole('button', {
-      name: /expand item/i,
+      name: /expand.*details/i,
     })[0];
     const expandIcon2 = screen.getAllByRole('button', {
-      name: /expand item/i,
+      name: /expand.*details/i,
     })[1];
 
     fireEvent.click(expandIcon1);

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItem.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItem.test.tsx
@@ -77,10 +77,10 @@ describe('QuickstartItem)', () => {
     ).toBeInTheDocument();
   });
 
-  it('calls handleOpen when expand/collapse icon is clicked', async () => {
+  it('calls handleOpen when expand/collapse item is clicked', async () => {
     await renderItem(false);
     const toggleBtn = screen.getByRole('button', {
-      name: /expand item/i,
+      name: /expand.*details/i,
     });
     fireEvent.click(toggleBtn);
     expect(mockHandleOpen).toHaveBeenCalled();

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItem.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartContent/QuickstartItem.tsx
@@ -67,7 +67,10 @@ export const QuickstartItem = ({
   }, [stepCompleted, setProgress]);
 
   return (
-    <Box sx={{ marginBottom: theme => `${theme.spacing(0.2)}` }}>
+    <Box
+      component="li"
+      sx={{ marginBottom: theme => `${theme.spacing(0.2)}`, listStyle: 'none' }}
+    >
       <ListItem
         key={itemKey}
         onClick={handleOpen}
@@ -122,11 +125,8 @@ export const QuickstartItem = ({
           }}
         />
         <IconButton
-          aria-label={
-            open
-              ? t('item.collapseButtonAriaLabel')
-              : t('item.expandButtonAriaLabel')
-          }
+          aria-hidden="true"
+          tabIndex={-1}
           sx={{
             ...(open
               ? { color: theme => theme.palette.text.primary }

--- a/workspaces/quickstart/plugins/quickstart/src/components/QuickstartFooter.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/components/QuickstartFooter.tsx
@@ -33,7 +33,11 @@ export const QuickstartFooter = ({
 
   return (
     <Box>
-      <LinearProgress variant="determinate" value={progress} />
+      <LinearProgress
+        variant="determinate"
+        value={progress}
+        aria-label={t('footer.progressBarLabel')}
+      />
       <Box
         sx={{
           display: 'flex',

--- a/workspaces/quickstart/plugins/quickstart/src/translations/de.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/de.ts
@@ -61,6 +61,7 @@ const quickstartTranslationDe = createTranslationMessages({
     'footer.progress': '{{progress}}% Fortschritt',
     'footer.notStarted': 'Nicht begonnen',
     'footer.hide': 'Ausblenden',
+    'footer.progressBarLabel': 'Schnellstart-Fortschritt',
     'content.emptyState.title':
       'Schnellstart-Inhalte sind für Ihre Rolle nicht verfügbar.',
     'item.expandAriaLabel': '{{title}} Details erweitern',

--- a/workspaces/quickstart/plugins/quickstart/src/translations/es.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/es.ts
@@ -61,6 +61,7 @@ const quickstartTranslationEs = createTranslationMessages({
     'footer.progress': '{{progress}}% de progreso',
     'footer.notStarted': 'No iniciado',
     'footer.hide': 'Ocultar',
+    'footer.progressBarLabel': 'Progreso de inicio rápido',
     'content.emptyState.title':
       'El contenido de inicio rápido no está disponible para tu rol.',
     'item.expandAriaLabel': 'Expandir detalles de {{title}}',

--- a/workspaces/quickstart/plugins/quickstart/src/translations/fr.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/fr.ts
@@ -66,6 +66,7 @@ const quickstartTranslationFr = createTranslationMessages({
     'footer.progress': '{{progress}}% de progrès',
     'footer.notStarted': 'Non démarré',
     'footer.hide': 'Cacher',
+    'footer.progressBarLabel': 'Progression du démarrage rapide',
     'content.emptyState.title':
       "Le contenu de démarrage rapide n'est pas disponible pour votre rôle.",
     'item.expandAriaLabel': 'Développer les détails de {{title}}',

--- a/workspaces/quickstart/plugins/quickstart/src/translations/it.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/it.ts
@@ -68,6 +68,7 @@ const quickstartTranslationIt = createTranslationMessages({
     'footer.progress': '{{progress}}% di avanzamento',
     'footer.notStarted': 'Non iniziato',
     'footer.hide': 'Nascondi',
+    'footer.progressBarLabel': "Avanzamento dell'avvio rapido",
     'content.emptyState.title':
       'Contenuto di avvio rapido non disponibile per il ruolo utente.',
     'item.expandAriaLabel': 'Espandi i dettagli di {{title}}',

--- a/workspaces/quickstart/plugins/quickstart/src/translations/ja.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/ja.ts
@@ -66,6 +66,7 @@ const quickstartTranslationJa = createTranslationMessages({
     'footer.progress': '進捗 {{progress}}%',
     'footer.notStarted': '開始されていません',
     'footer.hide': '非表示',
+    'footer.progressBarLabel': 'クイックスタートの進捗',
     'content.emptyState.title':
       '現在のロールではクイックスタートコンテンツを利用できません。',
     'item.expandAriaLabel': '{{title}} の詳細を展開',

--- a/workspaces/quickstart/plugins/quickstart/src/translations/ref.ts
+++ b/workspaces/quickstart/plugins/quickstart/src/translations/ref.ts
@@ -86,6 +86,7 @@ export const quickstartMessages = {
     progress: '{{progress}}% progress',
     notStarted: 'Not started',
     hide: 'Hide',
+    progressBarLabel: 'Quickstart progress',
   },
   content: {
     emptyState: {


### PR DESCRIPTION
## Summary

This PR addresses 3 accessibility violations identified by axe-core testing against WCAG 2.0/2.1 AA standards.

## Fixed 
- Fixes https://issues.redhat.com/browse/RHDHBUGS-2310

## Changes

### 1. aria-progressbar-name (WCAG 1.1.1)
- Added `aria-label` to `LinearProgress` component in `QuickstartFooter.tsx`
- Added new translation key `footer.progressBarLabel` across all supported languages (en, de, es, fr, it, ja)

### 2. Invalid list structure (WCAG 1.3.1)
- Changed outer `Box` wrapper in `QuickstartItem.tsx` to render as `<li>` element using `component="li"`
- Ensures proper HTML semantics where `<ul>` only contains `<li>` children

### 3. Nested interactive controls (WCAG 4.1.2)
- Modified `IconButton` in `QuickstartItem.tsx` to be purely decorative:
  - Added `aria-hidden="true"` to hide from screen readers
  - Added `tabIndex={-1}` to remove from tab order
- Parent `ListItem` with `role="button"` handles all interactivity

## UI after changes

https://github.com/user-attachments/assets/244e41cb-f9bf-4945-a62d-af5544e0778e


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
