### PR TITLE
RHDHBUGS-2516: orchestrator.workflow.[workflowId] permission description missing instance access behavior

### DIFF
--- a/workspaces/orchestrator/docs/Permissions.md
+++ b/workspaces/orchestrator/docs/Permissions.md
@@ -3,14 +3,14 @@ the RBAC plugin. The result is control over what users can see or execute.
 
 ## Orchestrator Permissions
 
-| Name                                     | Resource Type  | Policy | Description                                                                                    | Requirements |
-| ---------------------------------------- | -------------- | ------ | ---------------------------------------------------------------------------------------------- | ------------ |
-| orchestrator.workflow                    | named resource | read   | Allows the user to list and read any workflow definition and their instances that they created |              |
-| orchestrator.workflow.[`workflowId`]     | named resource | read   | Allows the user to list and read a _single_ workflow definition and its instances that they created                 |              |
-| orchestrator.workflow.use                | named resource | update | Allows the user to run or abort _any_ workflow                                                 |              |
-| orchestrator.workflow.use.[`workflowId`] | named resource | update | Allows the user to run or abort the _single_ workflow                                          |              |
-| orchestrator.workflowAdminView           | named resource | read   | Allows the user to view instance variables and workflow definition editor                      |              |
-| orchestrator.instanceAdminView           | named resource | read   | Allows the user to view all workflow instances, including those not created by them            |              |
+| Name                                     | Resource Type  | Policy | Description                                                                                         | Requirements |
+| ---------------------------------------- | -------------- | ------ | --------------------------------------------------------------------------------------------------- | ------------ |
+| orchestrator.workflow                    | named resource | read   | Allows the user to list and read any workflow definition and their instances that they created      |              |
+| orchestrator.workflow.[`workflowId`]     | named resource | read   | Allows the user to list and read a _single_ workflow definition and its instances that they created |              |
+| orchestrator.workflow.use                | named resource | update | Allows the user to run or abort _any_ workflow                                                      |              |
+| orchestrator.workflow.use.[`workflowId`] | named resource | update | Allows the user to run or abort the _single_ workflow                                               |              |
+| orchestrator.workflowAdminView           | named resource | read   | Allows the user to view instance variables and workflow definition editor                           |              |
+| orchestrator.instanceAdminView           | named resource | read   | Allows the user to view all workflow instances, including those not created by them                 |              |
 
 The user is permitted to do an action if either the generic permission or the specific one allows it.
 In other words, it is not possible to grant generic `orchestrator.workflow` and then selectively disable it for a specific workflow via `orchestrator.workflow.use.[workflowId]` with `deny`.


### PR DESCRIPTION
Update the orchestrator.workflow.[workflowId] description to:

Allows the user to list and read a single workflow definition and its instances that they created

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
