### PR TITLE
chore: update the orchestrator-node plugin to use the 1.5.0 version of the backend api plugin

### DIFF
--- a/workspaces/orchestrator/.changeset/empty-bikes-suffer.md
+++ b/workspaces/orchestrator/.changeset/empty-bikes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-node': patch
+---
+
+Updating the backend-plugin-api to 1.5.0 to be inline with the other packages

--- a/workspaces/orchestrator/plugins/orchestrator-node/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-node/package.json
@@ -42,7 +42,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "^1.4.4",
+    "@backstage/backend-plugin-api": "^1.5.0",
     "@red-hat-developer-hub/backstage-plugin-orchestrator-common": "workspace:^"
   },
   "devDependencies": {

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -12590,7 +12590,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@red-hat-developer-hub/backstage-plugin-orchestrator-node@workspace:plugins/orchestrator-node"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.4.4
+    "@backstage/backend-plugin-api": ^1.5.0
     "@backstage/cli": ^0.34.4
     "@red-hat-developer-hub/backstage-plugin-orchestrator-common": "workspace:^"
   languageName: unknown


### PR DESCRIPTION
 Related to errors while building production builds of the loki module

Same commit as the PR #2481 but this targets the orchestrator-1.9 branch

I wasn't sure which one to do,  so did both


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
