### PR TITLE
feat(x2a): Project Status and pie charts examples

### DIFF
--- a/workspaces/x2a/plugins/x2a/report.api.md
+++ b/workspaces/x2a/plugins/x2a/report.api.md
@@ -87,6 +87,7 @@ readonly "module.summary.error": string;
 readonly "module.summary.finished": string;
 readonly "module.summary.waiting": string;
 readonly "module.summary.pending": string;
+readonly "module.summary.toReview": string;
 readonly "module.name": string;
 readonly "module.artifacts": string;
 readonly "module.phases.none": string;

--- a/workspaces/x2a/plugins/x2a/src/components/ProjectList/ProjectStatusCell.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ProjectList/ProjectStatusCell.tsx
@@ -17,7 +17,8 @@ import { useState } from 'react';
 import { ProjectStatus } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import { PieChart, PieValueType } from '@mui/x-charts';
-import { Grid, makeStyles, Tooltip } from '@material-ui/core';
+import { Grid, makeStyles, Tooltip, Chip } from '@material-ui/core';
+import AssignmentTurnedInIcon from '@material-ui/icons/AssignmentTurnedIn';
 
 import { useTranslation } from '../../hooks/useTranslation';
 
@@ -75,7 +76,7 @@ export const ProjectStatusCell = ({
       {
         label: t('module.summary.waiting'),
         value: modulesSummary.waiting,
-        color: '#FFBB28',
+        color: '#4CAF50',
       },
       {
         label: t('module.summary.pending'),
@@ -85,7 +86,7 @@ export const ProjectStatusCell = ({
       {
         label: t('module.summary.running'),
         value: modulesSummary.running,
-        color: '#FF8042',
+        color: '#0088FE',
       },
       {
         label: t('module.summary.error'),
@@ -154,6 +155,22 @@ export const ProjectStatusCell = ({
       <Grid item alignContent="center">
         {t(`project.statuses.${projectStatus.state || 'none'}`)}
       </Grid>
+
+      {modulesSummary && modulesSummary.waiting > 0 && (
+        <Grid item alignContent="center">
+          <Chip
+            size="small"
+            variant="outlined"
+            color="primary"
+            icon={<AssignmentTurnedInIcon />}
+            label={`${modulesSummary.waiting} ${t('module.summary.toReview')}`}
+            onClick={event => {
+              event.stopPropagation();
+              setOpen(!open);
+            }}
+          />
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/workspaces/x2a/plugins/x2a/src/translations/de.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/de.ts
@@ -65,6 +65,7 @@ const x2aPluginTranslationDe = createTranslationMessages({
     'module.summary.pending': 'Ausstehend',
     'module.summary.running': 'Läuft',
     'module.summary.error': 'Fehler',
+    'module.summary.toReview': 'zu überprüfen',
     'module.actions.runNextPhase': 'Nächste Phase ausführen',
     'module.lastPhase': 'Letzte Phase',
     'module.name': 'Name',

--- a/workspaces/x2a/plugins/x2a/src/translations/es.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/es.ts
@@ -65,6 +65,7 @@ const x2aPluginTranslationEs = createTranslationMessages({
     'module.summary.pending': 'Pendiente',
     'module.summary.running': 'En ejecución',
     'module.summary.error': 'Error',
+    'module.summary.toReview': 'para revisar',
     'module.actions.runNextPhase': 'Ejecutar siguiente fase',
     'module.lastPhase': 'Última fase',
     'module.name': 'Nombre',

--- a/workspaces/x2a/plugins/x2a/src/translations/fr.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/fr.ts
@@ -65,6 +65,7 @@ const x2aPluginTranslationFr = createTranslationMessages({
     'module.summary.pending': 'En attente',
     'module.summary.running': 'En cours',
     'module.summary.error': 'Erreur',
+    'module.summary.toReview': 'à réviser',
     'module.actions.runNextPhase': 'Exécuter la phase suivante',
     'module.lastPhase': 'Dernière phase',
     'module.name': 'Nom',

--- a/workspaces/x2a/plugins/x2a/src/translations/it.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/it.ts
@@ -65,6 +65,7 @@ const x2aPluginTranslationIt = createTranslationMessages({
     'module.summary.pending': 'In attesa',
     'module.summary.running': 'In esecuzione',
     'module.summary.error': 'Errore',
+    'module.summary.toReview': 'da rivedere',
     'module.actions.runNextPhase': 'Esegui fase successiva',
     'module.lastPhase': 'Ultima fase',
     'module.name': 'Nome',

--- a/workspaces/x2a/plugins/x2a/src/translations/ref.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/ref.ts
@@ -127,6 +127,7 @@ export const x2aPluginMessages = {
       pending: 'Pending',
       running: 'Running',
       error: 'Error',
+      toReview: 'to review',
     },
     actions: {
       runNextPhase: 'Run Next Phase',


### PR DESCRIPTION

Now the colors are not longer yellow (Warning), and it's more like greener but with a chip on how to keep the task aware. For example, user should now if the project needs some inputs from the operator.

So:

Manager: can see that the project is running without "warnings", all green.
Operator: can see that the project is running, but there are some task that he/she needs to perform to finish the project.



<img width="3347" height="945" alt="image" src="https://github.com/user-attachments/assets/d91c486c-ae70-42ef-a549-3f59bfcdc196" />
