### PR TITLE
fix(orchestrator): remove web-library import in common-library

### DIFF
--- a/workspaces/orchestrator/.changeset/brave-horses-whisper.md
+++ b/workspaces/orchestrator/.changeset/brave-horses-whisper.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+remove web-library(core-plugin-api) import in a common-library

--- a/workspaces/orchestrator/plugins/orchestrator-common/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-common/package.json
@@ -55,7 +55,6 @@
     "openapi:check": "./scripts/openapi.sh check"
   },
   "dependencies": {
-    "@backstage/core-plugin-api": "^1.12.0",
     "@backstage/plugin-permission-common": "^0.9.3",
     "@backstage/types": "^1.2.2",
     "@serverlessworkflow/sdk-typescript": "^0.8.4",

--- a/workspaces/orchestrator/plugins/orchestrator-common/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-common/report.api.md
@@ -12,7 +12,6 @@ import { JsonObject } from '@backstage/types';
 import type { JSONSchema7 } from 'json-schema';
 import type { JSONSchema7Definition } from 'json-schema';
 import { JsonValue } from '@backstage/types';
-import { OAuthScope } from '@backstage/core-plugin-api';
 import type { RawAxiosRequestConfig } from 'axios';
 import type { Specification } from '@serverlessworkflow/sdk-typescript';
 
@@ -801,6 +800,9 @@ export interface NodeInstanceDTO {
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@memberof" is not defined in this configuration
     'type'?: string;
 }
+
+// @public
+export type OAuthScope = string | string[];
 
 // Warning: (ae-forgotten-export) The symbol "OmitDistributive" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "OmitRecursively" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/auth/tokenDescriptorTypes.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/auth/tokenDescriptorTypes.ts
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { OAuthScope } from '@backstage/core-plugin-api';
+
+/**
+ *
+ * @public
+ * An array of scopes, or a scope string formatted according to the
+ * auth provider, which is typically a space separated list.
+ */
+export type OAuthScope = string | string[];
 
 /**
  * Descriptor for authentication token configuration

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -12479,7 +12479,6 @@ __metadata:
   resolution: "@red-hat-developer-hub/backstage-plugin-orchestrator-common@workspace:plugins/orchestrator-common"
   dependencies:
     "@backstage/cli": ^0.34.5
-    "@backstage/core-plugin-api": ^1.12.0
     "@backstage/plugin-permission-common": ^0.9.3
     "@backstage/types": ^1.2.2
     "@openapitools/openapi-generator-cli": 2.25.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Fixes: https://issues.redhat.com/browse/RHDHBUGS-2624

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Remove `core-plugin-api` dependency from orchestrator-common. since common-library is used in both frontend and backend plugins, we should avoid frontend dependency as transitive dependency in the backend plugins.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
