### PR TITLE
feat(scorecard): Custom threshold keys and colors

### DIFF
--- a/workspaces/scorecard/.changeset/busy-mice-call.md
+++ b/workspaces/scorecard/.changeset/busy-mice-call.md
@@ -1,0 +1,8 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend': minor
+'@red-hat-developer-hub/backstage-plugin-scorecard-common': minor
+'@red-hat-developer-hub/backstage-plugin-scorecard-node': minor
+'@red-hat-developer-hub/backstage-plugin-scorecard': minor
+---
+
+Introduces custom threshold rule keys and colors that can be configured in `app-config.yaml`.

--- a/workspaces/scorecard/packages/app/e2e-tests/utils/scorecardResponseUtils.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/utils/scorecardResponseUtils.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { DEFAULT_NUMBER_THRESHOLDS } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+
 export const customScorecardResponse = [
   {
     id: 'github.open_prs',
@@ -189,6 +191,7 @@ export const githubAggregatedResponse = {
     ],
     total: 15,
     timestamp: '2026-01-24T14:10:32.858Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };
 
@@ -210,6 +213,7 @@ export const jiraAggregatedResponse = {
     ],
     total: 10,
     timestamp: '2026-01-24T14:10:32.776Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };
 
@@ -231,6 +235,7 @@ export const emptyJiraAggregatedResponse = {
       { count: 0, name: 'error' },
     ],
     timestamp: '2026-01-24T14:10:32.858Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };
 
@@ -252,5 +257,6 @@ export const emptyGithubAggregatedResponse = {
       { count: 0, name: 'error' },
     ],
     timestamp: '2026-01-24T14:10:32.858Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };

--- a/workspaces/scorecard/plugins/scorecard-backend/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/README.md
@@ -102,7 +102,7 @@ To use these providers, install the corresponding backend modules:
 
 ## Thresholds
 
-Thresholds define conditions that determine which category a metric value belongs to (`error`, `warning`, or `success`). The Scorecard plugin provides multiple ways to configure thresholds:
+Thresholds define conditions to assign metric values to specific visual categories (`success`, `warning`, `error` or any custom category). The Scorecard plugin provides multiple ways to configure thresholds:
 
 - **Provider Defaults**: Metric providers define default thresholds
 - **App Configuration**: Override defaults through `app-config.yaml`

--- a/workspaces/scorecard/plugins/scorecard-backend/config.d.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/config.d.ts
@@ -35,6 +35,11 @@ export interface Config {
               key: string;
               /** Threshold expression - supports: >=, <=, >, <, ==, !=, - (range) */
               expression: string;
+              /**
+               * Color for this threshold rule. Can be a theme palette path (e.g., 'error.main')
+               * or a direct color value (e.g., '#ADD8E6', 'blue', 'rgb(255,255,0)')
+               */
+              color?: string;
             }>;
           };
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;

--- a/workspaces/scorecard/plugins/scorecard-backend/config.d.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/config.d.ts
@@ -32,7 +32,7 @@ export interface Config {
           /** Threshold configuration for the metric */
           thresholds?: {
             rules?: Array<{
-              key: 'error' | 'warning' | 'success';
+              key: string;
               /** Threshold expression - supports: >=, <=, >, <, ==, !=, - (range) */
               expression: string;
             }>;

--- a/workspaces/scorecard/plugins/scorecard-backend/docs/thresholds.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/docs/thresholds.md
@@ -1,6 +1,6 @@
 # Thresholds Configuration
 
-Thresholds define conditions that determine which category a metric value belongs to (`success`, `warning`, or `error`). When a metric value matches a threshold condition, it gets assigned to that threshold's category. The Scorecard plugin provides multiple ways to configure thresholds with a flexible priority system.
+Thresholds define conditions to assign metric values to specific visual categories (`success`, `warning`, `error` or any custom category). When a metric value matches a threshold condition, it gets assigned to that threshold's category. The Scorecard plugin provides multiple ways to configure thresholds with a flexible priority system.
 
 ## Overview
 

--- a/workspaces/scorecard/plugins/scorecard-backend/docs/thresholds.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/docs/thresholds.md
@@ -6,8 +6,9 @@ Thresholds define conditions that determine which category a metric value belong
 
 Thresholds are evaluated in order and the **first matching** threshold rule is applied. Each threshold rule consists of:
 
-- **`key`**: The threshold category (only allowed keys are `success`, `warning`, `error`)
+- **`key`**: The threshold category (e.g., `success`, `warning`, `error`, or custom keys)
 - **`expression`**: The condition that determines if a metric value matches this threshold
+- **`color`** (optional): The color to display for this threshold in the UI (see [Threshold Colors](#threshold-colors))
 
 ## Threshold Configuration Options
 
@@ -219,6 +220,72 @@ rules:
   - key: error
     expression: '!=true'
 ```
+
+## Threshold Colors
+
+You can customize the color displayed for each threshold rule in the scorecard UI. Colors can be specified using predefined constants (`success.main`, `warning.main`, `error.main`), hex codes, or RGB/RGBA values.
+
+### Color Configuration
+
+Add a `color` property to any threshold rule:
+
+```yaml
+scorecard:
+  plugins:
+    myDatasource:
+      myMetric:
+        thresholds:
+          rules:
+            - key: success
+              expression: '<10'
+              color: 'success.main'
+            - key: warning
+              expression: '10-50'
+              color: '#FFA500'
+            - key: error
+              expression: '>50'
+              color: 'rgb(255, 0, 0)'
+```
+
+### Predefined Color Constants
+
+You can use the following predefined constants in your color configuration:
+
+- **`success.main`** - Maps to `theme.palette.success.main` (green)
+- **`warning.main`** - Maps to `theme.palette.warning.main` (orange/yellow)
+- **`error.main`** - Maps to `theme.palette.error.main` (red)
+
+Example configuration:
+
+```yaml
+scorecard:
+  plugins:
+    myDatasource:
+      myMetric:
+        thresholds:
+          rules:
+            - key: low
+              expression: '<50'
+              color: success.main
+            - key: medium
+              expression: '50-79'
+              color: warning.main
+            - key: high
+              expression: '80-100'
+              color: error.main
+```
+
+### Default Colors
+
+If no color is specified for a threshold rule, frontend will use these default colors for standard threshold rule keys:
+
+| Rule Key | Color                          |
+| -------- | ------------------------------ |
+| success  | `success.main` (green)         |
+| warning  | `warning.main` (orange/yellow) |
+| error    | `error.main` (red)             |
+
+**Important:** Custom threshold keys (not `success`, `warning`, or `error`) **must** specify a `color` property. The configuration will fail validation if a custom key is used without a color. This requirement ensures that all thresholds can be properly visualized in the UI.
 
 ## ThresholdEvaluator
 

--- a/workspaces/scorecard/plugins/scorecard-backend/knexfile.js
+++ b/workspaces/scorecard/plugins/scorecard-backend/knexfile.js
@@ -42,7 +42,7 @@ module.exports = {
     client: 'pg',
     connection: {
       host: process.env.POSTGRES_HOST,
-      port: parseInt(process.env.POSTGRES_PORT, 10),
+      port: Number.parseInt(process.env.POSTGRES_PORT, 10),
       user: process.env.POSTGRES_USER,
       password: process.env.POSTGRES_PASSWORD,
       database: process.env.POSTGRES_DB,

--- a/workspaces/scorecard/plugins/scorecard-backend/knexfile.js
+++ b/workspaces/scorecard/plugins/scorecard-backend/knexfile.js
@@ -16,16 +16,39 @@
 
 // To create new migration file use: "yarn knex migrate:make migrations",
 // open generated new migration file and edit it to complete code.
-// To run new migration use: "yarn knex migrate:up some_file_name"
-// To run latest migration use: "yarn knex migrate:latest"
-// To rollback concrete migration use: "yarn knex migrate:down some_file_name"
-// To rollback latest migration batch use: "yarn knex migrate:rollback"
+//
+// This `knexfile.js` exports multiple named environments, so you must specify
+// which one to use with `--env` when running migrations.
+//
+// Examples:
+// - sqlite3: "yarn knex --env sqlite3 migrate:latest"
+// - pg: "yarn knex --env pg migrate:latest"
+//
+// To run new migration use: "yarn knex --env sqlite3 migrate:up some_file_name"
+// To run latest migration use: "yarn knex --env sqlite3 migrate:latest"
+// To rollback concrete migration use: "yarn knex --env sqlite3 migrate:down some_file_name"
+// To rollback latest migration batch use: "yarn knex --env sqlite3 migrate:rollback"
 
 module.exports = {
-  client: 'better-sqlite3',
-  connection: ':memory:',
-  useNullAsDefault: true,
-  migrations: {
-    directory: './migrations',
+  sqlite3: {
+    client: 'better-sqlite3',
+    connection: ':memory:',
+    useNullAsDefault: true,
+    migrations: {
+      directory: './migrations',
+    },
+  },
+  pg: {
+    client: 'pg',
+    connection: {
+      host: process.env.POSTGRES_HOST,
+      port: parseInt(process.env.POSTGRES_PORT, 10),
+      user: process.env.POSTGRES_USER,
+      password: process.env.POSTGRES_PASSWORD,
+      database: process.env.POSTGRES_DB,
+    },
+    migrations: {
+      directory: './migrations',
+    },
   },
 };

--- a/workspaces/scorecard/plugins/scorecard-backend/knexfile.js
+++ b/workspaces/scorecard/plugins/scorecard-backend/knexfile.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// To create new migration file use: "yarn knex migrate:make migrations",
+// open generated new migration file and edit it to complete code.
+// To run new migration use: "yarn knex migrate:up some_file_name"
+// To run latest migration use: "yarn knex migrate:latest"
+// To rollback concrete migration use: "yarn knex migrate:down some_file_name"
+// To rollback latest migration batch use: "yarn knex migrate:rollback"
+
+module.exports = {
+  client: 'better-sqlite3',
+  connection: ':memory:',
+  useNullAsDefault: true,
+  migrations: {
+    directory: './migrations',
+  },
+};

--- a/workspaces/scorecard/plugins/scorecard-backend/migrations/20260206115752_remove_status_check_constraint.js
+++ b/workspaces/scorecard/plugins/scorecard-backend/migrations/20260206115752_remove_status_check_constraint.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async function up(knex) {
+  // Remove the status_check constraint that limits status values to 'success', 'warning', 'error'
+  const client = knex.client.config.client;
+
+  if (client === 'sqlite3' || client === 'better-sqlite3') {
+    await knex.raw(`
+      ALTER TABLE metric_values
+      RENAME COLUMN status TO status_old;
+    `);
+
+    await knex.raw(`
+      ALTER TABLE metric_values
+      ADD COLUMN status VARCHAR(255) NULL;
+    `);
+
+    await knex.raw(`
+      UPDATE metric_values
+      SET status = status_old;
+    `);
+
+    await knex.raw(`
+      ALTER TABLE metric_values
+      DROP COLUMN status_old;
+    `);
+  } else {
+    await knex.schema.alterTable('metric_values', table => {
+      table.dropChecks(['status_check']);
+    });
+  }
+};
+
+exports.down = async function down(knex) {
+  // Re-add the status_check constraint
+
+  // Fail if any incompatible rows with status values that don't match the constraint
+  const incompatibleRows = await knex('metric_values')
+    .whereNotIn('status', ['success', 'warning', 'error'])
+    .whereNotNull('status')
+    .count('* as count')
+    .first();
+  if (incompatibleRows && incompatibleRows.count > 0) {
+    throw new Error(
+      `Cannot rollback migration: Found ${incompatibleRows.count} rows with status values ` +
+        `outside of ['success', 'warning', 'error']. Please migrate or remove these rows before rolling back.`,
+    );
+  }
+
+  const client = knex.client.config.client;
+
+  if (client === 'sqlite3' || client === 'better-sqlite3') {
+    await knex.raw(`
+      ALTER TABLE metric_values
+      RENAME COLUMN status TO status_old;
+    `);
+
+    await knex.raw(`
+      ALTER TABLE metric_values
+      ADD COLUMN status VARCHAR(255) NULL
+      CHECK (status IN ('success', 'warning', 'error'));
+    `);
+
+    await knex.raw(`
+      UPDATE metric_values
+      SET status = status_old;
+    `);
+
+    await knex.raw(`
+      ALTER TABLE metric_values
+      DROP COLUMN status_old;
+    `);
+  } else {
+    await knex.raw(
+      "ALTER TABLE metric_values ADD CONSTRAINT status_check CHECK (status IN ('success', 'warning', 'error'))",
+    );
+  }
+};

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts
@@ -25,28 +25,46 @@ import { migrate } from './migration';
 
 jest.setTimeout(60000);
 
+const baseTimestamp = new Date('2023-01-01T00:00:00Z');
+
 const metricValues: DbMetricValueCreate[] = [
   {
     catalog_entity_ref: 'component:default/test-service',
     metric_id: 'github.metric1',
     value: 41,
-    timestamp: new Date('2023-01-01T00:00:00Z'),
+    timestamp: baseTimestamp,
     status: 'success',
   },
   {
     catalog_entity_ref: 'component:default/another-service',
     metric_id: 'github.metric1',
     value: 25,
-    timestamp: new Date('2023-01-01T00:00:00Z'),
+    timestamp: baseTimestamp,
     status: 'success',
   },
   {
     catalog_entity_ref: 'component:default/another-service',
     metric_id: 'github.metric2',
-    timestamp: new Date('2023-01-01T00:00:00Z'),
+    timestamp: baseTimestamp,
     error_message: 'Failed to fetch metric',
   },
 ];
+
+const createMetricValue = (overrides: {
+  entityRef: string;
+  metricId?: string;
+  timestamp?: Date;
+  value?: number | null;
+  status?: string | null;
+  errorMessage?: string | null;
+}) => ({
+  catalog_entity_ref: overrides.entityRef,
+  metric_id: overrides.metricId ?? 'github.metric1',
+  timestamp: overrides.timestamp ?? baseTimestamp,
+  value: overrides.value === undefined ? 10 : overrides.value,
+  error_message: overrides.errorMessage ?? null,
+  status: overrides.status === undefined ? 'success' : overrides.status,
+});
 
 describe('DatabaseMetricValues', () => {
   const databases = TestDatabases.create({
@@ -206,55 +224,295 @@ describe('DatabaseMetricValues', () => {
 
   describe('readAggregatedMetricByEntityRefs', () => {
     it.each(databases.eachSupportedId())(
-      'should return aggregated metrics by status for multiple entities - %p',
+      'should aggregate metrics by status for multiple entities - %p',
       async databaseId => {
         const { client, db } = await createDatabase(databaseId);
 
-        const baseTime = new Date('2023-01-01T00:00:00Z');
-        const laterTime = new Date('2023-01-01T01:00:00Z');
-
         await client('metric_values').insert([
-          {
-            ...metricValues[0],
-            timestamp: baseTime,
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            value: 5,
             status: 'success',
-          },
-          {
-            ...metricValues[1],
-            timestamp: baseTime,
-            status: 'success',
-          },
-          {
-            ...metricValues[2],
-            timestamp: laterTime,
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            value: 25,
             status: 'warning',
-            value: 10,
-          },
-          {
-            catalog_entity_ref: 'component:default/test-service',
-            metric_id: 'github.metric2',
-            timestamp: laterTime,
-            value: 20,
-            error_message: null,
-            status: 'error',
-          },
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service3',
+            value: 60,
+            status: 'critical',
+          }),
         ]);
 
         const result = await db.readAggregatedMetricByEntityRefs(
           [
-            'component:default/test-service',
-            'component:default/another-service',
+            'component:default/service1',
+            'component:default/service2',
+            'component:default/service3',
           ],
-          'github.metric2',
+          'github.metric1',
         );
 
-        expect(result).toBeDefined();
-        expect(result?.metric_id).toBe('github.metric2');
-        expect(result?.total).toBe(2);
-        expect(result?.success).toBe(0);
-        expect(result?.warning).toBe(1);
-        expect(result?.error).toBe(1);
-        expect(result?.max_timestamp).toEqual(laterTime);
+        expect(result).toEqual({
+          metric_id: 'github.metric1',
+          total: 3,
+          statusCounts: expect.arrayContaining([
+            { count: 1, name: 'success' },
+            { count: 1, name: 'warning' },
+            { count: 1, name: 'critical' },
+          ]),
+          max_timestamp: baseTimestamp,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should filter by catalog entity refs and metric_id - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        await client('metric_values').insert([
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            metricId: 'github.metric1',
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            metricId: 'github.metric1',
+            status: 'warning',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            metricId: 'github.metric2',
+            status: 'error',
+          }),
+        ]);
+
+        const result = await db.readAggregatedMetricByEntityRefs(
+          ['component:default/service1'],
+          'github.metric1',
+        );
+
+        expect(result).toEqual({
+          metric_id: 'github.metric1',
+          total: 1,
+          statusCounts: [{ count: 1, name: 'success' }],
+          max_timestamp: baseTimestamp,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should only include latest metric value per metric and entity - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        const olderTime = new Date('2023-01-01T00:00:00Z');
+        const newerTime = new Date('2023-01-01T01:00:00Z');
+
+        await client('metric_values').insert([
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            timestamp: olderTime,
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            timestamp: newerTime,
+            status: 'error',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            timestamp: olderTime,
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            timestamp: newerTime,
+            status: 'error',
+          }),
+        ]);
+
+        const result = await db.readAggregatedMetricByEntityRefs(
+          ['component:default/service1', 'component:default/service2'],
+          'github.metric1',
+        );
+
+        expect(result).toEqual({
+          metric_id: 'github.metric1',
+          total: 2,
+          statusCounts: [{ count: 2, name: 'error' }],
+          max_timestamp: newerTime,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should exclude entries with null value or status - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        await client('metric_values').insert([
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            value: 5,
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            value: null,
+            status: 'error',
+            errorMessage: 'Fetch failed',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service3',
+            value: 5,
+            status: null,
+            errorMessage: 'Invalid thresholds',
+          }),
+        ]);
+
+        const result = await db.readAggregatedMetricByEntityRefs(
+          [
+            'component:default/service1',
+            'component:default/service2',
+            'component:default/service3',
+          ],
+          'github.metric1',
+        );
+
+        expect(result).toEqual({
+          metric_id: 'github.metric1',
+          total: 1,
+          statusCounts: [{ count: 1, name: 'success' }],
+          max_timestamp: baseTimestamp,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return max timestamp across all status groups - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        const time1 = new Date('2023-01-01T00:00:00Z');
+        const time2 = new Date('2023-01-01T01:00:00Z');
+        const time3 = new Date('2023-01-01T02:00:00Z');
+
+        await client('metric_values').insert([
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            timestamp: time1,
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            timestamp: time2,
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            timestamp: time3,
+            status: 'error',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service3',
+            timestamp: time2,
+            status: 'warning',
+          }),
+        ]);
+
+        const result = await db.readAggregatedMetricByEntityRefs(
+          [
+            'component:default/service1',
+            'component:default/service2',
+            'component:default/service3',
+          ],
+          'github.metric1',
+        );
+
+        expect(result).toEqual({
+          metric_id: 'github.metric1',
+          total: 3,
+          statusCounts: expect.arrayContaining([
+            { count: 1, name: 'success' },
+            { count: 1, name: 'error' },
+            { count: 1, name: 'warning' },
+          ]),
+          max_timestamp: time3,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should count multiple entities with same status - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        await client('metric_values').insert([
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            value: 25,
+            status: 'warning',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service2',
+            value: 30,
+            status: 'warning',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service3',
+            value: 1,
+            status: 'success',
+          }),
+          createMetricValue({
+            entityRef: 'component:default/service4',
+            value: 35,
+            status: 'warning',
+          }),
+        ]);
+
+        const result = await db.readAggregatedMetricByEntityRefs(
+          [
+            'component:default/service1',
+            'component:default/service2',
+            'component:default/service3',
+          ],
+          'github.metric1',
+        );
+
+        expect(result).toEqual({
+          metric_id: 'github.metric1',
+          statusCounts: [
+            { count: 1, name: 'success' },
+            { count: 2, name: 'warning' },
+          ],
+          total: 3,
+          max_timestamp: baseTimestamp,
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return undefined when no matching entities - %p',
+      async databaseId => {
+        const { client, db } = await createDatabase(databaseId);
+
+        await client('metric_values').insert([
+          createMetricValue({
+            entityRef: 'component:default/service1',
+            status: 'success',
+          }),
+        ]);
+
+        const result = await db.readAggregatedMetricByEntityRefs(
+          ['component:default/non-existent'],
+          'github.metric1',
+        );
+        expect(result).toBeUndefined();
       },
     );
   });

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.test.ts
@@ -258,11 +258,11 @@ describe('DatabaseMetricValues', () => {
         expect(result).toEqual({
           metric_id: 'github.metric1',
           total: 3,
-          statusCounts: expect.arrayContaining([
-            { count: 1, name: 'success' },
-            { count: 1, name: 'warning' },
-            { count: 1, name: 'critical' },
-          ]),
+          statusCounts: expect.objectContaining({
+            success: 1,
+            warning: 1,
+            critical: 1,
+          }),
           max_timestamp: baseTimestamp,
         });
       },
@@ -299,7 +299,7 @@ describe('DatabaseMetricValues', () => {
         expect(result).toEqual({
           metric_id: 'github.metric1',
           total: 1,
-          statusCounts: [{ count: 1, name: 'success' }],
+          statusCounts: { success: 1 },
           max_timestamp: baseTimestamp,
         });
       },
@@ -344,7 +344,7 @@ describe('DatabaseMetricValues', () => {
         expect(result).toEqual({
           metric_id: 'github.metric1',
           total: 2,
-          statusCounts: [{ count: 2, name: 'error' }],
+          statusCounts: { error: 2 },
           max_timestamp: newerTime,
         });
       },
@@ -387,7 +387,7 @@ describe('DatabaseMetricValues', () => {
         expect(result).toEqual({
           metric_id: 'github.metric1',
           total: 1,
-          statusCounts: [{ count: 1, name: 'success' }],
+          statusCounts: { success: 1 },
           max_timestamp: baseTimestamp,
         });
       },
@@ -437,11 +437,11 @@ describe('DatabaseMetricValues', () => {
         expect(result).toEqual({
           metric_id: 'github.metric1',
           total: 3,
-          statusCounts: expect.arrayContaining([
-            { count: 1, name: 'success' },
-            { count: 1, name: 'error' },
-            { count: 1, name: 'warning' },
-          ]),
+          statusCounts: expect.objectContaining({
+            success: 1,
+            error: 1,
+            warning: 1,
+          }),
           max_timestamp: time3,
         });
       },
@@ -486,10 +486,7 @@ describe('DatabaseMetricValues', () => {
 
         expect(result).toEqual({
           metric_id: 'github.metric1',
-          statusCounts: [
-            { count: 1, name: 'success' },
-            { count: 2, name: 'warning' },
-          ],
+          statusCounts: { success: 1, warning: 2 },
           total: 3,
           max_timestamp: baseTimestamp,
         });

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
@@ -78,7 +78,7 @@ export class DatabaseMetricValues {
       .groupBy('catalog_entity_ref');
 
     const statusRows = await this.dbClient(this.tableName)
-      .select('status', 'metric_id')
+      .select('status')
       .count('* as count')
       .max('timestamp as max_timestamp')
       .whereIn('id', latestIdsSubquery)

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
@@ -105,23 +105,20 @@ export class DatabaseMetricValues {
       return new Date();
     };
 
-    const maxTimestamp = statusRows.reduce((max, row) => {
+    let maxTimestamp = new Date(0);
+    let total = 0;
+    const statusCounts: Record<string, number> = {};
+    for (const row of statusRows) {
       const rowTimestamp = normalizeTimestamp(row.max_timestamp);
-      return rowTimestamp > max ? rowTimestamp : max;
-    }, new Date(0));
+      if (rowTimestamp > maxTimestamp) {
+        maxTimestamp = rowTimestamp;
+      }
+      const name = row.status as string;
+      const count = Number(row.count);
+      statusCounts[name] = count;
+      total += count;
+    }
 
-    const statusCounts = statusRows.reduce<Record<string, number>>(
-      (acc, row) => {
-        const name = row.status as string;
-        acc[name] = Number(row.count);
-        return acc;
-      },
-      {},
-    );
-
-    const total = Object.values(statusCounts).reduce((sum, count) => {
-      return sum + count;
-    }, 0);
     return {
       metric_id,
       total,

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
@@ -75,58 +75,52 @@ export class DatabaseMetricValues {
       .max('id')
       .where('metric_id', metric_id)
       .whereIn('catalog_entity_ref', catalog_entity_refs)
-      .groupBy('metric_id', 'catalog_entity_ref');
+      .groupBy('catalog_entity_ref');
 
-    const [row] = await this.dbClient(this.tableName)
-      .select('metric_id')
-      .count('* as total')
+    const statusRows = await this.dbClient(this.tableName)
+      .select('status', 'metric_id')
+      .count('* as count')
       .max('timestamp as max_timestamp')
-      .select(
-        this.dbClient.raw(
-          "SUM(CASE WHEN status = 'success' AND value IS NOT NULL THEN 1 ELSE 0 END) as success",
-        ),
-      )
-      .select(
-        this.dbClient.raw(
-          "SUM(CASE WHEN status = 'warning' AND value IS NOT NULL THEN 1 ELSE 0 END) as warning",
-        ),
-      )
-      .select(
-        this.dbClient.raw(
-          "SUM(CASE WHEN status = 'error' AND value IS NOT NULL THEN 1 ELSE 0 END) as error",
-        ),
-      )
       .whereIn('id', latestIdsSubquery)
       .whereNotNull('status')
       .whereNotNull('value')
-      .groupBy('metric_id');
+      .groupBy('status');
+
+    if (!statusRows || statusRows.length === 0) {
+      return undefined;
+    }
 
     // Normalize types for cross-database compatibility
     // PostgreSQL returns COUNT/SUM as strings, SQLite returns numbers
     // PostgreSQL returns MAX(timestamp) as Date, SQLite returns number (milliseconds)
-    if (row) {
-      let maxTimestamp: Date;
-      if (row.max_timestamp instanceof Date) {
-        maxTimestamp = row.max_timestamp;
+    const normalizeTimestamp = (timestamp: any): Date => {
+      if (timestamp instanceof Date) {
+        return timestamp;
       } else if (
-        typeof row.max_timestamp === 'number' ||
-        typeof row.max_timestamp === 'string'
+        typeof timestamp === 'number' ||
+        typeof timestamp === 'string'
       ) {
-        maxTimestamp = new Date(row.max_timestamp as string | number);
-      } else {
-        maxTimestamp = new Date();
+        return new Date(timestamp);
       }
+      return new Date();
+    };
 
-      return {
-        metric_id: row.metric_id,
-        total: Number(row.total),
-        max_timestamp: maxTimestamp,
-        success: Number(row.success),
-        warning: Number(row.warning),
-        error: Number(row.error),
-      };
-    }
+    const maxTimestamp = statusRows.reduce((max, row) => {
+      const rowTimestamp = normalizeTimestamp(row.max_timestamp);
+      return rowTimestamp > max ? rowTimestamp : max;
+    }, new Date(0));
 
-    return undefined;
+    const statusCounts = statusRows.map(row => ({
+      name: row.status as string,
+      count: Number(row.count),
+    }));
+
+    const total = statusCounts.reduce((sum, { count }) => sum + count, 0);
+    return {
+      metric_id,
+      total,
+      max_timestamp: maxTimestamp,
+      statusCounts,
+    };
   }
 }

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/DatabaseMetricValues.ts
@@ -110,12 +110,18 @@ export class DatabaseMetricValues {
       return rowTimestamp > max ? rowTimestamp : max;
     }, new Date(0));
 
-    const statusCounts = statusRows.map(row => ({
-      name: row.status as string,
-      count: Number(row.count),
-    }));
+    const statusCounts = statusRows.reduce<Record<string, number>>(
+      (acc, row) => {
+        const name = row.status as string;
+        acc[name] = Number(row.count);
+        return acc;
+      },
+      {},
+    );
 
-    const total = statusCounts.reduce((sum, { count }) => sum + count, 0);
+    const total = Object.values(statusCounts).reduce((sum, count) => {
+      return sum + count;
+    }, 0);
     return {
       metric_id,
       total,

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/types.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/types.ts
@@ -39,8 +39,5 @@ export type DbAggregatedMetric = {
   metric_id: string;
   total: number;
   max_timestamp: Date;
-  statusCounts: Array<{
-    name: string;
-    count: number;
-  }>;
+  statusCounts: Record<string, number>;
 };

--- a/workspaces/scorecard/plugins/scorecard-backend/src/database/types.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/database/types.ts
@@ -16,15 +16,13 @@
 
 import { MetricValue } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 
-export type DbMetricValueStatus = 'success' | 'warning' | 'error';
-
 export type DbMetricValueCreate = {
   catalog_entity_ref: string;
   metric_id: string;
   value?: MetricValue;
   timestamp: Date;
   error_message?: string;
-  status?: DbMetricValueStatus;
+  status?: string | null;
 };
 
 export type DbMetricValue = {
@@ -34,14 +32,15 @@ export type DbMetricValue = {
   value: MetricValue | null;
   timestamp: Date;
   error_message: string | null;
-  status: DbMetricValueStatus | null;
+  status: string | null;
 };
 
 export type DbAggregatedMetric = {
   metric_id: string;
   total: number;
   max_timestamp: Date;
-  success: number;
-  warning: number;
-  error: number;
+  statusCounts: Array<{
+    name: string;
+    count: number;
+  }>;
 };

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
@@ -63,10 +63,10 @@ const aggregatedMetric: DbAggregatedMetric = {
   metric_id: 'github.important_metric',
   total: 2,
   max_timestamp: new Date('2024-01-15T12:00:00.000Z'),
-  statusCounts: [
-    { name: 'success', count: 1 },
-    { name: 'warning', count: 1 },
-  ],
+  statusCounts: {
+    success: 1,
+    warning: 1,
+  },
 };
 
 const metricsList = [
@@ -445,10 +445,10 @@ describe('CatalogMetricService', () => {
 
       it('should return aggregated metrics for multiple entities', async () => {
         expect(result).toEqual({
-          values: [
-            { count: 1, name: 'success' },
-            { count: 1, name: 'warning' },
-          ],
+          values: {
+            success: 1,
+            warning: 1,
+          },
           total: 2,
           timestamp: '2024-01-15T12:00:00.000Z',
         });
@@ -484,7 +484,7 @@ describe('CatalogMetricService', () => {
 
       it('should return empty aggregation when no entities provided', async () => {
         expect(result).toEqual({
-          values: [],
+          values: {},
           total: 0,
           timestamp: '2024-01-15T12:00:00.000Z',
         });

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
@@ -63,9 +63,10 @@ const aggregatedMetric: DbAggregatedMetric = {
   metric_id: 'github.important_metric',
   total: 2,
   max_timestamp: new Date('2024-01-15T12:00:00.000Z'),
-  success: 1,
-  warning: 1,
-  error: 0,
+  statusCounts: [
+    { name: 'success', count: 1 },
+    { name: 'warning', count: 1 },
+  ],
 };
 
 const metricsList = [
@@ -447,7 +448,6 @@ describe('CatalogMetricService', () => {
           values: [
             { count: 1, name: 'success' },
             { count: 1, name: 'warning' },
-            { count: 0, name: 'error' },
           ],
           total: 2,
           timestamp: '2024-01-15T12:00:00.000Z',
@@ -484,11 +484,7 @@ describe('CatalogMetricService', () => {
 
       it('should return empty aggregation when no entities provided', async () => {
         expect(result).toEqual({
-          values: [
-            { count: 0, name: 'success' },
-            { count: 0, name: 'warning' },
-            { count: 0, name: 'error' },
-          ],
+          values: [],
           total: 0,
           timestamp: '2024-01-15T12:00:00.000Z',
         });

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
@@ -40,11 +40,6 @@ type CatalogMetricServiceOptions = {
   database: DatabaseMetricValues;
 };
 
-export type AggregatedMetricsByStatus = Record<
-  string,
-  { values: { success: number; warning: number; error: number }; total: number }
->;
-
 export class CatalogMetricService {
   private readonly catalog: CatalogService;
   private readonly auth: AuthService;

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.test.ts
@@ -36,21 +36,21 @@ describe('AggregatedMetricMapper', () => {
         metric_id: 'test.metric',
         total: 10,
         max_timestamp: new Date('2024-01-15T10:00:00Z'),
-        statusCounts: [
-          { name: 'success', count: 5 },
-          { name: 'warning', count: 3 },
-          { name: 'error', count: 2 },
-        ],
+        statusCounts: {
+          success: 5,
+          warning: 3,
+          error: 2,
+        },
       };
 
       const result = AggregatedMetricMapper.toAggregatedMetric(dbMetric);
 
       expect(result).toEqual({
-        values: [
-          { name: 'success', count: 5 },
-          { name: 'warning', count: 3 },
-          { name: 'error', count: 2 },
-        ],
+        values: {
+          success: 5,
+          warning: 3,
+          error: 2,
+        },
         total: 10,
         timestamp: '2024-01-15T10:00:00.000Z',
       });
@@ -60,7 +60,7 @@ describe('AggregatedMetricMapper', () => {
       const result = AggregatedMetricMapper.toAggregatedMetric();
 
       expect(result).toEqual({
-        values: [],
+        values: {},
         total: 0,
         timestamp: expect.any(String),
       });
@@ -71,12 +71,12 @@ describe('AggregatedMetricMapper', () => {
         metric_id: 'test.metric',
         total: 0,
         max_timestamp: new Date('2024-01-15T10:00:00Z'),
-        statusCounts: [],
+        statusCounts: {},
       };
 
       const result = AggregatedMetricMapper.toAggregatedMetric(dbMetric);
 
-      expect(result.values).toEqual([]);
+      expect(result.values).toEqual({});
       expect(result.total).toBe(0);
     });
   });
@@ -86,11 +86,11 @@ describe('AggregatedMetricMapper', () => {
 
     it('should map to AggregatedMetricResult with all threshold keys present', () => {
       const aggregatedMetric = {
-        values: [
-          { name: 'success', count: 5 },
-          { name: 'warning', count: 3 },
-          { name: 'error', count: 2 },
-        ],
+        values: {
+          success: 5,
+          warning: 3,
+          error: 2,
+        },
         total: 10,
         timestamp: '2024-01-15T10:00:00.000Z',
       };
@@ -112,6 +112,11 @@ describe('AggregatedMetricMapper', () => {
         },
         result: {
           ...aggregatedMetric,
+          values: [
+            { name: 'success', count: 5 },
+            { name: 'warning', count: 3 },
+            { name: 'error', count: 2 },
+          ],
           thresholds,
         },
       });
@@ -119,7 +124,7 @@ describe('AggregatedMetricMapper', () => {
 
     it('should fill missing threshold keys with count 0', () => {
       const aggregatedMetric = {
-        values: [{ name: 'success', count: 5 }],
+        values: { success: 5 },
         total: 5,
         timestamp: '2024-01-15T10:00:00.000Z',
       };
@@ -140,10 +145,10 @@ describe('AggregatedMetricMapper', () => {
 
     it('should maintain threshold rules order', () => {
       const aggregatedMetric = {
-        values: [
-          { name: 'error', count: 2 },
-          { name: 'success', count: 5 },
-        ],
+        values: {
+          error: 2,
+          success: 5,
+        },
         total: 7,
         timestamp: '2024-01-15T10:00:00.000Z',
       };
@@ -172,10 +177,10 @@ describe('AggregatedMetricMapper', () => {
       };
 
       const aggregatedMetric = {
-        values: [
-          { name: 'critical', count: 1 },
-          { name: 'low', count: 8 },
-        ],
+        values: {
+          critical: 1,
+          low: 8,
+        },
         total: 9,
         timestamp: '2024-01-15T10:00:00.000Z',
       };
@@ -204,7 +209,7 @@ describe('AggregatedMetricMapper', () => {
       };
 
       const aggregatedMetric = {
-        values: [{ name: 'success', count: 5 }],
+        values: { success: 5 },
         total: 5,
         timestamp: '2024-01-15T10:00:00.000Z',
       };
@@ -224,7 +229,7 @@ describe('AggregatedMetricMapper', () => {
 
     it('should handle empty values with all threshold keys filled as 0', () => {
       const aggregatedMetric = {
-        values: [],
+        values: {},
         total: 0,
         timestamp: '2024-01-15T10:00:00.000Z',
       };

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.test.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AggregatedMetricMapper } from './mappers';
+import { DbAggregatedMetric } from '../database/types';
+import {
+  DEFAULT_NUMBER_THRESHOLDS,
+  Metric,
+  ThresholdConfig,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+
+describe('AggregatedMetricMapper', () => {
+  const mockMetric: Metric = {
+    id: 'test.metric',
+    title: 'Test Metric',
+    description: 'Test description',
+    type: 'number',
+  };
+
+  describe('toAggregatedMetric', () => {
+    it('should map DbAggregatedMetric to AggregatedMetric', () => {
+      const dbMetric: DbAggregatedMetric = {
+        metric_id: 'test.metric',
+        total: 10,
+        max_timestamp: new Date('2024-01-15T10:00:00Z'),
+        statusCounts: [
+          { name: 'success', count: 5 },
+          { name: 'warning', count: 3 },
+          { name: 'error', count: 2 },
+        ],
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetric(dbMetric);
+
+      expect(result).toEqual({
+        values: [
+          { name: 'success', count: 5 },
+          { name: 'warning', count: 3 },
+          { name: 'error', count: 2 },
+        ],
+        total: 10,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      });
+    });
+
+    it('should handle undefined input with defaults', () => {
+      const result = AggregatedMetricMapper.toAggregatedMetric();
+
+      expect(result).toEqual({
+        values: [],
+        total: 0,
+        timestamp: expect.any(String),
+      });
+    });
+
+    it('should handle empty statusCounts', () => {
+      const dbMetric: DbAggregatedMetric = {
+        metric_id: 'test.metric',
+        total: 0,
+        max_timestamp: new Date('2024-01-15T10:00:00Z'),
+        statusCounts: [],
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetric(dbMetric);
+
+      expect(result.values).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('toAggregatedMetricResult', () => {
+    const thresholds: ThresholdConfig = DEFAULT_NUMBER_THRESHOLDS;
+
+    it('should map to AggregatedMetricResult with all threshold keys present', () => {
+      const aggregatedMetric = {
+        values: [
+          { name: 'success', count: 5 },
+          { name: 'warning', count: 3 },
+          { name: 'error', count: 2 },
+        ],
+        total: 10,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetricResult(
+        mockMetric,
+        thresholds,
+        aggregatedMetric,
+      );
+
+      expect(result).toEqual({
+        id: 'test.metric',
+        status: 'success',
+        metadata: {
+          title: 'Test Metric',
+          description: 'Test description',
+          type: 'number',
+          history: undefined,
+        },
+        result: {
+          ...aggregatedMetric,
+          thresholds,
+        },
+      });
+    });
+
+    it('should fill missing threshold keys with count 0', () => {
+      const aggregatedMetric = {
+        values: [{ name: 'success', count: 5 }],
+        total: 5,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetricResult(
+        mockMetric,
+        thresholds,
+        aggregatedMetric,
+      );
+
+      expect(result.result.values).toEqual([
+        { name: 'success', count: 5 },
+        { name: 'warning', count: 0 },
+        { name: 'error', count: 0 },
+      ]);
+      expect(result.result.total).toBe(5);
+    });
+
+    it('should maintain threshold rules order', () => {
+      const aggregatedMetric = {
+        values: [
+          { name: 'error', count: 2 },
+          { name: 'success', count: 5 },
+        ],
+        total: 7,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetricResult(
+        mockMetric,
+        thresholds,
+        aggregatedMetric,
+      );
+
+      expect(result.result.values).toEqual([
+        { name: 'success', count: 5 },
+        { name: 'warning', count: 0 },
+        { name: 'error', count: 2 },
+      ]);
+    });
+
+    it('should handle custom threshold keys', () => {
+      const customThresholds: ThresholdConfig = {
+        rules: [
+          { key: 'critical', expression: '>100' },
+          { key: 'high', expression: '50-100' },
+          { key: 'warning', expression: '10-50' },
+          { key: 'low', expression: '<10' },
+        ],
+      };
+
+      const aggregatedMetric = {
+        values: [
+          { name: 'critical', count: 1 },
+          { name: 'low', count: 8 },
+        ],
+        total: 9,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetricResult(
+        mockMetric,
+        customThresholds,
+        aggregatedMetric,
+      );
+
+      expect(result.result.values).toEqual([
+        { name: 'critical', count: 1 },
+        { name: 'high', count: 0 },
+        { name: 'warning', count: 0 },
+        { name: 'low', count: 8 },
+      ]);
+    });
+
+    it('should include color in thresholds when provided', () => {
+      const thresholdsWithColor: ThresholdConfig = {
+        rules: [
+          { key: 'success', expression: '<10', color: '#4caf50' },
+          { key: 'warning', expression: '10-50', color: 'warning.main' },
+          { key: 'error', expression: '>50' },
+        ],
+      };
+
+      const aggregatedMetric = {
+        values: [{ name: 'success', count: 5 }],
+        total: 5,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetricResult(
+        mockMetric,
+        thresholdsWithColor,
+        aggregatedMetric,
+      );
+
+      expect(result.result.thresholds.rules).toEqual([
+        { key: 'success', expression: '<10', color: '#4caf50' },
+        { key: 'warning', expression: '10-50', color: 'warning.main' },
+        { key: 'error', expression: '>50' },
+      ]);
+    });
+
+    it('should handle empty values with all threshold keys filled as 0', () => {
+      const aggregatedMetric = {
+        values: [],
+        total: 0,
+        timestamp: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = AggregatedMetricMapper.toAggregatedMetricResult(
+        mockMetric,
+        thresholds,
+        aggregatedMetric,
+      );
+
+      expect(result.result.values).toEqual([
+        { name: 'success', count: 0 },
+        { name: 'warning', count: 0 },
+        { name: 'error', count: 0 },
+      ]);
+      expect(result.result.total).toBe(0);
+    });
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.ts
@@ -32,7 +32,7 @@ export class AggregatedMetricMapper {
       : new Date().toISOString();
 
     return {
-      values: aggregatedMetric?.statusCounts ?? [],
+      values: aggregatedMetric?.statusCounts ?? {},
       total,
       timestamp,
     };
@@ -43,13 +43,10 @@ export class AggregatedMetricMapper {
     thresholds: ThresholdConfig,
     aggregatedMetric: AggregatedMetric,
   ): AggregatedMetricResult {
-    const existingValuesMap = new Map(
-      aggregatedMetric.values.map(v => [v.name, v.count]),
-    );
     // Build values in threshold rules order, filling missing ones with 0
     const allStatusCountValues = thresholds.rules.map(rule => ({
       name: rule.key,
-      count: existingValuesMap.get(rule.key) ?? 0,
+      count: aggregatedMetric.values[rule.key] ?? 0,
     }));
 
     return {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/mappers.ts
@@ -18,6 +18,7 @@ import {
   AggregatedMetric,
   AggregatedMetricResult,
   Metric,
+  ThresholdConfig,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import { DbAggregatedMetric } from '../database/types';
 
@@ -25,20 +26,13 @@ export class AggregatedMetricMapper {
   static toAggregatedMetric(
     aggregatedMetric?: DbAggregatedMetric,
   ): AggregatedMetric {
-    const success = aggregatedMetric?.success ?? 0;
-    const warning = aggregatedMetric?.warning ?? 0;
-    const error = aggregatedMetric?.error ?? 0;
     const total = aggregatedMetric?.total ?? 0;
     const timestamp = aggregatedMetric?.max_timestamp
       ? new Date(aggregatedMetric.max_timestamp).toISOString()
       : new Date().toISOString();
 
     return {
-      values: [
-        { count: success, name: 'success' },
-        { count: warning, name: 'warning' },
-        { count: error, name: 'error' },
-      ],
+      values: aggregatedMetric?.statusCounts ?? [],
       total,
       timestamp,
     };
@@ -46,8 +40,18 @@ export class AggregatedMetricMapper {
 
   static toAggregatedMetricResult(
     metric: Metric,
+    thresholds: ThresholdConfig,
     aggregatedMetric: AggregatedMetric,
   ): AggregatedMetricResult {
+    const existingValuesMap = new Map(
+      aggregatedMetric.values.map(v => [v.name, v.count]),
+    );
+    // Build values in threshold rules order, filling missing ones with 0
+    const allStatusCountValues = thresholds.rules.map(rule => ({
+      name: rule.key,
+      count: existingValuesMap.get(rule.key) ?? 0,
+    }));
+
     return {
       id: metric.id,
       status: 'success',
@@ -57,7 +61,11 @@ export class AggregatedMetricMapper {
         type: metric.type,
         history: metric.history,
       },
-      result: aggregatedMetric,
+      result: {
+        ...aggregatedMetric,
+        values: allStatusCountValues,
+        thresholds,
+      },
     };
   }
 }

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/router.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/router.test.ts
@@ -29,6 +29,7 @@ import {
   githubNumberMetricMetadata,
 } from '../../__fixtures__/mockProviders';
 import {
+  AggregatedMetric,
   AggregatedMetricResult,
   Metric,
   MetricResult,
@@ -465,6 +466,16 @@ describe('createRouter', () => {
   });
 
   describe('GET /metrics/:metricId/catalog/aggregations', () => {
+    const mockAggregatedMetric: AggregatedMetric = {
+      values: [
+        { count: 3, name: 'error' },
+        { count: 4, name: 'warning' },
+        { count: 5, name: 'success' },
+      ],
+      total: 12,
+      timestamp: '2025-01-01T10:30:00.000Z',
+    };
+
     const mockAggregatedMetricResult: AggregatedMetricResult = {
       id: 'github.open_prs',
       status: 'success',
@@ -475,13 +486,14 @@ describe('createRouter', () => {
         history: undefined,
       },
       result: {
-        values: [
-          { count: 5, name: 'success' },
-          { count: 4, name: 'warning' },
-          { count: 3, name: 'error' },
-        ],
-        total: 12,
-        timestamp: '2025-01-01T10:30:00.000Z',
+        ...mockAggregatedMetric,
+        thresholds: {
+          rules: [
+            { key: 'error', expression: '>40' },
+            { key: 'warning', expression: '>20' },
+            { key: 'success', expression: '<=20' },
+          ],
+        },
       },
     };
 
@@ -522,7 +534,7 @@ describe('createRouter', () => {
 
       getAggregatedMetricByEntityRefsSpy = jest
         .spyOn(catalogMetricService, 'getAggregatedMetricByEntityRefs')
-        .mockResolvedValue(mockAggregatedMetricResult.result);
+        .mockResolvedValue(mockAggregatedMetric);
 
       toAggregatedMetricResultSpy = jest
         .spyOn(AggregatedMetricMapper, 'toAggregatedMetricResult')
@@ -645,6 +657,9 @@ describe('createRouter', () => {
       const emptyAggregatedMetricResult =
         AggregatedMetricMapper.toAggregatedMetricResult(
           metricProvidersRegistry.getMetric('github.open_prs'),
+          metricProvidersRegistry
+            .getProvider('github.open_prs')
+            .getMetricThresholds(),
           emptyAggregatedMetric,
         );
 
@@ -721,7 +736,10 @@ describe('createRouter', () => {
       expect(toAggregatedMetricResultSpy).toHaveBeenCalledTimes(1);
       expect(toAggregatedMetricResultSpy).toHaveBeenCalledWith(
         metricProvidersRegistry.getMetric('github.open_prs'),
-        mockAggregatedMetricResult.result,
+        metricProvidersRegistry
+          .getProvider('github.open_prs')
+          .getMetricThresholds(),
+        mockAggregatedMetric,
       );
     });
   });

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/router.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/router.test.ts
@@ -467,11 +467,11 @@ describe('createRouter', () => {
 
   describe('GET /metrics/:metricId/catalog/aggregations', () => {
     const mockAggregatedMetric: AggregatedMetric = {
-      values: [
-        { count: 3, name: 'error' },
-        { count: 4, name: 'warning' },
-        { count: 5, name: 'success' },
-      ],
+      values: {
+        error: 3,
+        warning: 4,
+        success: 5,
+      },
       total: 12,
       timestamp: '2025-01-01T10:30:00.000Z',
     };
@@ -486,7 +486,13 @@ describe('createRouter', () => {
         history: undefined,
       },
       result: {
-        ...mockAggregatedMetric,
+        total: mockAggregatedMetric.total,
+        timestamp: mockAggregatedMetric.timestamp,
+        values: [
+          { count: 3, name: 'error' },
+          { count: 4, name: 'warning' },
+          { count: 5, name: 'success' },
+        ],
         thresholds: {
           rules: [
             { key: 'error', expression: '>40' },

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/router.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/router.ts
@@ -156,7 +156,8 @@ export async function createRouter({
       scorecardMetricReadPermission,
     );
 
-    const metric = metricProvidersRegistry.getMetric(metricId);
+    const provider = metricProvidersRegistry.getProvider(metricId);
+    const metric = provider.getMetric();
     const authorizedMetrics = filterAuthorizedMetrics([metric], conditions);
 
     if (authorizedMetrics.length === 0) {
@@ -181,6 +182,7 @@ export async function createRouter({
       await checkEntityAccess(entityRef, req, permissions, httpAuth);
     }
 
+    const thresholds = provider.getMetricThresholds();
     const aggregatedMetric =
       await catalogMetricService.getAggregatedMetricByEntityRefs(
         entitiesOwnedByAUser,
@@ -188,7 +190,11 @@ export async function createRouter({
       );
 
     res.json(
-      AggregatedMetricMapper.toAggregatedMetricResult(metric, aggregatedMetric),
+      AggregatedMetricMapper.toAggregatedMetricResult(
+        metric,
+        thresholds,
+        aggregatedMetric,
+      ),
     );
   });
 

--- a/workspaces/scorecard/plugins/scorecard-backend/src/utils/mergeEntityAndProviderThresholds.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/utils/mergeEntityAndProviderThresholds.test.ts
@@ -208,6 +208,40 @@ describe('mergeEntityAndProviderThresholds', () => {
         ],
       });
     });
+
+    it('should preserve color from provider rules when overriding', () => {
+      class MockColorNumberProvider extends MockNumberProvider {
+        getMetricThresholds() {
+          return {
+            rules: [
+              { key: 'low', expression: '<10', color: 'success.main' },
+              { key: 'high', expression: '10-20', color: '#FF0000' },
+              { key: 'error', expression: '>20' },
+            ],
+          };
+        }
+      }
+
+      const provider = new MockColorNumberProvider(
+        'github.custom_metric',
+        'github',
+      );
+
+      entity.metadata.annotations = {
+        'scorecard.io/github.custom_metric.thresholds.rules.high': '10-60',
+        'scorecard.io/github.custom_metric.thresholds.rules.error': '>60',
+      };
+
+      const result = mergeEntityAndProviderThresholds(entity, provider);
+
+      expect(result).toEqual({
+        rules: [
+          { key: 'low', expression: '<10', color: 'success.main' },
+          { key: 'high', expression: '10-60', color: '#FF0000' },
+          { key: 'error', expression: '>60' },
+        ],
+      });
+    });
   });
 
   it('should throw error for invalid threshold expression', () => {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/utils/mergeEntityAndProviderThresholds.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/utils/mergeEntityAndProviderThresholds.ts
@@ -16,7 +16,6 @@
 
 import { stringifyEntityRef, type Entity } from '@backstage/catalog-model';
 import type {
-  MetricType,
   ThresholdConfig,
   ThresholdRule,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
@@ -27,32 +26,24 @@ import {
 import { isError } from '@backstage/errors';
 import type { MetricProvider } from '@red-hat-developer-hub/backstage-plugin-scorecard-node';
 
+const thresholdRulesAnnotationPrefix = (providerId: string) =>
+  `scorecard.io/${providerId}.thresholds.rules.`;
+
+/**
+ * Extract threshold override rules from entity annotations for a given provider, doesn't validate rules.
+ */
 function parseEntityOverrideThresholds(
   entity: Entity,
   providerId: string,
-  metricType: MetricType,
 ): ThresholdRule[] {
   const annotations = entity.metadata?.annotations || {};
-  const prefix = `scorecard.io/${providerId}.thresholds.rules.`;
+  const prefix = thresholdRulesAnnotationPrefix(providerId);
   const overrides: ThresholdRule[] = [];
 
   for (const [annotationKey, expression] of Object.entries(annotations)) {
     if (annotationKey.startsWith(prefix) && expression) {
       const key = annotationKey.substring(prefix.length);
-      const entityRule = { key, expression };
-      try {
-        validateThresholds({ rules: [entityRule] }, metricType);
-        overrides.push(entityRule);
-      } catch (e) {
-        if (isError(e)) {
-          throw new ThresholdConfigFormatError(
-            `Invalid threshold annotation '${annotationKey}: ${expression}' in entity '${stringifyEntityRef(
-              entity,
-            )}': ${e.message}`,
-          );
-        }
-        throw e;
-      }
+      overrides.push({ key, expression });
     }
   }
 
@@ -63,11 +54,12 @@ export function mergeEntityAndProviderThresholds(
   entity: Entity,
   provider: MetricProvider,
 ): ThresholdConfig {
+  const providerId = provider.getProviderId();
   const providerThresholds = provider.getMetricThresholds();
+  const providerMetricType = provider.getMetricType();
   const entityOverrideThresholds = parseEntityOverrideThresholds(
     entity,
-    provider.getProviderId(),
-    provider.getMetricType(),
+    providerId,
   );
 
   const mergedRules = [...providerThresholds.rules];
@@ -79,13 +71,27 @@ export function mergeEntityAndProviderThresholds(
           entity,
         )} thresholds by ${JSON.stringify(
           override,
-        )}, metric provider ${provider.getProviderId()} does not support key ${
-          override.key
-        }`,
+        )}, metric provider ${providerId} does not support key ${override.key}`,
       );
     }
 
-    mergedRules[foundKey] = override;
+    const mergedRule: ThresholdRule = { ...mergedRules[foundKey], ...override };
+    try {
+      validateThresholds({ rules: [mergedRule] }, providerMetricType);
+    } catch (e) {
+      if (isError(e)) {
+        throw new ThresholdConfigFormatError(
+          `Invalid threshold annotation '${thresholdRulesAnnotationPrefix(
+            providerId,
+          )}${override.key}: ${
+            override.expression
+          }' in entity '${stringifyEntityRef(entity)}': ${e.message}`,
+        );
+      }
+      throw e;
+    }
+
+    mergedRules[foundKey] = mergedRule;
   }
 
   return {

--- a/workspaces/scorecard/plugins/scorecard-common/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard-common/report.api.md
@@ -77,6 +77,13 @@ export type MetricValue<T extends MetricType = MetricType> = T extends 'number'
 export const RESOURCE_TYPE_SCORECARD_METRIC = 'scorecard-metric';
 
 // @public
+export const SCORECARD_THRESHOLD_RULE_COLOR_VALUES: (
+  | 'success.main'
+  | 'warning.main'
+  | 'error.main'
+)[];
+
+// @public
 export type ScorecardMetricPermission = ResourcePermission<
   typeof RESOURCE_TYPE_SCORECARD_METRIC
 >;
@@ -86,6 +93,13 @@ export const scorecardMetricReadPermission: ResourcePermission<'scorecard-metric
 
 // @public (undocumented)
 export const scorecardPermissions: ResourcePermission<'scorecard-metric'>[];
+
+// @public
+export const ScorecardThresholdRuleColors: {
+  readonly SUCCESS: 'success.main';
+  readonly WARNING: 'warning.main';
+  readonly ERROR: 'error.main';
+};
 
 // @public
 export type ThresholdConfig = {

--- a/workspaces/scorecard/plugins/scorecard-common/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard-common/report.api.md
@@ -7,7 +7,7 @@ import { ResourcePermission } from '@backstage/plugin-permission-common';
 
 // @public (undocumented)
 export type AggregatedMetric = {
-  values: AggregatedMetricValue[];
+  values: Record<string, number>;
   total: number;
   timestamp: string;
 };
@@ -22,7 +22,8 @@ export type AggregatedMetricResult = {
     type: MetricType;
     history?: boolean;
   };
-  result: AggregatedMetric & {
+  result: Omit<AggregatedMetric, 'values'> & {
+    values: AggregatedMetricValue[];
     thresholds: ThresholdConfig;
   };
 };

--- a/workspaces/scorecard/plugins/scorecard-common/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard-common/report.api.md
@@ -22,13 +22,15 @@ export type AggregatedMetricResult = {
     type: MetricType;
     history?: boolean;
   };
-  result: AggregatedMetric;
+  result: AggregatedMetric & {
+    thresholds: ThresholdConfig;
+  };
 };
 
 // @public (undocumented)
 export type AggregatedMetricValue = {
   count: number;
-  name: 'success' | 'warning' | 'error';
+  name: string;
 };
 
 // @public
@@ -102,6 +104,7 @@ export type ThresholdResult = {
 export type ThresholdRule = {
   key: string;
   expression: string;
+  color?: string;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ThresholdResult } from './threshold';
+import { ThresholdConfig, ThresholdResult } from './threshold';
 
 /**
  * @public
@@ -90,5 +90,7 @@ export type AggregatedMetricResult = {
     type: MetricType;
     history?: boolean;
   };
-  result: AggregatedMetric;
+  result: AggregatedMetric & {
+    thresholds: ThresholdConfig;
+  };
 };

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
@@ -35,7 +35,7 @@ export type MetricValue<T extends MetricType = MetricType> = T extends 'number'
  */
 export type AggregatedMetricValue = {
   count: number;
-  name: 'success' | 'warning' | 'error';
+  name: string;
 };
 
 /**

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
@@ -73,7 +73,8 @@ export type MetricResult = {
  * @public
  */
 export type AggregatedMetric = {
-  values: AggregatedMetricValue[];
+  /** Counts by status name */
+  values: Record<string, number>;
   total: number;
   timestamp: string;
 };
@@ -90,7 +91,8 @@ export type AggregatedMetricResult = {
     type: MetricType;
     history?: boolean;
   };
-  result: AggregatedMetric & {
+  result: Omit<AggregatedMetric, 'values'> & {
+    values: AggregatedMetricValue[];
     thresholds: ThresholdConfig;
   };
 };

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/threshold.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/threshold.ts
@@ -21,6 +21,7 @@
 export type ThresholdRule = {
   key: string;
   expression: string;
+  color?: string;
 };
 
 /**

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/threshold.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/threshold.ts
@@ -53,3 +53,24 @@ export const DEFAULT_NUMBER_THRESHOLDS: ThresholdConfig = {
     { key: 'error', expression: '>50' },
   ],
 };
+
+/**
+ * Predefined scorecard threshold rule color constants.
+ * Use in threshold rule color configurations instead of hex/RGB values.
+ * Map to theme.palette colors.
+ *
+ * @public
+ */
+export const ScorecardThresholdRuleColors = {
+  SUCCESS: 'success.main',
+  WARNING: 'warning.main',
+  ERROR: 'error.main',
+} as const;
+
+/**
+ * All valid scorecard threshold color values (for validation in threshold configs)
+ * @public
+ */
+export const SCORECARD_THRESHOLD_RULE_COLOR_VALUES = Object.values(
+  ScorecardThresholdRuleColors,
+);

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.test.ts
@@ -16,6 +16,7 @@
 
 import { validateThresholds } from './validateThresholds';
 import { ThresholdConfigFormatError } from '../../errors';
+import { ScorecardThresholdRuleColors } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 
 describe('validateThresholds', () => {
   describe('validateThresholds - valid configs', () => {
@@ -68,6 +69,53 @@ describe('validateThresholds', () => {
           { key: 'medium', expression: '40-59' },
           { key: 'low', expression: '20-39' },
           { key: 'success', expression: '<20' },
+        ],
+      };
+
+      expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
+    });
+
+    it('should validate config with predefined color constants', () => {
+      const validConfig = {
+        rules: [
+          {
+            key: 'success',
+            expression: '<=20',
+            color: ScorecardThresholdRuleColors.SUCCESS,
+          },
+          {
+            key: 'warning',
+            expression: '>20',
+            color: ScorecardThresholdRuleColors.WARNING,
+          },
+          {
+            key: 'error',
+            expression: '>40',
+            color: ScorecardThresholdRuleColors.ERROR,
+          },
+        ],
+      };
+
+      expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
+    });
+
+    it('should validate config with hex color', () => {
+      const validConfig = {
+        rules: [
+          { key: 'success', expression: '<5', color: '#dc5a33' },
+          { key: 'warning', expression: '<=10', color: '#AB3' },
+          { key: 'error', expression: '>10', color: '#FF5733AA' },
+        ],
+      };
+
+      expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
+    });
+
+    it('should validate config with RGB color', () => {
+      const validConfig = {
+        rules: [
+          { key: 'warning', expression: '<5', color: 'rgb(255, 87, 51)' },
+          { key: 'error', expression: '<5', color: 'rgba(255, 87, 51, 0.5)' },
         ],
       };
 
@@ -171,5 +219,63 @@ describe('validateThresholds', () => {
         ),
       );
     });
+
+    it.each([
+      {
+        description: 'missing # in hex color',
+        config: {
+          rules: [{ key: 'custom', expression: '<5', color: 'FF5733' }],
+        },
+        expectedError:
+          'Invalid color format for rule "custom": "FF5733" must be either a predefined constant (\'success.main\', \'warning.main\', \'error.main\'), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")',
+      },
+      {
+        description: 'invalid hex characters',
+        config: {
+          rules: [{ key: 'custom', expression: '<5', color: '#GGGGGG' }],
+        },
+        expectedError:
+          'Invalid color format for rule "custom": "#GGGGGG" must be either a predefined constant (\'success.main\', \'warning.main\', \'error.main\'), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")',
+      },
+      {
+        description: 'invalid predefined constant',
+        config: {
+          rules: [{ key: 'custom', expression: '<5', color: 'invalid.color' }],
+        },
+        expectedError:
+          'Invalid color format for rule "custom": "invalid.color" must be either a predefined constant (\'success.main\', \'warning.main\', \'error.main\'), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")',
+      },
+      {
+        description: 'empty color string',
+        config: {
+          rules: [{ key: 'custom', expression: '<5', color: '' }],
+        },
+        expectedError:
+          'Invalid color format for rule "custom": color must be a non-empty string',
+      },
+      {
+        description: 'non-string color',
+        config: {
+          rules: [{ key: 'custom', expression: '<5', color: 123 } as any],
+        },
+        expectedError:
+          'Invalid color format for rule "custom": color must be a non-empty string',
+      },
+      {
+        description: 'RGB with missing comma',
+        config: {
+          rules: [{ key: 'custom', expression: '<5', color: 'rgb(50, 87 37)' }],
+        },
+        expectedError:
+          'Invalid color format for rule "custom": "rgb(50, 87 37)" must be either a predefined constant (\'success.main\', \'warning.main\', \'error.main\'), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")',
+      },
+    ])(
+      'should throw error for invalid color: $description',
+      ({ config, expectedError }) => {
+        expect(() => validateThresholds(config, 'number')).toThrow(
+          new ThresholdConfigFormatError(expectedError),
+        );
+      },
+    );
   });
 });

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.test.ts
@@ -61,18 +61,30 @@ describe('validateThresholds', () => {
       expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
     });
 
-    it('should validate config with custom threshold keys', () => {
+    it('should validate config with custom threshold keys and colors', () => {
       const validConfig = {
         rules: [
-          { key: 'critical', expression: '>80' },
-          { key: 'high', expression: '60-79' },
-          { key: 'medium', expression: '40-59' },
-          { key: 'low', expression: '20-39' },
+          { key: 'critical', expression: '>80', color: '#d32f2f' },
+          { key: 'high', expression: '60-79', color: '#ff9800' },
+          { key: 'medium', expression: '40-59', color: '#ffc107' },
+          { key: 'low', expression: '20-39', color: '#4caf50' },
           { key: 'success', expression: '<20' },
         ],
       };
 
       expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
+    });
+
+    it('should validate standard keys without colors', () => {
+      const config = {
+        rules: [
+          { key: 'success', expression: '<20' },
+          { key: 'warning', expression: '20-50' },
+          { key: 'error', expression: '>50' },
+        ],
+      };
+
+      expect(() => validateThresholds(config, 'number')).not.toThrow();
     });
 
     it('should validate config with predefined color constants', () => {
@@ -216,6 +228,21 @@ describe('validateThresholds', () => {
       expect(() => validateThresholds(config, 'number')).toThrow(
         new ThresholdConfigFormatError(
           'Duplicate key detected for "error" with expression ">50"',
+        ),
+      );
+    });
+
+    it('should throw error for custom threshold key without color', () => {
+      const config = {
+        rules: [
+          { key: 'success', expression: '<20' },
+          { key: 'critical', expression: '>=20' },
+        ],
+      };
+
+      expect(() => validateThresholds(config, 'number')).toThrow(
+        new ThresholdConfigFormatError(
+          "Custom threshold key \"critical\" must specify a color property. Only standard keys ('success', 'warning', 'error') have default colors.",
         ),
       );
     });

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.test.ts
@@ -59,6 +59,20 @@ describe('validateThresholds', () => {
 
       expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
     });
+
+    it('should validate config with custom threshold keys', () => {
+      const validConfig = {
+        rules: [
+          { key: 'critical', expression: '>80' },
+          { key: 'high', expression: '60-79' },
+          { key: 'medium', expression: '40-59' },
+          { key: 'low', expression: '20-39' },
+          { key: 'success', expression: '<20' },
+        ],
+      };
+
+      expect(() => validateThresholds(validConfig, 'number')).not.toThrow();
+    });
   });
 
   describe('validateThresholds - invalid configs', () => {
@@ -91,52 +105,42 @@ describe('validateThresholds', () => {
       {
         config: { rules: [null] },
         expectedError:
-          'Invalid threshold rule format "null": must be an object with "key" and "expression" string properties',
+          'Invalid threshold rule format "null": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [5] },
         expectedError:
-          'Invalid threshold rule format "5": must be an object with "key" and "expression" string properties',
+          'Invalid threshold rule format "5": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [{ key: 'success' }] } as any,
         expectedError:
-          'Invalid threshold rule format "{"key":"success"}": must be an object with "key" and "expression" string properties',
+          'Invalid threshold rule format "{"key":"success"}": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [{ expression: '>20' }] } as any,
         expectedError:
-          'Invalid threshold rule format "{"expression":">20"}": must be an object with "key" and "expression" string properties',
+          'Invalid threshold rule format "{"expression":">20"}": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [{ key: 123, expression: '>20' }] } as any,
         expectedError:
-          'Invalid threshold rule format "{"key":123,"expression":">20"}": must be an object with "key" and "expression" string properties',
+          'Invalid threshold rule format "{"key":123,"expression":">20"}": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [{ key: 'success', expression: 123 }] } as any,
         expectedError:
-          'Invalid threshold rule format "{"key":"success","expression":123}": must be an object with "key" and "expression" string properties',
-      },
-      {
-        config: { rules: [{ key: 'invalid', expression: '>20' }] },
-        expectedError:
-          'Invalid threshold rule key "invalid": only supported values are "success", "warning", "error"',
-      },
-      {
-        config: { rules: [{ key: 'ERROR', expression: '>20' }] },
-        expectedError:
-          'Invalid threshold rule key "ERROR": only supported values are "success", "warning", "error"',
+          'Invalid threshold rule format "{"key":"success","expression":123}": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [{ key: '', expression: '>20' }] },
         expectedError:
-          'Invalid threshold rule key "": only supported values are "success", "warning", "error"',
+          'Invalid threshold rule format "{"key":"","expression":">20"}": must be an object with "key" and "expression" non-empty string properties',
       },
       {
-        config: { rules: [{ key: 'critical', expression: '>20' }] },
+        config: { rules: [{ key: 'success', expression: '' }] },
         expectedError:
-          'Invalid threshold rule key "critical": only supported values are "success", "warning", "error"',
+          'Invalid threshold rule format "{"key":"success","expression":""}": must be an object with "key" and "expression" non-empty string properties',
       },
       {
         config: { rules: [{ key: 'success', expression: 'invalid' }] },
@@ -164,21 +168,6 @@ describe('validateThresholds', () => {
       expect(() => validateThresholds(config, 'number')).toThrow(
         new ThresholdConfigFormatError(
           'Duplicate key detected for "error" with expression ">50"',
-        ),
-      );
-    });
-
-    it('should fail for mixed valid and invalid rules', () => {
-      const config = {
-        rules: [
-          { key: 'success', expression: '>20' },
-          { key: 'invalid', expression: '>10' },
-        ],
-      };
-
-      expect(() => validateThresholds(config, 'number')).toThrow(
-        new ThresholdConfigFormatError(
-          'Invalid threshold rule key "invalid": only supported values are "success", "warning", "error"',
         ),
       );
     });

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
@@ -128,15 +128,12 @@ export function validateThresholds(
     isThresholdRule(rule);
     validateRuleColor(rule);
 
-    const standard_threshold_rule_keys = ['success', 'warning', 'error'];
-    if (
-      !standard_threshold_rule_keys.includes(rule.key) &&
-      !('color' in rule)
-    ) {
+    const standardThresholdRuleKeys = ['success', 'warning', 'error'];
+    if (!standardThresholdRuleKeys.includes(rule.key) && !('color' in rule)) {
       throw new ThresholdConfigFormatError(
         `Custom threshold key "${
           rule.key
-        }" must specify a color property. Only standard keys (${standard_threshold_rule_keys
+        }" must specify a color property. Only standard keys (${standardThresholdRuleKeys
           .map(k => `'${k}'`)
           .join(', ')}) have default colors.`,
       );

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
@@ -49,17 +49,14 @@ export function validateThresholds(
       !('key' in rule) ||
       !('expression' in rule) ||
       typeof rule.key !== 'string' ||
-      typeof rule.expression !== 'string'
+      typeof rule.expression !== 'string' ||
+      rule.key.trim() === '' ||
+      rule.expression.trim() === ''
     ) {
       throw new ThresholdConfigFormatError(
         `Invalid threshold rule format "${JSON.stringify(
           rule,
-        )}": must be an object with "key" and "expression" string properties`,
-      );
-    }
-    if (!['error', 'warning', 'success'].includes(rule.key)) {
-      throw new ThresholdConfigFormatError(
-        `Invalid threshold rule key "${rule.key}": only supported values are "success", "warning", "error"`,
+        )}": must be an object with "key" and "expression" non-empty string properties`,
       );
     }
     if (seenKeys.has(rule.key)) {

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
@@ -19,8 +19,45 @@ import type {
   MetricType,
   ThresholdConfig,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import {
+  SCORECARD_THRESHOLD_RULE_COLOR_VALUES,
+  ScorecardThresholdRuleColors,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import { ThresholdConfigFormatError } from '../../errors';
 import { parseThresholdExpression } from './parseThresholdExpression';
+
+/**
+ * Validates if a color string is valid
+ * - Predefined constants: {@link ScorecardThresholdRuleColors}
+ * - Hex colors: #RGB, #RRGGBB, #RRGGBBAA
+ * - RGB/RGBA colors: rgb(r, g, b), rgba(r, g, b, a)
+ */
+function isValidColor(color: string): boolean {
+  if (
+    SCORECARD_THRESHOLD_RULE_COLOR_VALUES.some(
+      validColor => validColor === color,
+    )
+  ) {
+    return true;
+  }
+
+  // Check for hex color format: #RGB, #RRGGBB, #RRGGBBAA
+  const hexColorRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+  if (hexColorRegex.test(color)) {
+    return true;
+  }
+
+  // Check for RGB color format: rgb(r, g, b)
+  const rgbRegex = /^rgb\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)$/;
+  if (rgbRegex.test(color)) {
+    return true;
+  }
+
+  // Check for RGBA color format: rgba(r, g, b, a)
+  const rgbaRegex =
+    /^rgba\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d+(?:\.\d+)?\s*\)$/;
+  return rgbaRegex.test(color);
+}
 
 /**
  * Validate thresholds configuration
@@ -59,6 +96,26 @@ export function validateThresholds(
         )}": must be an object with "key" and "expression" non-empty string properties`,
       );
     }
+
+    if ('color' in rule) {
+      if (typeof rule.color !== 'string' || rule.color.trim() === '') {
+        throw new ThresholdConfigFormatError(
+          `Invalid color format for rule "${rule.key}": color must be a non-empty string`,
+        );
+      }
+      if (!isValidColor(rule.color)) {
+        throw new ThresholdConfigFormatError(
+          `Invalid color format for rule "${rule.key}": "${
+            rule.color
+          }" must be either a predefined constant (${SCORECARD_THRESHOLD_RULE_COLOR_VALUES.map(
+            v => `'${v}'`,
+          ).join(
+            ', ',
+          )}), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")`,
+        );
+      }
+    }
+
     if (seenKeys.has(rule.key)) {
       throw new ThresholdConfigFormatError(
         `Duplicate key detected for "${rule.key}" with expression "${rule.expression}"`,

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
@@ -18,6 +18,7 @@ import type { JsonValue } from '@backstage/types';
 import type {
   MetricType,
   ThresholdConfig,
+  ThresholdRule,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import {
   SCORECARD_THRESHOLD_RULE_COLOR_VALUES,
@@ -34,9 +35,7 @@ import { parseThresholdExpression } from './parseThresholdExpression';
  */
 function isValidColor(color: string): boolean {
   if (
-    SCORECARD_THRESHOLD_RULE_COLOR_VALUES.some(
-      validColor => validColor === color,
-    )
+    (SCORECARD_THRESHOLD_RULE_COLOR_VALUES as readonly string[]).includes(color)
   ) {
     return true;
   }
@@ -60,6 +59,52 @@ function isValidColor(color: string): boolean {
 }
 
 /**
+ * Validates the color format if present in a rule
+ */
+function validateRuleColor(rule: ThresholdRule): void {
+  if (!('color' in rule)) {
+    return;
+  }
+
+  if (typeof rule.color !== 'string' || rule.color.trim() === '') {
+    throw new ThresholdConfigFormatError(
+      `Invalid color format for rule "${rule.key}": color must be a non-empty string`,
+    );
+  }
+
+  if (!isValidColor(rule.color)) {
+    throw new ThresholdConfigFormatError(
+      `Invalid color format for rule "${rule.key}": "${
+        rule.color
+      }" must be either a predefined constant (${SCORECARD_THRESHOLD_RULE_COLOR_VALUES.map(
+        v => `'${v}'`,
+      ).join(
+        ', ',
+      )}), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")`,
+    );
+  }
+}
+
+function isThresholdRule(rule: unknown): asserts rule is ThresholdRule {
+  if (
+    typeof rule !== 'object' ||
+    rule === null ||
+    !('key' in rule) ||
+    !('expression' in rule) ||
+    typeof rule.key !== 'string' ||
+    typeof rule.expression !== 'string' ||
+    rule.key.trim() === '' ||
+    rule.expression.trim() === ''
+  ) {
+    throw new ThresholdConfigFormatError(
+      `Invalid threshold rule format "${JSON.stringify(
+        rule,
+      )}": must be an object with "key" and "expression" non-empty string properties`,
+    );
+  }
+}
+
+/**
  * Validate thresholds configuration
  * @public
  */
@@ -80,51 +125,21 @@ export function validateThresholds(
 
   const seenKeys = new Set<string>();
   for (const rule of thresholds.rules) {
-    if (
-      typeof rule !== 'object' ||
-      rule === null ||
-      !('key' in rule) ||
-      !('expression' in rule) ||
-      typeof rule.key !== 'string' ||
-      typeof rule.expression !== 'string' ||
-      rule.key.trim() === '' ||
-      rule.expression.trim() === ''
-    ) {
-      throw new ThresholdConfigFormatError(
-        `Invalid threshold rule format "${JSON.stringify(
-          rule,
-        )}": must be an object with "key" and "expression" non-empty string properties`,
-      );
-    }
+    isThresholdRule(rule);
+    validateRuleColor(rule);
 
-    const standardKeys = ['success', 'warning', 'error'];
-    if (!standardKeys.includes(rule.key) && !('color' in rule)) {
+    const standard_threshold_rule_keys = ['success', 'warning', 'error'];
+    if (
+      !standard_threshold_rule_keys.includes(rule.key) &&
+      !('color' in rule)
+    ) {
       throw new ThresholdConfigFormatError(
         `Custom threshold key "${
           rule.key
-        }" must specify a color property. Only standard keys (${standardKeys
+        }" must specify a color property. Only standard keys (${standard_threshold_rule_keys
           .map(k => `'${k}'`)
           .join(', ')}) have default colors.`,
       );
-    }
-
-    if ('color' in rule) {
-      if (typeof rule.color !== 'string' || rule.color.trim() === '') {
-        throw new ThresholdConfigFormatError(
-          `Invalid color format for rule "${rule.key}": color must be a non-empty string`,
-        );
-      }
-      if (!isValidColor(rule.color)) {
-        throw new ThresholdConfigFormatError(
-          `Invalid color format for rule "${rule.key}": "${
-            rule.color
-          }" must be either a predefined constant (${SCORECARD_THRESHOLD_RULE_COLOR_VALUES.map(
-            v => `'${v}'`,
-          ).join(
-            ', ',
-          )}), a hex color (e.g., "#ADD8E6"), or an RGB/RGBA color (e.g., "rgb(255, 255, 0)")`,
-        );
-      }
     }
 
     if (seenKeys.has(rule.key)) {
@@ -133,6 +148,7 @@ export function validateThresholds(
       );
     }
     seenKeys.add(rule.key);
+
     parseThresholdExpression(rule.expression, expectedMetricType);
   }
 }

--- a/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
+++ b/workspaces/scorecard/plugins/scorecard-node/src/utils/thresholds/validateThresholds.ts
@@ -97,6 +97,17 @@ export function validateThresholds(
       );
     }
 
+    const standardKeys = ['success', 'warning', 'error'];
+    if (!standardKeys.includes(rule.key) && !('color' in rule)) {
+      throw new ThresholdConfigFormatError(
+        `Custom threshold key "${
+          rule.key
+        }" must specify a color property. Only standard keys (${standardKeys
+          .map(k => `'${k}'`)
+          .join(', ')}) have default colors.`,
+      );
+    }
+
     if ('color' in rule) {
       if (typeof rule.color !== 'string' || rule.color.trim() === '') {
         throw new ThresholdConfigFormatError(

--- a/workspaces/scorecard/plugins/scorecard/__fixtures__/aggregatedScorecardData.ts
+++ b/workspaces/scorecard/plugins/scorecard/__fixtures__/aggregatedScorecardData.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { AggregatedMetricResult } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import {
+  AggregatedMetricResult,
+  DEFAULT_NUMBER_THRESHOLDS,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 
 export const mockAggregatedScorecardSuccessData: AggregatedMetricResult = {
   id: 'github.open_prs',
@@ -34,5 +37,6 @@ export const mockAggregatedScorecardSuccessData: AggregatedMetricResult = {
     ],
     total: 37,
     timestamp: '2024-01-15T10:30:00Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
@@ -24,6 +24,7 @@ import Typography from '@mui/material/Typography';
 import { styled, useTheme } from '@mui/material/styles';
 
 import { useTranslation } from '../../hooks/useTranslation';
+import { getThresholdRuleColor, resolveStatusColor } from '../../utils/utils';
 
 const StyledLegend = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -75,15 +76,14 @@ const CustomLegend = (props: CustomLegendProps) => {
           return (
             <StyledLegendItem key={`legend-${ruleKey}`}>
               <StyledLegendColorBox
-                color={
-                  (
-                    {
-                      error: theme.palette.error.main,
-                      warning: theme.palette.warning.main,
-                      success: theme.palette.success.main,
-                    } as Record<string, string>
-                  )[ruleKey] ?? theme.palette.success.main
-                }
+                data-testid={`legend-colorbox-${ruleKey}`}
+                color={resolveStatusColor(
+                  theme,
+                  getThresholdRuleColor(
+                    thresholds.definition?.rules ?? [],
+                    ruleKey,
+                  ) ?? 'success.main',
+                )}
               />
               <Typography
                 variant="body2"

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
@@ -24,7 +24,11 @@ import Typography from '@mui/material/Typography';
 import { styled, useTheme } from '@mui/material/styles';
 
 import { useTranslation } from '../../hooks/useTranslation';
-import { getThresholdRuleColor, resolveStatusColor } from '../../utils';
+import {
+  getThresholdRuleColor,
+  resolveStatusColor,
+  SCORECARD_ERROR_STATE_COLOR,
+} from '../../utils';
 
 const StyledLegend = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -82,7 +86,7 @@ const CustomLegend = (props: CustomLegendProps) => {
                   getThresholdRuleColor(
                     thresholds.definition?.rules ?? [],
                     ruleKey,
-                  ) ?? 'success.main',
+                  ) ?? SCORECARD_ERROR_STATE_COLOR,
                 )}
               />
               <Typography

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
@@ -24,7 +24,7 @@ import Typography from '@mui/material/Typography';
 import { styled, useTheme } from '@mui/material/styles';
 
 import { useTranslation } from '../../hooks/useTranslation';
-import { getThresholdRuleColor, resolveStatusColor } from '../../utils/utils';
+import { getThresholdRuleColor, resolveStatusColor } from '../../utils';
 
 const StyledLegend = styled(Box)(({ theme }) => ({
   display: 'flex',

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/EntityScorecardContent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/EntityScorecardContent.tsx
@@ -23,7 +23,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import NoScorecardsState from '../Common/NoScorecardsState';
 import Scorecard from './Scorecard';
 import { useScorecards } from '../../hooks/useScorecards';
-import { getStatusConfig } from '../../utils/utils';
+import { getStatusConfig } from '../../utils';
 import PermissionRequiredState from '../Common/PermissionRequiredState';
 import { useTranslation } from '../../hooks/useTranslation';
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/EntityScorecardContent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/EntityScorecardContent.tsx
@@ -75,6 +75,7 @@ export const EntityScorecardContent = () => {
           evaluation: metric.result?.thresholdResult?.evaluation,
           thresholdStatus: metric.result?.thresholdResult?.status,
           metricStatus: metric.status,
+          thresholdRules: metric.result.thresholdResult.definition?.rules,
         });
 
         // Use metric ID to construct translation keys, fallback to original title/description

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/Scorecard.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/Scorecard.tsx
@@ -37,8 +37,8 @@ import { CardWrapper } from '../Common/CardWrapper';
 import CustomLegend from './CustomLegend';
 import {
   getHeightForCenterLabel,
-  getRingColor,
   getYOffsetForCenterLabel,
+  resolveStatusColor,
 } from '../../utils/utils';
 import { ErrorTooltip } from '../Common/ErrorTooltip';
 
@@ -58,7 +58,6 @@ interface ScorecardProps {
 const ScorecardCenterLabel = ({
   cx,
   cy,
-  statusColor,
   StatusIcon,
   value,
   isErrorState,
@@ -69,7 +68,6 @@ const ScorecardCenterLabel = ({
 }: {
   cx: number;
   cy: number;
-  statusColor: string;
   StatusIcon: React.ElementType;
   value: MetricValue | null;
   isErrorState: boolean;
@@ -108,10 +106,7 @@ const ScorecardCenterLabel = ({
         <StatusIcon
           sx={{
             fontSize: 24,
-            color: (muiTheme: any) => {
-              const [paletteKey, shade] = statusColor.split('.');
-              return muiTheme.palette[paletteKey][shade];
-            },
+            color,
           }}
         />
       </foreignObject>
@@ -176,9 +171,13 @@ const Scorecard = ({
 
   const isErrorState = isMetricDataError || isThresholdError;
 
-  const ringColor = getRingColor(theme, statusColor, isErrorState);
+  const resolvedStatusColor = resolveStatusColor(
+    theme,
+    statusColor,
+    isErrorState,
+  );
 
-  const pieData = [{ name: 'full', value: 100, color: ringColor }];
+  const pieData = [{ name: 'full', value: 100, color: resolvedStatusColor }];
 
   return (
     <CardWrapper
@@ -251,22 +250,6 @@ const Scorecard = ({
               label={({ cx, cy }) => {
                 if (cx === null || cy === null) return null;
 
-                const palettePath = statusColor.split('.');
-                let color: string | undefined;
-                const paletteRoot =
-                  theme.palette[palettePath[0] as keyof typeof theme.palette];
-                if (palettePath.length === 1) {
-                  color = paletteRoot as string | undefined;
-                } else if (palettePath.length === 2) {
-                  color = (paletteRoot as Record<string, any>)?.[
-                    palettePath[1]
-                  ] as string | undefined;
-                } else if (palettePath.length === 3) {
-                  color = (paletteRoot as Record<string, any>)?.[
-                    palettePath[1]
-                  ]?.[palettePath[2]] as string | undefined;
-                }
-
                 let errorLabel = '';
                 if (isMetricDataError) {
                   errorLabel = t('errors.metricDataUnavailable');
@@ -278,12 +261,11 @@ const Scorecard = ({
                   <ScorecardCenterLabel
                     cx={Number(cx)}
                     cy={Number(cy)}
-                    statusColor={statusColor}
                     StatusIcon={StatusIcon}
                     value={value}
                     isErrorState={isErrorState}
                     errorLabel={errorLabel}
-                    color={color}
+                    color={resolvedStatusColor}
                     onLabelMouseEnter={e => {
                       setIsPieAreaActive(true);
                       e.stopPropagation();

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/Scorecard.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/Scorecard.tsx
@@ -39,8 +39,9 @@ import {
   getHeightForCenterLabel,
   getYOffsetForCenterLabel,
   resolveStatusColor,
-} from '../../utils/utils';
+} from '../../utils';
 import { ErrorTooltip } from '../Common/ErrorTooltip';
+import type { PieData } from '../types';
 
 interface ScorecardProps {
   cardTitle: string;
@@ -173,7 +174,9 @@ const Scorecard = ({
 
   const resolvedStatusColor = resolveStatusColor(theme, statusColor);
 
-  const pieData = [{ name: 'full', value: 100, color: resolvedStatusColor }];
+  const pieData: PieData[] = [
+    { name: 'full', value: 100, color: resolvedStatusColor },
+  ];
 
   return (
     <CardWrapper

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/Scorecard.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/Scorecard.tsx
@@ -171,11 +171,7 @@ const Scorecard = ({
 
   const isErrorState = isMetricDataError || isThresholdError;
 
-  const resolvedStatusColor = resolveStatusColor(
-    theme,
-    statusColor,
-    isErrorState,
-  );
+  const resolvedStatusColor = resolveStatusColor(theme, statusColor);
 
   const pieData = [{ name: 'full', value: 100, color: resolvedStatusColor }];
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/CustomLegend.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/CustomLegend.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { ThresholdResult } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import { useTheme } from '@mui/material/styles';
+import CustomLegend from '../CustomLegend';
+
+jest.mock('@mui/material/styles', () => ({
+  ...jest.requireActual('@mui/material/styles'),
+  useTheme: jest.fn(),
+}));
+
+const useThemeMock = jest.mocked(useTheme);
+
+const mockTheme = {
+  palette: {
+    success: {
+      main: '#2e7d32',
+    },
+    warning: {
+      main: '#ed6c02',
+    },
+    error: {
+      main: '#d32f2f',
+    },
+  },
+};
+
+describe('CustomLegend', () => {
+  beforeEach(() => {
+    useThemeMock.mockReturnValue(mockTheme);
+  });
+
+  const thresholds: ThresholdResult = {
+    definition: {
+      rules: [
+        { key: 'custom', expression: '<=10', color: '#add8e6' },
+        { key: 'success', expression: '<=20' },
+        { key: 'warning', expression: '<=40' },
+        { key: 'error', expression: '>40' },
+      ],
+    },
+    status: 'success',
+    evaluation: 'custom',
+  };
+
+  it('should render threshold labels and expressions', () => {
+    render(<CustomLegend thresholds={thresholds} />);
+
+    expect(screen.getByText(/Custom/)).toBeInTheDocument();
+    expect(screen.getByText(/<=10/)).toBeInTheDocument();
+
+    expect(screen.getByText(/Success/)).toBeInTheDocument();
+    expect(screen.getByText(/<=20/)).toBeInTheDocument();
+
+    expect(screen.getByText(/Warning/)).toBeInTheDocument();
+    expect(screen.getByText(/<=40/)).toBeInTheDocument();
+
+    expect(screen.getByText(/Error/)).toBeInTheDocument();
+    expect(screen.getByText(/>40/)).toBeInTheDocument();
+  });
+
+  it('should render color boxes', () => {
+    const { container } = render(<CustomLegend thresholds={thresholds} />);
+
+    const colorBoxes = container.querySelectorAll(
+      '[data-testid^="legend-colorbox-"]',
+    );
+    expect(colorBoxes).toHaveLength(4);
+
+    expect(screen.getByTestId('legend-colorbox-custom')).toHaveStyle(
+      'background-color: #add8e6',
+    );
+    expect(screen.getByTestId('legend-colorbox-success')).toHaveStyle(
+      'background-color: #2e7d32',
+    );
+    expect(screen.getByTestId('legend-colorbox-warning')).toHaveStyle(
+      'background-color: #ed6c02',
+    );
+    expect(screen.getByTestId('legend-colorbox-error')).toHaveStyle(
+      'background-color: #d32f2f',
+    );
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/EntityScorecardContent.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/EntityScorecardContent.test.tsx
@@ -84,13 +84,13 @@ jest.mock('../../../hooks/useScorecards', () => ({
   useScorecards: jest.fn(),
 }));
 
-jest.mock('../../../utils/utils', () => ({
+jest.mock('../../../utils', () => ({
   getStatusConfig: jest.fn(),
 }));
 
 // Get the mocked functions
 const { useScorecards } = require('../../../hooks/useScorecards');
-const { getStatusConfig } = require('../../../utils/utils');
+const { getStatusConfig } = require('../../../utils');
 
 describe('EntityScorecardContent Component', () => {
   beforeEach(() => {

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/EntityScorecardContent.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/EntityScorecardContent.test.tsx
@@ -181,12 +181,16 @@ describe('EntityScorecardContent Component', () => {
       thresholdStatus:
         mockScorecardSuccessData[0].result.thresholdResult.status,
       metricStatus: mockScorecardSuccessData[0].status,
+      thresholdRules:
+        mockScorecardSuccessData[0].result.thresholdResult.definition?.rules,
     });
     expect(getStatusConfig).toHaveBeenCalledWith({
       evaluation: mockScorecardSuccessData[1].result.thresholdResult.evaluation,
       thresholdStatus:
         mockScorecardSuccessData[1].result.thresholdResult.status,
       metricStatus: mockScorecardSuccessData[1].status,
+      thresholdRules:
+        mockScorecardSuccessData[1].result.thresholdResult.definition?.rules,
     });
   });
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/Scorecard.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/Scorecard.test.tsx
@@ -29,7 +29,28 @@ jest.mock('recharts', () => ({
 
   PieChart: ({ children }: any) => <div>{children}</div>,
 
-  Pie: ({ label }: any) => <svg>{label?.({ cx: 0, cy: 0 })}</svg>,
+  Pie: ({
+    data,
+    label,
+    children,
+  }: {
+    data?: { name: string; value: number; color: string }[];
+    label?: (center: { cx: number; cy: number }) => React.ReactNode;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="pie-chart">
+      {data?.map((entry: any) => (
+        <div
+          key={entry.name}
+          data-testid={`pie-ring-${entry.name}`}
+          data-color={entry.color}
+          style={{ backgroundColor: entry.color }}
+        />
+      ))}
+      {label && <div>{label({ cx: 0, cy: 0 })}</div>}
+      {children}
+    </div>
+  ),
 
   Cell: () => null,
 
@@ -56,7 +77,7 @@ describe('Scorecard Component', () => {
     cardTitle: 'GitHub open PRs',
     description:
       'Current count of open Pull Requests for a given GitHub repository.',
-    statusColor: 'success',
+    statusColor: 'success.main',
     StatusIcon: CheckCircleOutlineIcon,
     value: 8,
     thresholds: {
@@ -64,7 +85,7 @@ describe('Scorecard Component', () => {
       definition: {
         rules: [
           { key: 'success', expression: '<= 20' },
-          { key: 'warning', expression: '> 20' },
+          { key: 'warning', expression: '<= 40' },
           { key: 'error', expression: '> 40' },
         ],
       },
@@ -105,7 +126,7 @@ describe('Scorecard Component', () => {
     );
 
     expect(screen.getByText('Success <= 20')).toBeInTheDocument();
-    expect(screen.getByText('Warning > 20')).toBeInTheDocument();
+    expect(screen.getByText('Warning <= 40')).toBeInTheDocument();
     expect(screen.getByText('Error > 40')).toBeInTheDocument();
   });
 
@@ -132,10 +153,23 @@ describe('Scorecard Component', () => {
     expect(screen.getByText('0')).toBeInTheDocument();
   });
 
+  it('should render with success status', () => {
+    render(
+      <TestWrapper>
+        <Scorecard {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByTestId('pie-ring-full')).toHaveAttribute(
+      'data-color',
+      '#52c41a',
+    );
+  });
+
   it('should render with warning status', () => {
     const warningProps = {
       ...defaultProps,
-      statusColor: 'warning',
+      statusColor: 'warning.main',
       StatusIcon: WarningAmberIcon,
       value: 25,
     };
@@ -147,23 +181,60 @@ describe('Scorecard Component', () => {
     );
 
     expect(screen.getByText('25')).toBeInTheDocument();
+    expect(screen.getByTestId('pie-ring-full')).toHaveAttribute(
+      'data-color',
+      '#F0AB00',
+    );
   });
 
-  it('should render with critical status', () => {
-    const criticalProps = {
+  it('should render with error status', () => {
+    const errorProps = {
       ...defaultProps,
-      statusColor: 'error',
+      statusColor: 'error.main',
       StatusIcon: DangerousOutlinedIcon,
       value: 75,
     };
 
     render(
       <TestWrapper>
-        <Scorecard {...criticalProps} />
+        <Scorecard {...errorProps} />
       </TestWrapper>,
     );
 
     expect(screen.getByText('75')).toBeInTheDocument();
+    expect(screen.getByTestId('pie-ring-full')).toHaveAttribute(
+      'data-color',
+      '#C9190B',
+    );
+  });
+
+  it('should render with custom status', () => {
+    const customProps = {
+      ...defaultProps,
+      statusColor: '#FF5733',
+      StatusIcon: CheckCircleOutlineIcon,
+      value: 4,
+      thresholds: {
+        ...defaultProps.thresholds,
+        definition: {
+          rules: [
+            { key: 'custom', expression: '<=5', color: '#FF5733' },
+            ...defaultProps.thresholds.definition.rules,
+          ],
+        },
+      },
+    };
+
+    render(
+      <TestWrapper>
+        <Scorecard {...customProps} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByTestId('pie-ring-full')).toHaveAttribute(
+      'data-color',
+      '#FF5733',
+    );
   });
 
   it('should render with large values', () => {
@@ -243,7 +314,7 @@ describe('Scorecard Component', () => {
 
     // Check that threshold rules are rendered with appropriate styling
     const errorRule = screen.getByText('Error > 40');
-    const warningRule = screen.getByText('Warning > 20');
+    const warningRule = screen.getByText('Warning <= 40');
     const successRule = screen.getByText('Success <= 20');
 
     expect(errorRule).toBeInTheDocument();

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomLegend.tsx
@@ -18,7 +18,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 
-import type { PieData as PieDataProps } from '../../utils/utils';
+import type { PieData as PieDataProps } from '../types';
 import { useTranslation } from '../../hooks/useTranslation';
 
 const StyledLegend = styled(Box)(({ theme }) => ({

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomLegend.tsx
@@ -108,7 +108,10 @@ const CustomLegend = (props: CustomLegendProps) => {
               }
             }}
           >
-            <StyledLegendColorBox color={category?.color} />
+            <StyledLegendColorBox
+              data-testid={`legend-colorbox-${category.name}`}
+              color={category?.color}
+            />
             <Typography
               variant="body2"
               sx={{ fontSize: '0.875rem', fontWeight: 400 }}

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomTooltip.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomTooltip.tsx
@@ -19,7 +19,7 @@ import type { TooltipProps } from 'recharts';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
-import type { PieData } from '../../utils/utils';
+import type { PieData } from '../types';
 import { useTranslation } from '../../hooks/useTranslation';
 
 type CustomTooltipPayload = {

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/EmptyStatePanel.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/EmptyStatePanel.tsx
@@ -25,10 +25,11 @@ import {
   getYOffsetForCenterLabel,
   getHeightForCenterLabel,
   resolveStatusColor,
-} from '../../utils/utils';
+} from '../../utils';
 import CustomLegend from '../Scorecard/CustomLegend';
 import { ErrorTooltip } from '../Common/ErrorTooltip';
 import { ResponsivePieChart } from './ResponsivePieChart';
+import type { PieData } from '../types';
 
 const CenterLabel = ({
   cx,
@@ -126,7 +127,9 @@ export const EmptyStatePanel = ({
 
   const resolvedStatusColor = resolveStatusColor(theme, statusConfig.color);
 
-  const pieData = [{ name: 'full', value: 100, color: resolvedStatusColor }];
+  const pieData: PieData[] = [
+    { name: 'full', value: 100, color: resolvedStatusColor },
+  ];
 
   return (
     <CardWrapper

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/EmptyStatePanel.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/EmptyStatePanel.tsx
@@ -124,11 +124,7 @@ export const EmptyStatePanel = ({
     thresholdStatus: 'error',
   });
 
-  const resolvedStatusColor = resolveStatusColor(
-    theme,
-    statusConfig.color,
-    true,
-  );
+  const resolvedStatusColor = resolveStatusColor(theme, statusConfig.color);
 
   const pieData = [{ name: 'full', value: 100, color: resolvedStatusColor }];
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/EmptyStatePanel.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/EmptyStatePanel.tsx
@@ -22,9 +22,9 @@ import { CardWrapper } from '../Common/CardWrapper';
 import { useTranslation } from '../../hooks/useTranslation';
 import {
   getStatusConfig,
-  getRingColor,
   getYOffsetForCenterLabel,
   getHeightForCenterLabel,
+  resolveStatusColor,
 } from '../../utils/utils';
 import CustomLegend from '../Scorecard/CustomLegend';
 import { ErrorTooltip } from '../Common/ErrorTooltip';
@@ -124,9 +124,13 @@ export const EmptyStatePanel = ({
     thresholdStatus: 'error',
   });
 
-  const ringColor = getRingColor(theme, statusConfig.color, true);
+  const resolvedStatusColor = resolveStatusColor(
+    theme,
+    statusConfig.color,
+    true,
+  );
 
-  const pieData = [{ name: 'full', value: 100, color: ringColor }];
+  const pieData = [{ name: 'full', value: 100, color: resolvedStatusColor }];
 
   return (
     <CardWrapper
@@ -165,28 +169,12 @@ export const EmptyStatePanel = ({
             const centerX = Number(cx);
             const centerY = Number(cy);
 
-            const palettePath = statusConfig.color.split('.');
-            let color: string | undefined;
-            const paletteRoot =
-              theme.palette[palettePath[0] as keyof typeof theme.palette];
-            if (palettePath.length === 1) {
-              color = paletteRoot as string | undefined;
-            } else if (palettePath.length === 2) {
-              color = (paletteRoot as Record<string, string>)?.[
-                palettePath[1]
-              ] as string | undefined;
-            } else if (palettePath.length === 3) {
-              color = (paletteRoot as Record<string, any>)?.[palettePath[1]]?.[
-                palettePath[2]
-              ];
-            }
-
             return (
               <CenterLabel
                 cx={centerX}
                 cy={centerY}
                 label={label}
-                color={color}
+                color={resolvedStatusColor}
                 onLabelMouseEnter={e => {
                   setIsLabelHovered(true);
                   e.stopPropagation();

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ResponsivePieChart.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ResponsivePieChart.tsx
@@ -23,7 +23,7 @@ import {
   Tooltip,
   PieLabelRenderProps,
 } from 'recharts';
-import { PieData } from '../../utils/utils';
+import type { PieData } from '../types';
 
 interface PieTooltipPayload {
   name?: string;

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
@@ -24,8 +24,8 @@ import { useTheme } from '@mui/material/styles';
 import { CardWrapper } from '../Common/CardWrapper';
 import { CustomTooltip } from './CustomTooltip';
 import CustomLegend from './CustomLegend';
-import type { PieData } from '../../utils/utils';
-import { getThresholdRuleColor, resolveStatusColor } from '../../utils/utils';
+import type { PieData } from '../types';
+import { getThresholdRuleColor, resolveStatusColor } from '../../utils';
 import { useTranslation } from '../../hooks/useTranslation';
 import { ResponsivePieChart } from './ResponsivePieChart';
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
@@ -25,6 +25,7 @@ import { CardWrapper } from '../Common/CardWrapper';
 import { CustomTooltip } from './CustomTooltip';
 import CustomLegend from './CustomLegend';
 import type { PieData } from '../../utils/utils';
+import { getThresholdRuleColor, resolveStatusColor } from '../../utils/utils';
 import { useTranslation } from '../../hooks/useTranslation';
 import { ResponsivePieChart } from './ResponsivePieChart';
 
@@ -50,12 +51,12 @@ export const ScorecardHomepageCardComponent = ({
     scorecard.result.values?.map(value => ({
       name: value.name,
       value: value.count,
-      color:
-        {
-          success: theme.palette.success.main,
-          warning: theme.palette.warning.main,
-          error: theme.palette.error.main,
-        }[value.name] || theme.palette.success.main,
+      color: resolveStatusColor(
+        theme,
+        getThresholdRuleColor(scorecard.result.thresholds.rules, value.name) ??
+          'success.main',
+        false,
+      ),
     })) ?? [];
 
   return (

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
@@ -55,7 +55,6 @@ export const ScorecardHomepageCardComponent = ({
         theme,
         getThresholdRuleColor(scorecard.result.thresholds.rules, value.name) ??
           'success.main',
-        false,
       ),
     })) ?? [];
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ScorecardHomepageCardComponent.tsx
@@ -25,7 +25,11 @@ import { CardWrapper } from '../Common/CardWrapper';
 import { CustomTooltip } from './CustomTooltip';
 import CustomLegend from './CustomLegend';
 import type { PieData } from '../types';
-import { getThresholdRuleColor, resolveStatusColor } from '../../utils';
+import {
+  getThresholdRuleColor,
+  resolveStatusColor,
+  SCORECARD_ERROR_STATE_COLOR,
+} from '../../utils';
 import { useTranslation } from '../../hooks/useTranslation';
 import { ResponsivePieChart } from './ResponsivePieChart';
 
@@ -54,7 +58,7 @@ export const ScorecardHomepageCardComponent = ({
       color: resolveStatusColor(
         theme,
         getThresholdRuleColor(scorecard.result.thresholds.rules, value.name) ??
-          'success.main',
+          SCORECARD_ERROR_STATE_COLOR,
       ),
     })) ?? [];
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/CustomLegend.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/CustomLegend.test.tsx
@@ -26,9 +26,9 @@ jest.mock('../../../hooks/useTranslation', () => ({
 
 describe('CustomLegend', () => {
   const pieData = [
-    { name: 'success', value: 10, color: 'red' },
-    { name: 'warning', value: 20, color: 'blue' },
-    { name: 'error', value: 30, color: 'green' },
+    { name: 'success', value: 10, color: '#52c41a' },
+    { name: 'warning', value: 20, color: '#F0AB00' },
+    { name: 'error', value: 30, color: '#C9190B' },
   ];
 
   it('should render correct number of legend items', () => {
@@ -116,5 +116,33 @@ describe('CustomLegend', () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it('should display colors from pieData', () => {
+    const { container } = render(
+      <div data-chart-container>
+        <CustomLegend
+          pieData={pieData}
+          activeIndex={null}
+          setActiveIndex={jest.fn()}
+          setTooltipPosition={jest.fn()}
+        />
+      </div>,
+    );
+
+    const colorBoxes = container.querySelectorAll(
+      '[data-testid^="legend-colorbox-"]',
+    );
+    expect(colorBoxes).toHaveLength(3);
+
+    expect(screen.getByTestId('legend-colorbox-success')).toHaveStyle(
+      'background-color: #52c41a',
+    );
+    expect(screen.getByTestId('legend-colorbox-warning')).toHaveStyle(
+      'background-color: #F0AB00',
+    );
+    expect(screen.getByTestId('legend-colorbox-error')).toHaveStyle(
+      'background-color: #C9190B',
+    );
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageCard.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageCard.test.tsx
@@ -63,9 +63,9 @@ jest.mock('../ResponsivePieChart', () => ({
   }) => (
     <div data-testid="responsive-pie-chart">
       <div data-testid="pie-data-length">{pieData.length}</div>
-      {pieData.map((data, index) => (
+      {pieData.map(data => (
         <div
-          key={index}
+          key={data.name}
           data-testid={`pie-segment-${data.name}`}
           data-color={data.color}
         >

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageCard.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageCard.test.tsx
@@ -18,7 +18,10 @@ import { render, screen } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 import { ScorecardHomepageCardComponent } from '../ScorecardHomepageCardComponent';
-import type { AggregatedMetricResult } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import {
+  DEFAULT_NUMBER_THRESHOLDS,
+  type AggregatedMetricResult,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 
 // --------------------
 // Mocks
@@ -60,6 +63,15 @@ jest.mock('../ResponsivePieChart', () => ({
   }) => (
     <div data-testid="responsive-pie-chart">
       <div data-testid="pie-data-length">{pieData.length}</div>
+      {pieData.map((data, index) => (
+        <div
+          key={index}
+          data-testid={`pie-segment-${data.name}`}
+          data-color={data.color}
+        >
+          {data.name}: {data.value}
+        </div>
+      ))}
       <div data-testid="legend">{legendContent({})}</div>
       <div data-testid="tooltip">
         {tooltipContent({ active: true, payload: [] })}
@@ -117,6 +129,7 @@ const mockScorecard: AggregatedMetricResult = {
       { name: 'error', count: 12 },
     ],
     timestamp: '2024-01-01T00:00:00Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };
 
@@ -171,6 +184,29 @@ describe('ScorecardHomepageCardComponent', () => {
     );
 
     expect(screen.getByTestId('responsive-pie-chart')).toBeInTheDocument();
+  });
+
+  it('should pass correct colors for rings to ResponsivePieChart', () => {
+    render(
+      <ScorecardHomepageCardComponent
+        scorecard={mockScorecard}
+        cardTitle="Test"
+        description="desc"
+      />,
+    );
+
+    expect(screen.getByTestId('pie-segment-success')).toHaveAttribute(
+      'data-color',
+      '#2e7d32',
+    );
+    expect(screen.getByTestId('pie-segment-warning')).toHaveAttribute(
+      'data-color',
+      '#ed6c02',
+    );
+    expect(screen.getByTestId('pie-segment-error')).toHaveAttribute(
+      'data-color',
+      '#d32f2f',
+    );
   });
 
   it('should pass correct pie data length', () => {

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageSection.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageSection.test.tsx
@@ -19,7 +19,10 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 import { ScorecardHomepageCard } from '../ScorecardHomepageCard';
 
-import type { AggregatedMetricResult } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import {
+  DEFAULT_NUMBER_THRESHOLDS,
+  type AggregatedMetricResult,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 
 jest.mock('@backstage/core-components', () => ({
   ResponseErrorPanel: ({ error }: { error: Error }) => (
@@ -87,6 +90,7 @@ const mockScorecard: AggregatedMetricResult = {
     total: 8,
     values: [{ name: 'success', count: 8 }],
     timestamp: '2024-01-01T00:00:00Z',
+    thresholds: DEFAULT_NUMBER_THRESHOLDS,
   },
 };
 

--- a/workspaces/scorecard/plugins/scorecard/src/components/types.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/components/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type PieData = {
+  name: string;
+  value: number;
+  color?: string;
+};

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/colorUtils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/colorUtils.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Theme } from '@mui/material/styles';
+import {
+  DEFAULT_NUMBER_THRESHOLDS,
+  ThresholdRule,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import {
+  getThresholdRuleColor,
+  resolveStatusColor,
+  SCORECARD_ERROR_STATE_COLOR,
+} from '..';
+
+describe('colorUtils', () => {
+  describe('getThresholdRuleColor', () => {
+    const mockRules: ThresholdRule[] = [
+      { key: 'custom', expression: '<5', color: '#FF5733' },
+      { key: 'success', expression: '<10', color: '#4caf50' },
+      { key: 'warning', expression: '10-50' },
+      { key: 'critical', expression: '>50', color: 'error.main' },
+    ];
+
+    it('should return color for matching threshold key', () => {
+      expect(getThresholdRuleColor(mockRules, 'custom')).toEqual('#FF5733');
+      expect(getThresholdRuleColor(mockRules, 'success')).toEqual('#4caf50');
+      expect(getThresholdRuleColor(mockRules, 'critical')).toEqual(
+        'error.main',
+      );
+    });
+
+    it('should return undefined for non-matching key', () => {
+      expect(getThresholdRuleColor(mockRules, 'low')).toBeUndefined();
+    });
+
+    it('should return default color for default rule keys', () => {
+      expect(
+        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'success'),
+      ).toEqual('success.main');
+      expect(
+        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'warning'),
+      ).toEqual('warning.main');
+      expect(
+        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'error'),
+      ).toEqual('error.main');
+    });
+
+    it('should handle empty rules array', () => {
+      expect(getThresholdRuleColor([], 'medium')).toBeUndefined();
+    });
+  });
+
+  describe('resolveStatusColor', () => {
+    const mockTheme = {
+      palette: {
+        primary: { main: '#0066cc' },
+        success: { main: '#2e7d32' },
+        warning: { main: '#ed6c02' },
+        error: { main: '#d32f2f' },
+        rhdh: {
+          general: {
+            cardBorderColor: '#c7c7c7',
+          },
+        },
+      },
+    } as any as Theme;
+
+    it('should resolve theme palette reference', () => {
+      const color = resolveStatusColor(mockTheme, 'success.main');
+      expect(color).toBe('#2e7d32');
+    });
+
+    it('should resolve theme reference with nested levels', () => {
+      const color = resolveStatusColor(mockTheme, SCORECARD_ERROR_STATE_COLOR);
+      expect(color).toBe('#c7c7c7');
+    });
+
+    it('should return custom hex color directly', () => {
+      const color = resolveStatusColor(mockTheme, '#9933ff');
+      expect(color).toBe('#9933ff');
+    });
+
+    it('should return custom color name directly', () => {
+      const color = resolveStatusColor(mockTheme, 'blue');
+      expect(color).toBe('blue');
+    });
+
+    it('should return custom rgb color directly', () => {
+      const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)');
+      expect(color).toBe('rgb(255, 0, 0)');
+    });
+
+    it('should fallback to cardBorderColor when theme path not found', () => {
+      const color = resolveStatusColor(mockTheme, 'nonexistent.path');
+      expect(color).toBe('#c7c7c7');
+    });
+
+    it('should fallback to error.main when theme path not found and cardBorderColor is undefined', () => {
+      const themeWithoutCardBorder = {
+        palette: {
+          error: { main: '#d32f2f' },
+        },
+      } as any as Theme;
+      const color = resolveStatusColor(
+        themeWithoutCardBorder,
+        'nonexistent.path',
+      );
+      expect(color).toBe('#d32f2f');
+    });
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/colorUtils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/colorUtils.test.tsx
@@ -93,14 +93,14 @@ describe('colorUtils', () => {
       expect(color).toBe('#9933ff');
     });
 
-    it('should return custom color name directly', () => {
-      const color = resolveStatusColor(mockTheme, 'blue');
-      expect(color).toBe('blue');
-    });
-
     it('should return custom rgb color directly', () => {
       const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)');
       expect(color).toBe('rgb(255, 0, 0)');
+    });
+
+    it('should return custom rgba color directly', () => {
+      const color = resolveStatusColor(mockTheme, 'rgba(255, 0, 0, 0.7)');
+      expect(color).toBe('rgba(255, 0, 0, 0.7)');
     });
 
     it('should fallback to cardBorderColor when theme path not found', () => {

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/statusUtils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/statusUtils.test.tsx
@@ -14,60 +14,14 @@
  * limitations under the License.
  */
 
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
-import {
-  getStatusConfig,
-  getThresholdRuleColor,
-  resolveStatusColor,
-  SCORECARD_ERROR_STATE_COLOR,
-} from '../utils';
-import {
-  DEFAULT_NUMBER_THRESHOLDS,
-  ThresholdRule,
-} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
-import { Theme } from '@mui/material/styles';
+import { DEFAULT_NUMBER_THRESHOLDS } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import { getStatusConfig, SCORECARD_ERROR_STATE_COLOR } from '..';
 
-describe('utils', () => {
-  describe('getThresholdRuleColor', () => {
-    const mockRules: ThresholdRule[] = [
-      { key: 'custom', expression: '<5', color: '#FF5733' },
-      { key: 'success', expression: '<10', color: '#4caf50' },
-      { key: 'warning', expression: '10-50' },
-      { key: 'critical', expression: '>50', color: 'error.main' },
-    ];
-
-    it('should return color for matching threshold key', () => {
-      expect(getThresholdRuleColor(mockRules, 'custom')).toEqual('#FF5733');
-      expect(getThresholdRuleColor(mockRules, 'success')).toEqual('#4caf50');
-      expect(getThresholdRuleColor(mockRules, 'critical')).toEqual(
-        'error.main',
-      );
-    });
-
-    it('should return undefined for non-matching key', () => {
-      expect(getThresholdRuleColor(mockRules, 'low')).toBeUndefined();
-    });
-
-    it('should return default color for default rule keys', () => {
-      expect(
-        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'success'),
-      ).toEqual('success.main');
-      expect(
-        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'warning'),
-      ).toEqual('warning.main');
-      expect(
-        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'error'),
-      ).toEqual('error.main');
-    });
-
-    it('should handle empty rules array', () => {
-      expect(getThresholdRuleColor([], 'medium')).toBeUndefined();
-    });
-  });
-
+describe('statusUtils', () => {
   describe('getStatusConfig', () => {
     describe('error handling', () => {
       it('should return error state color when thresholdStatus is error', () => {
@@ -245,65 +199,6 @@ describe('utils', () => {
           icon: CheckCircleOutlineIcon,
         });
       });
-    });
-  });
-
-  describe('resolveStatusColor', () => {
-    const mockTheme = {
-      palette: {
-        primary: { main: '#0066cc' },
-        success: { main: '#2e7d32' },
-        warning: { main: '#ed6c02' },
-        error: { main: '#d32f2f' },
-        rhdh: {
-          general: {
-            cardBorderColor: '#c7c7c7',
-          },
-        },
-      },
-    } as any as Theme;
-
-    it('should resolve theme palette reference', () => {
-      const color = resolveStatusColor(mockTheme, 'success.main');
-      expect(color).toBe('#2e7d32');
-    });
-
-    it('should resolve theme reference with nested levels', () => {
-      const color = resolveStatusColor(mockTheme, SCORECARD_ERROR_STATE_COLOR);
-      expect(color).toBe('#c7c7c7');
-    });
-
-    it('should return custom hex color directly', () => {
-      const color = resolveStatusColor(mockTheme, '#9933ff');
-      expect(color).toBe('#9933ff');
-    });
-
-    it('should return custom color name directly', () => {
-      const color = resolveStatusColor(mockTheme, 'blue');
-      expect(color).toBe('blue');
-    });
-
-    it('should return custom rgb color directly', () => {
-      const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)');
-      expect(color).toBe('rgb(255, 0, 0)');
-    });
-
-    it('should fallback to cardBorderColor when theme path not found', () => {
-      const color = resolveStatusColor(mockTheme, 'nonexistent.path');
-      expect(color).toBe('#c7c7c7');
-    });
-
-    it('should fallback to error.main when theme path not found and cardBorderColor is undefined', () => {
-      const themeWithoutCardBorder = {
-        palette: {
-          error: { main: '#d32f2f' },
-        },
-      } as any as Theme;
-      const color = resolveStatusColor(
-        themeWithoutCardBorder,
-        'nonexistent.path',
-      );
-      expect(color).toBe('#d32f2f');
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
@@ -69,7 +69,7 @@ describe('utils', () => {
 
   describe('getStatusConfig', () => {
     describe('error handling', () => {
-      it('should return rhdh.general.disabled color when thresholdStatus is error', () => {
+      it('should return rhdh.general.cardBorderColor color when thresholdStatus is error', () => {
         const result = getStatusConfig({
           evaluation: 'success',
           thresholdStatus: 'error',
@@ -77,11 +77,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.disabled',
+          color: 'rhdh.general.cardBorderColor',
         });
       });
 
-      it('should return rhdh.general.disabled color when metricStatus is error', () => {
+      it('should return rhdh.general.cardBorderColor color when metricStatus is error', () => {
         const result = getStatusConfig({
           evaluation: 'success',
           thresholdStatus: 'success',
@@ -89,11 +89,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.disabled',
+          color: 'rhdh.general.cardBorderColor',
         });
       });
 
-      it('should return rhdh.general.disabled color when both thresholdStatus and metricStatus are error', () => {
+      it('should return rhdh.general.cardBorderColor color when both thresholdStatus and metricStatus are error', () => {
         const result = getStatusConfig({
           evaluation: 'success',
           thresholdStatus: 'error',
@@ -101,11 +101,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.disabled',
+          color: 'rhdh.general.cardBorderColor',
         });
       });
 
-      it('should return rhdh.general.disabled color when thresholdStatus is error regardless of evaluation', () => {
+      it('should return rhdh.general.cardBorderColor color when thresholdStatus is error regardless of evaluation', () => {
         const result = getStatusConfig({
           evaluation: 'error',
           thresholdStatus: 'error',
@@ -113,11 +113,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.disabled',
+          color: 'rhdh.general.cardBorderColor',
         });
       });
 
-      it('should return rhdh.general.disabled color when metricStatus is error regardless of evaluation', () => {
+      it('should return rhdh.general.cardBorderColor color when metricStatus is error regardless of evaluation', () => {
         const result = getStatusConfig({
           evaluation: 'warning',
           thresholdStatus: 'success',
@@ -125,7 +125,7 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.disabled',
+          color: 'rhdh.general.cardBorderColor',
         });
       });
     });
@@ -256,7 +256,6 @@ describe('utils', () => {
         error: { main: '#d32f2f' },
         rhdh: {
           general: {
-            disabled: '#6a6e73',
             cardBorderColor: '#c7c7c7',
           },
         },

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
@@ -18,146 +18,303 @@ import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
-import { getStatusConfig } from '../utils';
+import {
+  getStatusConfig,
+  getThresholdRuleColor,
+  resolveStatusColor,
+} from '../utils';
+import {
+  DEFAULT_NUMBER_THRESHOLDS,
+  ThresholdRule,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import { Theme } from '@mui/material/styles';
 
-describe('getStatusConfig', () => {
-  describe('error handling', () => {
-    it('should return rhdh.general.disabled color when thresholdStatus is error', () => {
-      const result = getStatusConfig({
-        evaluation: 'success',
-        thresholdStatus: 'error',
-        metricStatus: 'success',
+describe('utils', () => {
+  describe('getThresholdRuleColor', () => {
+    const mockRules: ThresholdRule[] = [
+      { key: 'custom', expression: '<5', color: '#FF5733' },
+      { key: 'success', expression: '<10', color: '#4caf50' },
+      { key: 'warning', expression: '10-50' },
+      { key: 'critical', expression: '>50', color: 'error.main' },
+    ];
+
+    it('should return color for matching threshold key', () => {
+      expect(getThresholdRuleColor(mockRules, 'custom')).toEqual('#FF5733');
+      expect(getThresholdRuleColor(mockRules, 'success')).toEqual('#4caf50');
+      expect(getThresholdRuleColor(mockRules, 'critical')).toEqual(
+        'error.main',
+      );
+    });
+
+    it('should return undefined for non-matching key', () => {
+      expect(getThresholdRuleColor(mockRules, 'low')).toBeUndefined();
+    });
+
+    it('should return default color for default rule keys', () => {
+      expect(
+        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'success'),
+      ).toEqual('success.main');
+      expect(
+        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'warning'),
+      ).toEqual('warning.main');
+      expect(
+        getThresholdRuleColor(DEFAULT_NUMBER_THRESHOLDS.rules, 'error'),
+      ).toEqual('error.main');
+    });
+
+    it('should handle empty rules array', () => {
+      expect(getThresholdRuleColor([], 'medium')).toBeUndefined();
+    });
+  });
+
+  describe('getStatusConfig', () => {
+    describe('error handling', () => {
+      it('should return rhdh.general.disabled color when thresholdStatus is error', () => {
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdStatus: 'error',
+          metricStatus: 'success',
+        });
+
+        expect(result).toEqual({
+          color: 'rhdh.general.disabled',
+        });
       });
 
-      expect(result).toEqual({
-        color: 'rhdh.general.disabled',
+      it('should return rhdh.general.disabled color when metricStatus is error', () => {
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdStatus: 'success',
+          metricStatus: 'error',
+        });
+
+        expect(result).toEqual({
+          color: 'rhdh.general.disabled',
+        });
+      });
+
+      it('should return rhdh.general.disabled color when both thresholdStatus and metricStatus are error', () => {
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdStatus: 'error',
+          metricStatus: 'error',
+        });
+
+        expect(result).toEqual({
+          color: 'rhdh.general.disabled',
+        });
+      });
+
+      it('should return rhdh.general.disabled color when thresholdStatus is error regardless of evaluation', () => {
+        const result = getStatusConfig({
+          evaluation: 'error',
+          thresholdStatus: 'error',
+          metricStatus: 'success',
+        });
+
+        expect(result).toEqual({
+          color: 'rhdh.general.disabled',
+        });
+      });
+
+      it('should return rhdh.general.disabled color when metricStatus is error regardless of evaluation', () => {
+        const result = getStatusConfig({
+          evaluation: 'warning',
+          thresholdStatus: 'success',
+          metricStatus: 'error',
+        });
+
+        expect(result).toEqual({
+          color: 'rhdh.general.disabled',
+        });
       });
     });
 
-    it('should return rhdh.general.disabled color when metricStatus is error', () => {
-      const result = getStatusConfig({
-        evaluation: 'success',
-        thresholdStatus: 'success',
-        metricStatus: 'error',
+    describe('evaluation status handling', () => {
+      it('should return error status config when evaluation is error and no error status', () => {
+        const result = getStatusConfig({
+          evaluation: 'error',
+          thresholdStatus: 'success',
+          metricStatus: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
+
+        expect(result).toEqual({
+          color: 'error.main',
+          icon: DangerousOutlinedIcon,
+        });
       });
 
-      expect(result).toEqual({
-        color: 'rhdh.general.disabled',
+      it('should return warning status config when evaluation is warning and no error status', () => {
+        const result = getStatusConfig({
+          evaluation: 'warning',
+          thresholdStatus: 'success',
+          metricStatus: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
+
+        expect(result).toEqual({
+          color: 'warning.main',
+          icon: WarningAmberIcon,
+        });
+      });
+
+      it('should return success status config when evaluation is success and no error status', () => {
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdStatus: 'success',
+          metricStatus: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
+
+        expect(result).toEqual({
+          color: 'success.main',
+          icon: CheckCircleOutlineIcon,
+        });
+      });
+
+      it('should return custom color from threshold configuration', () => {
+        const mockThresholds = {
+          rules: [
+            { key: 'critical', expression: '>80', color: '#ff0000' },
+            { key: 'warning', expression: '40-79', color: '#ffa500' },
+            { key: 'success', expression: '<40', color: '#00ff00' },
+          ],
+        };
+
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdRules: mockThresholds.rules,
+        });
+
+        expect(result).toEqual({
+          color: '#00ff00',
+          icon: CheckCircleOutlineIcon,
+        });
+      });
+
+      it('should return default color for default rule keys', () => {
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
+
+        expect(result).toEqual({
+          color: 'success.main',
+          icon: CheckCircleOutlineIcon,
+        });
       });
     });
 
-    it('should return rhdh.general.disabled color when both thresholdStatus and metricStatus are error', () => {
-      const result = getStatusConfig({
-        evaluation: 'success',
-        thresholdStatus: 'error',
-        metricStatus: 'error',
+    describe('optional parameters', () => {
+      it('should work when thresholdStatus is undefined', () => {
+        const result = getStatusConfig({
+          evaluation: 'error',
+          metricStatus: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
+
+        expect(result).toEqual({
+          color: 'error.main',
+          icon: DangerousOutlinedIcon,
+        });
       });
 
-      expect(result).toEqual({
-        color: 'rhdh.general.disabled',
-      });
-    });
+      it('should work when metricStatus is undefined', () => {
+        const result = getStatusConfig({
+          evaluation: 'warning',
+          thresholdStatus: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
 
-    it('should return rhdh.general.disabled color when thresholdStatus is error regardless of evaluation', () => {
-      const result = getStatusConfig({
-        evaluation: 'error',
-        thresholdStatus: 'error',
-        metricStatus: 'success',
-      });
-
-      expect(result).toEqual({
-        color: 'rhdh.general.disabled',
-      });
-    });
-
-    it('should return rhdh.general.disabled color when metricStatus is error regardless of evaluation', () => {
-      const result = getStatusConfig({
-        evaluation: 'warning',
-        thresholdStatus: 'success',
-        metricStatus: 'error',
+        expect(result).toEqual({
+          color: 'warning.main',
+          icon: WarningAmberIcon,
+        });
       });
 
-      expect(result).toEqual({
-        color: 'rhdh.general.disabled',
+      it('should work when both thresholdStatus and metricStatus are undefined', () => {
+        const result = getStatusConfig({
+          evaluation: 'success',
+          thresholdRules: DEFAULT_NUMBER_THRESHOLDS.rules,
+        });
+
+        expect(result).toEqual({
+          color: 'success.main',
+          icon: CheckCircleOutlineIcon,
+        });
       });
     });
   });
 
-  describe('evaluation status handling', () => {
-    it('should return error status config when evaluation is error and no error status', () => {
-      const result = getStatusConfig({
-        evaluation: 'error',
-        thresholdStatus: 'success',
-        metricStatus: 'success',
-      });
+  describe('resolveStatusColor', () => {
+    const mockTheme = {
+      palette: {
+        primary: { main: '#0066cc' },
+        success: { main: '#2e7d32' },
+        warning: { main: '#ed6c02' },
+        error: { main: '#d32f2f' },
+        rhdh: {
+          general: {
+            disabled: '#6a6e73',
+            cardBorderColor: '#c7c7c7',
+          },
+        },
+      },
+    } as any as Theme;
 
-      expect(result).toEqual({
-        color: 'error.main',
-        icon: DangerousOutlinedIcon,
-      });
+    it('should resolve theme palette reference', () => {
+      const color = resolveStatusColor(mockTheme, 'success.main', false);
+      expect(color).toBe('#2e7d32');
     });
 
-    it('should return warning status config when evaluation is warning and no error status', () => {
-      const result = getStatusConfig({
-        evaluation: 'warning',
-        thresholdStatus: 'success',
-        metricStatus: 'success',
-      });
-
-      expect(result).toEqual({
-        color: 'warning.main',
-        icon: WarningAmberIcon,
-      });
+    it('should resolve theme reference with nested levels', () => {
+      const color = resolveStatusColor(
+        mockTheme,
+        'rhdh.general.cardBorderColor',
+        false,
+      );
+      expect(color).toBe('#c7c7c7');
     });
 
-    it('should return success status config when evaluation is success and no error status', () => {
-      const result = getStatusConfig({
-        evaluation: 'success',
-        thresholdStatus: 'success',
-        metricStatus: 'success',
-      });
-
-      expect(result).toEqual({
-        color: 'success.main',
-        icon: CheckCircleOutlineIcon,
-      });
-    });
-  });
-
-  describe('optional parameters', () => {
-    it('should work when thresholdStatus is undefined', () => {
-      const result = getStatusConfig({
-        evaluation: 'error',
-        metricStatus: 'success',
-      });
-
-      expect(result).toEqual({
-        color: 'error.main',
-        icon: DangerousOutlinedIcon,
-      });
+    it('should return fallback for invalid theme reference', () => {
+      const color = resolveStatusColor(mockTheme, 'invalid.path.here', false);
+      expect(color).toBe('#2e7d32');
     });
 
-    it('should work when metricStatus is undefined', () => {
-      const result = getStatusConfig({
-        evaluation: 'warning',
-        thresholdStatus: 'success',
-      });
-
-      expect(result).toEqual({
-        color: 'warning.main',
-        icon: WarningAmberIcon,
-      });
+    it('should return custom hex color directly', () => {
+      const color = resolveStatusColor(mockTheme, '#9933ff', false);
+      expect(color).toBe('#9933ff');
     });
 
-    it('should work when both thresholdStatus and metricStatus are undefined', () => {
-      const result = getStatusConfig({
-        evaluation: 'success',
-      });
+    it('should return custom color name directly', () => {
+      const color = resolveStatusColor(mockTheme, 'blue', false);
+      expect(color).toBe('blue');
+    });
 
-      expect(result).toEqual({
-        color: 'success.main',
-        icon: CheckCircleOutlineIcon,
-      });
+    it('should return custom rgb color directly', () => {
+      const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)', false);
+      expect(color).toBe('rgb(255, 0, 0)');
+    });
+
+    it('should return card border color when isError is true', () => {
+      const color = resolveStatusColor(mockTheme, 'anything', true);
+      expect(color).toBe('#c7c7c7');
+    });
+
+    it('should return fallback when cardBorderColor is not defined when isError is true', () => {
+      const themeWithoutCardBorder = {
+        palette: {
+          success: { main: '#0066cc' },
+        },
+      } as any as Theme;
+
+      const color = resolveStatusColor(
+        themeWithoutCardBorder,
+        'anything',
+        true,
+      );
+      expect(color).toBe('#0066cc');
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
@@ -22,6 +22,7 @@ import {
   getStatusConfig,
   getThresholdRuleColor,
   resolveStatusColor,
+  SCORECARD_ERROR_STATE_COLOR,
 } from '../utils';
 import {
   DEFAULT_NUMBER_THRESHOLDS,
@@ -69,7 +70,7 @@ describe('utils', () => {
 
   describe('getStatusConfig', () => {
     describe('error handling', () => {
-      it('should return rhdh.general.cardBorderColor color when thresholdStatus is error', () => {
+      it('should return error state color when thresholdStatus is error', () => {
         const result = getStatusConfig({
           evaluation: 'success',
           thresholdStatus: 'error',
@@ -77,11 +78,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.cardBorderColor',
+          color: SCORECARD_ERROR_STATE_COLOR,
         });
       });
 
-      it('should return rhdh.general.cardBorderColor color when metricStatus is error', () => {
+      it('should return error state color when metricStatus is error', () => {
         const result = getStatusConfig({
           evaluation: 'success',
           thresholdStatus: 'success',
@@ -89,11 +90,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.cardBorderColor',
+          color: SCORECARD_ERROR_STATE_COLOR,
         });
       });
 
-      it('should return rhdh.general.cardBorderColor color when both thresholdStatus and metricStatus are error', () => {
+      it('should return error state color when both thresholdStatus and metricStatus are error', () => {
         const result = getStatusConfig({
           evaluation: 'success',
           thresholdStatus: 'error',
@@ -101,11 +102,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.cardBorderColor',
+          color: SCORECARD_ERROR_STATE_COLOR,
         });
       });
 
-      it('should return rhdh.general.cardBorderColor color when thresholdStatus is error regardless of evaluation', () => {
+      it('should return error state color when thresholdStatus is error regardless of evaluation', () => {
         const result = getStatusConfig({
           evaluation: 'error',
           thresholdStatus: 'error',
@@ -113,11 +114,11 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.cardBorderColor',
+          color: SCORECARD_ERROR_STATE_COLOR,
         });
       });
 
-      it('should return rhdh.general.cardBorderColor color when metricStatus is error regardless of evaluation', () => {
+      it('should return error state color when metricStatus is error regardless of evaluation', () => {
         const result = getStatusConfig({
           evaluation: 'warning',
           thresholdStatus: 'success',
@@ -125,7 +126,7 @@ describe('utils', () => {
         });
 
         expect(result).toEqual({
-          color: 'rhdh.general.cardBorderColor',
+          color: SCORECARD_ERROR_STATE_COLOR,
         });
       });
     });
@@ -268,10 +269,7 @@ describe('utils', () => {
     });
 
     it('should resolve theme reference with nested levels', () => {
-      const color = resolveStatusColor(
-        mockTheme,
-        'rhdh.general.cardBorderColor',
-      );
+      const color = resolveStatusColor(mockTheme, SCORECARD_ERROR_STATE_COLOR);
       expect(color).toBe('#c7c7c7');
     });
 

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
@@ -287,5 +287,23 @@ describe('utils', () => {
       const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)');
       expect(color).toBe('rgb(255, 0, 0)');
     });
+
+    it('should fallback to cardBorderColor when theme path not found', () => {
+      const color = resolveStatusColor(mockTheme, 'nonexistent.path');
+      expect(color).toBe('#c7c7c7');
+    });
+
+    it('should fallback to error.main when theme path not found and cardBorderColor is undefined', () => {
+      const themeWithoutCardBorder = {
+        palette: {
+          error: { main: '#d32f2f' },
+        },
+      } as any as Theme;
+      const color = resolveStatusColor(
+        themeWithoutCardBorder,
+        'nonexistent.path',
+      );
+      expect(color).toBe('#d32f2f');
+    });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/utils.test.tsx
@@ -263,7 +263,7 @@ describe('utils', () => {
     } as any as Theme;
 
     it('should resolve theme palette reference', () => {
-      const color = resolveStatusColor(mockTheme, 'success.main', false);
+      const color = resolveStatusColor(mockTheme, 'success.main');
       expect(color).toBe('#2e7d32');
     });
 
@@ -271,49 +271,23 @@ describe('utils', () => {
       const color = resolveStatusColor(
         mockTheme,
         'rhdh.general.cardBorderColor',
-        false,
       );
       expect(color).toBe('#c7c7c7');
     });
 
-    it('should return fallback for invalid theme reference', () => {
-      const color = resolveStatusColor(mockTheme, 'invalid.path.here', false);
-      expect(color).toBe('#2e7d32');
-    });
-
     it('should return custom hex color directly', () => {
-      const color = resolveStatusColor(mockTheme, '#9933ff', false);
+      const color = resolveStatusColor(mockTheme, '#9933ff');
       expect(color).toBe('#9933ff');
     });
 
     it('should return custom color name directly', () => {
-      const color = resolveStatusColor(mockTheme, 'blue', false);
+      const color = resolveStatusColor(mockTheme, 'blue');
       expect(color).toBe('blue');
     });
 
     it('should return custom rgb color directly', () => {
-      const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)', false);
+      const color = resolveStatusColor(mockTheme, 'rgb(255, 0, 0)');
       expect(color).toBe('rgb(255, 0, 0)');
-    });
-
-    it('should return card border color when isError is true', () => {
-      const color = resolveStatusColor(mockTheme, 'anything', true);
-      expect(color).toBe('#c7c7c7');
-    });
-
-    it('should return fallback when cardBorderColor is not defined when isError is true', () => {
-      const themeWithoutCardBorder = {
-        palette: {
-          success: { main: '#0066cc' },
-        },
-      } as any as Theme;
-
-      const color = resolveStatusColor(
-        themeWithoutCardBorder,
-        'anything',
-        true,
-      );
-      expect(color).toBe('#0066cc');
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/utils/chartLabelUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/chartLabelUtils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const getYOffsetForCenterLabel = (lineCount: number) => {
+  switch (lineCount) {
+    case 2:
+      return -17;
+    case 3:
+      return -24;
+    default:
+      return -8;
+  }
+};
+
+export const getHeightForCenterLabel = (lineCount: number) => {
+  switch (lineCount) {
+    case 2:
+      return 48;
+    case 3:
+      return 56;
+    default:
+      return 40;
+  }
+};

--- a/workspaces/scorecard/plugins/scorecard/src/utils/colorUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/colorUtils.ts
@@ -55,7 +55,8 @@ export const resolveStatusColor = (
   theme: Theme,
   statusColor: string,
 ): string => {
-  if (!statusColor.includes('.')) {
+  // Theme palette paths are dot-separated; rgba(...) may include '.' in its alpha value.
+  if (!statusColor.includes('.') || statusColor.includes('rgba')) {
     return statusColor;
   }
 

--- a/workspaces/scorecard/plugins/scorecard/src/utils/colorUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/colorUtils.ts
@@ -14,31 +14,12 @@
  * limitations under the License.
  */
 
-import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
 import {
   ScorecardThresholdRuleColors,
   ThresholdRule,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import type { Theme } from '@mui/material/styles';
 import type { ThemeConfig } from '@red-hat-developer-hub/backstage-plugin-theme';
-
-export type StatusConfig = {
-  color: string;
-  icon?: React.ElementType;
-};
-
-export type PieData = {
-  name: string;
-  value: number;
-  color?: string;
-};
-
-/**
- * Color used when there's an error with scorecard data (e.g., threshold evaluation error, metric fetch error)
- */
-export const SCORECARD_ERROR_STATE_COLOR = 'rhdh.general.cardBorderColor';
 
 export const getThresholdRuleColor = (
   rules: ThresholdRule[],
@@ -58,43 +39,6 @@ export const getThresholdRuleColor = (
       return ScorecardThresholdRuleColors.SUCCESS;
     default:
       return undefined;
-  }
-};
-
-/**
- * @param evaluation - The evaluation status of the metric.
- * colors are mapped to MUI palette strings (e.g., 'error.main', 'warning.main', 'success.main').
- * @returns StatusConfig
- */
-export const getStatusConfig = ({
-  evaluation,
-  thresholdStatus,
-  metricStatus,
-  thresholdRules,
-}: {
-  evaluation: string | null;
-  thresholdStatus?: 'success' | 'error';
-  metricStatus?: 'success' | 'error';
-  thresholdRules?: ThresholdRule[];
-}): StatusConfig => {
-  // If threshold or metric has an error, return error state color
-  if (thresholdStatus === 'error' || metricStatus === 'error') {
-    return { color: SCORECARD_ERROR_STATE_COLOR };
-  }
-
-  let evaluationColor: string | undefined;
-  if (thresholdRules && evaluation) {
-    evaluationColor = getThresholdRuleColor(thresholdRules, evaluation);
-  }
-  const color = evaluationColor ?? SCORECARD_ERROR_STATE_COLOR;
-
-  switch (evaluation) {
-    case 'error':
-      return { color, icon: DangerousOutlinedIcon };
-    case 'warning':
-      return { color, icon: WarningAmberIcon };
-    default:
-      return { color, icon: CheckCircleOutlineIcon };
   }
 };
 
@@ -135,26 +79,4 @@ export const resolveStatusColor = (
     (theme as ThemeConfig).palette?.rhdh?.general?.cardBorderColor ??
     theme.palette.error.main
   );
-};
-
-export const getYOffsetForCenterLabel = (lineCount: number) => {
-  switch (lineCount) {
-    case 2:
-      return -17;
-    case 3:
-      return -24;
-    default:
-      return -8;
-  }
-};
-
-export const getHeightForCenterLabel = (lineCount: number) => {
-  switch (lineCount) {
-    case 2:
-      return 48;
-    case 3:
-      return 56;
-    default:
-      return 40;
-  }
 };

--- a/workspaces/scorecard/plugins/scorecard/src/utils/constants.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/constants.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Color used when there's an error with scorecard data (e.g., threshold evaluation error, metric fetch error)
+ */
+export const SCORECARD_ERROR_STATE_COLOR = 'rhdh.general.cardBorderColor';

--- a/workspaces/scorecard/plugins/scorecard/src/utils/index.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  getHeightForCenterLabel,
+  getYOffsetForCenterLabel,
+} from './chartLabelUtils';
+export { getThresholdRuleColor, resolveStatusColor } from './colorUtils';
+export { SCORECARD_ERROR_STATE_COLOR } from './constants';
+export { getStatusConfig } from './statusUtils';

--- a/workspaces/scorecard/plugins/scorecard/src/utils/statusUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/statusUtils.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
+import type { ThresholdRule } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+
+import { SCORECARD_ERROR_STATE_COLOR } from './constants';
+import { ElementType } from 'react';
+import { getThresholdRuleColor } from './colorUtils';
+
+export type StatusConfig = {
+  color: string;
+  icon?: ElementType;
+};
+
+/**
+ * @param evaluation - The evaluation status of the metric.
+ * colors are mapped to MUI palette strings (e.g., 'error.main', 'warning.main', 'success.main').
+ * @returns StatusConfig
+ */
+export const getStatusConfig = ({
+  evaluation,
+  thresholdStatus,
+  metricStatus,
+  thresholdRules,
+}: {
+  evaluation: string | null;
+  thresholdStatus?: 'success' | 'error';
+  metricStatus?: 'success' | 'error';
+  thresholdRules?: ThresholdRule[];
+}): StatusConfig => {
+  // If threshold or metric has an error, return error state color
+  if (thresholdStatus === 'error' || metricStatus === 'error') {
+    return { color: SCORECARD_ERROR_STATE_COLOR };
+  }
+
+  let evaluationColor: string | undefined;
+  if (thresholdRules && evaluation) {
+    evaluationColor = getThresholdRuleColor(thresholdRules, evaluation);
+  }
+  const color = evaluationColor ?? SCORECARD_ERROR_STATE_COLOR;
+
+  switch (evaluation) {
+    case 'error':
+      return { color, icon: DangerousOutlinedIcon };
+    case 'warning':
+      return { color, icon: WarningAmberIcon };
+    default:
+      return { color, icon: CheckCircleOutlineIcon };
+  }
+};

--- a/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
@@ -17,7 +17,10 @@
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
-import { ThresholdRule } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import {
+  ScorecardThresholdRuleColors,
+  ThresholdRule,
+} from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import type { ThemeConfig } from '@red-hat-developer-hub/backstage-plugin-theme';
 import type { Theme } from '@mui/material/styles';
 
@@ -43,11 +46,11 @@ export const getThresholdRuleColor = (
 
   switch (ruleKey) {
     case 'error':
-      return 'error.main';
+      return ScorecardThresholdRuleColors.ERROR;
     case 'warning':
-      return 'warning.main';
+      return ScorecardThresholdRuleColors.WARNING;
     case 'success':
-      return 'success.main';
+      return ScorecardThresholdRuleColors.SUCCESS;
     default:
       return undefined;
   }
@@ -112,22 +115,22 @@ export const resolveStatusColor = (
     );
   }
 
-  // If statusColor contains a dot, treat it as a theme palette reference
-  if (statusColor.includes('.')) {
-    const parts = statusColor.split('.');
-    let value: any = theme.palette;
-
-    for (const part of parts) {
-      value = value?.[part];
-      if (value === undefined) {
-        break;
-      }
-    }
-
-    return typeof value === 'string' ? value : theme.palette.success.main;
+  if (!statusColor.includes('.')) {
+    return statusColor;
   }
 
-  return statusColor;
+  // Resolve theme palette reference
+  const parts = statusColor.split('.');
+  let value: any = theme.palette;
+
+  for (const part of parts) {
+    value = value?.[part];
+    if (value === undefined) {
+      break;
+    }
+  }
+
+  return typeof value === 'string' ? value : theme.palette.success.main;
 };
 
 export const getYOffsetForCenterLabel = (lineCount: number) => {

--- a/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
@@ -17,6 +17,9 @@
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import DangerousOutlinedIcon from '@mui/icons-material/DangerousOutlined';
+import { ThresholdRule } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import type { ThemeConfig } from '@red-hat-developer-hub/backstage-plugin-theme';
+import type { Theme } from '@mui/material/styles';
 
 export type StatusConfig = {
   color: string;
@@ -29,6 +32,27 @@ export type PieData = {
   color?: string;
 };
 
+export const getThresholdRuleColor = (
+  rules: ThresholdRule[],
+  ruleKey: string,
+): string | undefined => {
+  const rule = rules.find(r => r.key === ruleKey);
+  if (rule?.color) {
+    return rule.color;
+  }
+
+  switch (ruleKey) {
+    case 'error':
+      return 'error.main';
+    case 'warning':
+      return 'warning.main';
+    case 'success':
+      return 'success.main';
+    default:
+      return undefined;
+  }
+};
+
 /**
  * @param evaluation - The evaluation status of the metric.
  * colors are mapped to MUI palette strings (e.g., 'error.main', 'warning.main', 'success.main').
@@ -38,37 +62,72 @@ export const getStatusConfig = ({
   evaluation,
   thresholdStatus,
   metricStatus,
+  thresholdRules,
 }: {
   evaluation: string | null;
   thresholdStatus?: 'success' | 'error';
   metricStatus?: 'success' | 'error';
+  thresholdRules?: ThresholdRule[];
 }): StatusConfig => {
   // If threshold or metric has an error, return grey.400 color
   if (thresholdStatus === 'error' || metricStatus === 'error') {
     return { color: 'rhdh.general.disabled' };
   }
 
+  let evaluationColor: string | undefined;
+  if (thresholdRules && evaluation) {
+    evaluationColor = getThresholdRuleColor(thresholdRules, evaluation);
+  }
+  const color = evaluationColor ?? 'success.main';
+
   switch (evaluation) {
     case 'error':
-      return { color: 'error.main', icon: DangerousOutlinedIcon };
+      return { color, icon: DangerousOutlinedIcon };
     case 'warning':
-      return { color: 'warning.main', icon: WarningAmberIcon };
+      return { color, icon: WarningAmberIcon };
     default:
-      return { color: 'success.main', icon: CheckCircleOutlineIcon };
+      return { color, icon: CheckCircleOutlineIcon };
   }
 };
 
-export const getRingColor = (
-  theme: any,
+/**
+ * Resolves a color value from the theme palette or returns a custom color.
+ * Supports both theme palette paths (e.g., 'error.main', 'rhdh.general.disabled')
+ * and direct color values (e.g., '#FF5733', 'blue', 'rgb(255,0,0)').
+ *
+ * @param theme - The theme configuration object
+ * @param statusColor - Either a theme palette path or a direct color value
+ * @param isError - If true, returns the theme's card border color for error states, defaults to false
+ * @returns The resolved color string
+ */
+export const resolveStatusColor = (
+  theme: Theme,
   statusColor: string,
-  isError: boolean,
-) => {
+  isError: boolean = false,
+): string => {
   if (isError) {
-    return theme.palette.rhdh.general.cardBorderColor;
+    return (
+      (theme as ThemeConfig).palette?.rhdh?.general?.cardBorderColor ??
+      theme.palette.success.main
+    );
   }
 
-  const [paletteKey, shade] = statusColor.split('.');
-  return theme.palette?.[paletteKey]?.[shade] ?? statusColor;
+  // If statusColor contains a dot, treat it as a theme palette reference
+  if (statusColor.includes('.')) {
+    const parts = statusColor.split('.');
+    let value: any = theme.palette;
+
+    for (const part of parts) {
+      value = value?.[part];
+      if (value === undefined) {
+        break;
+      }
+    }
+
+    return typeof value === 'string' ? value : theme.palette.success.main;
+  }
+
+  return statusColor;
 };
 
 export const getYOffsetForCenterLabel = (lineCount: number) => {

--- a/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
@@ -21,7 +21,6 @@ import {
   ScorecardThresholdRuleColors,
   ThresholdRule,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
-import type { ThemeConfig } from '@red-hat-developer-hub/backstage-plugin-theme';
 import type { Theme } from '@mui/material/styles';
 
 export type StatusConfig = {
@@ -95,26 +94,17 @@ export const getStatusConfig = ({
 
 /**
  * Resolves a color value from the theme palette or returns a custom color.
- * Supports both theme palette paths (e.g., 'error.main', 'rhdh.general.disabled')
+ * Supports theme palette paths (e.g., 'error.main', 'rhdh.general.cardBorderColor')
  * and direct color values (e.g., '#FF5733', 'blue', 'rgb(255,0,0)').
  *
  * @param theme - The theme configuration object
  * @param statusColor - Either a theme palette path or a direct color value
- * @param isError - If true, returns the theme's card border color for error states, defaults to false
  * @returns The resolved color string
  */
 export const resolveStatusColor = (
   theme: Theme,
   statusColor: string,
-  isError: boolean = false,
 ): string => {
-  if (isError) {
-    return (
-      (theme as ThemeConfig).palette?.rhdh?.general?.cardBorderColor ??
-      theme.palette.success.main
-    );
-  }
-
   if (!statusColor.includes('.')) {
     return statusColor;
   }

--- a/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
@@ -34,6 +34,11 @@ export type PieData = {
   color?: string;
 };
 
+/**
+ * Color used when there's an error with scorecard data (e.g., threshold evaluation error, metric fetch error)
+ */
+export const SCORECARD_ERROR_STATE_COLOR = 'rhdh.general.cardBorderColor';
+
 export const getThresholdRuleColor = (
   rules: ThresholdRule[],
   ruleKey: string,
@@ -71,9 +76,9 @@ export const getStatusConfig = ({
   metricStatus?: 'success' | 'error';
   thresholdRules?: ThresholdRule[];
 }): StatusConfig => {
-  // If threshold or metric has an error, return grey.400 color
+  // If threshold or metric has an error, return error state color
   if (thresholdStatus === 'error' || metricStatus === 'error') {
-    return { color: 'rhdh.general.cardBorderColor' };
+    return { color: SCORECARD_ERROR_STATE_COLOR };
   }
 
   let evaluationColor: string | undefined;

--- a/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
@@ -22,6 +22,7 @@ import {
   ThresholdRule,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import type { Theme } from '@mui/material/styles';
+import type { ThemeConfig } from '@red-hat-developer-hub/backstage-plugin-theme';
 
 export type StatusConfig = {
   color: string;
@@ -85,7 +86,7 @@ export const getStatusConfig = ({
   if (thresholdRules && evaluation) {
     evaluationColor = getThresholdRuleColor(thresholdRules, evaluation);
   }
-  const color = evaluationColor ?? 'success.main';
+  const color = evaluationColor ?? SCORECARD_ERROR_STATE_COLOR;
 
   switch (evaluation) {
     case 'error':
@@ -125,7 +126,15 @@ export const resolveStatusColor = (
     }
   }
 
-  return typeof value === 'string' ? value : theme.palette.success.main;
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  // Fallback to error state color, then error.main
+  return (
+    (theme as ThemeConfig).palette?.rhdh?.general?.cardBorderColor ??
+    theme.palette.error.main
+  );
 };
 
 export const getYOffsetForCenterLabel = (lineCount: number) => {

--- a/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/utils.ts
@@ -74,7 +74,7 @@ export const getStatusConfig = ({
 }): StatusConfig => {
   // If threshold or metric has an error, return grey.400 color
   if (thresholdStatus === 'error' || metricStatus === 'error') {
-    return { color: 'rhdh.general.disabled' };
+    return { color: 'rhdh.general.cardBorderColor' };
   }
 
   let evaluationColor: string | undefined;


### PR DESCRIPTION
### **User description**
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Introduces support for custom threshold keys and colors.
Users can specify colors as RGB or HEX.
Example config of custom threshold keys and colors:
```
scorecard:
  plugins:
    github:
      open_prs:
        thresholds:
          rules:
            - key: success
              expression: '<=2'
            - key: warning
              expression: '<=35'
            - key: critical
              expression: '>35'
              color: '#0000FF'  # or 'error.main', rgb(255,255,0)
```

- out of scope: icon handling, to be worked in following PR, right now default icon is set to CheckCircleOutlineIcon


#### Demo

<img width="1509" height="863" alt="Screenshot 2026-02-24 at 16 37 08" src="https://github.com/user-attachments/assets/8201c86a-e718-4197-b8a5-44d8e34bfb31" />
<img width="1509" height="863" alt="Screenshot 2026-02-24 at 16 37 23" src="https://github.com/user-attachments/assets/4578f3dc-8165-4909-8a4e-04fafc3389f7" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [X] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

#### Fixes
Fixes https://issues.redhat.com/browse/RHIDP-11915


___

### **PR Type**
Enhancement


___

### **Description**
- Support custom threshold keys with optional color configuration

- Refactor aggregated metric structure to use dynamic status counts

- Add color validation for hex, RGB/RGBA, and theme palette references

- Unify color resolution logic across scorecard components

- Expand test coverage for threshold validation and color handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Threshold Config"] -->|custom keys + colors| B["Validation"]
  B -->|validate color format| C["Color Constants"]
  A -->|rules with colors| D["Database"]
  D -->|statusCounts| E["Aggregation Mapper"]
  E -->|fill missing keys| F["UI Components"]
  F -->|resolveStatusColor| G["Theme Palette"]
  G -->|render colors| H["Scorecard Display"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>config.d.ts</strong><dd><code>Allow custom threshold keys and optional colors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-c21b2c593cca597bb1c63cd7fd2f14911d2b78ddf3e0fa187f5895937949f302">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>knexfile.js</strong><dd><code>Add knex configuration for database migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-f1af7f6220cdd000fba1101404787950f2ef81d383dd70011e9fd3f2cb882f62">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>20260206115752_remove_status_check_constraint.js</strong><dd><code>Remove status enum constraint for custom keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-e4af6ebde0a0d15f17be8e089eb32bc5ba9a5687427e6f148c326a5560f9704a">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>Change status to string and refactor aggregated metric</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-c05a3dc23bdafae134301eb3d58ca898c41254ae46ea572e42246c8b9568cc85">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DatabaseMetricValues.ts</strong><dd><code>Refactor aggregation to use dynamic status counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-41791eb507899dc42c2e3d2520fb77aa5ea994f25cb8beff3332e70ec2b443b4">+33/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CatalogMetricService.ts</strong><dd><code>Remove hardcoded aggregated metrics type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-b0070e8a2e955516b79a3df7ffe460387e7b892f229d0c69958effeb8f36edd2">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mappers.ts</strong><dd><code>Map aggregated metrics with threshold-ordered status counts</code></dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-bacd748a2909ccbd9c9192b95c66ad54836ba80c99f0103bb6e65590b97736c6">+17/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Pass thresholds to aggregation mapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-f8fa08b9bd2b23304839203f34a85e7e7ac1e4b0e1210f0dcdaf30cc9a15e10a">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validateThresholds.ts</strong><dd><code>Validate custom threshold keys and color formats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-08095f67e81bd3ec768826be19ba22d89c011128134ea5a4979877f7ffd6adf2">+95/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>threshold.ts</strong><dd><code>Add optional color property to threshold rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-996b0b38852c30aac93678ffeecc16cd83b25a3e4290363ff3f7b10cc89fa322">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Metric.ts</strong><dd><code>Update aggregated metric types with thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-e8ba9c72ca1f63c3169e704e956927e7ef22118dd22bb2a5b53816affffef310">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.ts</strong><dd><code>Add color resolution and threshold rule color utilities</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-2f842e88964a93965abd5d9b685b1b82a75beac84cb55bc5e00cc70c6c134b2e">+79/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CustomLegend.tsx</strong><dd><code>Use threshold rule colors in legend display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-20a08abc36432ffb88e685b61710ba4f46c215cd3b720864c3f3427c0c1f372d">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EntityScorecardContent.tsx</strong><dd><code>Pass threshold rules to status config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-95fd7c3fd17b405c12c09018a64321a6a4958893a0397728468f024f2ccf3f16">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Scorecard.tsx</strong><dd><code>Simplify color resolution using new utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-5c4c205273ca3b662c62736fd9eca97ac8d0cdb9f9b4cf6e6226b0daaf6824ba">+6/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CustomLegend.tsx</strong><dd><code>Add test ID to legend color boxes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-e2c0c9f0e67e823b04d1d24beeed2d4a3cf0a80d72c76896b7dee8860e117ae8">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EmptyStatePanel.tsx</strong><dd><code>Use new color resolution utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-b187eae46f03476ec87e9c000bd51ca25c6cba87e81afa1ce4718c83ea09d4a4">+4/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScorecardHomepageCardComponent.tsx</strong><dd><code>Apply threshold rule colors to pie chart segments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-d29ec503fba7a864b34244ee66c84b92774d853c7be149de02b9e0ddbabd26c2">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>DatabaseMetricValues.test.ts</strong><dd><code>Expand tests for aggregated metric functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-d20525583c634107b248a8adc3f840d38e2bd67fecd1c08010a8f576e991ab0b">+295/-37</a></td>

</tr>

<tr>
  <td><strong>CatalogMetricService.test.ts</strong><dd><code>Update tests for new aggregation structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-b2088507f01a8ae9a2e4fd91345c7dcb1fb5a48a94e6fc60d64ff6d647814600">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mappers.test.ts</strong><dd><code>Add comprehensive mapper tests for custom thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-a286aeefc76049ce6160ae5ca37ecf11e5ed475ac285d386d2b21cdaa8f3dbe6">+246/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>router.test.ts</strong><dd><code>Update router tests for threshold parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-e4fc2fd3121941b2fd36e7e7bff6e81a2bd674fa691837000098a55b08c8a692">+27/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validateThresholds.test.ts</strong><dd><code>Add tests for custom keys and color validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-2f288c1129f34ecb9f3ee03b7eceac1625cbc9aae7640cc9cdf14103b03ab0b8">+145/-23</a></td>

</tr>

<tr>
  <td><strong>CustomLegend.test.tsx</strong><dd><code>Add tests for custom legend color rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>Scorecard.test.tsx</strong><dd><code>Update scorecard tests for color resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-e7e84aefe027eb4fc5d8df8000ad1b6ed5b9e2b8a8f3a332f830338df539e390">+81/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>EntityScorecardContent.test.tsx</strong><dd><code>Update entity scorecard tests for threshold rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-216150d4f1f30f7b04979495496cd3cdf751564ef6f1186916e882fb064ad565">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CustomLegend.test.tsx</strong><dd><code>Add color display tests for legend items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-fcfbb97fb8c0e56af90cc7d4555ba4b14266ed94647bbd74474b8be6ba3fcb1c">+31/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScorecardHomepageCard.test.tsx</strong><dd><code>Add tests for pie segment colors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-d111bbb1b2752e98bdf3a3395514c4c6a26f422ef202fe873c9d2c3d9a608d26">+37/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScorecardHomepageSection.test.tsx</strong><dd><code>Update test fixtures with threshold data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-0fcf6330b8e8ac44f5d680d18646673fbdae4138dddb1fcc3ead12161dcd6f88">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.test.tsx</strong><dd><code>Add comprehensive tests for color utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-42e51fafceeb20a301d4d64bb961987abaeeab8bdfe8e20f2c8d663158a07093">+246/-100</a></td>

</tr>

<tr>
  <td><strong>aggregatedScorecardData.ts</strong><dd><code>Add threshold data to mock aggregated scorecard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-939b51a028aeb7f87f1a23d9ef0c98b91aeb51754acaad1f7b20d442f7451111">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>thresholds.md</strong><dd><code>Document custom threshold keys and color configuration</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-fc3db9e5ba7479a48889e0ee8414c3384979b6b266cd020923b215f29591a1c0">+68/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>report.api.md</strong><dd><code>Update API report with new color constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-807d2903217e3cb54d3771fbd9a15521ca2925a3171778f657b532d99ea0dc21">+19/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>busy-mice-call.md</strong><dd><code>Add changeset for custom thresholds feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-3cbe6d016ba47c258f6e62c53e167b3f9d046c07c6d71ad85e27f77038fc7334">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CustomLegend.test.tsx</strong></td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2378/files#diff-c26bfb2ea29a5df4462374be32ea00d061ae1a961b9929deb0bb8ffe061f88ca">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

