### PR TITLE
fix(orchestrator): evaluate JSONata in fetch/validate request bodies

### DIFF
--- a/workspaces/orchestrator/.changeset/jsonata-body-eval.md
+++ b/workspaces/orchestrator/.changeset/jsonata-body-eval.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Evaluate JSONata expressions in fetch/validate request bodies on the client before sending.

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -544,6 +544,17 @@ Various selectors (like `fetch:response:*`) are processed by the [jsonata](https
 
 If a template for a field of one of those properties evaluates to just an empty or undefined value, the **field is skipped** from the HTTP request (body, headers).
 
+JSONata expressions are also supported in `fetch:body` and `validate:body`. To evaluate a value as JSONata against the current form data, prefix it with `jsonata:`.
+
+Example:
+
+```json
+"fetch:body": {
+  "platformId": "jsonata:$.appRegistration.xParams.platformProfileID",
+  "fallback": "$${{current.appRegistration.xParams.platformProfileID}}"
+}
+```
+
 ### Authentication
 
 To make the `identityApi` working, the [Backstage authentication](https://backstage.io/docs/auth/#sign-in-configuration) needs to be configured.

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useRequestInit.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useRequestInit.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import get from 'lodash/get';
+import { JsonObject } from '@backstage/types';
+import { evaluateTemplateProps } from './evaluateTemplate';
+import { getRequestInit } from './useRequestInit';
+
+const unitEvaluator: evaluateTemplateProps['unitEvaluator'] = async (
+  unit,
+  formData,
+) => {
+  return Promise.resolve(get(formData, unit));
+};
+
+describe('getRequestInit', () => {
+  it('evaluates JSONata expressions in fetch:body', async () => {
+    const uiProps: JsonObject = {
+      'fetch:method': 'POST',
+      'fetch:body': {
+        result: 'jsonata:$.payload',
+        literal: 'keep-me',
+      },
+    };
+    const formData: JsonObject = {
+      payload: { foo: 'bar' },
+    };
+
+    const requestInit = await getRequestInit(
+      uiProps,
+      'fetch',
+      unitEvaluator,
+      formData,
+    );
+    expect(requestInit.body).toBeDefined();
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      result: { foo: 'bar' },
+      literal: 'keep-me',
+    });
+  });
+
+  it('evaluates JSONata expressions in validate:body', async () => {
+    const uiProps: JsonObject = {
+      'validate:method': 'POST',
+      'validate:body': {
+        name: 'jsonata:$.user.name',
+      },
+    };
+    const formData: JsonObject = {
+      user: { name: 'Marek' },
+    };
+
+    const requestInit = await getRequestInit(
+      uiProps,
+      'validate',
+      unitEvaluator,
+      formData,
+    );
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      name: 'Marek',
+    });
+  });
+
+  it('still evaluates template units in body values', async () => {
+    const uiProps: JsonObject = {
+      'fetch:method': 'POST',
+      'fetch:body': {
+        name: '$${{current.name}}',
+      },
+    };
+    const formData: JsonObject = {
+      current: { name: 'Zara' },
+    };
+
+    const requestInit = await getRequestInit(
+      uiProps,
+      'fetch',
+      unitEvaluator,
+      formData,
+    );
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      name: 'Zara',
+    });
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2519

- This PR adds client-side JSONata evaluation for fetch:body and validate:body in orchestrator form widgets.
- Values prefixed with jsonata: are now evaluated against the current form data before the request is sent.
- Previously JSONata expressions in fetch:body / validate:body were sent as literal strings. This enables dynamic request payloads derived from form data.

How users configure it
In any workflow schema, inside ui:props, prefix a body value with jsonata::

```
"ui:props": {
  "fetch:method": "POST",
  "fetch:url": "...",
  "fetch:body": {
    "id": "jsonata:$.appRegistration.xParams.platformProfileID"
  },
  "validate:method": "POST",
  "validate:url": "...",
  "validate:body": {
    "id": "jsonata:$.appRegistration.xParams.platformProfileID"
  }
}
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
