### PR TITLE
feat(x2a): add configurable callback URL for local development

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/config.d.ts
+++ b/workspaces/x2a/plugins/x2a-backend/config.d.ts
@@ -62,6 +62,15 @@ export interface X2AConfig {
 export interface Config {
   x2a?: {
     /**
+     * Callback base URL for job-to-backend communication
+     * Overrides the URL used for Kubernetes jobs to call back to the backend.
+     * If not set, uses discoveryApi.getBaseUrl('x2a') (default: backend.baseUrl).
+     * Useful for local development when jobs need to reach the backend via LAN IP.
+     * @example "http://192.168.2.193:7007"
+     * @visibility backend
+     */
+    callbackBaseUrl?: string;
+    /**
      * Kubernetes configuration for X2A jobs
      */
     kubernetes?: {

--- a/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
@@ -317,7 +317,10 @@ export function registerModuleRoutes(
 
       // Create Kubernetes job (will create both project and job secrets)
       // Use discoveryApi for consistent URL resolution
-      const moduleBaseUrl = await discoveryApi.getBaseUrl('x2a');
+      // Allow override via config for local development (e.g., using LAN IP)
+      const moduleBaseUrl =
+        config.getOptionalString('x2a.callbackBaseUrl') ??
+        (await discoveryApi.getBaseUrl('x2a'));
       const callbackUrl = `${moduleBaseUrl}/projects/${projectId}/collectArtifacts`;
       const { k8sJobName } = await kubeService.createJob({
         jobId: job.id,

--- a/workspaces/x2a/plugins/x2a-backend/src/router/projects.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/projects.ts
@@ -310,7 +310,10 @@ export function registerProjectRoutes(
       // Create Kubernetes job (will create both project and job secrets)
       // Use HTTP for in-cluster service-to-service communication
       // Jobs call back to Backstage within the same cluster
-      const baseUrl = await discoveryApi.getBaseUrl('x2a');
+      // Allow override via config for local development (e.g., using LAN IP)
+      const baseUrl =
+        config.getOptionalString('x2a.callbackBaseUrl') ??
+        (await discoveryApi.getBaseUrl('x2a'));
       const callbackUrl = `${baseUrl}/projects/${projectId}/collectArtifacts`;
       const { k8sJobName } = await kubeService.createJob({
         jobId: job.id,


### PR DESCRIPTION
### **User description**
Introduces x2a.callbackBaseUrl config option to support local development scenarios where Kubernetes jobs need to reach the backend via LAN IP instead of the default discovery service URL. Useful when running jobs that need to communicate back to a locally-running backend instance.


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable `callbackBaseUrl` option for local development scenarios

- Allow Kubernetes jobs to reach backend via custom URL (e.g., LAN IP)

- Override default discovery service URL when needed

- Update TypeScript config interface and router implementations


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.d.ts</strong><dd><code>Add callbackBaseUrl config property definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/config.d.ts

<ul><li>Add <code>callbackBaseUrl</code> optional string property to X2A config interface<br> <li> Include JSDoc documentation with usage example and visibility marker<br> <li> Explain purpose for local development and LAN IP scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2359/files#diff-d0ec3dd90216d904fb350ccd60592390ae35b4579b0816f909c93029f5d683ee">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modules.ts</strong><dd><code>Use configurable callback URL in modules router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/src/router/modules.ts

<ul><li>Replace direct <code>discoveryApi.getBaseUrl()</code> call with config-aware <br>fallback<br> <li> Check <code>x2a.callbackBaseUrl</code> config first, then fall back to discovery <br>API<br> <li> Add comment explaining local development override capability</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2359/files#diff-a178e2ea3dfa24ee48b2ec451aeffaea747f14c9419b24080f59750331688f18">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>projects.ts</strong><dd><code>Use configurable callback URL in projects router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/src/router/projects.ts

<ul><li>Replace direct <code>discoveryApi.getBaseUrl()</code> call with config-aware <br>fallback<br> <li> Check <code>x2a.callbackBaseUrl</code> config first, then fall back to discovery <br>API<br> <li> Add comment explaining local development override capability</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2359/files#diff-272124295e6cd44ec427ee0a337431ee937722b3d2dc1db3706a515107c920bf">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

