### PR TITLE
feat[Orchestrator]: Allow ActiveDropdown selectors to use form data

### DIFF
--- a/workspaces/orchestrator/.changeset/active-dropdown-selector-context.md
+++ b/workspaces/orchestrator/.changeset/active-dropdown-selector-context.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Allow ActiveDropdown fetch selectors to reference current form data via the combined response/current context.

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -334,6 +334,10 @@ Therefore, both arrays must be of equal length.
 
 The final value of the field is determined by the values provided by the `fetch:response:value` selector.
 
+When a selector references `response` or `current`, it is evaluated against a combined context:
+`{ response: fetchResponse, current: formData }`. Use `response.*` for the fetch payload and `current.*` for form data.
+Selectors that do not reference `response` or `current` continue to evaluate directly against the fetch response for backwards compatibility.
+
 ### ActiveDropdown widget ui:props
 
 The widget supports following `ui:props`:

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
@@ -111,10 +111,26 @@ export const ActiveDropdown: Widget<
       return;
     }
 
+    const getSelectorContext = (selector: string) => {
+      if (/\b(current|response)\b/.test(selector)) {
+        return {
+          response: data,
+          current: formData ?? {},
+        };
+      }
+      return data;
+    };
+
     const doItAsync = async () => {
       await wrapProcessing(async () => {
-        const selectedLabels = await applySelectorArray(data, labelSelector);
-        const selectedValues = await applySelectorArray(data, valueSelector);
+        const selectedLabels = await applySelectorArray(
+          getSelectorContext(labelSelector),
+          labelSelector,
+        );
+        const selectedValues = await applySelectorArray(
+          getSelectorContext(valueSelector),
+          valueSelector,
+        );
 
         if (selectedLabels.length !== selectedValues.length) {
           setLocalError(
@@ -129,7 +145,7 @@ export const ActiveDropdown: Widget<
     };
 
     doItAsync();
-  }, [labelSelector, valueSelector, data, props.id, wrapProcessing]);
+  }, [labelSelector, valueSelector, data, formData, props.id, wrapProcessing]);
 
   const handleChange = useCallback(
     (changed: string, isByUser: boolean) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2593

#### Description:

- Evaluate fetch:response:label/value against a combined context when response or current is referenced.
- Keep legacy selectors working by defaulting to raw fetch response when context keys aren’t used.


--------------


https://github.com/user-attachments/assets/15d37d4d-bd8c-4701-a4ec-4374a7cf61af



--------------

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
