### PR TITLE
chore: initial Qodo configuration

### DIFF
--- a/.github/workflows/toml-checks.yaml
+++ b/.github/workflows/toml-checks.yaml
@@ -1,0 +1,21 @@
+name: PR TOML Validator
+
+on:
+  push:
+    paths:
+      - '**.toml'
+  pull_request:
+    paths:
+      - '**.toml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: tombi-toml/setup-tombi@f7cb38e77d9a62bc27a8445bf50e660e9496b893 # v1.0.7
+        with:
+          version: 'v0.7.22'
+          checksum: '2f96342066b02ac374b2b457c9927264fd086256c1c6ccc817eced8367f1d83c'
+      - name: Validate TOML files
+        run: tombi lint

--- a/pr_agent.toml
+++ b/pr_agent.toml
@@ -1,0 +1,38 @@
+[jira]
+jira_api_token = "${{ secrets.JIRA_API_TOKEN }}"
+jira_base_url = "https://issues.redhat.com"
+
+[github_app]
+# what should be launched automatically
+pr_commands = [
+    "/review",
+    "/describe --pr_description.final_update_message=false",
+    "/improve",
+]
+feedback_on_draft_pr = true
+
+[pr_reviewer] # /review #
+persistent_comment = true
+require_tests_review = false
+require_ticket_analysis_review = true
+enable_review_labels_security = true
+enable_review_labels_effort = true
+
+[pr_description] # /describe #
+enable_pr_diagram = false
+publish_labels = true
+final_update_message = true
+# without this, it can interfere with Sourcery AI
+publish_description_as_comment = true
+publish_description_as_comment_persistent = true
+add_original_user_description = false
+
+[pr_code_suggestions]
+commitable_code_suggestions = false
+
+[config]
+ignore_pr_authors = ["renovate", "rhdh-bot", "dependabot"]
+
+[rag_arguments]
+enable_rag=true
+rag_repo_list=['redhat-developer/rhdh','redhat-developer/red-hat-developers-documentation-rhdh']


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

- Add Qodo PR agent configuration file
- Set up Jira integration 
- Description as a comment, instead of updating the PR description.
- Disable the diagram
- Automatically apply labels to the PR according to the type
- Keep the code suggestions in one comment instead of inline suggestions.
- Don't trigger Qodo for Renovate and rhdh-bot PRs.

Configuration can be found in Qodo docs:

- [docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file](https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file)
- [docs.qodo.ai/qodo-documentation/qodo-merge/tools/tools-list](https://docs.qodo.ai/qodo-documentation/qodo-merge/tools/tools-list)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
