### PR TITLE
fix: use RHDH_BOT_TOKEN for CODEOWNERS validation workflow

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Validate CODEOWNERS entries against team membership
         run: node scripts/ci/validate-codeowners.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}


### PR DESCRIPTION
### **User description**
## Summary
- Switch the validate-codeowners workflow from `GITHUB_TOKEN` to `RHDH_BOT_TOKEN`
- The default `GITHUB_TOKEN` lacks permission to query org team membership, causing validation failures

## Test plan
- [ ] Verify the workflow runs successfully on a PR that modifies `.github/CODEOWNERS`
- [ ] Confirm the bot token has the required `read:org` scope to query team membership


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `GITHUB_TOKEN` with `RHDH_BOT_TOKEN` in CODEOWNERS validation workflow

- Resolves permission issue preventing org team membership queries


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate-codeowners.yml</strong><dd><code>Switch to RHDH_BOT_TOKEN for team membership queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/validate-codeowners.yml

<ul><li>Changed environment variable from <code>GITHUB_TOKEN</code> to <code>RHDH_BOT_TOKEN</code> in <br>the CODEOWNERS validation step<br> <li> Enables workflow to query org team membership with required <code>read:org</code> <br>scope</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2366/files#diff-8e4f84c27b52c67a5b0f10df80e399d042b605b638c64e67332c74512d029b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

