### PR TITLE
fix(lightspeed): render new lines in deep thinking component

### DIFF
--- a/workspaces/lightspeed/.changeset/tasty-pumpkins-design.md
+++ b/workspaces/lightspeed/.changeset/tasty-pumpkins-design.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Render new lines in deepThinking component

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
@@ -248,6 +248,10 @@ export const LightspeedChatBox = forwardRef(
 
             if (reasoningContent) {
               deepThinking = {
+                cardBodyProps: {
+                  id: `deep-thinking-${index}`,
+                  style: { whiteSpace: 'pre-line' },
+                },
                 toggleContent: t('reasoning.thinking'),
                 body: reasoningContent,
                 expandableSectionProps: {},

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChatBox.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChatBox.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChatbotDisplayMode } from '@patternfly/chatbot';
+import { render, screen } from '@testing-library/react';
+
+import { mockUseTranslation } from '../../test-utils/mockTranslations';
+import { LightspeedChatBox } from '../LightspeedChatBox';
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: jest.fn(() => mockUseTranslation()),
+}));
+
+jest.mock('../../hooks/useAutoScroll', () => ({
+  useAutoScroll: jest.fn(() => ({
+    autoScroll: true,
+    resumeAutoScroll: jest.fn(),
+    stopAutoScroll: jest.fn(),
+    scrollToBottom: jest.fn(),
+    scrollToTop: jest.fn(),
+  })),
+}));
+
+jest.mock('../../hooks/useBufferedMessages', () => ({
+  useBufferedMessages: jest.fn(messages => {
+    return messages || [];
+  }),
+}));
+
+jest.mock('../../hooks/useFeedbackActions', () => ({
+  useFeedbackActions: jest.fn(messages => {
+    return messages || [];
+  }),
+}));
+
+jest.mock('@patternfly/chatbot', () => {
+  const actual = jest.requireActual('@patternfly/chatbot');
+  return {
+    ...actual,
+    DeepThinking: ({
+      body,
+      cardBodyProps,
+    }: {
+      body: React.ReactNode;
+      cardBodyProps?: any;
+    }) => (
+      <div data-testid="deep-thinking" {...cardBodyProps}>
+        {body}
+      </div>
+    ),
+    MessageBox: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="message-box">{children}</div>
+    ),
+    Message: (props: any) => (
+      <div data-testid={`message-${props.role || 'unknown'}`}>
+        {props.extraContent?.beforeMainContent}
+        {props.content}
+        {props.extraContent?.afterMainContent}
+      </div>
+    ),
+  };
+});
+
+describe('LightspeedChatBox', () => {
+  const defaultProps = {
+    userName: 'user:test',
+    messages: [],
+    announcement: undefined,
+    conversationId: 'test-conversation-id',
+    profileLoading: false,
+    welcomePrompts: [],
+    isStreaming: false,
+    topicRestrictionEnabled: false,
+    displayMode: ChatbotDisplayMode.embedded,
+  };
+
+  it('should render reasoning content with newlines using pre-line style', () => {
+    const messagesWithReasoning = [
+      {
+        role: 'bot' as const,
+        content: '<think>Line 1\nLine 2\nLine 3</think>Main response content',
+        timestamp: '2026-01-22T00:00:00Z',
+      },
+    ];
+
+    render(
+      <LightspeedChatBox {...defaultProps} messages={messagesWithReasoning} />,
+    );
+
+    const deepThinking = screen.getByTestId('deep-thinking');
+    expect(deepThinking).toBeInTheDocument();
+
+    // Check that the reasoning body contains the content
+    const reasoningContent = deepThinking.textContent;
+    expect(reasoningContent).toContain('Line 1');
+    expect(reasoningContent).toContain('Line 2');
+    expect(reasoningContent).toContain('Line 3');
+
+    expect(deepThinking).toHaveStyle({ whiteSpace: 'pre-line' });
+  });
+
+  it('should handle reasoning content without newlines', () => {
+    const messagesWithReasoning = [
+      {
+        role: 'bot' as const,
+        content: '<think>Single line reasoning</think>Main response',
+        name: 'assistant',
+        timestamp: '2024-01-01T00:00:00Z',
+      },
+    ];
+
+    render(
+      <LightspeedChatBox {...defaultProps} messages={messagesWithReasoning} />,
+    );
+
+    const deepThinking = screen.getByTestId('deep-thinking');
+    expect(deepThinking).toBeInTheDocument();
+    expect(deepThinking).toHaveTextContent('Single line reasoning');
+
+    expect(deepThinking).toHaveStyle({ whiteSpace: 'pre-line' });
+  });
+
+  it('should handle reasoning in progress with newlines', () => {
+    const messagesWithReasoningInProgress = [
+      {
+        role: 'bot' as const,
+        content: '<think>Line 1\nLine 2\nLine 3',
+        timestamp: '2024-01-01T00:00:00Z',
+        name: 'assistant',
+      },
+    ];
+
+    render(
+      <LightspeedChatBox
+        {...defaultProps}
+        messages={messagesWithReasoningInProgress}
+      />,
+    );
+
+    const deepThinking = screen.getByTestId('deep-thinking');
+    expect(deepThinking).toBeInTheDocument();
+
+    expect(deepThinking).toHaveStyle({ whiteSpace: 'pre-line' });
+    expect(deepThinking.textContent).toContain('Line 1');
+    expect(deepThinking.textContent).toContain('Line 2');
+    expect(deepThinking.textContent).toContain('Line 3');
+  });
+
+  it('should handle reasoning content with multiple newlines', () => {
+    const messagesWithReasoningInProgress = [
+      {
+        role: 'bot' as const,
+        content: '<think>Line 1\n\n\nLine 2\nLine 3',
+        timestamp: '2024-01-01T00:00:00Z',
+        name: 'assistant',
+      },
+    ];
+
+    render(
+      <LightspeedChatBox
+        {...defaultProps}
+        messages={messagesWithReasoningInProgress}
+      />,
+    );
+
+    const deepThinking = screen.getByTestId('deep-thinking');
+    expect(deepThinking).toBeInTheDocument();
+
+    expect(deepThinking).toHaveStyle({ whiteSpace: 'pre-line' });
+    expect(deepThinking.textContent).toContain('Line 1');
+    expect(deepThinking.textContent).toContain('Line 2');
+    expect(deepThinking.textContent).toContain('Line 3');
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Fixes:**
https://issues.redhat.com/browse/RHDHBUGS-2535


Add line breaks in the deep thinking component to increase the readability.


**Before fix:**
<img width="1705" height="960" alt="DeepThinking" src="https://github.com/user-attachments/assets/9dafcf1e-4cbb-4027-bdbf-6ffbc0023b4c" /> 

---

**After fix:**
<img width="1699" height="951" alt="Deep Thinking_after_fix" src="https://github.com/user-attachments/assets/c5e5146b-5018-42b0-98e8-519f23ea1e37" />




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
