### PR TITLE
chore(x2a): move k8s client to dynamic import

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/src/plugin.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/plugin.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { x2aDatabaseServiceRef } from './services/X2ADatabaseService';
+import { kubeServiceRef } from './services/KubeService';
 import { x2APlugin } from './plugin';
 import request from 'supertest';
 import {
@@ -81,6 +82,10 @@ const getX2aDatabaseServiceMock = () => ({
   updateJob: jest.fn().mockRejectedValue(new NotAllowedError('mock error')),
 });
 
+const getKubeServiceMock = () => ({
+  getPods: jest.fn().mockResolvedValue({ items: [] }),
+});
+
 async function startBackendServer(
   config?: Record<PropertyKey, unknown>,
   authorizeResult?: AuthorizeResult.DENY | AuthorizeResult.ALLOW,
@@ -100,6 +105,11 @@ async function startBackendServer(
       ],
     }).factory,
     mockServices.userInfo.factory(),
+    createServiceFactory({
+      service: kubeServiceRef,
+      deps: {},
+      factory: async () => getKubeServiceMock(),
+    }),
   ];
   return (await startTestBackend({ features })).server;
 }
@@ -157,6 +167,11 @@ describe('plugin', () => {
           service: x2aDatabaseServiceRef,
           deps: {},
           factory: getX2aDatabaseServiceMock,
+        }),
+        createServiceFactory({
+          service: kubeServiceRef,
+          deps: {},
+          factory: async () => getKubeServiceMock(),
         }),
       ],
     });

--- a/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.test.ts
@@ -19,12 +19,12 @@ import { KubeService } from './KubeService';
 describe('KubeService', () => {
   let kubeService: KubeService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Reset mocks
     jest.clearAllMocks();
 
     // mock referenced services for the KubeService for tests
-    kubeService = KubeService.create({
+    kubeService = await KubeService.create({
       // use logger: mockServices.logger.mock() to silence the logger
       logger: console as any,
     });

--- a/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.ts
@@ -21,20 +21,26 @@ import {
   LoggerService,
 } from '@backstage/backend-plugin-api';
 import { Expand } from '@backstage/types';
-import { CoreV1Api, V1Pod, V1PodList } from '@kubernetes/client-node';
+import type { CoreV1Api, V1Pod, V1PodList } from '@kubernetes/client-node';
 import { makeK8sClient } from './makeK8sClient';
 
 export class KubeService {
   readonly #logger: LoggerService;
   readonly #k8sApi: CoreV1Api;
 
-  static create(options: { logger: LoggerService }) {
-    return new KubeService(options.logger);
+  static async create(options: { logger: LoggerService }) {
+    const service = new KubeService(options.logger);
+    await service.initialize();
+    return service;
   }
 
   private constructor(logger: LoggerService) {
     this.#logger = logger;
-    this.#k8sApi = makeK8sClient(this.#logger);
+    this.#k8sApi = null as any; // Initialized in initialize()
+  }
+
+  private async initialize() {
+    (this.#k8sApi as any) = await makeK8sClient(this.#logger);
   }
 
   // To test it

--- a/workspaces/x2a/plugins/x2a-backend/src/services/makeK8sClient.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/makeK8sClient.ts
@@ -15,7 +15,7 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { CoreV1Api, KubeConfig } from '@kubernetes/client-node';
+import type { CoreV1Api } from '@kubernetes/client-node';
 
 /**
  * TODO: Make this configurable
@@ -23,7 +23,10 @@ import { CoreV1Api, KubeConfig } from '@kubernetes/client-node';
  * Load Kubernetes config from default locations
  * This will check KUBECONFIG env var, ~/.kube/config, or ~/.kube/kubeconfig, or in-cluster config
  */
-export const makeK8sClient = (logger: LoggerService): CoreV1Api => {
+export const makeK8sClient = async (
+  logger: LoggerService,
+): Promise<CoreV1Api> => {
+  const { KubeConfig } = await import('@kubernetes/client-node');
   const kc = new KubeConfig();
 
   try {
@@ -60,5 +63,6 @@ export const makeK8sClient = (logger: LoggerService): CoreV1Api => {
     }
   }
 
+  const { CoreV1Api } = await import('@kubernetes/client-node');
   return kc.makeApiClient(CoreV1Api);
 };


### PR DESCRIPTION
When I run `npx @red-hat-developer-hub/cli plugin export` I got this:

```
Error: Unable to validate plugin entry points: Error [ERR_REQUIRE_ESM]: require() of ES Module /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-backend/dist-dynamic/node_modules/@kubernetes/client-node/dist/index.js from /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-backend/dist-dynamic/dist/services/makeK8sClient.cjs.js not supported.
Instead change the require of index.js in /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-backend/dist-dynamic/dist/services/makeK8sClient.cjs.js to a dynamic import() which is available in all CommonJS modules.
```

With these changes, I can happily export the plugin:

```
$ -> npx @red-hat-developer-hub/cli plugin export
Building embedded package @red-hat-developer-hub/backstage-plugin-x2a-common in /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-common
  executing     yarn build ✔
Packing embedded package @red-hat-developer-hub/backstage-plugin-x2a-common in /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-common to embedded/red-hat-developer-hub-backstage-plugin-x2a-common
Customizing embedded package @red-hat-developer-hub/backstage-plugin-x2a-common for dynamic loading
  moving @backstage/plugin-permission-common to peerDependencies
Building main package
  executing     yarn build ✔
Packing main package to dist-dynamic/package.json
Customizing main package in dist-dynamic/package.json for dynamic loading
  moving @backstage/backend-defaults to peerDependencies
  moving @backstage/backend-openapi-utils to peerDependencies
  moving @backstage/backend-plugin-api to peerDependencies
  moving @backstage/catalog-client to peerDependencies
  moving @backstage/errors to peerDependencies
  moving @backstage/plugin-auth-backend to peerDependencies
  moving @backstage/plugin-auth-backend-module-github-provider to peerDependencies
  moving @backstage/plugin-auth-backend-module-guest-provider to peerDependencies
  moving @backstage/plugin-catalog-backend to peerDependencies
  moving @backstage/plugin-catalog-node to peerDependencies
  moving @backstage/plugin-permission-common to peerDependencies
  moving @backstage/types to peerDependencies
Hoisting peer dependencies of embedded packages to the main package
Installing private dependencies of the main package
  executing     yarn install --immutable > yarn-install.log ✔
Validating private dependencies
Validating plugin entry points
Saving self-contained config schema in /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-backend/dist-dynamic/dist/configSchema.json and /home/eloy/dev/upstream/redhat-developer/plugins-test/workspaces/x2a/plugins/x2a-backend/dist-dynamic/dist/.config-schema.json
Filling supported-versions with 1.45.0.
```

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
