### PR TITLE
feat(orchestrator): add dynamic plugin export support for orchestrator-backend-module-loki

### DIFF
--- a/workspaces/orchestrator/.changeset/add-loki-dynamic-export.md
+++ b/workspaces/orchestrator/.changeset/add-loki-dynamic-export.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki': patch
+---
+
+Add dynamic plugin export support for orchestrator-backend-module-loki

--- a/workspaces/orchestrator/plugins/orchestrator-backend-module-loki/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-backend-module-loki/package.json
@@ -34,7 +34,8 @@
     "postpack": "backstage-cli package postpack",
     "tsc": "tsc",
     "prettier:check": "prettier --ignore-unknown --check .",
-    "prettier:fix": "prettier --ignore-unknown --write ."
+    "prettier:fix": "prettier --ignore-unknown --write .",
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package '@red-hat-developer-hub/backstage-plugin-orchestrator-node'"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.5.0",
@@ -45,10 +46,13 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.10.0",
     "@backstage/cli": "^0.34.5",
-    "@backstage/config": "^1.3.6"
+    "@backstage/config": "^1.3.6",
+    "@janus-idp/cli": "3.6.1"
   },
   "files": [
     "dist",
+    "dist-dynamic/*.*",
+    "dist-dynamic/dist/**",
     "config.d.ts"
   ],
   "repository": {


### PR DESCRIPTION
## Summary
This PR adds dynamic plugin export support for the orchestrator-backend-module-loki plugin.

### Changes:
- Added `export-dynamic` script to package.json
- Added `@janus-idp/cli` dev dependency for dynamic export
- Added `dist-dynamic` to files array for publishing

This enables the Loki module to be exported as a dynamic plugin for RHDH.