### PR TITLE
fix(adoption-insights): resolve lint errors

### DIFF
--- a/workspaces/adoption-insights/.changeset/tidy-cities-go.md
+++ b/workspaces/adoption-insights/.changeset/tidy-cities-go.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+---
+
+Add missing direct dependencies to package

--- a/workspaces/adoption-insights/packages/backend/package.json
+++ b/workspaces/adoption-insights/packages/backend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@backstage/backend-defaults": "^0.15.1",
+    "@backstage/backend-plugin-api": "^1.6.2",
     "@backstage/config": "^1.3.6",
     "@backstage/plugin-app-backend": "^0.5.10",
     "@backstage/plugin-auth-backend": "^0.26.0",
@@ -38,6 +39,7 @@
     "@backstage/plugin-permission-node": "^0.10.9",
     "@backstage/plugin-proxy-backend": "^0.6.9",
     "@backstage/plugin-scaffolder-backend": "^3.1.2",
+    "@backstage/plugin-scaffolder-backend-module-github": "^0.9.5",
     "@backstage/plugin-search-backend": "^2.0.11",
     "@backstage/plugin-search-backend-module-catalog": "^0.3.11",
     "@backstage/plugin-search-backend-module-pg": "^0.5.51",

--- a/workspaces/adoption-insights/plugins/adoption-insights-common/.eslintignore
+++ b/workspaces/adoption-insights/plugins/adoption-insights-common/.eslintignore
@@ -1,4 +1,2 @@
 dist-dynamic
 dist-scalprum
-!.eslintrc.js
-!.prettierrc.js

--- a/workspaces/adoption-insights/yarn.lock
+++ b/workspaces/adoption-insights/yarn.lock
@@ -15027,6 +15027,7 @@ __metadata:
   resolution: "backend@workspace:packages/backend"
   dependencies:
     "@backstage/backend-defaults": ^0.15.1
+    "@backstage/backend-plugin-api": ^1.6.2
     "@backstage/cli": ^0.35.3
     "@backstage/config": ^1.3.6
     "@backstage/plugin-app-backend": ^0.5.10
@@ -15044,6 +15045,7 @@ __metadata:
     "@backstage/plugin-permission-node": ^0.10.9
     "@backstage/plugin-proxy-backend": ^0.6.9
     "@backstage/plugin-scaffolder-backend": ^3.1.2
+    "@backstage/plugin-scaffolder-backend-module-github": ^0.9.5
     "@backstage/plugin-search-backend": ^2.0.11
     "@backstage/plugin-search-backend-module-catalog": ^0.3.11
     "@backstage/plugin-search-backend-module-pg": ^0.5.51


### PR DESCRIPTION
Fixes lint errors on the `adoption-insights` workspace by adding missing direct dependencies, and by ignoring the linting configuration in the linting process (aligned with other workspaces).