### PR TITLE
fix(x2a): alignment and wrapping of module and status cells

### DIFF
--- a/workspaces/x2a/.changeset/bold-frogs-clap.md
+++ b/workspaces/x2a/.changeset/bold-frogs-clap.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+Fix alignment and wrapping of module and status with icons.

--- a/workspaces/x2a/plugins/x2a/src/components/ItemField.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ItemField.tsx
@@ -26,9 +26,13 @@ export const ItemField = ({
 }) => {
   return (
     <AboutField label={label}>
-      <Typography variant="subtitle2" component="div">
-        {typeof value === 'string' ? <b>{value}</b> : value}
-      </Typography>
+      {typeof value === 'string' ? (
+        <Typography variant="subtitle2" component="div">
+          <b>{value}</b>
+        </Typography>
+      ) : (
+        value
+      )}
     </AboutField>
   );
 };

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModuleDetailsCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/ModuleDetailsCard.tsx
@@ -20,6 +20,7 @@ import { InfoCard } from '@backstage/core-components';
 
 import { useTranslation } from '../../hooks/useTranslation';
 import { ItemField } from '../ItemField';
+import { ModuleStatusCell } from '../ModuleStatusCell';
 
 export const ModuleDetailsCard = ({ module }: { module?: Module }) => {
   const { t } = useTranslation();
@@ -34,7 +35,7 @@ export const ModuleDetailsCard = ({ module }: { module?: Module }) => {
         <Grid item xs={4}>
           <ItemField
             label={t('module.status')}
-            value={module?.status || empty}
+            value={<ModuleStatusCell module={module} />}
           />
         </Grid>
         <Grid item xs={4}>

--- a/workspaces/x2a/plugins/x2a/src/components/ModuleStatusCell.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModuleStatusCell.tsx
@@ -34,20 +34,48 @@ const useStyles = makeStyles(theme => ({
     marginLeft: theme.spacing(1),
     marginBottom: 0,
   },
+  unknownStatus: {
+    fontWeight: theme.typography.fontWeightMedium as any,
+    display: 'flex',
+    alignItems: 'baseline',
+  },
+  unknownStatusIcon: {
+    flexShrink: 0,
+    position: 'relative',
+    top: '0.125em',
+    marginRight: theme.spacing(1),
+    width: '0.8em',
+    height: '0.8em',
+  },
 }));
 
-const StatusIcon = ({ status }: { status?: ModuleStatus }) => {
+const StatusWithText = ({
+  status,
+  children,
+}: {
+  status?: ModuleStatus;
+  children?: React.ReactNode;
+}) => {
+  const classes = useStyles();
   switch (status) {
     case 'success':
-      return <StatusOK />;
+      return <StatusOK>{children}</StatusOK>;
     case 'error':
-      return <StatusError />;
+      return <StatusError>{children}</StatusError>;
     case 'running':
-      return <StatusRunning />;
+      return <StatusRunning>{children}</StatusRunning>;
     case 'pending':
-      return <StatusPending />;
+      return <StatusPending>{children}</StatusPending>;
     default:
-      return <HelpOutlineIcon fontSize="small" color="disabled" />;
+      return (
+        <Box component="span" className={classes.unknownStatus}>
+          <HelpOutlineIcon
+            color="disabled"
+            className={classes.unknownStatusIcon}
+          />
+          {children}
+        </Box>
+      );
   }
 };
 
@@ -83,9 +111,10 @@ export const ModuleStatusCell = ({ module }: { module?: Module }) => {
   const status = module?.status;
   const statusText = t(`module.statuses.${status || 'none'}`);
   const content = (
-    <Box display="flex" alignItems="center">
-      <StatusIcon status={status} />
-      <div>{statusText}</div>
+    <Box display="flex" flexWrap="wrap" alignItems="center">
+      <Box whiteSpace="nowrap">
+        <StatusWithText status={status}>{statusText}</StatusWithText>
+      </Box>
       {chip}
     </Box>
   );

--- a/workspaces/x2a/plugins/x2a/src/components/ProjectPage/ProjectModulesCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ProjectPage/ProjectModulesCard.tsx
@@ -48,7 +48,7 @@ export const ProjectModulesCard = ({ modules }: { modules: Module[] }) => {
           const lastJob = getLastPhaseReached(module);
           return (
             <Fragment key={module.id}>
-              <Grid item xs={4}>
+              <Grid item xs={12} sm={4}>
                 <Link
                   to={modulePath({
                     projectId: module.projectId,
@@ -58,10 +58,10 @@ export const ProjectModulesCard = ({ modules }: { modules: Module[] }) => {
                   {module.name}
                 </Link>
               </Grid>
-              <Grid item xs={4}>
+              <Grid item xs={12} sm={4}>
                 <ModuleStatusCell module={module} />
               </Grid>
-              <Grid item xs={4}>
+              <Grid item xs={12} sm={4}>
                 <CurrentPhaseCell phase={lastJob?.phase} />
               </Grid>
               {index < modules.length - 1 && (

--- a/workspaces/x2a/plugins/x2a/src/components/ProjectStatusCell.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ProjectStatusCell.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 import { ProjectStatus } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import { PieChart, PieValueType } from '@mui/x-charts';
-import { Grid, makeStyles, Tooltip, Chip } from '@material-ui/core';
+import { Box, Grid, makeStyles, Tooltip, Chip } from '@material-ui/core';
 import AssignmentTurnedInIcon from '@material-ui/icons/AssignmentTurnedIn';
 
 import { useTranslation } from '../hooks/useTranslation';
@@ -27,6 +27,13 @@ const size = 25;
 const styles = makeStyles({
   tooltip: {
     width: 100,
+  },
+  statusText: {
+    overflowWrap: 'anywhere',
+    minWidth: 0,
+  },
+  clickable: {
+    cursor: 'pointer',
   },
 });
 
@@ -132,33 +139,35 @@ export const ProjectStatusCell = ({
   }
 
   return (
-    <Grid container direction="row" spacing={2}>
-      {isModulesSummary && (
-        <Grid item alignContent="flex-start" xs={2}>
-          <Tooltip
-            open={open}
-            onClose={() => setOpen(false)}
-            leaveDelay={1000}
-            placement="bottom"
-            arrow
-            title={tooltipContent}
-          >
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={(event: React.MouseEvent) => {
+    <Box>
+      {isModulesSummary ? (
+        <Tooltip
+          open={open}
+          onClose={() => setOpen(false)}
+          leaveDelay={1000}
+          placement="left-start"
+          arrow
+          title={tooltipContent}
+        >
+          <Box
+            display="flex"
+            alignItems="flex-start"
+            role="button"
+            tabIndex={0}
+            onClick={(event: React.MouseEvent) => {
+              event.stopPropagation();
+              setOpen(!open);
+            }}
+            onKeyDown={(event: React.KeyboardEvent) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
                 event.stopPropagation();
                 setOpen(!open);
-              }}
-              onKeyDown={(event: React.KeyboardEvent) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  setOpen(!open);
-                }
-              }}
-              style={{ cursor: 'pointer' }}
-            >
+              }
+            }}
+            className={classes.clickable}
+          >
+            <Box flexShrink={0} mr={1}>
               <PieChart
                 series={[{ innerRadius: 0, outerRadius: size / 2, data }]}
                 margin={{ right: 5 }}
@@ -166,17 +175,20 @@ export const ProjectStatusCell = ({
                 height={size}
                 slotProps={{ legend: { hidden: true } }}
               />
-            </div>
-          </Tooltip>
-        </Grid>
+            </Box>
+            <Box className={classes.statusText}>
+              {t(`project.statuses.${projectStatus.state || 'none'}`)}
+            </Box>
+          </Box>
+        </Tooltip>
+      ) : (
+        <Box className={classes.statusText}>
+          {t(`project.statuses.${projectStatus.state || 'none'}`)}
+        </Box>
       )}
 
-      <Grid item alignContent="center" xs={isModulesSummary ? 8 : 12}>
-        {t(`project.statuses.${projectStatus.state || 'none'}`)}
-      </Grid>
-
       {modulesSummary?.waiting > 0 && (
-        <Grid item alignContent="center">
+        <Box mt={0.5}>
           <Chip
             size="small"
             variant="outlined"
@@ -186,8 +198,8 @@ export const ProjectStatusCell = ({
               count: modulesSummary.waiting,
             })}
           />
-        </Grid>
+        </Box>
       )}
-    </Grid>
+    </Box>
   );
 };


### PR DESCRIPTION
Fix alignment and wrapping of module and status with icons.


Before:
<img width="423" height="1057" alt="Screenshot From 2026-03-09 09-38-29" src="https://github.com/user-attachments/assets/8179ae09-46a5-44ab-8dc4-c7249336ca70" />

---

After:
<img width="485" height="1261" alt="Screenshot From 2026-03-09 09-40-14" src="https://github.com/user-attachments/assets/38c9af81-4a87-4cb2-ae5d-0350f1d08858" />
