### PR TITLE
chores(x2a): support noisy warnings in tests by libraries

### DIFF
--- a/workspaces/x2a/packages/app/src/setupTests.ts
+++ b/workspaces/x2a/packages/app/src/setupTests.ts
@@ -13,4 +13,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-console */
+
 import '@testing-library/jest-dom';
+
+// Suppress noisy errors/warnings from underlying libraries that don't affect tests.
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+const suppressPatterns = [
+  'Could not parse CSS stylesheet', // JSDOM doesn't support modern CSS (@layer, var())
+  'Support for defaultProps will be removed', // @material-table/core deprecation
+  'React Router Future Flag Warning', // react-router v7 migration notices
+  'findDOMNode is deprecated', // @material-ui/core
+  'validateDOMNesting', // React DOM nesting (e.g. div inside p from Typography)
+  'Not implemented: HTMLCanvasElement.prototype.getContext', // JSDOM canvas
+];
+const getMatchedPattern = (args: unknown[]): string | null => {
+  const first = args[0];
+  const msg =
+    typeof first === 'object' &&
+    first !== null &&
+    'message' in first &&
+    typeof (first as { message?: string }).message === 'string'
+      ? (first as { message: string }).message
+      : String(first?.toString?.() ?? first ?? '');
+  return suppressPatterns.find(p => msg.includes(p)) ?? null;
+};
+const handleFiltered = (pattern: string): void => {
+  process.stdout.write(`[Suppressed] ${pattern}\n`);
+};
+console.error = (...args: unknown[]) => {
+  const pattern = getMatchedPattern(args);
+  if (pattern) {
+    handleFiltered(pattern);
+    return;
+  }
+  originalConsoleError.apply(console, args);
+};
+console.warn = (...args: unknown[]) => {
+  const pattern = getMatchedPattern(args);
+  if (pattern) {
+    handleFiltered(pattern);
+    return;
+  }
+  originalConsoleWarn.apply(console, args);
+};

--- a/workspaces/x2a/plugins/x2a/src/setupTests.ts
+++ b/workspaces/x2a/plugins/x2a/src/setupTests.ts
@@ -13,4 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-console */
 import '@testing-library/jest-dom';
+
+// Suppress noisy errors/warnings from underlying libraries that don't affect tests.
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+const suppressPatterns = [
+  'Could not parse CSS stylesheet', // JSDOM doesn't support modern CSS (@layer, var())
+  'Support for defaultProps will be removed', // @material-table/core deprecation
+  'React Router Future Flag Warning', // react-router v7 migration notices
+  'findDOMNode is deprecated', // @material-ui/core
+  'validateDOMNesting', // React DOM nesting (e.g. div inside p from Typography)
+  'Not implemented: HTMLCanvasElement.prototype.getContext', // JSDOM canvas
+];
+const getMatchedPattern = (args: unknown[]): string | null => {
+  const first = args[0];
+  const msg =
+    typeof first === 'object' &&
+    first !== null &&
+    'message' in first &&
+    typeof (first as { message?: string }).message === 'string'
+      ? (first as { message: string }).message
+      : String(first?.toString?.() ?? first ?? '');
+  return suppressPatterns.find(p => msg.includes(p)) ?? null;
+};
+const handleFiltered = (pattern: string): void => {
+  process.stdout.write(`[Suppressed] ${pattern}\n`);
+};
+console.error = (...args: unknown[]) => {
+  const pattern = getMatchedPattern(args);
+  if (pattern) {
+    handleFiltered(pattern);
+    return;
+  }
+  originalConsoleError.apply(console, args);
+};
+console.warn = (...args: unknown[]) => {
+  const pattern = getMatchedPattern(args);
+  if (pattern) {
+    handleFiltered(pattern);
+    return;
+  }
+  originalConsoleWarn.apply(console, args);
+};


### PR DESCRIPTION
### **User description**
This patch has no effect at runtime, it's about tests only.

Underlying libraries are producing a lot of useless errors/warnings which we have no way to address considering we are bound to their particular versions. Let's skip them in tests (still present in production browser's log)


___

### **PR Type**
Tests


___

### **Description**
- Suppress noisy library warnings in test environments

- Filter console.error and console.warn with pattern matching

- Preserve actual errors while hiding known library deprecations

- Applied to both app and plugin test setup files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup Files"] --> B["Console Interception"]
  B --> C["Pattern Matching"]
  C --> D["Filter Known Warnings"]
  D --> E["Suppress Output"]
  C --> F["Pass Through Errors"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setupTests.ts</strong><dd><code>Add console warning suppression to app tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/packages/app/src/setupTests.ts

<ul><li>Added console.error and console.warn interception logic<br> <li> Defined suppressPatterns array with 6 known noisy warnings from <br>libraries<br> <li> Implemented getMatchedPattern function to extract and match error <br>messages<br> <li> Routes matched patterns to handleFiltered for suppression, others to <br>original handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2399/files#diff-174183ff5d6a4fed16d4e1334bc6a6e3cc75d59614a26cad614139b04d9cf2e2">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>setupTests.ts</strong><dd><code>Add console warning suppression to plugin tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/x2a/plugins/x2a/src/setupTests.ts

<ul><li>Added console.error and console.warn interception logic<br> <li> Defined suppressPatterns array with 6 known noisy warnings from <br>libraries<br> <li> Implemented getMatchedPattern function to extract and match error <br>messages<br> <li> Routes matched patterns to handleFiltered for suppression, others to <br>original handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2399/files#diff-2ca768ce32c71358dc005335cb59a6953d49b8e0909144b5679b9215482f10c9">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

