### PR TITLE
chore(x2a): bump permissions version

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/package.json
+++ b/workspaces/x2a/plugins/x2a-backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.14",
     "@backstage/plugin-catalog-backend": "^3.2.0",
     "@backstage/plugin-catalog-node": "^1.20.0",
-    "@backstage/plugin-permission-common": "^0.9.3",
+    "@backstage/plugin-permission-common": "^0.9.4",
     "@backstage/types": "^1.2.2",
     "@kubernetes/client-node": "^1.4.0",
     "@red-hat-developer-hub/backstage-plugin-x2a-common": "workspace:*",

--- a/workspaces/x2a/yarn.lock
+++ b/workspaces/x2a/yarn.lock
@@ -11553,7 +11553,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-guest-provider": ^0.2.14
     "@backstage/plugin-catalog-backend": ^3.2.0
     "@backstage/plugin-catalog-node": ^1.20.0
-    "@backstage/plugin-permission-common": ^0.9.3
+    "@backstage/plugin-permission-common": ^0.9.4
     "@backstage/repo-tools": ^0.16.2
     "@backstage/types": ^1.2.2
     "@kubernetes/client-node": ^1.4.0


### PR DESCRIPTION
### **User description**
Because container image failed to build:

```
 ========== Exporting backend plugin plugins/x2a-backend ==========
  > npx --yes @red-hat-developer-hub/cli@1.9.1 plugin export --embed-package @red-hat-developer-hub/backstage-plugin-x2a-common
Error running CLI: Building embedded package @red-hat-developer-hub/backstage-plugin-x2a-common in /home/runner/work/rhdh-plugin-export-overlays/rhdh-plugin-export-overlays/source-repo/workspaces/x2a/plugins/x2a-common
  executing     yarn build ✔
Packing embedded package @red-hat-developer-hub/backstage-plugin-x2a-common in /home/runner/work/rhdh-plugin-export-overlays/rhdh-plugin-export-overlays/source-repo/workspaces/x2a/plugins/x2a-common to embedded/red-hat-developer-hub-backstage-plugin-x2a-common
Customizing embedded package @red-hat-developer-hub/backstage-plugin-x2a-common for dynamic loading
  moving @backstage/plugin-permission-common to peerDependencies
Building main package
  executing     yarn build ✔
Packing main package to dist-dynamic/package.json
Customizing main package in dist-dynamic/package.json for dynamic loading
  moving @backstage/backend-defaults to peerDependencies
  moving @backstage/backend-openapi-utils to peerDependencies
  moving @backstage/backend-plugin-api to peerDependencies
  moving @backstage/catalog-client to peerDependencies
  moving @backstage/errors to peerDependencies
  moving @backstage/plugin-auth-backend to peerDependencies
  moving @backstage/plugin-auth-backend-module-github-provider to peerDependencies
  moving @backstage/plugin-auth-backend-module-guest-provider to peerDependencies
  moving @backstage/plugin-catalog-backend to peerDependencies
  moving @backstage/plugin-catalog-node to peerDependencies
  moving @backstage/plugin-permission-common to peerDependencies
  moving @backstage/types to peerDependencies
Hoisting peer dependencies of embedded packages to the main package
Error: The version of a dependency ('@backstage/plugin-permission-common') of an embedded module conflicts with main module dependencies: '^0.9.4', '^0.9.3': cannot proceed!
Plugins with failed exports: plugins/x2a-backend
```

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


___

### **PR Type**
Bug fix


___

### **Description**
- Bump `@backstage/plugin-permission-common` from ^0.9.3 to ^0.9.4

- Resolves dependency version conflict in embedded package hoisting

- Fixes container image build failure in x2a-backend plugin


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["x2a-backend package.json"] -- "update dependency version" --> B["@backstage/plugin-permission-common ^0.9.4"]
  B -- "resolves conflict" --> C["Successful container build"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update permission-common dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/package.json

<ul><li>Updated <code>@backstage/plugin-permission-common</code> dependency from ^0.9.3 to <br>^0.9.4<br> <li> Resolves version conflict between embedded module and main module <br>dependencies<br> <li> Fixes container image build failure caused by incompatible peer <br>dependency versions</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2220/files#diff-ce395f7220563419fd784cf969aee321dbdea81b6d971bc62fdddcbb434c1d83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

