### PR TITLE
Port over list-scaffolder-actions tool

### DIFF
--- a/workspaces/mcp-integrations/.changeset/shy-flies-accept.md
+++ b/workspaces/mcp-integrations/.changeset/shy-flies-accept.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scaffolder-mcp-extras': minor
+---
+
+Port over list-scaffolder-actions MCP tool

--- a/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createListScaffolderActionsAction.test.ts
+++ b/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createListScaffolderActionsAction.test.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createListScaffolderActionsAction } from './createListScaffolderActionsAction';
+import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import type { ScaffolderActionsListProvider } from './createListScaffolderActionsAction';
+
+type MockAction = {
+  id: string;
+  description?: string;
+  schema?: { input?: unknown; output?: unknown };
+  examples?: unknown[];
+};
+
+describe('createListScaffolderActionsAction', () => {
+  it('should list all scaffolder actions successfully', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockActions = createMockActions();
+    const mockTemplateActionRegistry =
+      createMockTemplateActionRegistry(mockActions);
+
+    createListScaffolderActionsAction({
+      actionsRegistry: mockActionsRegistry,
+      templateActionRegistry: mockTemplateActionRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+
+    // Verify output structure
+    expect(result.output).toHaveProperty('actions');
+    const output = result.output as { actions: Array<{ id: string }> };
+    expect(Array.isArray(output.actions)).toBe(true);
+    expect(output.actions).toHaveLength(3);
+
+    // Verify actions are sorted by id
+    const actionIds = output.actions.map(a => a.id);
+    expect(actionIds).toEqual([
+      'catalog:register',
+      'debug:log',
+      'fetch:template',
+    ]);
+
+    // Verify action structure
+    const firstAction = output.actions[0] as Record<string, unknown>;
+    expect(firstAction).toEqual({
+      id: 'catalog:register',
+      description: 'Registers entities in the catalog',
+      schema: {
+        input: { type: 'object' },
+        output: { type: 'object' },
+      },
+      examples: [{ description: 'Basic usage', example: 'register entity' }],
+    });
+  });
+
+  it('should handle actions without descriptions, schemas, or examples', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockActions: MockAction[] = [
+      {
+        id: 'minimal-action',
+      },
+    ];
+    const mockTemplateActionRegistry =
+      createMockTemplateActionRegistry(mockActions);
+
+    createListScaffolderActionsAction({
+      actionsRegistry: mockActionsRegistry,
+      templateActionRegistry: mockTemplateActionRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+
+    const output = result.output as { actions: unknown[] };
+    expect(output.actions).toHaveLength(1);
+    expect(output.actions[0]).toEqual({
+      id: 'minimal-action',
+      description: '',
+      schema: { input: {}, output: {} },
+      examples: [],
+    });
+  });
+
+  it('should return empty array when no actions are registered', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockTemplateActionRegistry = createMockTemplateActionRegistry([]);
+
+    createListScaffolderActionsAction({
+      actionsRegistry: mockActionsRegistry,
+      templateActionRegistry: mockTemplateActionRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+
+    const output = result.output as { actions: unknown[] };
+    expect(output.actions).toEqual([]);
+  });
+
+  it('should return empty array when templateActionRegistry is not provided', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createListScaffolderActionsAction({
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+
+    const output = result.output as { actions: unknown[] };
+    expect(output.actions).toEqual([]);
+  });
+
+  it('should maintain consistent sorting across multiple calls', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockActions: MockAction[] = [
+      createMockAction('z-action', 'Last alphabetically'),
+      createMockAction('a-action', 'First alphabetically'),
+      createMockAction('middle-action', 'Middle alphabetically'),
+    ];
+    const mockTemplateActionRegistry =
+      createMockTemplateActionRegistry(mockActions);
+
+    createListScaffolderActionsAction({
+      actionsRegistry: mockActionsRegistry,
+      templateActionRegistry: mockTemplateActionRegistry,
+    });
+
+    const result1 = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+    const result2 = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+
+    const output1 = result1.output as { actions: { id: string }[] };
+    const output2 = result2.output as { actions: { id: string }[] };
+    const ids1 = output1.actions.map(a => a.id);
+    const ids2 = output2.actions.map(a => a.id);
+
+    expect(ids1).toEqual(['a-action', 'middle-action', 'z-action']);
+    expect(ids1).toEqual(ids2);
+  });
+
+  it('should include all action properties in the output', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const complexAction: MockAction = {
+      id: 'complex-action',
+      description: 'A complex action with all properties',
+      schema: {
+        input: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            count: { type: 'number' },
+          },
+        },
+        output: {
+          type: 'object',
+          properties: {
+            result: { type: 'string' },
+          },
+        },
+      },
+      examples: [
+        {
+          description: 'Example 1',
+          example: 'example content 1',
+        },
+        {
+          description: 'Example 2',
+          example: 'example content 2',
+        },
+      ],
+    };
+
+    const mockTemplateActionRegistry = createMockTemplateActionRegistry([
+      complexAction,
+    ]);
+
+    createListScaffolderActionsAction({
+      actionsRegistry: mockActionsRegistry,
+      templateActionRegistry: mockTemplateActionRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-actions',
+      input: {},
+    });
+
+    const output = result.output as { actions: unknown[] };
+    expect(output.actions[0]).toEqual({
+      id: 'complex-action',
+      description: 'A complex action with all properties',
+      schema: {
+        input: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            count: { type: 'number' },
+          },
+        },
+        output: {
+          type: 'object',
+          properties: {
+            result: { type: 'string' },
+          },
+        },
+      },
+      examples: [
+        {
+          description: 'Example 1',
+          example: 'example content 1',
+        },
+        {
+          description: 'Example 2',
+          example: 'example content 2',
+        },
+      ],
+    });
+  });
+});
+
+function createMockAction(id: string, description: string): MockAction {
+  return {
+    id,
+    description,
+    schema: {
+      input: { type: 'object' },
+      output: { type: 'object' },
+    },
+    examples: [],
+  };
+}
+
+function createMockActions(): MockAction[] {
+  return [
+    {
+      id: 'fetch:template',
+      description: 'Fetches a template',
+      schema: {
+        input: { type: 'object' },
+        output: { type: 'object' },
+      },
+      examples: [],
+    },
+    {
+      id: 'catalog:register',
+      description: 'Registers entities in the catalog',
+      schema: {
+        input: { type: 'object' },
+        output: { type: 'object' },
+      },
+      examples: [{ description: 'Basic usage', example: 'register entity' }],
+    },
+    {
+      id: 'debug:log',
+      description: 'Logs debug information',
+      schema: {
+        input: { type: 'object' },
+        output: { type: 'object' },
+      },
+      examples: [],
+    },
+  ];
+}
+
+function createMockTemplateActionRegistry(
+  actions: MockAction[] = [],
+): ScaffolderActionsListProvider {
+  const actionsMap = new Map(
+    actions.map(action => [
+      action.id,
+      {
+        id: action.id,
+        description: action.description,
+        schema: action.schema,
+        examples: action.examples,
+      },
+    ]),
+  );
+
+  return {
+    list: jest.fn().mockResolvedValue(actionsMap),
+  };
+}

--- a/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createListScaffolderActionsAction.ts
+++ b/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createListScaffolderActionsAction.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActionsRegistryService,
+  type ActionsService,
+} from '@backstage/backend-plugin-api/alpha';
+import { BackstageCredentials } from '@backstage/backend-plugin-api';
+
+/**
+ * Minimal interface for listing scaffolder/template actions.
+ * Used so we do not depend on the non-exported TemplateActionRegistry from
+ * @backstage/plugin-scaffolder-backend. Any implementation that can list
+ * actions with this shape (e.g. TemplateActionRegistry) can be passed in.
+ *
+ * @internal
+ */
+export interface ScaffolderActionsListProvider {
+  list(options: { credentials: BackstageCredentials }): Promise<
+    Map<
+      string,
+      {
+        id: string;
+        description?: string;
+        schema?: { input?: unknown; output?: unknown };
+        examples?: unknown[];
+      }
+    >
+  >;
+}
+
+/**
+ * Builds a ScaffolderActionsListProvider from the backend ActionsService.
+ * Lists all actions registered with the backend (e.g. MCP actions and any
+ * template actions exposed via the actions service).
+ *
+ * @public
+ */
+export function scaffolderActionsListProviderFromActionsService(
+  actionsService: ActionsService,
+): ScaffolderActionsListProvider {
+  return {
+    async list({ credentials }) {
+      const { actions } = await actionsService.list({ credentials });
+      return new Map(
+        actions.map(a => [
+          a.id,
+          {
+            id: a.id,
+            description: a.description,
+            schema: {
+              input: a.schema?.input ?? {},
+              output: a.schema?.output ?? {},
+            },
+            examples: [],
+          },
+        ]),
+      );
+    },
+  };
+}
+
+export const createListScaffolderActionsAction = ({
+  actionsRegistry,
+  templateActionRegistry,
+}: {
+  actionsRegistry: ActionsRegistryService;
+  /**
+   * Optional. When provided, returns the real list from the registry.
+   * When omitted, the action is still registered but returns an empty list when invoked.
+   */
+  templateActionRegistry?: ScaffolderActionsListProvider;
+}) => {
+  actionsRegistry.register({
+    name: 'list-scaffolder-actions',
+    title: 'List Scaffolder Actions',
+    attributes: {
+      destructive: false,
+      readOnly: true,
+      idempotent: true,
+    },
+    description: `Lists all installed Scaffolder actions.
+Each action includes:
+- id: The action identifier
+- description: What the action does
+- schema: Input and output JSON schemas
+- examples: Usage examples (if available)`,
+    schema: {
+      input: z => z.object({}).describe('No input is required'),
+      output: z =>
+        z.object({
+          actions: z.array(
+            z.object({
+              id: z.string(),
+              description: z.string(),
+              schema: z.object({
+                input: z
+                  .object({})
+                  .passthrough()
+                  .describe('JSON Schema for input of Action'),
+                output: z
+                  .object({})
+                  .passthrough()
+                  .describe('JSON Schema for output of Action'),
+              }),
+              examples: z.array(z.any()).optional(),
+            }),
+          ),
+        }),
+    },
+    action: async ({ credentials }) => {
+      if (!templateActionRegistry) {
+        return { output: { actions: [] } };
+      }
+      const actionsMap = await templateActionRegistry.list({ credentials });
+      const scaffolderActions = Array.from(actionsMap.values()).map(action => ({
+        id: action.id,
+        description: action.description ?? '',
+        schema: {
+          input: { ...(action.schema?.input ?? {}) },
+          output: { ...(action.schema?.output ?? {}) },
+        },
+        examples: action.examples ?? [],
+      }));
+      return {
+        output: {
+          actions: scaffolderActions.sort((a, b) => a.id.localeCompare(b.id)),
+        },
+      };
+    },
+  });
+};

--- a/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/index.ts
+++ b/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/index.ts
@@ -17,13 +17,31 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { createFetchTemplateMetadataAction } from './createFetchTemplateMetadataAction.ts';
+import { createListScaffolderActionsAction } from './createListScaffolderActionsAction.ts';
+import type { ScaffolderActionsListProvider } from './createListScaffolderActionsAction.ts';
 
 export { createFetchTemplateMetadataAction } from './createFetchTemplateMetadataAction.ts';
+export {
+  createListScaffolderActionsAction,
+  scaffolderActionsListProviderFromActionsService,
+  type ScaffolderActionsListProvider,
+} from './createListScaffolderActionsAction.ts';
 
 export const createScaffolderActions = (options: {
   actionsRegistry: ActionsRegistryService;
   catalog: CatalogService;
   logger: LoggerService;
+  /**
+   * Optional. When provided, list-scaffolder-actions returns the real list.
+   * When omitted, the tool is still registered but returns an empty list.
+   * Not exported from @backstage/plugin-scaffolder-backend; pass an implementation
+   * (e.g. TemplateActionRegistry from the scaffolder backend when wired by the host app).
+   */
+  templateActionRegistry?: ScaffolderActionsListProvider;
 }) => {
   createFetchTemplateMetadataAction(options);
+  createListScaffolderActionsAction({
+    actionsRegistry: options.actionsRegistry,
+    templateActionRegistry: options.templateActionRegistry,
+  });
 };

--- a/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/plugin.ts
+++ b/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/plugin.ts
@@ -18,8 +18,14 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node';
-import { actionsRegistryServiceRef } from '@backstage/backend-plugin-api/alpha';
-import { createScaffolderActions } from './actions';
+import {
+  actionsRegistryServiceRef,
+  actionsServiceRef,
+} from '@backstage/backend-plugin-api/alpha';
+import {
+  createScaffolderActions,
+  scaffolderActionsListProviderFromActionsService,
+} from './actions';
 
 /**
  * mcpScaffolderExtrasPlugin backend plugin
@@ -32,13 +38,20 @@ export const mcpScaffolderExtrasPlugin = createBackendPlugin({
     env.registerInit({
       deps: {
         actionsRegistry: actionsRegistryServiceRef,
+        actionsService: actionsServiceRef,
         logger: coreServices.logger,
         httpAuth: coreServices.httpAuth,
         httpRouter: coreServices.httpRouter,
         catalog: catalogServiceRef,
       },
-      async init({ actionsRegistry, catalog, logger }) {
-        createScaffolderActions({ actionsRegistry, catalog, logger });
+      async init({ actionsRegistry, actionsService, catalog, logger }) {
+        createScaffolderActions({
+          actionsRegistry,
+          catalog,
+          logger,
+          templateActionRegistry:
+            scaffolderActionsListProviderFromActionsService(actionsService),
+        });
       },
     });
   },


### PR DESCRIPTION
### **User description**
## Hey, I just made a Pull Request!

Ports over the list-scaffolder-action from https://github.com/yangcao77/backstage/tree/scaffolder-action so that is installable as a dynamic plugin (under scaffolder-mcp-extras).

CC @yangcao77 per our discussion on slack, I did end up needing to add a reimplemented `ScaffolderActionsListProvider` interface and `scaffolderActionsListProviderFromActionsService` function, but it seemingly works (though you may want to check this branch out and give it a try yourself).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add list-scaffolder-actions MCP tool to enumerate installed actions

- Implement ScaffolderActionsListProvider interface for action discovery

- Create scaffolderActionsListProviderFromActionsService helper function

- Add comprehensive test coverage for action listing functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AS["ActionsService"] -- "scaffolderActionsListProviderFromActionsService" --> SALP["ScaffolderActionsListProvider"]
  SALP -- "provides" --> CLSAA["createListScaffolderActionsAction"]
  CLSAA -- "registers" --> ARS["ActionsRegistryService"]
  ARS -- "exposes" --> LSA["list-scaffolder-actions action"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createListScaffolderActionsAction.ts</strong><dd><code>Implement list-scaffolder-actions action and provider</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createListScaffolderActionsAction.ts

<ul><li>Define ScaffolderActionsListProvider interface for listing scaffolder <br>actions<br> <li> Implement scaffolderActionsListProviderFromActionsService function to <br>build provider from ActionsService<br> <li> Create createListScaffolderActionsAction function that registers the <br>list-scaffolder-actions action<br> <li> Action returns sorted array of actions with id, description, schema, <br>and examples</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2409/files#diff-7788413cbceaa4eea95ce51e7012036a09632e2afc8d8218aad8c800c511abe5">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export list-scaffolder-actions and integrate into actions</code></dd></summary>
<hr>

workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/index.ts

<ul><li>Import and export createListScaffolderActionsAction and related types<br> <li> Add templateActionRegistry optional parameter to <br>createScaffolderActions options<br> <li> Register list-scaffolder-actions action alongside existing <br>fetch-template-metadata action<br> <li> Export ScaffolderActionsListProvider interface and <br>scaffolderActionsListProviderFromActionsService function</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2409/files#diff-20ab78f294006e815964018b2d1804516c38411912f2e50aa9417fc04f5b317e">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plugin.ts</strong><dd><code>Wire up ActionsService for list-scaffolder-actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/plugin.ts

<ul><li>Add actionsServiceRef dependency to plugin initialization<br> <li> Import scaffolderActionsListProviderFromActionsService helper function<br> <li> Create ScaffolderActionsListProvider instance from ActionsService<br> <li> Pass templateActionRegistry to createScaffolderActions during plugin <br>initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2409/files#diff-8c2c53b3e8b437712d47f3ba0535435075ecd7c78ff3c2d23f0b1c7ef62464ef">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createListScaffolderActionsAction.test.ts</strong><dd><code>Add comprehensive tests for list-scaffolder-actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createListScaffolderActionsAction.test.ts

<ul><li>Add comprehensive test suite with 6 test cases covering action listing <br>functionality<br> <li> Test successful listing with proper sorting and structure validation<br> <li> Test edge cases including minimal actions, empty registries, and <br>missing providers<br> <li> Test consistency across multiple invocations and complex action <br>properties</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2409/files#diff-5de82be467208d7a4039b3bf11ed9aecbf7c3685b62fba339c40f97352a66db7">+310/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shy-flies-accept.md</strong><dd><code>Add changeset for list-scaffolder-actions feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspaces/mcp-integrations/.changeset/shy-flies-accept.md

<ul><li>Add changeset documenting the porting of list-scaffolder-actions MCP <br>tool<br> <li> Mark as minor version bump for scaffolder-mcp-extras plugin</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-plugins/pull/2409/files#diff-f85fbffdd187f1ef7a9389f3714d72da6eb3b2c03f24b265f180e78eaf9e05fc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

