### PR TITLE
fix: use GitHub App token for CODEOWNERS validation workflow

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -17,6 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        with:
+          app-id: ${{ secrets.RHDH_GH_APP_ID }}
+          private-key: ${{ secrets.RHDH_GH_APP_PRIVATE_KEY }}
+          owner: redhat-developer
+
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -25,4 +33,4 @@ jobs:
       - name: Validate CODEOWNERS entries against team membership
         run: node scripts/ci/validate-codeowners.js
         env:
-          GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### **User description**
Replace RHDH_BOT_TOKEN PAT with a token generated from the rhdh-gh-app GitHub App, which has the read:org scope needed to query team membership.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace RHDH_BOT_TOKEN PAT with GitHub App token

- Add token generation step using rhdh-gh-app

- Enable read:org scope for team membership queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Checkout code"] --> B["Generate GitHub App Token"]
  B --> C["Set up Node"]
  C --> D["Validate CODEOWNERS entries"]
  D --> E["Query team membership"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate-codeowners.yml</strong><dd><code>Replace PAT with GitHub App token generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/validate-codeowners.yml

<ul><li>Added new step to generate GitHub App token using <br><code>actions/create-github-app-token</code><br> <li> Configured token generation with app-id and private-key secrets<br> <li> Replaced <code>RHDH_BOT_TOKEN</code> with dynamically generated token from <br><code>steps.generate-token.outputs.token</code><br> <li> Token scoped to <code>redhat-developer</code> organization for team membership <br>queries</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2379/files#diff-8e4f84c27b52c67a5b0f10df80e399d042b605b638c64e67332c74512d029b15">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

