### PR TITLE
chore(workflows/release): add Yarn 4 guard for publish step

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -152,7 +152,12 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{ secrets.RHDH_NPM_TOKEN }}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+          YARN_VERSION="$(yarn --version)"
+          if [[ "$YARN_VERSION" == 4.* ]]; then
+            yarn workspaces foreach -A -v --no-private npm publish --access public --tolerate-republish
+          else
+            yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RHDH_NPM_TOKEN }}
 

--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -182,7 +182,12 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "$NODE_AUTH_TOKEN"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
+          YARN_VERSION="$(yarn --version)"
+          if [[ "$YARN_VERSION" == 4.* ]]; then
+            yarn workspaces foreach -A -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
+          else
+            yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RHDH_NPM_TOKEN }}
       


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
### Description

After #2142 PR merged, I noticed that the `"Release all workspaces"` failed at the `publish` step:

![Screenshot 2026-01-26 at 10 53 37](https://github.com/user-attachments/assets/e10948b3-26e9-44c3-9fe8-182658076e75)

Job: https://github.com/redhat-developer/rhdh-plugins/actions/runs/21294851539/job/61298178895

It seems yarn 4.* requires a scope flag (all/recursive/since/worktree) for `yarn workspaces foreach`, otherwise it fails. This PR adds `-A` scope flag only when Yarn 4 is detected to preserve Yarn 3 behavior.

### Extra info

I tried using yarn 3.8.7 locally, but `yarn dedupe` hit an assertion error.

I tried to fix it, but did not succeed. That's why I opted to use yarn 4, since it worked fine.

If yarn 3 is preferred, I'm happy to adjust. let me know if you've seen this issue before and how to fix it :coffee:


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
