### PR TITLE
[Konflux] fix "Check if release" failure

### DIFF
--- a/workspaces/konflux/package.json
+++ b/workspaces/konflux/package.json
@@ -23,7 +23,8 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub"
+    "new": "backstage-cli new --scope @red-hat-developer-hub",
+    "postinstall": "cd ../../ && yarn install"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
I noticed there's one job failing after merging my latest PR into `main`: 

![Screenshot 2026-01-23 at 9 17 37](https://github.com/user-attachments/assets/dee8efd5-a7b8-4a48-a73b-8b5f8f835dae)

GH job that failed: https://github.com/redhat-developer/rhdh-plugins/actions/runs/21278617503/job/61243223686

after debugging, I saw that the `konflux` workspace didn’t have a `postinstall` script, while other workspaces (e.g. mcp-integrations) do. This PR adds `postinstall` to `konflux` to align the workspace setup and `may` (🙏) fix the missing dependency in the release check.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
