### PR TITLE
fix(extensions): show error when toggle fails

### DIFF
--- a/workspaces/extensions/.changeset/popular-pumpkins-punch.md
+++ b/workspaces/extensions/.changeset/popular-pumpkins-punch.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-extensions': patch
+---
+
+show error in the UI when toggle action fails

--- a/workspaces/extensions/plugins/extensions/src/components/ExtensionsPackageEditContent.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/ExtensionsPackageEditContent.tsx
@@ -55,6 +55,7 @@ import { TabPanel } from './TabPanel';
 import { useInstallationContext } from './InstallationContext';
 import { useTranslation } from '../hooks/useTranslation';
 import { ExtensionsStatus, getPluginActionTooltipMessage } from '../utils';
+import { InstallationWarning } from './InstallationWarning';
 
 interface TabItem {
   label: string;
@@ -197,6 +198,13 @@ export const ExtensionsPackageEditContent = ({
 
   const showRightCard = hasPackageExamples;
 
+  const showEditWarning =
+    (pkgConfig.data as any)?.error?.message &&
+    (pkgConfig.data as any)?.error?.reason !==
+      ExtensionsStatus.INSTALLATION_DISABLED &&
+    (pkgConfig.data as any)?.error?.reason !==
+      ExtensionsStatus.INSTALLATION_DISABLED_IN_PRODUCTION;
+
   const handleSave = async () => {
     try {
       setSaveError(null);
@@ -279,6 +287,12 @@ export const ExtensionsPackageEditContent = ({
 
   return (
     <>
+      {showEditWarning && <InstallationWarning configData={pkgConfig.data} />}
+      {saveError && (
+        <Alert severity="error" sx={{ mb: '1rem' }}>
+          {saveError}
+        </Alert>
+      )}
       {!pkg.spec?.dynamicArtifact && (
         <Alert severity="error" sx={{ mb: '1rem' }}>
           <AlertTitle>{t('alert.missingDynamicArtifactTitle')}</AlertTitle>

--- a/workspaces/extensions/plugins/extensions/src/components/InstalledPackages/InstalledPackagesTable.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/InstalledPackages/InstalledPackagesTable.tsx
@@ -27,6 +27,8 @@ import { Query, QueryResult } from '@material-table/core';
 import { useQuery } from '@tanstack/react-query';
 
 import Box from '@mui/material/Box';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 import {
   ExtensionsPackage,
   ExtensionsPackageInstallStatus,
@@ -58,6 +60,8 @@ import {
 
 export const InstalledPackagesTable = () => {
   const { t } = useTranslation();
+  const [rowActionError, setRowActionError] = useState<string | null>(null);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
   const extensionsConfig = useExtensionsConfiguration();
   const { installedPackages } = useInstallationContext();
   const nodeEnvironment = useNodeEnvironment();
@@ -187,11 +191,19 @@ export const InstalledPackagesTable = () => {
             <DownloadPackageYaml
               pkg={row}
               isProductionEnv={isProductionEnvironment}
+              onError={(err: string) => {
+                setRowActionError(err);
+                setSnackbarOpen(true);
+              }}
             />
             <TogglePackage
               pkg={row}
               isProductionEnv={isProductionEnvironment}
               isInstallationEnabled={extensionsConfig.data?.enabled ?? false}
+              onError={(err: string) => {
+                setRowActionError(err);
+                setSnackbarOpen(true);
+              }}
             />
           </Box>
         );
@@ -359,6 +371,31 @@ export const InstalledPackagesTable = () => {
         onClose={setOpenInstalledPackagesDialog}
         showPackages
       />
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={6000}
+        onClose={() => {
+          setSnackbarOpen(false);
+          setRowActionError(null);
+        }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        sx={{
+          top: '80px !important',
+        }}
+      >
+        <Alert
+          onClose={() => {
+            setSnackbarOpen(false);
+            setRowActionError(null);
+          }}
+          severity="error"
+          sx={{ width: '100%' }}
+        >
+          {Array.isArray(rowActionError)
+            ? rowActionError.map((err, idx) => <div key={idx}>{err}</div>)
+            : rowActionError}
+        </Alert>
+      </Snackbar>
     </>
   );
 };

--- a/workspaces/extensions/plugins/extensions/src/pages/ExtensionsPackageInstallPage.tsx
+++ b/workspaces/extensions/plugins/extensions/src/pages/ExtensionsPackageInstallPage.tsx
@@ -35,7 +35,7 @@ const PackageEditHeader = () => {
 
   const pkg = usePackage(params.namespace, params.name);
 
-  const displayName = pkg.data?.metadata.title ?? params.name;
+  const displayName = pkg.data?.metadata?.title ?? params.name;
   const title =
     location?.state?.viewOnly || !pkg.data?.spec?.dynamicArtifact
       ? displayName


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://issues.redhat.com/browse/RHDHBUGS-2125

When the dynamic-plugins yaml file configured in the extensions configuration is incorrect, the toggle action fails due to "FILE_NOT_EXISTS" err. The network call fails, but the err is not displayed in the UI. This gives the impression that the toggle button doesn't work.

As part of this PR
- If the toggle fails for any reason, it is displayed in the UI via a Snackbar Alert
- but for the 'Download YAML` action, if the configured file is incorrect, we let the user download a minimal version of the plugin, which would look like
```
- package: ../<package-path>
  disabled: false
```
Along with an info in the browser's console saying `No configuration found for package <package-name>, downloaded a minimal YAML`


Currently, whether the configured file exists or not is evaluated only when the package/plugin configuration is fetched. Because of this, the UI cannot determine the file’s existence beforehand

cc @dzemanov 




**GIF:**


https://github.com/user-attachments/assets/e9f0919e-19d6-488a-a900-c613c345e636



**Test setup:**

In your extensions configuration, configure a file that doesn't exist

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
