### PR TITLE
chore: update bulk-import app-config to have the default orchestrator…

### DIFF
--- a/workspaces/bulk-import/app-config.yaml
+++ b/workspaces/bulk-import/app-config.yaml
@@ -141,11 +141,11 @@ orchestrator:
     # runtime: podman
     baseUrl: http://localhost
     port: 8899
-    autoStart: false
+    autoStart: true
     # If you're using a MacBook with M-series chips, uncomment the line below to use ARM images.
     # To pull the image, you'll first need to authenticate with the registry.
     # For more information, visit: https://red.ht/410mMNU.
-    container: registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.36.0
+    # container: registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.36.0
     # notsecret
     notificationsBearerToken: bXljdXJscGFzc3dkCg==
     notificationsUrl: http://host.docker.internal:7007
@@ -156,7 +156,7 @@ orchestrator:
     # persistence:
     #  path: ./.devModeTemp/db_persistence # this will be under packages/backend
     workflowsSource:
-      gitRepositoryUrl: https://github.com/AndrienkoAleksandr/backstage-orchestrator-workflows.git
+      gitRepositoryUrl: https://github.com/rhdhorchestrator/backstage-orchestrator-workflows.git
       localPath: ./.devModeTemp/repository # this will be under packages/backend
   dataIndexService:
     url: http://localhost:8899


### PR DESCRIPTION
… values

## Hey, I just made a Pull Request!


This is a very simple update.  It changes the orchestrator setup in the app-config of the bulk-import plugin back to its defaults.

cc @AndrienkoAleksandr 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
