### PR TITLE
fix(ai-integrations): fix TypeScript type errors in test files

### DIFF
--- a/workspaces/ai-integrations/.changeset/fix-test-type-errors.md
+++ b/workspaces/ai-integrations/.changeset/fix-test-type-errors.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-ai-experience': patch
+---
+
+Fixed TypeScript type errors in test files by using `lightTheme` directly instead of wrapping with `createTheme()`

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/LearnSection.test.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/LearnSection.test.tsx
@@ -15,7 +15,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import { LearnSection } from '../LearnSection/LearnSection';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme } from '@backstage/theme';
 import { mockUseTranslation } from '../../test-utils/mockTranslations';
 
@@ -32,10 +32,8 @@ jest.mock('../LearnSection/CardWrapper', () => ({
   ),
 }));
 
-const theme = createTheme(lightTheme);
-
 const renderWithTheme = (component: React.ReactElement) => {
-  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+  return render(<ThemeProvider theme={lightTheme}>{component}</ThemeProvider>);
 };
 
 // Mock dependencies

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/NewsCard.test.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/NewsCard.test.tsx
@@ -15,7 +15,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import { NewsCard, Article } from '../NewsPage/NewsCard';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme } from '@backstage/theme';
 import { MemoryRouter } from 'react-router-dom'; // Import MemoryRouter
 
@@ -29,14 +29,12 @@ jest.mock('@backstage/core-components', () => ({
   ),
 }));
 
-const theme = createTheme(lightTheme);
-
 const renderInTheme = (children: React.ReactNode) =>
   render(
     <MemoryRouter>
       {' '}
       {/* Wrap with MemoryRouter */}
-      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
     </MemoryRouter>,
   );
 

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/NewsGrid.test.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/NewsGrid.test.tsx
@@ -18,7 +18,7 @@ import { NewsGrid } from '../NewsPage/NewsGrid';
 import { useApi } from '@backstage/core-plugin-api';
 import { parseStringPromise } from 'xml2js';
 import { sanitizeXML, extractImageFromHTML } from '../../utils/rss-utils';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme } from '@backstage/theme';
 import { TestApiProvider } from '@backstage/test-utils';
 import { mockUseTranslation } from '../../test-utils/mockTranslations';
@@ -45,12 +45,10 @@ const mockRssApi = {
   fetch: jest.fn(),
 };
 
-const theme = createTheme(lightTheme);
-
 const renderWithTheme = (component: React.ReactElement) => {
   return render(
     <TestApiProvider apis={[]}>
-      <ThemeProvider theme={theme}>{component}</ThemeProvider>
+      <ThemeProvider theme={lightTheme}>{component}</ThemeProvider>
     </TestApiProvider>,
   );
 };

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/NewsHeader.test.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/NewsHeader.test.tsx
@@ -15,7 +15,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import { NewsHeader } from '../NewsPage/NewsHeader';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme } from '@backstage/theme';
 import { mockUseTranslation } from '../../test-utils/mockTranslations';
 
@@ -34,10 +34,8 @@ jest.mock('@backstage/core-components', () => ({
   ),
 }));
 
-const theme = createTheme(lightTheme);
-
 const renderWithTheme = (component: React.ReactElement) => {
-  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+  return render(<ThemeProvider theme={lightTheme}>{component}</ThemeProvider>);
 };
 
 describe('NewsHeader', () => {

--- a/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/TagList.test.tsx
+++ b/workspaces/ai-integrations/plugins/ai-experience/src/components/__tests__/TagList.test.tsx
@@ -15,7 +15,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import TagList from '../ModelSection/TagList';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme } from '@backstage/theme';
 import { mockUseTranslation } from '../../test-utils/mockTranslations';
 
@@ -24,10 +24,8 @@ jest.mock('../../hooks/useTranslation', () => ({
   useTranslation: () => mockUseTranslation(),
 }));
 
-const theme = createTheme(lightTheme);
-
 const renderWithTheme = (component: React.ReactElement) => {
-  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+  return render(<ThemeProvider theme={lightTheme}>{component}</ThemeProvider>);
 };
 
 describe('TagList', () => {


### PR DESCRIPTION
Use `lightTheme` directly from `@backstage/theme` instead of wrapping with `createTheme()` to fix type incompatibility with newer MUI types.