### PR TITLE
feat(x2a): query user prompt before running the Next phase action

### DIFF
--- a/workspaces/x2a/.changeset/wet-webs-send.md
+++ b/workspaces/x2a/.changeset/wet-webs-send.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+A modal dialog opens to query user prompt before running the next phase.

--- a/workspaces/x2a/plugins/x2a/report.api.md
+++ b/workspaces/x2a/plugins/x2a/report.api.md
@@ -62,6 +62,11 @@ readonly "sidebar.x2a.title": string;
 readonly "wizard.cancel": string;
 readonly "wizard.next": string;
 readonly "wizard.back": string;
+readonly "userPromptDialog.title": string;
+readonly "userPromptDialog.promptLabel": string;
+readonly "userPromptDialog.promptPlaceholder": string;
+readonly "userPromptDialog.run": string;
+readonly "userPromptDialog.moduleName": string;
 }>;
 
 // @public

--- a/workspaces/x2a/plugins/x2a/src/components/ModuleTable/UserPromptDialog.test.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModuleTable/UserPromptDialog.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mockUseTranslation } from '../../test-utils/mockTranslations';
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserPromptDialog } from './UserPromptDialog';
+
+describe('UserPromptDialog', () => {
+  const onClose = jest.fn();
+  const onConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render dialog content when closed', async () => {
+    await renderInTestApp(
+      <UserPromptDialog open={false} onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    // When closed, no visible dialog (MUI may keep dialog in DOM with aria-hidden)
+    expect(
+      screen.queryByRole('dialog', { hidden: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders dialog with title when open', async () => {
+    await renderInTestApp(
+      <UserPromptDialog open onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Run next phase')).toBeInTheDocument();
+  });
+
+  it('renders title with phase name when phaseName is provided', async () => {
+    await renderInTestApp(
+      <UserPromptDialog
+        open
+        onClose={onClose}
+        onConfirm={onConfirm}
+        phaseName="Analyze"
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Run next phase: Analyze')).toBeInTheDocument();
+  });
+
+  it('renders moduleName description when moduleName is provided', async () => {
+    await renderInTestApp(
+      <UserPromptDialog
+        open
+        onClose={onClose}
+        onConfirm={onConfirm}
+        moduleName="my-module"
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'Provide additional requirements before triggering the next phase for the my-module module',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('has prompt input and run button', async () => {
+    await renderInTestApp(
+      <UserPromptDialog open onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByTestId('user-prompt-input')).toBeInTheDocument();
+    expect(within(dialog).getByTestId('user-prompt-run')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    await renderInTestApp(
+      <UserPromptDialog open onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm with empty string and onClose when Run is clicked with no input', async () => {
+    const user = userEvent.setup();
+    await renderInTestApp(
+      <UserPromptDialog open onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByTestId('user-prompt-run'));
+
+    expect(onConfirm).toHaveBeenCalledWith('');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm with trimmed prompt and onClose when Run is clicked with input', async () => {
+    const user = userEvent.setup();
+    await renderInTestApp(
+      <UserPromptDialog open onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const input = within(dialog).getByTestId('user-prompt-input');
+    await user.type(input, '  my custom prompt  ');
+    await user.click(within(dialog).getByTestId('user-prompt-run'));
+
+    expect(onConfirm).toHaveBeenCalledWith('my custom prompt');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show moduleName text when moduleName is not provided', async () => {
+    await renderInTestApp(
+      <UserPromptDialog open onClose={onClose} onConfirm={onConfirm} />,
+    );
+
+    expect(
+      screen.queryByText(/Provide additional requirements before triggering/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/workspaces/x2a/plugins/x2a/src/components/ModuleTable/UserPromptDialog.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModuleTable/UserPromptDialog.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Button from '@material-ui/core/Button';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import { useTranslation } from '../../hooks/useTranslation';
+
+export type UserPromptDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (userPrompt: string) => void;
+  phaseName?: string;
+  moduleName?: string;
+};
+
+/**
+ * Modal dialog that collects an optional text prompt before running the next phase.
+ */
+export const UserPromptDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  phaseName,
+  moduleName,
+}: UserPromptDialogProps) => {
+  const { t } = useTranslation();
+  const [prompt, setPrompt] = useState('');
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(prompt.trim());
+    setPrompt('');
+    onClose();
+  }, [onConfirm, onClose, prompt]);
+
+  const handleCancel = useCallback(() => {
+    setPrompt('');
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) setPrompt('');
+  }, [open]);
+
+  const title = phaseName
+    ? `${t('userPromptDialog.title')}: ${phaseName}`
+    : t('userPromptDialog.title');
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="md" fullWidth>
+      <DialogTitle id="user-prompt-dialog-title">{title}</DialogTitle>
+      <DialogContent>
+        {moduleName && (
+          <Typography variant="body1" gutterBottom>
+            {t('userPromptDialog.moduleName' as any, { moduleName })}
+          </Typography>
+        )}
+        <TextField
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          margin="dense"
+          label={t('userPromptDialog.promptLabel')}
+          placeholder={t('userPromptDialog.promptPlaceholder')}
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          fullWidth
+          multiline
+          minRows={3}
+          maxRows={8}
+          variant="outlined"
+          inputProps={{ 'data-testid': 'user-prompt-input' }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel}>{t('wizard.cancel')}</Button>
+        <Button
+          onClick={handleConfirm}
+          color="primary"
+          variant="contained"
+          data-testid="user-prompt-run"
+        >
+          {t('userPromptDialog.run')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/workspaces/x2a/plugins/x2a/src/translations/de.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/de.ts
@@ -61,6 +61,13 @@ const x2aPluginTranslationDe = createTranslationMessages({
     'artifact.types.migration_plan': 'Migrationsplan',
     'artifact.types.module_migration_plan': 'Modulplan',
     'artifact.types.migrated_sources': 'Migrierte Quellen',
+    'userPromptDialog.title': 'Nächste Phase ausführen',
+    'userPromptDialog.promptLabel': 'Benutzereingabe',
+    'userPromptDialog.promptPlaceholder':
+      'Optional Anweisungen oder Kontext für diesen Lauf angeben. Lassen Sie es leer für Standardverhalten.',
+    'userPromptDialog.run': 'Ausführen',
+    'userPromptDialog.moduleName':
+      'Geben Sie vor dem Start der nächsten Phase für das Modul {{moduleName}} zusätzliche Anforderungen an.',
   },
 });
 

--- a/workspaces/x2a/plugins/x2a/src/translations/es.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/es.ts
@@ -61,6 +61,13 @@ const x2aPluginTranslationEs = createTranslationMessages({
     'artifact.types.migration_plan': 'Plan de migración',
     'artifact.types.module_migration_plan': 'Plan del módulo',
     'artifact.types.migrated_sources': 'Fuentes migradas',
+    'userPromptDialog.title': 'Ejecutar siguiente fase',
+    'userPromptDialog.promptLabel': 'Prompt de usuario',
+    'userPromptDialog.promptPlaceholder':
+      'Opcionalmente añada instrucciones o contexto para esta ejecución. Déjelo en blanco para el comportamiento predeterminado.',
+    'userPromptDialog.run': 'Ejecutar',
+    'userPromptDialog.moduleName':
+      'Proporcione requisitos adicionales antes de activar la siguiente fase para el módulo {{moduleName}}.',
   },
 });
 

--- a/workspaces/x2a/plugins/x2a/src/translations/fr.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/fr.ts
@@ -61,6 +61,13 @@ const x2aPluginTranslationFr = createTranslationMessages({
     'artifact.types.migration_plan': 'Plan de migration',
     'artifact.types.module_migration_plan': 'Plan du module',
     'artifact.types.migrated_sources': 'Sources migrées',
+    'userPromptDialog.title': 'Exécuter la phase suivante',
+    'userPromptDialog.promptLabel': 'Invite utilisateur',
+    'userPromptDialog.promptPlaceholder':
+      'Ajoutez éventuellement des instructions ou du contexte pour cette exécution. Laissez-le vide pour le comportement par défaut.',
+    'userPromptDialog.run': 'Exécuter',
+    'userPromptDialog.moduleName':
+      'Fournissez des exigences supplémentaires avant de déclencher la phase suivante pour le module {{moduleName}}.',
   },
 });
 

--- a/workspaces/x2a/plugins/x2a/src/translations/it.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/it.ts
@@ -61,6 +61,13 @@ const x2aPluginTranslationIt = createTranslationMessages({
     'artifact.types.migration_plan': 'Piano di migrazione',
     'artifact.types.module_migration_plan': 'Piano del modulo',
     'artifact.types.migrated_sources': 'Sorgenti migrate',
+    'userPromptDialog.title': 'Esegui fase successiva',
+    'userPromptDialog.promptLabel': 'Prompt utente',
+    'userPromptDialog.promptPlaceholder':
+      'Aggiungi eventualmente istruzioni o contesto per questa esecuzione. Lascialo vuoto per il comportamento predefinito.',
+    'userPromptDialog.run': 'Esegui',
+    'userPromptDialog.moduleName':
+      'Fornisci requisiti aggiuntivi prima di avviare la fase successiva per il modulo {{moduleName}}.',
   },
 });
 

--- a/workspaces/x2a/plugins/x2a/src/translations/ref.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/ref.ts
@@ -87,6 +87,15 @@ export const x2aPluginMessages = {
       migrated_sources: 'Migrated Sources',
     },
   },
+  userPromptDialog: {
+    title: 'Run next phase',
+    promptLabel: 'User prompt',
+    promptPlaceholder:
+      'Optionally add instructions or context for this run. Leave it blank for default behavior.',
+    run: 'Run',
+    moduleName:
+      'Provide additional requirements before triggering the next phase for the {{moduleName}} module',
+  },
 };
 
 /**


### PR DESCRIPTION
Fixes: FLPATH-3198

## Hey, I just made a Pull Request!

A modal dialog opens to query user prompt before running the next phase.

We do not persist the prompts, let's evaluate the needs first.
We might prefill the former prompt for a module-phase for retrigger or provide a default.

<img width="1424" height="667" alt="Screenshot From 2026-02-09 10-35-07" src="https://github.com/user-attachments/assets/8fbca192-8007-494d-af35-1be4e1475172" />


<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
