### PR TITLE
Fix Dynamic Plugin Script - Prevent running cd <DIR> on files

### DIFF
--- a/workspaces/cost-management/scripts/dynamic-plugins.sh
+++ b/workspaces/cost-management/scripts/dynamic-plugins.sh
@@ -61,10 +61,11 @@ function clean {
 }
 
 function _update_version {
-  for dir in $(ls -1d plugins/* | tail -n +2); do
-    cd "$(realpath $dir)"
+  for dir in "$workspace_dir"/plugins/*/; do
+    [[ -d "$dir" ]] || continue
+    cd "$dir"
     yarn version $VERSION --immediate
-    cd -
+    cd - > /dev/null
   done
 }
 


### PR DESCRIPTION
While Running VERSION=<X.X.X> ./script/dynamic-plugin.sh oci

we have the following issue:
The file "<FILE_NAME>.md" is not a directory.

so the fix is basically to check if the current path is not directory, then ignore.