### PR TITLE
fix(x2a): env fix when running on openshift

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts
@@ -269,6 +269,19 @@ export class JobResourceBuilder {
                 ],
                 // Additional env vars specific to this job (metadata, not credentials)
                 env: [
+                  // OpenShift compatibility: redirect HOME and caches to writable workspace
+                  {
+                    name: 'HOME',
+                    value: '/workspace',
+                  },
+                  {
+                    name: 'XDG_CACHE_HOME',
+                    value: '/workspace/.cache',
+                  },
+                  {
+                    name: 'GIT_CONFIG_GLOBAL',
+                    value: '/workspace/.gitconfig',
+                  },
                   {
                     name: 'PHASE',
                     value: params.phase,


### PR DESCRIPTION
### **User description**
To avoid this:

```

$ -> oc -n x2ansible logs -f job-x2a-init-30d126bd-zhxnt
==========================================
  X2A init Phase
==========================================

Job Configuration:
  Project ID:    4dde21dd-b8a8-403c-ad6e-1e2aac3c9f67
  Project Abbrev: myprj
  Module ID:     N/A
  Module Name:   N/A
  Job ID:        bf0bca2b-5dd6-49f6-a05f-02df0d907f91
  Phase:         init

error: could not lock config file //.gitconfig: Permission denied
Reporting result: status=error, phase=init
error: Failed to initialize cache at `/.cache/uv`
  Caused by: failed to create directory `/.cache/uv`: Permission denied (os error 13)
WARNING: Failed to report result to backend
```


___

### **PR Type**
Bug fix


___

### **Description**
- Redirect HOME and cache directories to writable workspace

- Set XDG_CACHE_HOME to prevent permission errors

- Configure GIT_CONFIG_GLOBAL for git operations

- Fixes permission denied errors when running on OpenShift


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Job Container"] -->|"Set HOME to /workspace"| B["Writable Workspace"]
  A -->|"Set XDG_CACHE_HOME"| B
  A -->|"Set GIT_CONFIG_GLOBAL"| B
  B -->|"Prevents permission denied"| C["Successful Execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JobResourceBuilder.ts</strong><dd><code>Add OpenShift-compatible environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts

<ul><li>Added three environment variables to job container configuration<br> <li> HOME redirected to /workspace for writable home directory<br> <li> XDG_CACHE_HOME set to /workspace/.cache for cache directory<br> <li> GIT_CONFIG_GLOBAL set to /workspace/.gitconfig for git configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2384/files#diff-4a65778496d1d84d75030abd5456b5203e43ff227fd0b234f72eca12eaa94610">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

