### PR TITLE
fix(scorecard): fix no entities supporting metric provider in Catalog

### DIFF
--- a/workspaces/scorecard/.changeset/breezy-cases-agree.md
+++ b/workspaces/scorecard/.changeset/breezy-cases-agree.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend': patch
+---
+
+Fixed an issue when PullMetricsByProviderTask would fail when no entities in Catalog supported metric provider that was processed

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts
@@ -104,6 +104,19 @@ describe('DatabaseMetricValues', () => {
         });
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'should handle empty metric values - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        await expect(db.createMetricValues([])).resolves.not.toThrow();
+
+        const insertedValues = await client('metric_values').select('*');
+
+        expect(insertedValues).toHaveLength(0);
+      },
+    );
   });
 
   describe('readLatestEntityMetricValues', () => {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
@@ -30,6 +30,9 @@ export class DatabaseMetricValues {
    * Insert multiple metric values
    */
   async createMetricValues(metricValues: DbMetricValueCreate[]): Promise<void> {
+    if (metricValues.length === 0) {
+      return;
+    }
     await this.dbClient(this.tableName).insert(metricValues);
   }
 


### PR DESCRIPTION
### **User description**
## Hey, I just made a Pull Request!

Fixed an issue when PullMetricsByProviderTask would fail when no entities in Catalog supported metric provider that was processed

#### Fixes 
Fixes https://issues.redhat.com/browse/RHDHBUGS-2572

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Handle empty metric values gracefully in database operations

- Add early return when no metric values to insert

- Add test case for empty metric values scenario


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PullMetricsByProviderTask"] -->|"processes metric provider"| B["DatabaseMetricValues.createMetricValues"]
  B -->|"empty array check"| C["Early return if empty"]
  C -->|"prevents error"| D["Task completes successfully"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DatabaseMetricValues.ts</strong><dd><code>Add empty array guard to createMetricValues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts

<ul><li>Added early return guard when <code>metricValues</code> array is empty<br> <li> Prevents unnecessary database insert operation on empty data<br> <li> Resolves failure when no entities support the metric provider</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2219/files#diff-41791eb507899dc42c2e3d2520fb77aa5ea994f25cb8beff3332e70ec2b443b4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DatabaseMetricValues.test.ts</strong><dd><code>Add test for empty metric values handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts

<ul><li>Added new test case for empty metric values scenario<br> <li> Tests that <code>createMetricValues([])</code> resolves without throwing<br> <li> Verifies no rows are inserted when array is empty<br> <li> Uses parameterized testing with <code>it.each</code> for all supported databases</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2219/files#diff-d20525583c634107b248a8adc3f840d38e2bd67fecd1c08010a8f576e991ab0b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>breezy-cases-agree.md</strong><dd><code>Add changeset for bug fix release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/.changeset/breezy-cases-agree.md

<ul><li>Created changeset documenting the bug fix<br> <li> Marks as patch version bump for scorecard-backend package<br> <li> Describes the fix for PullMetricsByProviderTask failure scenario</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2219/files#diff-c0ea75eb13bb263fa4d0db71b84ddea186cca0dfab722d0d9ccbd8bb4d4d2d66">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

