### PR TITLE
fix(x2a): fix tsc error from PR #2397

### DIFF
--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/PhasesCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/PhasesCard.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles(theme => ({
     maxWidth: '33.33%',
     minHeight: 64,
     fontSize: theme.typography.pxToRem(16),
-    fontWeight: theme.typography.fontWeightMedium,
+    fontWeight: theme.typography.fontWeightMedium as number,
     textTransform: 'none' as const,
     padding: theme.spacing(2, 3),
     '&:hover': {


### PR DESCRIPTION
### **User description**
My mistake sorry!


___

### **PR Type**
Bug fix


___

### **Description**
- Cast `theme.typography.fontWeightMedium` to `number` type

- Resolves TypeScript compilation error in PhasesCard component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fontWeightMedium property"] -- "add type cast" --> B["as number"]
  B -- "resolves" --> C["TypeScript error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhasesCard.tsx</strong><dd><code>Add type cast to fontWeightMedium property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a/src/components/ModulePage/PhasesCard.tsx

<ul><li>Added <code>as number</code> type cast to <code>theme.typography.fontWeightMedium</code> <br>property<br> <li> Resolves TypeScript compilation error in tab styling configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2398/files#diff-6559e256e04273c956909aede21bc83658f14d69255c7c2d11d5f5e2f07ce63c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

