### PR TITLE
fix(extensions-catalog): add @types/js-yaml to devdeps

### DIFF
--- a/workspaces/extensions/.changeset/big-keys-smoke.md
+++ b/workspaces/extensions/.changeset/big-keys-smoke.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions': patch
+---
+
+Add missing `@types/js-yaml` dependency to the `devDependencies`

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/package.json
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/package.json
@@ -51,7 +51,8 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.10.0",
     "@backstage/cli": "^0.34.5",
-    "@types/glob": "^8.1.0"
+    "@types/glob": "^8.1.0",
+    "@types/js-yaml": "^4.0.9"
   },
   "files": [
     "dist"

--- a/workspaces/extensions/yarn.lock
+++ b/workspaces/extensions/yarn.lock
@@ -11488,6 +11488,7 @@ __metadata:
     "@backstage/types": ^1.2.2
     "@red-hat-developer-hub/backstage-plugin-extensions-common": "workspace:^"
     "@types/glob": ^8.1.0
+    "@types/js-yaml": ^4.0.9
     find-root: ^1.1.0
     glob: ^8.1.0
     js-yaml: ^4.1.0
@@ -14617,7 +14618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:^4.0.1":
+"@types/js-yaml@npm:^4.0.1, @types/js-yaml@npm:^4.0.9":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: e5e5e49b5789a29fdb1f7d204f82de11cb9e8f6cb24ab064c616da5d6e1b3ccfbf95aa5d1498a9fbd3b9e745564e69b4a20b6c530b5a8bbb2d4eb830cda9bc69


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `@types/js-yaml` dependency to the `devDependencies`

Fixes: [RHIDP-11463
](https://issues.redhat.com/browse/RHIDP-11463)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
