### PR TITLE
fix(x2a): icon alignment and branch icon size

### DIFF
--- a/workspaces/x2a/.changeset/cool-ads-wait.md
+++ b/workspaces/x2a/.changeset/cool-ads-wait.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+Fixing alignment of the external link icon. Sprucing up the git branch icon. Rearranging the description field.

--- a/workspaces/x2a/plugins/x2a/src/components/ArtifactLink.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ArtifactLink.tsx
@@ -25,10 +25,11 @@ const useStyles = makeStyles({
   artifact: {
     margin: 0,
     padding: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
   },
   externalIcon: {
     marginLeft: 4,
-    verticalAlign: 'middle',
     fontSize: 'inherit',
   },
 });

--- a/workspaces/x2a/plugins/x2a/src/components/ProjectPage/ProjectDetailsCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ProjectPage/ProjectDetailsCard.tsx
@@ -50,13 +50,6 @@ export const ProjectDetailsCard = ({ project }: { project: Project }) => {
           />
         </Grid>
 
-        <Grid {...gridItemProps} xs={8}>
-          <ItemField
-            label={t('projectDetailsCard.description')}
-            value={project.description || empty}
-          />
-        </Grid>
-
         <Grid {...gridItemProps}>
           <ItemField
             label={t('projectDetailsCard.abbreviation')}
@@ -109,6 +102,13 @@ export const ProjectDetailsCard = ({ project }: { project: Project }) => {
                 t('empty')
               )
             }
+          />
+        </Grid>
+
+        <Grid {...gridItemProps} xs={12}>
+          <ItemField
+            label={t('projectDetailsCard.description')}
+            value={project.description || empty}
           />
         </Grid>
       </Grid>

--- a/workspaces/x2a/plugins/x2a/src/components/Repository.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/Repository.tsx
@@ -25,26 +25,40 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column' as const,
     alignItems: 'flex-start',
     gap: theme.spacing(0.5),
+    overflow: 'hidden',
+  },
+  externalLink: {
+    wordBreak: 'break-all' as const,
   },
   externalIcon: {
     marginLeft: 4,
-    verticalAlign: 'middle',
+    verticalAlign: 'text-bottom',
     fontSize: 'inherit',
+  },
+  branchIcon: {
+    marginLeft: '5px',
   },
 }));
 
-const GitBranchIcon = () => (
-  <SvgIcon fontSize="small" viewBox="0 0 24 24">
-    <path
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="M6 3v12m0 0a3 3 0 1 0 3 3m-3-3a3 3 0 0 1 3 3m0 0h6a3 3 0 0 0 3-3V9m0 0a3 3 0 1 0-3-3m3 3a3 3 0 0 1-3-3"
-    />
-  </SvgIcon>
-);
+const GitBranchIcon = () => {
+  const classes = useStyles();
+  return (
+    <SvgIcon
+      fontSize="inherit"
+      viewBox="0 0 24 24"
+      className={classes.branchIcon}
+    >
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M6 3v12m0 0a3 3 0 1 0 3 3m-3-3a3 3 0 0 1 3 3m0 0h6a3 3 0 0 0 3-3V9m0 0a3 3 0 1 0-3-3m3 3a3 3 0 0 1-3-3"
+      />
+    </SvgIcon>
+  );
+};
 
 export const Repository = ({
   url,
@@ -68,6 +82,7 @@ export const Repository = ({
           to={buildRepoBranchUrl(url, branch)}
           target="_blank"
           rel="noopener noreferrer"
+          className={classes.externalLink}
         >
           {url}
           <LaunchIcon className={classes.externalIcon} aria-hidden />


### PR DESCRIPTION
Fixing alignment of the external link icon.
Sprucing up the git branch icon.
Rearranging the description field.

<img width="525" height="587" alt="Screenshot From 2026-03-09 08-30-25" src="https://github.com/user-attachments/assets/d8c89ec5-179d-40fe-b3c2-59ff80eb29ef" />

---

<img width="755" height="565" alt="Screenshot From 2026-03-09 08-30-35" src="https://github.com/user-attachments/assets/2c7aa60b-6d96-4d77-8895-4ff4ced39a90" />
