### PR TITLE
fix(x2a): artifacts value as text

### DIFF
--- a/workspaces/x2a/package.json
+++ b/workspaces/x2a/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_OPTIONS=--no-node-snapshot ; backstage-cli repo start",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
-    "build:api-reports": "yarn build:api-reports:only --tsc",
+    "build:api-reports": "yarn tsc:full; yarn build:api-reports:only",
     "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type,ae-undocumented --validate-release-tags --exclude client/src/schema/openapi/generated",
     "build:knip-reports": "backstage-repo-tools knip-reports",
     "build-image": "yarn workspace backend build-image",

--- a/workspaces/x2a/plugins/x2a-backend/migrations/2025012401_create_jobs_table.ts
+++ b/workspaces/x2a/plugins/x2a-backend/migrations/2025012401_create_jobs_table.ts
@@ -68,7 +68,7 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('artifacts', table => {
     table.uuid('id').primary();
     table.string('type').notNullable(); // The artifact type
-    table.string('value').notNullable(); // The artifact string value
+    table.text('value').notNullable(); // The artifact value - can be large content
     table
       .uuid('job_id')
       .notNullable()


### PR DESCRIPTION
### **User description**
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


___

### **PR Type**
Bug fix


___

### **Description**
- Changed artifacts table column from string to text type

- Allows storage of large artifact content without truncation

- Updated build script to include TypeScript compilation step


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["artifacts table schema"] -- "value column type" --> B["string → text"]
  C["build:api-reports script"] -- "add tsc compilation" --> D["tsc:full + api-reports:only"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>2025012401_create_jobs_table.ts</strong><dd><code>Change artifacts value column to text type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a-backend/migrations/2025012401_create_jobs_table.ts

<ul><li>Changed <code>value</code> column type from <code>string</code> to <code>text</code> in artifacts table<br> <li> Updated comment to reflect that column can store large content<br> <li> Enables storage of larger artifact values without database truncation</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2396/files#diff-0321cd3fbac70a4c549e2995579355e109791131453bb240bf29a95dcd91ff6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add TypeScript compilation to build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/package.json

<ul><li>Modified <code>build:api-reports</code> script to run <code>yarn tsc:full</code> before <br><code>build:api-reports:only</code><br> <li> Ensures TypeScript compilation completes before API report generation<br> <li> Prevents potential build failures from uncompiled TypeScript code</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2396/files#diff-62f39d330cb644a94dd30b34ebd02b9b9d802e46201c0612bf213c0f718f6b64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

