### PR TITLE
chore: Add a .gitleaks.toml to fix the false/positives from the infosec scans

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[allowlist]
+description = "Global Allowlist"
+
+regexes = [
+  '''ABTLWHOULUVAXGTRYU7OC2876QJ2O''',
+  '''GR1348941oP5naQnWsbJRTvXHC7VJ''',
+  '''ghs_16C7e42F292c6912E7710c838347Ae178B4a''',
+]


### PR DESCRIPTION

There were some invalid access tokens in some of the test files that were triggering the infosec scans to report false positives.  

After talking with that group, it was recommended that we add this `.gitleaks.toml` file and add those to the allowed list so the scans would not report them.

I confirmed that the scan ignores these by running the rh-gitleaks tool locally.

cc @kim-tsao 


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
