### PR TITLE
chore(release): fix typo that results in is_version_pr being falsely evaluated

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -34,7 +34,7 @@ jobs:
               if [[ "$PR_TITLE" == Version*Packages* \
               && "$USER_LOGIN" == "rhdh-bot" ]] \
               && [[ "$HEAD_REF" == maintenance-changesets-release/* ]] \
-              && [[ "PR_MERGED" == "true" ]]; then
+              && [[ "$PR_MERGED" == "true" ]]; then
                 echo "is_version_pr=true" >> $GITHUB_OUTPUT
               else
                 echo "is_version_pr=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Hey, I just made a Pull Request!

See https://github.com/redhat-developer/rhdh-plugins/actions/runs/22719300104/job/65887209269#step:2:98 where `is_version_pr` is incorrectly set to `false`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
