### PR TITLE
fix(x2a): Removing Authentication of collectArtifact endpoint

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/src/plugin.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/plugin.test.ts
@@ -215,6 +215,21 @@ describe('plugin', () => {
     });
   });
 
+  it('should allow unauthenticated access to collectArtifacts callback', async () => {
+    const server = await startBackendServer();
+    const fakeProjectId = '00000000-0000-0000-0000-000000000000';
+    const fakeJobId = '00000000-0000-0000-0000-000000000001';
+
+    const res = await request(server)
+      .post(`/api/x2a/projects/${fakeProjectId}/collectArtifacts?phase=init`)
+      .send({ status: 'success', jobId: fakeJobId, artifacts: [] });
+
+    // Should NOT be 401/403 — the endpoint allows unauthenticated access.
+    // 404 is expected because the job doesn't exist.
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+
   it('should forward errors from the X2ADatabaseService', async () => {
     const { server } = await startTestBackend({
       features: [

--- a/workspaces/x2a/plugins/x2a-backend/src/plugin.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/plugin.ts
@@ -55,6 +55,11 @@ export const x2APlugin = createBackendPlugin({
       }) {
         await migrate(database);
 
+        httpRouter.addAuthPolicy({
+          path: '/projects/:projectId/collectArtifacts',
+          allow: 'unauthenticated',
+        });
+
         httpRouter.use(
           await createRouter({
             httpAuth,

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
@@ -355,6 +355,7 @@ paths:
 
   /projects/{projectId}/collectArtifacts:
     post:
+      security: []
       summary: Collects artifacts from a completed X2Ansible job
       description: |
         Callback endpoint for X2Ansible jobs to submit execution artifacts and results.

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
@@ -547,6 +547,7 @@ export const spec = {
     },
     "/projects/{projectId}/collectArtifacts": {
       "post": {
+        "security": [],
         "summary": "Collects artifacts from a completed X2Ansible job",
         "description": "Callback endpoint for X2Ansible jobs to submit execution artifacts and results.\nThis endpoint is called by the X2Ansible job runner when a migration phase completes.\n",
         "parameters": [


### PR DESCRIPTION
To simplify and move faster in the MVP, the collectArtifact bypasses authentication and can be called anywhere. This will help us until the project can stably run containerized outside the dev env. 