### PR TITLE
feat[Orchestrator]: Allow skipping initial fetch defaults for orchestrator form widgets

### DIFF
--- a/workspaces/orchestrator/.changeset/skip-initial-value-defaults.md
+++ b/workspaces/orchestrator/.changeset/skip-initial-value-defaults.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Add fetch:skipInitialValue to keep fields empty until user input and treat empty-string defaults as valid.

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -244,6 +244,7 @@ The data are further re-fetched, if the value of one of the `fetch:retrigger` re
 If the `fetch:retrigger` is omitted, the fetch is issued just once to preload the data.
 
 Because a text input’s default value only applies when the field is initially empty, any changes to the returned value in subsequent requests are ignored if the user has already entered data into that field.
+If you want to keep the field empty until the user interacts with it, set `fetch:skipInitialValue` to `true`.
 
 ### ActiveTextInput Data validation
 
@@ -302,6 +303,7 @@ The widget supports following `ui:props`:
 - fetch:retrigger
 - fetch:error:ignoreUnready
 - fetch:error:silent
+- fetch:skipInitialValue
 - fetch:response:value
 - fetch:response:default
 - fetch:response:autocomplete
@@ -343,6 +345,7 @@ The widget supports following `ui:props`:
 - fetch:retrigger
 - fetch:error:ignoreUnready
 - fetch:error:silent
+- fetch:skipInitialValue
 - fetch:response:value
 - fetch:response:default
 - fetch:response:label
@@ -393,6 +396,7 @@ The widget supports following `ui:props`:
 - fetch:retrigger
 - fetch:error:ignoreUnready
 - fetch:error:silent
+- fetch:skipInitialValue
 - fetch:response:autocomplete
 - fetch:response:mandatory
 - fetch:response:value
@@ -532,7 +536,8 @@ Various selectors (like `fetch:response:*`) are processed by the [jsonata](https
 |       fetch:retrigger       |                                                                                                                                                An array of keys/key families as described in the Backstage API Exposed Parts. If the value referenced by any key from this list is changed, the fetch is triggered.                                                                                                                                                |                      `["current.solutionName", "identityApi.profileName"]`                      |
 |  fetch:error:ignoreUnready  |                                                                                                 When set to `true`, suppresses fetch error display until all `fetch:retrigger` dependencies have non-empty values. This is useful when fetch depends on other fields that are not filled yet, preventing expected errors from being displayed during initial load.                                                                                                 |                               `true`, `false` (default: `false`)                                |
 |     fetch:error:silent      |                                                                                                                         When set to `true`, suppresses fetch error display when the fetch request returns a non-OK status (4xx/5xx). Use this when you want to handle error states via conditional UI instead of showing the widget error.                                                                                                                         |                               `true`, `false` (default: `false`)                                |
-|   fetch:response:default    |                                                                   A static default value that is applied immediately when the widget mounts, before any fetch completes. Acts as a fallback when fetch fails or has not completed yet. Gets overridden by `fetch:response:value` once fetch succeeds. For ActiveTextInput/ActiveDropdown use a string, for ActiveMultiSelect use a string array.                                                                   |                        `"create"` (string) or `["tag1", "tag2"]` (array)                        |
+|   fetch:skipInitialValue    |                                                                                                                                                       When set to `true`, prevents applying the initial value from `fetch:response:value`, keeping the field empty until the user selects or types a value.                                                                                                                                                        |                               `true`, `false` (default: `false`)                                |
+|   fetch:response:default    |                                                  A static default value that is applied immediately when the widget mounts, before any fetch completes. Acts as a fallback when fetch fails or has not completed yet. Gets overridden by `fetch:response:value` once fetch succeeds. Empty string defaults are valid. For ActiveTextInput/ActiveDropdown use a string, for ActiveMultiSelect use a string array.                                                   |                        `"create"` (string) or `["tag1", "tag2"]` (array)                        |
 | fetch:response:\[YOUR_KEY\] |                                                                                            A JSONata selector (string) or object value for extracting data from the fetch response. There can be any count of the \[YOUR_KEY\] properties, so a single fetch response can be used to retrieve multiple records. Supports both string selectors and object type values.                                                                                             |                                 Account.Order.Product.ProductID                                 |
 |    fetch:response:label     |                                                                                                                                                                         Special (well-known) case of the fetch:response:\[YOUR_KEY\] . Used i.e. by the ActiveDropdown to label the items.                                                                                                                                                                         |                                                                                                 |
 |    fetch:response:value     |                                                                                                                                                                Like fetch:response:label, but gives i.e. ActiveDropdown item values (not visible to the user but actually used as the field value)                                                                                                                                                                 |                                                                                                 |

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/uiPropTypes.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/uiPropTypes.ts
@@ -27,6 +27,7 @@ export type UiProps = {
   'fetch:retrigger'?: string[];
   'fetch:error:ignoreUnready'?: boolean;
   'fetch:error:silent'?: boolean;
+  'fetch:skipInitialValue'?: boolean;
   [key: `fetch:response:${string}`]: JsonValue;
 };
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
@@ -75,8 +75,9 @@ export const ActiveDropdown: Widget<
   const labelSelector = uiProps['fetch:response:label']?.toString();
   const valueSelector = uiProps['fetch:response:value']?.toString();
   const staticDefault = uiProps['fetch:response:default'];
-  const staticDefaultValue =
-    typeof staticDefault === 'string' ? staticDefault : undefined;
+  const hasStaticDefault = typeof staticDefault === 'string';
+  const staticDefaultValue = hasStaticDefault ? staticDefault : undefined;
+  const skipInitialValue = uiProps['fetch:skipInitialValue'] === true;
 
   const [localError, setLocalError] = useState<string | undefined>(
     !labelSelector || !valueSelector
@@ -145,16 +146,31 @@ export const ActiveDropdown: Widget<
   // Priority: static default (if valid option) > first fetched option
   // Note: Static defaults are applied at form initialization level (in OrchestratorForm)
   useEffect(() => {
-    if (!isChangedByUser && !value && values && values.length > 0) {
+    if (
+      !skipInitialValue &&
+      !isChangedByUser &&
+      !value &&
+      values &&
+      values.length > 0
+    ) {
       // If static default is provided and is a valid option, use it
-      if (staticDefaultValue && values.includes(staticDefaultValue)) {
-        handleChange(staticDefaultValue, false);
+      if (hasStaticDefault && values.includes(staticDefault)) {
+        handleChange(staticDefault, false);
       } else {
         // Otherwise use the first fetched value
         handleChange(values[0], false);
       }
     }
-  }, [handleChange, value, values, isChangedByUser, staticDefaultValue]);
+  }, [
+    handleChange,
+    value,
+    values,
+    isChangedByUser,
+    staticDefault,
+    staticDefaultValue,
+    hasStaticDefault,
+    skipInitialValue,
+  ]);
 
   const shouldShowFetchError = uiProps['fetch:error:silent'] !== true;
   const suppressFetchError = !shouldShowFetchError && !!error;
@@ -165,7 +181,7 @@ export const ActiveDropdown: Widget<
 
   // Compute display options: use fetched options, or fall back to static default
   const hasOptions = labels && labels.length > 0 && values && values.length > 0;
-  const hasFallbackDefault = !hasOptions && staticDefaultValue;
+  const hasFallbackDefault = !hasOptions && hasStaticDefault;
 
   // Show loading only if we have no options AND no fallback default
   if (completeLoading && !hasFallbackDefault && !suppressFetchError) {

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
@@ -84,6 +84,7 @@ export const ActiveMultiSelect: Widget<
   const defaultValueSelector = uiProps['fetch:response:value']?.toString();
   const allowNewItems = uiProps['ui:allowNewItems'] === true;
   const staticDefault = uiProps['fetch:response:default'];
+  const skipInitialValue = uiProps['fetch:skipInitialValue'] === true;
   const staticDefaultValues = Array.isArray(staticDefault)
     ? (staticDefault as string[])
     : undefined;
@@ -174,7 +175,7 @@ export const ActiveMultiSelect: Widget<
         }
 
         let defaults: string[] = [];
-        if (!isChangedByUser) {
+        if (!skipInitialValue && !isChangedByUser) {
           // set this just once, when the user has not touched the field
           if (defaultValueSelector) {
             defaults = await applySelectorArray(
@@ -219,6 +220,7 @@ export const ActiveMultiSelect: Widget<
     autocompleteOptions,
     mandatoryValues,
     isChangedByUser,
+    skipInitialValue,
     data,
     props.id,
     value,

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
@@ -70,14 +70,14 @@ export const ActiveTextInput: Widget<
   const autocompleteSelector =
     uiProps['fetch:response:autocomplete']?.toString();
   const staticDefault = uiProps['fetch:response:default'];
-  const staticDefaultValue =
-    typeof staticDefault === 'string' ? staticDefault : undefined;
+  const hasStaticDefault = typeof staticDefault === 'string';
+  const skipInitialValue = uiProps['fetch:skipInitialValue'] === true;
   const hasFetchUrl = !!uiProps['fetch:url'];
 
   // If fetch:url is configured, either fetch:response:value OR fetch:response:default should be set
   // to provide meaningful behavior. Without fetch:url, the widget works as a plain text input.
   const [localError] = useState<string | undefined>(
-    hasFetchUrl && !defaultValueSelector && !staticDefaultValue
+    hasFetchUrl && !defaultValueSelector && !hasStaticDefault
       ? `When fetch:url is configured, either fetch:response:value or fetch:response:default should be set for ${props.id}.`
       : undefined,
   );
@@ -123,7 +123,7 @@ export const ActiveTextInput: Widget<
     const doItAsync = async () => {
       await wrapProcessing(async () => {
         // Only apply fetched value if user hasn't changed the field
-        if (!isChangedByUser && defaultValueSelector) {
+        if (!skipInitialValue && !isChangedByUser && defaultValueSelector) {
           const fetchedValue = await applySelectorString(
             data,
             defaultValueSelector,
@@ -157,6 +157,7 @@ export const ActiveTextInput: Widget<
     value,
     handleChange,
     isChangedByUser,
+    skipInitialValue,
     wrapProcessing,
   ]);
 
@@ -168,7 +169,7 @@ export const ActiveTextInput: Widget<
 
   // Show loading only if we don't have a static default value to display
   // This ensures the default is shown instantly while fetch happens in background
-  if (completeLoading && !staticDefaultValue) {
+  if (completeLoading && !hasStaticDefault) {
     return <CircularProgress size={20} />;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes

https://issues.redhat.com/browse/RHDHBUGS-2508

#### Summary

- Add `fetch:skipInitialValue` to keep fields empty until user interaction
- Treat `fetch:response:default: ""` as a valid default
- Document the new option and behavior

#### Changes

- Update ActiveTextInput, ActiveDropdown, and ActiveMultiSelect defaulting logic
- Extend UiProps with `fetch:skipInitialValue`

#### Screen recording

![Orchestrator - skip initial prop](https://github.com/user-attachments/assets/084b0d53-e066-4569-a28c-8681caf30592)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
