### PR TITLE
feat[Orchestrator]: exclude omitFromWorkflowInput from payloads and add hidden params toggle

### DIFF
--- a/workspaces/orchestrator/.changeset/omit-hidden-fields-review-toggle.md
+++ b/workspaces/orchestrator/.changeset/omit-hidden-fields-review-toggle.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Exclude omitFromWorkflowInput fields from execution payloads and add a review
+toggle to show hidden parameters.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -28,7 +28,7 @@ import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-p
 import { TranslationFunction } from '../hooks/useTranslation';
 import extractStaticDefaults from '../utils/extractStaticDefaults';
 import generateUiSchema from '../utils/generateUiSchema';
-import { pruneFormData } from '../utils/pruneFormData';
+import { omitFromWorkflowInput, pruneFormData } from '../utils/pruneFormData';
 import { StepperContextProvider } from '../utils/StepperContext';
 import OrchestratorFormWrapper from './OrchestratorFormWrapper';
 import ReviewStep from './ReviewStep';
@@ -149,10 +149,14 @@ const OrchestratorForm = ({
     return pruneFormData(formData, schema);
   }, [formData, schema]);
 
+  const workflowInputData = useMemo(() => {
+    return omitFromWorkflowInput(prunedFormData, schema);
+  }, [prunedFormData, schema]);
+
   const _handleExecute = useCallback(() => {
     // Use pruned data for execution to avoid submitting stale properties
-    handleExecute(prunedFormData);
-  }, [prunedFormData, handleExecute]);
+    handleExecute(workflowInputData);
+  }, [workflowInputData, handleExecute]);
 
   const onSubmit = useCallback(
     (_formData: JsonObject) => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Content } from '@backstage/core-components';
 import { JsonObject } from '@backstage/types';
@@ -22,7 +22,10 @@ import { JsonObject } from '@backstage/types';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
 import type { JSONSchema7 } from 'json-schema';
 import { get } from 'lodash';
 import { makeStyles } from 'tss-react/mui';
@@ -59,6 +62,12 @@ const useStyles = makeStyles()(theme => ({
   },
   hiddenFieldsAlert: {
     marginBottom: theme.spacing(2),
+  },
+  hiddenFieldsAction: {
+    marginLeft: theme.spacing(2),
+  },
+  hiddenFieldsText: {
+    fontSize: theme.typography.body1.fontSize,
   },
 }));
 
@@ -115,9 +124,12 @@ const ReviewStep = ({
 
   const { classes } = useStyles();
   const { handleBack } = useStepperContext();
+  const [showHiddenFields, setShowHiddenFields] = useState(false);
   const displayData = useMemo<JsonObject>(() => {
-    return generateReviewTableData(schema, data);
-  }, [schema, data]);
+    return generateReviewTableData(schema, data, {
+      includeHiddenFields: showHiddenFields,
+    });
+  }, [schema, data, showHiddenFields]);
 
   const showHiddenFieldsNote = useMemo(() => {
     return hasHiddenFields(schema);
@@ -127,8 +139,32 @@ const ReviewStep = ({
     <Content noPadding>
       <Paper square elevation={0} className={classes.paper}>
         {showHiddenFieldsNote && (
-          <Alert severity="info" className={classes.hiddenFieldsAlert}>
-            {t('reviewStep.hiddenFieldsNote')}
+          <Alert
+            severity="info"
+            className={classes.hiddenFieldsAlert}
+            action={
+              <FormControlLabel
+                className={classes.hiddenFieldsAction}
+                control={
+                  <Switch
+                    checked={showHiddenFields}
+                    onChange={event =>
+                      setShowHiddenFields(event.target.checked)
+                    }
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography className={classes.hiddenFieldsText}>
+                    {t('reviewStep.showHiddenParameters')}
+                  </Typography>
+                }
+              />
+            }
+          >
+            <Typography className={classes.hiddenFieldsText}>
+              {t('reviewStep.hiddenFieldsNote')}
+            </Typography>
           </Alert>
         )}
         <NestedReviewTable data={displayData} />

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.test.ts
@@ -204,6 +204,38 @@ describe('mapSchemaToData', () => {
     expect(result).toEqual(expectedResult);
   });
 
+  it('should include hidden fields when includeHiddenFields is true', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        visibleField: {
+          type: 'string',
+          title: 'Visible Field',
+        },
+        hiddenField: {
+          type: 'string',
+          title: 'Hidden Field',
+          'ui:hidden': true,
+        } as JSONSchema7,
+      },
+    };
+
+    const data = {
+      visibleField: 'shown',
+      hiddenField: 'should appear',
+    };
+
+    const expectedResult = {
+      'Visible Field': 'shown',
+      'Hidden Field': 'should appear',
+    };
+
+    const result = generateReviewTableData(schema, data, {
+      includeHiddenFields: true,
+    });
+    expect(result).toEqual(expectedResult);
+  });
+
   it('should exclude nested hidden fields from review table', () => {
     const schema: JSONSchema7 = {
       type: 'object',

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.test.ts
@@ -18,7 +18,7 @@ import { JsonObject } from '@backstage/types';
 
 import { JSONSchema7 } from 'json-schema';
 
-import { pruneFormData } from './pruneFormData';
+import { omitFromWorkflowInput, pruneFormData } from './pruneFormData';
 
 describe('pruneFormData', () => {
   describe('Basic Property Handling', () => {
@@ -724,6 +724,65 @@ describe('pruneFormData', () => {
       });
       expect(result.step1).not.toHaveProperty('advancedField1');
       expect(result.step1).not.toHaveProperty('advancedField2');
+    });
+  });
+
+  describe('omitFromWorkflowInput', () => {
+    it('should remove properties marked with omitFromWorkflowInput', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          visible: { type: 'string' },
+          hidden: {
+            type: 'string',
+            omitFromWorkflowInput: true,
+          } as JSONSchema7,
+        },
+      };
+
+      const formData = {
+        visible: 'keep',
+        hidden: 'omit',
+      };
+
+      const result = omitFromWorkflowInput(formData, schema);
+
+      expect(result).toEqual({ visible: 'keep' });
+      expect(result).not.toHaveProperty('hidden');
+    });
+
+    it('should remove nested properties marked with omitFromWorkflowInput', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          step: {
+            type: 'object',
+            properties: {
+              visible: { type: 'string' },
+              secret: {
+                type: 'string',
+                omitFromWorkflowInput: true,
+              } as JSONSchema7,
+            },
+          },
+        },
+      };
+
+      const formData = {
+        step: {
+          visible: 'keep',
+          secret: 'omit',
+        },
+      };
+
+      const result = omitFromWorkflowInput(formData, schema);
+
+      expect(result).toEqual({
+        step: {
+          visible: 'keep',
+        },
+      });
+      expect(result.step).not.toHaveProperty('secret');
     });
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -164,6 +164,7 @@ readonly "tooltips.workflowDown": string;
 readonly "tooltips.suspended": string;
 readonly "tooltips.userNotAuthorizedAbort": string;
 readonly "reviewStep.hiddenFieldsNote": string;
+readonly "reviewStep.showHiddenParameters": string;
 readonly "permissions.accessDenied": string;
 readonly "permissions.accessDeniedDescription": string;
 readonly "permissions.requiredPermission": string;
@@ -185,7 +186,7 @@ export const orchestratorTranslations: TranslationResource<"plugin.orchestrator"
 // src/components/catalogComponents/CatalogTab.d.ts:1:22 - (ae-undocumented) Missing documentation for "IsOrchestratorCatalogTabAvailable".
 // src/components/catalogComponents/CatalogTab.d.ts:2:22 - (ae-undocumented) Missing documentation for "OrchestratorCatalogTab".
 // src/translations/index.d.ts:2:22 - (ae-undocumented) Missing documentation for "orchestratorTranslations".
-// src/translations/ref.d.ts:200:22 - (ae-undocumented) Missing documentation for "orchestratorTranslationRef".
+// src/translations/ref.d.ts:201:22 - (ae-undocumented) Missing documentation for "orchestratorTranslationRef".
 
 // (No @packageDocumentation comment for this package)
 

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -148,7 +148,8 @@ const orchestratorTranslationDe = createTranslationMessages({
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'Zusätzliche Informationen zu diesem Fehler sind nicht verfügbar',
     'reviewStep.hiddenFieldsNote':
-      'Einige Felder sind auf dieser Seite ausgeblendet, werden aber in die Workflow-Ausführungsanforderung aufgenommen.',
+      'Einige Parameter sind auf dieser Seite ausgeblendet.',
+    'reviewStep.showHiddenParameters': 'Verborgene Parameter anzeigen',
     'common.close': 'Schließen',
     'common.cancel': 'Abbrechen',
     'common.execute': 'Ausführen',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -149,7 +149,8 @@ const orchestratorTranslationEs = createTranslationMessages({
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'No hay detalles adicionales sobre este error disponibles',
     'reviewStep.hiddenFieldsNote':
-      'Algunos campos están ocultos en esta página pero se incluirán en la solicitud de ejecución del flujo de trabajo.',
+      'Algunos parámetros están ocultos en esta página.',
+    'reviewStep.showHiddenParameters': 'Mostrar parámetros ocultos',
     'common.close': 'Cerrar',
     'common.cancel': 'Cancelar',
     'common.execute': 'Ejecutar',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -151,6 +151,9 @@ const orchestratorTranslationFr = createTranslationMessages({
       "Ce workflow n'a pas de schéma JSON défini pour la validation des entrées. Vous pouvez toujours exécuter le workflow, mais la validation des entrées sera limitée.",
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'Des détails supplémentaires sur cette erreur ne sont pas disponibles',
+    'reviewStep.hiddenFieldsNote':
+      'Certains paramètres sont masqués sur cette page.',
+    'reviewStep.showHiddenParameters': 'Afficher les paramètres masqués',
     'common.close': 'Fermer',
     'common.cancel': 'Annuler',
     'common.execute': 'Exécuter',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -152,6 +152,9 @@ const orchestratorTranslationIt = createTranslationMessages({
       "Nessuno schema JSON definito per la convalida dell'input di questo flusso di lavoro. È comunque possibile eseguire il flusso di lavoro, ma la convalida degli input sarà limitata.",
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'Non sono disponibili ulteriori dettagli su questo errore',
+    'reviewStep.hiddenFieldsNote':
+      'Alcuni parametri sono nascosti in questa pagina.',
+    'reviewStep.showHiddenParameters': 'Mostra parametri nascosti',
     'common.close': 'Chiudi',
     'common.cancel': 'Cancella',
     'common.execute': 'Esegui',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
@@ -146,6 +146,9 @@ const orchestratorTranslationJa = createTranslationMessages({
       'このワークフローには、入力検証用に定義された JSON スキーマがありません。ワークフローの実行は可能ですが、入力の検証は限定的になります。',
     'messages.additionalDetailsAboutThisErrorAreNotAvailable':
       'このエラーに関する追加情報はありません',
+    'reviewStep.hiddenFieldsNote':
+      'このページでは一部のパラメーターが非表示です。',
+    'reviewStep.showHiddenParameters': '非表示のパラメーターを表示',
     'common.close': '閉じる',
     'common.cancel': 'キャンセル',
     'common.execute': '実行',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -176,8 +176,8 @@ export const orchestratorMessages = {
       'Additional details about this error are not available',
   },
   reviewStep: {
-    hiddenFieldsNote:
-      'Some fields are hidden on this page but will be included in the workflow execution request.',
+    hiddenFieldsNote: 'Some parameters are hidden on this page.',
+    showHiddenParameters: 'Show hidden parameters',
   },
   common: {
     close: 'Close',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes

https://issues.redhat.com/browse/RHDHBUGS-2510

- Exclude fields marked `omitFromWorkflowInput` from the execution payload while keeping them in form state.
- Add a “Show hidden parameters” toggle to the review step 

#### Recording


https://github.com/user-attachments/assets/658fdb27-2f0d-4303-9436-a3526453e208



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
