### PR TITLE
fix(x2a): module should be running when create the k8s job

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/src/router/modules.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/modules.test.ts
@@ -515,7 +515,7 @@ describe('createRouter – modules', () => {
 
         expect(response.status).toBe(200);
         expect(response.body).toMatchObject({
-          status: 'pending',
+          status: 'running',
           jobId: expect.any(String),
         });
       },

--- a/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
@@ -346,17 +346,18 @@ export function registerModuleRoutes(
         aapCredentials,
       });
 
-      // Update job with k8s job name
+      // Update job with k8s job name and mark as running
       await x2aDatabase.updateJob({
         id: job.id,
         k8sJobName,
+        status: 'running',
       });
 
       logger.info(
         `${phase} job created: jobId=${job.id}, moduleId=${moduleId}, k8sJobName=${k8sJobName}`,
       );
 
-      return res.json({ status: 'pending', jobId: job.id } as any);
+      return res.json({ status: 'running', jobId: job.id } as any);
     },
   );
 }


### PR DESCRIPTION
### **User description**
Fix: FLPATH-3287


___

### **PR Type**
Bug fix


___

### **Description**
- Module status changed from 'pending' to 'running' when Kubernetes job is created

- Job status updated in database immediately after k8s job creation

- Test expectations updated to reflect correct initial status


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modules.ts</strong><dd><code>Update job status to running on k8s creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/src/router/modules.ts

<ul><li>Updated job status to 'running' in database after k8s job creation<br> <li> Changed API response status from 'pending' to 'running'<br> <li> Updated comment to reflect status change behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2362/files#diff-a178e2ea3dfa24ee48b2ec451aeffaea747f14c9419b24080f59750331688f18">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modules.test.ts</strong><dd><code>Update test to expect running status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/src/router/modules.test.ts

<ul><li>Updated test expectation for module run response status<br> <li> Changed expected status from 'pending' to 'running'</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2362/files#diff-f97d00533e588f077cc71509d775dc7a674573dcad93e1d82b71e2d2e8f6fecd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

