### PR TITLE
fix[Orchestrator]: bold Details title in workflow run card

### DIFF
--- a/workspaces/orchestrator/.changeset/bold-details-title.md
+++ b/workspaces/orchestrator/.changeset/bold-details-title.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Make the workflow run Details card title bold and consistent with other InfoCard titles.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
@@ -91,6 +91,9 @@ const useStyles = makeStyles()(() => ({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
+  detailsTitle: {
+    fontWeight: 700,
+  },
 }));
 
 export const WorkflowInstancePageContent: React.FC<{
@@ -170,7 +173,13 @@ export const WorkflowInstancePageContent: React.FC<{
           <InfoCard
             title={
               <div className={classes.titleContainer}>
-                <Typography component="span">{t('common.details')}</Typography>
+                <Typography
+                  component="span"
+                  variant="h5"
+                  className={classes.detailsTitle}
+                >
+                  {t('common.details')}
+                </Typography>
                 {viewVariables}
               </div>
             }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2600


Updates the workflow instance “Details” InfoCard title to match the default InfoCard header styling (font size + weight).

-----BEFORE----

<img width="1395" height="999" alt="image" src="https://github.com/user-attachments/assets/a87cc8fe-3802-4383-bae1-e3acaa3efdd7" />

--------

-----AFTER-------

<img width="934" height="736" alt="Screenshot 2026-02-06 at 4 05 32 PM" src="https://github.com/user-attachments/assets/a9d0941c-ced8-4c56-9c18-9ff0b70ecfb7" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
