### PR TITLE
feat(x2a): show icon for external links

### DIFF
--- a/workspaces/x2a/.changeset/free-mice-vanish.md
+++ b/workspaces/x2a/.changeset/free-mice-vanish.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+Add icon for external links.

--- a/workspaces/x2a/plugins/x2a/src/components/ArtifactLink.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ArtifactLink.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Link } from '@backstage/core-components';
+import { makeStyles } from '@material-ui/core';
+import LaunchIcon from '@material-ui/icons/Launch';
+import { Artifact } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+
+import { useTranslation } from '../hooks/useTranslation';
+import { buildArtifactUrl, humanizeArtifactType } from './tools';
+
+const useStyles = makeStyles({
+  artifact: {
+    margin: 0,
+    padding: 0,
+  },
+  externalIcon: {
+    marginLeft: 4,
+    verticalAlign: 'middle',
+    fontSize: 'inherit',
+  },
+});
+
+export const ArtifactLink = ({
+  artifact,
+  targetRepoUrl,
+  targetRepoBranch,
+}: {
+  artifact?: Artifact;
+  targetRepoUrl: string;
+  targetRepoBranch: string;
+}) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  if (!artifact) {
+    return t('module.phases.none');
+  }
+
+  return (
+    <Link
+      to={buildArtifactUrl(artifact.value, targetRepoUrl, targetRepoBranch)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={classes.artifact}
+    >
+      {humanizeArtifactType(t, artifact.type)}
+      <LaunchIcon className={classes.externalIcon} aria-hidden />
+    </Link>
+  );
+};

--- a/workspaces/x2a/plugins/x2a/src/components/Artifacts.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/Artifacts.tsx
@@ -14,43 +14,11 @@
  * limitations under the License.
  */
 import { Fragment } from 'react';
-import { Link } from '@backstage/core-components';
-import { makeStyles } from '@material-ui/core';
 import { Artifact } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
-import { useTranslation } from '../hooks/useTranslation';
-import { buildArtifactUrl, humanizeArtifactType } from './tools';
+import { ArtifactLink } from './ArtifactLink';
 
-const styles = makeStyles({
-  artifact: {
-    margin: 0,
-    padding: 0,
-  },
-});
-
-export const ArtifactLink = ({
-  artifact,
-  targetRepoUrl,
-  targetRepoBranch,
-}: {
-  artifact: Artifact;
-  targetRepoUrl: string;
-  targetRepoBranch: string;
-}) => {
-  const classes = styles();
-  const { t } = useTranslation();
-  return (
-    <Link
-      to={buildArtifactUrl(artifact.value, targetRepoUrl, targetRepoBranch)}
-      target="_blank"
-      rel="noopener noreferrer"
-      key={artifact.id}
-      className={classes.artifact}
-    >
-      {humanizeArtifactType(t, artifact.type)}
-    </Link>
-  );
-};
+export { ArtifactLink } from './ArtifactLink';
 
 export const Artifacts = ({
   artifacts,
@@ -61,7 +29,6 @@ export const Artifacts = ({
   targetRepoUrl: string;
   targetRepoBranch: string;
 }) => {
-  // Keep it dense
   return (
     <div>
       {artifacts.map(artifact => (

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/ArtifactsCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/ArtifactsCard.tsx
@@ -22,32 +22,8 @@ import { Grid } from '@material-ui/core';
 
 import { useTranslation } from '../../hooks/useTranslation';
 import { ItemField } from '../ItemField';
-import { Link, InfoCard } from '@backstage/core-components';
-import { buildArtifactUrl, humanizeArtifactType } from '../tools';
-
-const ArtifactLink = ({
-  artifact,
-  targetRepoUrl,
-  targetRepoBranch,
-}: {
-  artifact?: Artifact;
-  targetRepoUrl: string;
-  targetRepoBranch: string;
-}) => {
-  const { t } = useTranslation();
-  if (!artifact) {
-    return t('module.phases.none');
-  }
-  return (
-    <Link
-      to={buildArtifactUrl(artifact.value, targetRepoUrl, targetRepoBranch)}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {humanizeArtifactType(t, artifact.type)}
-    </Link>
-  );
-};
+import { InfoCard } from '@backstage/core-components';
+import { ArtifactLink } from '../ArtifactLink';
 
 export const ArtifactsCard = ({
   module,

--- a/workspaces/x2a/plugins/x2a/src/components/Repository.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/Repository.tsx
@@ -16,6 +16,7 @@
 
 import { Link } from '@backstage/core-components';
 import { Chip, makeStyles, SvgIcon, Typography } from '@material-ui/core';
+import LaunchIcon from '@material-ui/icons/Launch';
 import { buildRepoBranchUrl } from './tools';
 
 const useStyles = makeStyles(theme => ({
@@ -24,6 +25,11 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column' as const,
     alignItems: 'flex-start',
     gap: theme.spacing(0.5),
+  },
+  externalIcon: {
+    marginLeft: 4,
+    verticalAlign: 'middle',
+    fontSize: 'inherit',
   },
 }));
 
@@ -64,6 +70,7 @@ export const Repository = ({
           rel="noopener noreferrer"
         >
           {url}
+          <LaunchIcon className={classes.externalIcon} aria-hidden />
         </Link>
       </Typography>
     </div>

--- a/workspaces/x2a/plugins/x2a/src/components/tools/buildArtifactUrl.test.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/buildArtifactUrl.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildArtifactUrl } from './buildArtifactUrl';
+
+describe('buildArtifactUrl', () => {
+  describe('GitHub', () => {
+    it('builds blob URL for a GitHub repo', () => {
+      expect(
+        buildArtifactUrl(
+          'path/to/file.txt',
+          'https://github.com/owner/repo',
+          'main',
+        ),
+      ).toBe('https://github.com/owner/repo/blob/main/path/to/file.txt');
+    });
+
+    it('strips .git suffix', () => {
+      expect(
+        buildArtifactUrl(
+          'README.md',
+          'https://github.com/owner/repo.git',
+          'main',
+        ),
+      ).toBe('https://github.com/owner/repo/blob/main/README.md');
+    });
+
+    it('handles trailing slash in repo URL', () => {
+      expect(
+        buildArtifactUrl(
+          'src/index.ts',
+          'https://github.com/owner/repo/',
+          'develop',
+        ),
+      ).toBe('https://github.com/owner/repo/blob/develop/src/index.ts');
+    });
+
+    it('encodes branch names with special characters', () => {
+      expect(
+        buildArtifactUrl(
+          'file.txt',
+          'https://github.com/org/repo',
+          'feature/foo-bar',
+        ),
+      ).toBe('https://github.com/org/repo/blob/feature%2Ffoo-bar/file.txt');
+    });
+
+    it('handles nested path (org/group/repo)', () => {
+      expect(
+        buildArtifactUrl(
+          'docs/README.md',
+          'https://github.com/org/group/repo',
+          'main',
+        ),
+      ).toBe('https://github.com/org/group/repo/blob/main/docs/README.md');
+    });
+  });
+
+  describe('GitLab', () => {
+    it('builds blob URL with /-/ prefix for GitLab.com', () => {
+      expect(
+        buildArtifactUrl(
+          'path/to/file.txt',
+          'https://gitlab.com/group/project',
+          'main',
+        ),
+      ).toBe('https://gitlab.com/group/project/-/blob/main/path/to/file.txt');
+    });
+
+    it('strips .git suffix for GitLab', () => {
+      expect(
+        buildArtifactUrl(
+          'README.md',
+          'https://gitlab.com/group/project.git',
+          'main',
+        ),
+      ).toBe('https://gitlab.com/group/project/-/blob/main/README.md');
+    });
+
+    it('handles self-hosted GitLab', () => {
+      expect(
+        buildArtifactUrl(
+          'src/main.py',
+          'https://gitlab.example.com/myorg/myproject',
+          'develop',
+        ),
+      ).toBe(
+        'https://gitlab.example.com/myorg/myproject/-/blob/develop/src/main.py',
+      );
+    });
+
+    it('handles trailing slash in GitLab repo URL', () => {
+      expect(
+        buildArtifactUrl(
+          'file.txt',
+          'https://gitlab.com/group/project/',
+          'main',
+        ),
+      ).toBe('https://gitlab.com/group/project/-/blob/main/file.txt');
+    });
+
+    it('encodes branch names with special characters', () => {
+      expect(
+        buildArtifactUrl(
+          'file.txt',
+          'https://gitlab.com/group/repo',
+          'feature/foo-bar',
+        ),
+      ).toBe('https://gitlab.com/group/repo/-/blob/feature%2Ffoo-bar/file.txt');
+    });
+  });
+
+  describe('invalid URL', () => {
+    it('falls back to simple concatenation for invalid URLs', () => {
+      expect(buildArtifactUrl('file.txt', 'not-a-valid-url', 'main')).toBe(
+        'not-a-valid-url/blob/main/file.txt',
+      );
+    });
+
+    it('falls back to simple concatenation for empty URL', () => {
+      expect(buildArtifactUrl('file.txt', '', 'main')).toBe(
+        '/blob/main/file.txt',
+      );
+    });
+  });
+});

--- a/workspaces/x2a/plugins/x2a/src/components/tools/buildArtifactUrl.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/buildArtifactUrl.ts
@@ -13,15 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { getScmProvider } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+
+/**
+ * Builds a URL to a specific file (artifact) in a repository at a given branch.
+ * Supports GitHub and GitLab (including self-hosted).
+ */
 export const buildArtifactUrl = (
   value: string,
   targetRepoUrl: string,
   targetRepoBranch: string,
 ): string => {
-  // Remove .git suffix if present (repos normalized for cloning have .git)
   const baseUrl = targetRepoUrl.endsWith('.git')
     ? targetRepoUrl.slice(0, -4)
     : targetRepoUrl;
 
-  return `${baseUrl}/blob/${targetRepoBranch}/${value}`;
+  try {
+    const parsed = new URL(baseUrl);
+    const provider = getScmProvider(baseUrl);
+    const pathWithoutTrailingSlash = parsed.pathname.replace(/\/$/, '');
+    const encodedBranch = encodeURIComponent(targetRepoBranch);
+
+    if (provider === 'gitlab') {
+      return `${parsed.origin}${pathWithoutTrailingSlash}/-/blob/${encodedBranch}/${value}`;
+    }
+
+    return `${parsed.origin}${pathWithoutTrailingSlash}/blob/${encodedBranch}/${value}`;
+  } catch {
+    return `${baseUrl}/blob/${targetRepoBranch}/${value}`;
+  }
 };


### PR DESCRIPTION
Partial fix: FLPATH-3388

## Hey, I just made a Pull Request!

External links are newly marked with an icon for better visibility.

<img width="1442" height="898" alt="Screenshot From 2026-03-06 11-30-08" src="https://github.com/user-attachments/assets/a2dc51ae-a9c3-42f4-805d-386cd8bbb977" />

---

<img width="1442" height="898" alt="Screenshot From 2026-03-06 11-30-16" src="https://github.com/user-attachments/assets/4da84169-6274-44ea-ac8c-50a9529773a0" />
