### PR TITLE
feat(lightspeed): add e2e test for thinking section

### DIFF
--- a/workspaces/lightspeed/packages/app/e2e-tests/fixtures/responses.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/fixtures/responses.ts
@@ -68,6 +68,10 @@ export const moreConversations = [
   },
 ];
 
+export const thinkingContent =
+  'The user wants to start a new conversation. I should respond helpfully and concisely.';
+export const assistantResponse = 'Still a placeholder message';
+
 export const contents = [
   {
     provider: models[1].provider_id,
@@ -78,7 +82,7 @@ export const contents = [
         type: 'user',
       },
       {
-        content: "Still a placeholder message'",
+        content: `<think>\n${thinkingContent}\n</think>\n\n${assistantResponse}`,
         type: 'assistant',
       },
     ],

--- a/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
+++ b/workspaces/lightspeed/packages/app/e2e-tests/lightspeed.test.ts
@@ -23,6 +23,8 @@ import {
   botResponse,
   moreConversations,
   mockedShields,
+  thinkingContent,
+  assistantResponse,
 } from './fixtures/responses';
 import {
   openLightspeed,
@@ -368,6 +370,23 @@ test.describe('Lightspeed tests', () => {
       await verifySidePanelConversation(sharedPage, translations);
     });
 
+    test('Verify thinking section is displayed in bot response', async () => {
+      const botMessage = sharedPage.locator('.pf-chatbot__message--bot').last();
+      await expect(botMessage).toBeVisible();
+
+      await expect(
+        sharedPage.getByRole('button', {
+          name: translations['reasoning.thinking'],
+        }),
+      ).toBeVisible();
+
+      await expect(sharedPage.locator('#deep-thinking-1')).toBeVisible();
+
+      await expect(
+        sharedPage.getByLabel(translations['reasoning.thinking']),
+      ).toContainText(thinkingContent);
+    });
+
     test('Verify scroll controls in Conversation', async ({
       browser,
     }, testInfo) => {
@@ -464,7 +483,7 @@ test.describe('Lightspeed tests', () => {
         devMode ? contents[0].messages[0].content : 'tell me about Backstage',
       );
       await expect(botMessage).toContainText(
-        devMode ? contents[0].messages[1].content : 'Backstage',
+        devMode ? assistantResponse : 'Backstage',
       );
     });
 

--- a/workspaces/lightspeed/playwright.config.ts
+++ b/workspaces/lightspeed/playwright.config.ts
@@ -62,7 +62,6 @@ export default defineConfig({
       },
     },
     // TODO: Enable after translation bugs are fixed
-    // See bug report: [add your bug link here]
     // {
     //   name: 'it',
     //   testDir: 'packages/app/e2e-tests',


### PR DESCRIPTION
## Summary
Adds e2e test coverage for the AI thinking/reasoning section feature in Lightspeed chatbot.

**Resolves:**
https://issues.redhat.com/browse/RHIDP-10860

### Changes
- Added `thinkingContent` and `assistantResponse` to existing `contents` fixture with `<think>` tags
- Added test case to verify thinking section toggle button and content display
- Uses existing translations (`reasoning.thinking`) for i18n support

###  Related Issues
[RHDHBUGS-2553](https://issues.redhat.com/browse/RHDHBUGS-2553): Thinking feature breaks chat title generation in sidebar panel