### PR TITLE
fix(x2a): Module page fix title

### DIFF
--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModulePage.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModulePage.tsx
@@ -133,14 +133,9 @@ export const ModulePage = () => {
 
   return (
     <Page themeId="tool">
-      <Header
-        title={
-          <>
-            <ModulePageBreadcrumb />
-            <p>{t('modulePage.title')}</p>
-          </>
-        }
-      />
+      <Header title={module?.name || t('modulePage.title')}>
+        <ModulePageBreadcrumb />
+      </Header>
 
       <Content>
         {error && (


### PR DESCRIPTION
### **User description**
Before was `[object object] | X2Ansible convertor` now is module.name


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed module page header title displaying `[object object]` instead of module name

- Refactored Header component to use `module?.name` as title prop

- Moved ModulePageBreadcrumb into Header children for better structure


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModulePage.tsx</strong><dd><code>Refactor Header title to use module name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a/src/components/ModulePage/ModulePage.tsx

<ul><li>Changed Header title from JSX fragment with hardcoded text to dynamic <br><code>module?.name</code> property<br> <li> Moved ModulePageBreadcrumb from title prop to Header children<br> <li> Simplified Header component structure by removing unnecessary wrapper <br>elements<br> <li> Fallback to translated text when module name is unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2365/files#diff-148b32958f50f88b610aa05006b88fb66d088c12bfeed9d5831408fb8fbfb879">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

