### PR TITLE
feat(x2a): removing user prompt except the project init phase

### DIFF
--- a/workspaces/x2a/.changeset/green-candles-play.md
+++ b/workspaces/x2a/.changeset/green-candles-play.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+'@red-hat-developer-hub/backstage-plugin-x2a-common': patch
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+The user prompt is removed except for the project init phase.

--- a/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
@@ -180,7 +180,6 @@ export function registerModuleRoutes(
             password: z.string().optional(),
           })
           .optional(),
-        userPrompt: z.string().optional(),
       });
 
       const parsedBody = runModuleRequestSchema
@@ -189,13 +188,8 @@ export function registerModuleRoutes(
       if (!parsedBody.success) {
         throw new InputError(`Invalid body ${endpoint}: ${parsedBody.error}`);
       }
-      const {
-        phase,
-        sourceRepoAuth,
-        targetRepoAuth,
-        aapCredentials,
-        userPrompt,
-      } = parsedBody.data;
+      const { phase, sourceRepoAuth, targetRepoAuth, aapCredentials } =
+        parsedBody.data;
 
       // Get tokens with config-based fallback
       const sourceToken =
@@ -295,7 +289,6 @@ export function registerModuleRoutes(
           token: targetToken,
         },
         aapCredentials,
-        userPrompt,
       });
 
       // Update job with k8s job name

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
@@ -290,11 +290,7 @@ paths:
                 targetRepoAuth:
                   $ref: '#/components/schemas/GitRepoAuth'
                 aapCredentials:
-                  # TODO: reuse from project's init phase
                   $ref: '#/components/schemas/AAPCredentials'
-                userPrompt:
-                  type: string
-                  description: Optional user prompt for customizing the migration
               required:
                 - phase
                 - sourceRepoAuth

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/models/ProjectsProjectIdModulesModuleIdRunPostRequest.model.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/models/ProjectsProjectIdModulesModuleIdRunPostRequest.model.ts
@@ -29,8 +29,4 @@ export interface ProjectsProjectIdModulesModuleIdRunPostRequest {
   sourceRepoAuth: GitRepoAuth;
   targetRepoAuth: GitRepoAuth;
   aapCredentials?: AAPCredentials;
-  /**
-   * Optional user prompt for customizing the migration
-   */
-  userPrompt?: string;
 }

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
@@ -444,10 +444,6 @@ export const spec = {
                   },
                   "aapCredentials": {
                     "$ref": "#/components/schemas/AAPCredentials"
-                  },
-                  "userPrompt": {
-                    "type": "string",
-                    "description": "Optional user prompt for customizing the migration"
                   }
                 },
                 "required": [

--- a/workspaces/x2a/plugins/x2a-common/client/src/schema/openapi/generated/models/ProjectsProjectIdModulesModuleIdRunPostRequest.model.ts
+++ b/workspaces/x2a/plugins/x2a-common/client/src/schema/openapi/generated/models/ProjectsProjectIdModulesModuleIdRunPostRequest.model.ts
@@ -29,8 +29,4 @@ export interface ProjectsProjectIdModulesModuleIdRunPostRequest {
   sourceRepoAuth: GitRepoAuth;
   targetRepoAuth: GitRepoAuth;
   aapCredentials?: AAPCredentials;
-  /**
-   * Optional user prompt for customizing the migration
-   */
-  userPrompt?: string;
 }

--- a/workspaces/x2a/plugins/x2a-common/report.api.md
+++ b/workspaces/x2a/plugins/x2a-common/report.api.md
@@ -211,7 +211,6 @@ export interface ProjectsProjectIdModulesModuleIdRunPostRequest {
     sourceRepoAuth: GitRepoAuth;
     // (undocumented)
     targetRepoAuth: GitRepoAuth;
-    userPrompt?: string;
 }
 
 // @public (undocumented)

--- a/workspaces/x2a/plugins/x2a/src/components/ModuleTable/ModuleTable.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModuleTable/ModuleTable.tsx
@@ -133,8 +133,7 @@ export const ModuleTable = ({
               token:
                 'TODO:placeholder - the token needs to be renewed for each run',
             },
-            userPrompt: 'TODO: user prompt - collect per run',
-            // skipping AAP credentials in favor of app-config.yaml
+            // skipping AAP credentials in favor of the app-config.yaml
           },
         });
 


### PR DESCRIPTION
Fixes: FLPATH-3206

The `module/run` actions are newly not provided with a user prompt. The user can provide additional context data into the plans.

The user prompt remains for the project's init phase.