### PR TITLE
fix(x2a): Rearrange ModulePage

### DIFF
--- a/workspaces/x2a/.changeset/wet-wolves-make.md
+++ b/workspaces/x2a/.changeset/wet-wolves-make.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+Rearrange the ModulePage grid items to make the artifacts and details card more readable.

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/ArtifactsCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/ArtifactsCard.tsx
@@ -50,7 +50,7 @@ export const ArtifactsCard = ({
   return (
     <InfoCard title={t('modulePage.artifacts.title')} variant="gridItem">
       <Grid container direction="row" spacing={3}>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField
             label={t('modulePage.artifacts.migration_plan')}
             value={
@@ -62,7 +62,7 @@ export const ArtifactsCard = ({
             }
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField
             label={t('modulePage.artifacts.module_migration_plan')}
             value={
@@ -74,7 +74,7 @@ export const ArtifactsCard = ({
             }
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField
             label={t('modulePage.artifacts.migrated_sources')}
             value={
@@ -86,7 +86,7 @@ export const ArtifactsCard = ({
             }
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField
             label={t('modulePage.artifacts.ansible_project')}
             value={
@@ -98,6 +98,7 @@ export const ArtifactsCard = ({
             }
           />
         </Grid>
+
         <Grid item xs={12}>
           {t('modulePage.artifacts.description')}
         </Grid>

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModuleDetailsCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModuleDetailsCard.tsx
@@ -28,16 +28,16 @@ export const ModuleDetailsCard = ({ module }: { module?: Module }) => {
   return (
     <InfoCard title={t('modulePage.title')} variant="gridItem">
       <Grid container direction="row" spacing={3}>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField label={t('module.name')} value={module?.name || empty} />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField
             label={t('module.status')}
             value={module?.status || empty}
           />
         </Grid>
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <ItemField
             label={t('module.sourcePath')}
             value={module?.sourcePath || empty}

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModulePage.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModulePage.tsx
@@ -154,8 +154,8 @@ export const ModulePage = () => {
         )}
         {isLoading && <Progress />}
         {!isLoading && (
-          <Grid container spacing={3} direction="column">
-            <Grid item>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
               <ArtifactsCard
                 module={module}
                 targetRepoUrl={project?.targetRepoUrl || ''}
@@ -163,10 +163,10 @@ export const ModulePage = () => {
                 migrationPlanArtifact={project?.migrationPlan}
               />
             </Grid>
-            <Grid item>
+            <Grid item xs={12} md={6}>
               <ModuleDetailsCard module={module} />
             </Grid>
-            <Grid item>
+            <Grid item xs={12}>
               <PhasesCard
                 module={module}
                 projectId={projectId}


### PR DESCRIPTION
Fixes: FLPATH-3388

Rearrange the ModulePage grid items to make the artifacts and details card more readable.

Before:

<img width="1290" height="1051" alt="Screenshot From 2026-03-09 09-14-44" src="https://github.com/user-attachments/assets/88765858-5c9c-4f4d-bc91-0748bb193325" />

---

After:

<img width="1290" height="1051" alt="Screenshot From 2026-03-09 09-14-11" src="https://github.com/user-attachments/assets/47382650-1137-4a2a-bb08-e132fe44c42b" />

