### PR TITLE
feat(x2a): add Input/output tokens

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/src/router/collectArtifacts.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/collectArtifacts.test.ts
@@ -415,6 +415,70 @@ describe('collectArtifacts routes', () => {
         }),
       );
     });
+
+    it('should persist telemetry with inputTokens and outputTokens', async () => {
+      const job: Job & { callbackToken?: string } = {
+        id: jobId,
+        projectId,
+        moduleId: undefined,
+        phase: 'init',
+        status: 'running',
+        startedAt: new Date(),
+        k8sJobName,
+        callbackToken,
+      };
+
+      const telemetry = {
+        summary: 'Init phase completed',
+        phase: 'init',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        agents: {
+          'agent-1': {
+            name: 'agent-1',
+            startedAt: new Date().toISOString(),
+            endedAt: new Date().toISOString(),
+            durationSeconds: 10.5,
+            inputTokens: 1500,
+            outputTokens: 800,
+            metrics: { key: 'value' },
+            toolCalls: { read: 5 },
+          },
+        },
+      };
+
+      mockDeps.x2aDatabase.getJob.mockResolvedValue(job);
+      mockDeps.kubeService.getJobLogs.mockResolvedValue('logs');
+      mockDeps.x2aDatabase.updateJob.mockResolvedValue(undefined);
+
+      const requestBody = {
+        status: 'success',
+        jobId,
+        artifacts: [],
+        telemetry,
+      };
+      const signature = signRequestBody(requestBody, callbackToken);
+
+      const res = await request(app)
+        .post(`/projects/${projectId}/collectArtifacts?phase=init`)
+        .set('X-Callback-Signature', signature)
+        .send(requestBody);
+
+      expect(res.status).toBe(200);
+      expect(mockDeps.x2aDatabase.updateJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telemetry: expect.objectContaining({
+            summary: 'Init phase completed',
+            agents: expect.objectContaining({
+              'agent-1': expect.objectContaining({
+                inputTokens: 1500,
+                outputTokens: 800,
+              }),
+            }),
+          }),
+        }),
+      );
+    });
   });
 
   describe('phase actions', () => {

--- a/workspaces/x2a/plugins/x2a-backend/src/router/collectArtifacts.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/collectArtifacts.ts
@@ -37,6 +37,8 @@ const agentMetricsSchema = z.object({
   startedAt: z.string().optional(),
   endedAt: z.string().optional(),
   durationSeconds: z.number(),
+  inputTokens: z.number().optional(),
+  outputTokens: z.number().optional(),
   metrics: z.record(z.any()).optional(),
   toolCalls: z.record(z.number()).optional(),
 });

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
@@ -851,6 +851,12 @@ components:
           type: number
           format: double
           description: Execution duration in seconds
+        inputTokens:
+          type: integer
+          description: LLM input token count for this agent
+        outputTokens:
+          type: integer
+          description: LLM output token count for this agent
         metrics:
           type: object
           additionalProperties: true

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/models/AgentMetrics.model.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/models/AgentMetrics.model.ts
@@ -40,6 +40,14 @@ export interface AgentMetrics {
    */
   durationSeconds: number;
   /**
+   * LLM input token count for this agent
+   */
+  inputTokens?: number;
+  /**
+   * LLM output token count for this agent
+   */
+  outputTokens?: number;
+  /**
    * Custom key-value metrics recorded by the agent
    */
   metrics?: { [key: string]: any };

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
@@ -1173,6 +1173,14 @@ export const spec = {
             "format": "double",
             "description": "Execution duration in seconds"
           },
+          "inputTokens": {
+            "type": "integer",
+            "description": "LLM input token count for this agent"
+          },
+          "outputTokens": {
+            "type": "integer",
+            "description": "LLM output token count for this agent"
+          },
           "metrics": {
             "type": "object",
             "additionalProperties": true,

--- a/workspaces/x2a/plugins/x2a-common/client/src/schema/openapi/generated/models/AgentMetrics.model.ts
+++ b/workspaces/x2a/plugins/x2a-common/client/src/schema/openapi/generated/models/AgentMetrics.model.ts
@@ -40,6 +40,14 @@ export interface AgentMetrics {
    */
   durationSeconds: number;
   /**
+   * LLM input token count for this agent
+   */
+  inputTokens?: number;
+  /**
+   * LLM output token count for this agent
+   */
+  outputTokens?: number;
+  /**
    * Custom key-value metrics recorded by the agent
    */
   metrics?: { [key: string]: any };

--- a/workspaces/x2a/plugins/x2a-common/report.api.md
+++ b/workspaces/x2a/plugins/x2a-common/report.api.md
@@ -19,10 +19,12 @@ export interface AAPCredentials {
 export interface AgentMetrics {
     durationSeconds: number;
     endedAt?: Date;
+    inputTokens?: number;
     metrics?: {
         [key: string]: any;
     };
     name: string;
+    outputTokens?: number;
     startedAt?: Date;
     toolCalls?: {
         [key: string]: number;


### PR DESCRIPTION
Collect that information on collectArtifacts.
Push that information on the Job status.

Related to: https://github.com/x2ansible/x2a-convertor/pull/149
The information to be stacked on top of: https://github.com/redhat-developer/rhdh-plugins/pull/2500