### PR TITLE
fix(scorecard): update default schedule for pulling metrics

### DIFF
--- a/workspaces/scorecard/.changeset/weak-bananas-bake.md
+++ b/workspaces/scorecard/.changeset/weak-bananas-bake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend': patch
+---
+
+Updated default schedule for pulling metrics to have `initialDelay` of 1 minute

--- a/workspaces/scorecard/app-config.yaml
+++ b/workspaces/scorecard/app-config.yaml
@@ -159,3 +159,19 @@ permission:
     admin:
       users:
         - name: user:development/guest
+
+# Scorecard development configuration
+scorecard:
+  plugins:
+    jira:
+      open_issues:
+        schedule:
+          frequency: { minutes: 5 }
+          timeout: { minutes: 10 }
+          initialDelay: { seconds: 5 }
+    github:
+      open_prs:
+        schedule:
+          frequency: { minutes: 5 }
+          timeout: { minutes: 10 }
+          initialDelay: { seconds: 5 }

--- a/workspaces/scorecard/plugins/scorecard-backend/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/README.md
@@ -71,6 +71,19 @@ This policy would allow users to read only the GitHub Open PRs metric, while res
 
 The Scorecard plugin collects metrics from third-party data sources using metric providers. The Scorecard node plugin provides `scorecardMetricsExtensionPoint` extension point that is used to connect your backend plugin module that exports custom metrics via metric providers to the Scorecard backend plugin. For detailed information on creating metric providers, see [providers.md](./docs/providers.md).
 
+### Metric Collection Scheduling
+
+The Scorecard plugin automatically collects metrics on a scheduled basis. You can customize the schedule for any metric provider in your `app-config.yaml`. If no schedule is configured, metric providers use the following default schedule:
+
+```yaml
+schedule:
+  frequency: { hours: 1 }
+  timeout: { minutes: 15 }
+  initialDelay: { minutes: 1 }
+```
+
+For more information about schedule configuration options, see the [Metric Collection Scheduling](./docs/providers.md#metric-collection-scheduling) section in providers.md.
+
 ### Available Metric Providers
 
 The following metric providers are available:

--- a/workspaces/scorecard/plugins/scorecard-backend/docs/providers.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/docs/providers.md
@@ -173,6 +173,15 @@ The schedule configuration follows Backstage's `SchedulerServiceTaskScheduleDefi
 
 Make sure the configured schedule stays within provider API rate limits.
 
+If no schedule is configured, metric providers use the following default schedule:
+
+```yaml
+schedule:
+  frequency: { hours: 1 }
+  timeout: { minutes: 15 }
+  initialDelay: { minutes: 1 }
+```
+
 ## Example Metric Providers
 
 The following are examples of existing metric providers that you can reference:

--- a/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.test.ts
@@ -164,7 +164,7 @@ describe('PullMetricsByProviderTask', () => {
       expect(config).toEqual({
         frequency: { hours: 1 },
         timeout: { minutes: 15 },
-        initialDelay: { seconds: 3 },
+        initialDelay: { minutes: 1 },
       });
     });
 

--- a/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts
@@ -61,7 +61,7 @@ export class PullMetricsByProviderTask implements SchedulerTask {
     {
       frequency: { hours: 1 },
       timeout: { minutes: 15 },
-      initialDelay: { seconds: 3 },
+      initialDelay: { minutes: 1 },
     };
 
   constructor(options: Options, provider: MetricProvider) {


### PR DESCRIPTION
### **User description**
## Hey, I just made a Pull Request!

Updating default schedule for scorecard plugin to have initialDelay of 1 minute to avoid problems when no entities are yet loaded in Catalog on the first run of fresh install.

#### Fixes
Fixes https://issues.redhat.com/browse/RHDHBUGS-2586

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [X] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Updated default `initialDelay` from 3 seconds to 1 minute
  - Prevents issues when entities aren't loaded on fresh install

- Added metric collection scheduling documentation
  - Documented default schedule configuration
  - Added example schedule configurations in app-config.yaml

- Updated test expectations to match new default


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default Schedule Config"] -->|"initialDelay changed"| B["3 seconds → 1 minute"]
  B -->|"prevents"| C["Catalog Load Issues"]
  D["Documentation"] -->|"added"| E["Schedule Configuration Guide"]
  F["Test"] -->|"updated"| G["Verify New Default"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PullMetricsByProviderTask.ts</strong><dd><code>Update default schedule initialDelay value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts

<ul><li>Updated <code>DEFAULT_SCHEDULE</code> constant <code>initialDelay</code> from 3 seconds to 1 <br>minute<br> <li> Aligns with the new default schedule for metric collection</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2242/files#diff-cffbdf786cff2091b11db28f5a95a8d0c6e5542dc06e892a1e8c62f8ab85dfab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PullMetricsByProviderTask.test.ts</strong><dd><code>Update test default schedule assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.test.ts

<ul><li>Updated test expectation for default schedule <code>initialDelay</code> to 1 minute<br> <li> Ensures test validates the new default behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2242/files#diff-f3bf5e91a8bd721ea9e97a3dd28d8a02eb1e847e374bc5a5250ed2026e2b45a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weak-bananas-bake.md</strong><dd><code>Add changeset for schedule update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/.changeset/weak-bananas-bake.md

<ul><li>Created changeset documenting the patch update<br> <li> Records the <code>initialDelay</code> configuration change</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2242/files#diff-64dab268d14a81446f5ad6f11e673aff6577168bdd6956ec4061db8835c79c73">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add metric scheduling documentation section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/plugins/scorecard-backend/README.md

<ul><li>Added new "Metric Collection Scheduling" section<br> <li> Documents default schedule configuration<br> <li> References detailed scheduling documentation in providers.md</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2242/files#diff-8c8f9fca6e863de9300ce21041720fb0e1bd697d49100fe2a02b758abd9c6c22">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>providers.md</strong><dd><code>Document default metric collection schedule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/plugins/scorecard-backend/docs/providers.md

<ul><li>Added default schedule configuration documentation<br> <li> Clarifies fallback behavior when no custom schedule is configured<br> <li> Provides YAML example of default schedule values</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2242/files#diff-5d7996d0cae1d6713bacea59be254dd9b09009b3ca85311bc92ae78641357817">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app-config.yaml</strong><dd><code>Add scorecard development configuration examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/scorecard/app-config.yaml

<ul><li>Added scorecard development configuration section<br> <li> Included example schedules for Jira and GitHub metric providers<br> <li> Demonstrates custom schedule configuration with 5-minute frequency</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2242/files#diff-dfb0e68d54570dbc91eb21d0a4bae758ddd8b7b50d8bdd0ff6b1ca7e9a576ddd">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

