### PR TITLE
feat(orchestrator): add card height mode config for workflow run page…

### DIFF
--- a/workspaces/orchestrator/.changeset/workflow-instance-card-height.md
+++ b/workspaces/orchestrator/.changeset/workflow-instance-card-height.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+Add workflow instance card height mode config for fixed or content-based layouts.

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -103,5 +103,19 @@ export interface Config {
         value: string;
       }>;
     };
+    /**
+     * UI configuration for the workflow instance page.
+     * @visibility frontend
+     */
+    workflowInstancePage?: {
+      /**
+       * Controls card height behavior on the workflow instance page.
+       * "fixed" keeps the current fixed-height cards with internal scrolling.
+       * "content" lets cards expand to fit their content.
+       * Default: fixed
+       * @visibility frontend
+       */
+      cardHeightMode?: 'fixed' | 'content';
+    };
   };
 }

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
@@ -36,6 +36,7 @@ import {
 import { orchestratorApiRef } from '../../api/api';
 import { VALUE_UNAVAILABLE } from '../../constants';
 import { useTranslation } from '../../hooks/useTranslation';
+import { useWorkflowInstanceCardHeightMode } from '../../hooks/useWorkflowInstanceCardHeightMode';
 import { formatDuration } from '../../utils/DurationUtils';
 import { WorkflowRunDetail } from '../types/WorkflowRunDetail';
 import { VariablesDialog } from './VariablesDialog';
@@ -102,6 +103,11 @@ export const WorkflowInstancePageContent: React.FC<{
   const { t } = useTranslation();
   const { classes } = useStyles();
   const orchestratorApi = useApi(orchestratorApiRef);
+  const cardHeightMode = useWorkflowInstanceCardHeightMode();
+  const isFixedHeightMode = cardHeightMode !== 'content';
+  const topRowClassName = isFixedHeightMode ? classes.topRowCard : '';
+  const bottomRowClassName = isFixedHeightMode ? classes.bottomRowCard : '';
+  const cardOverflowClassName = isFixedHeightMode ? classes.cardClassName : '';
 
   const details = useMemo(
     () => mapProcessInstanceToDetails(instance, t),
@@ -161,6 +167,61 @@ export const WorkflowInstancePageContent: React.FC<{
     </Link>
   );
 
+  const detailsCard = (
+    <InfoCard
+      title={
+        <div className={classes.titleContainer}>
+          <Typography
+            component="span"
+            variant="h5"
+            className={classes.detailsTitle}
+          >
+            {t('common.details')}
+          </Typography>
+          {viewVariables}
+        </div>
+      }
+      divider={false}
+      className={topRowClassName}
+      cardClassName={cardOverflowClassName}
+    >
+      <WorkflowRunDetails details={details} />
+    </InfoCard>
+  );
+
+  const resultCard = (
+    <WorkflowResult
+      className={topRowClassName}
+      cardClassName={cardOverflowClassName}
+      instance={instance}
+    />
+  );
+
+  const inputsCard = (
+    <WorkflowInputs
+      className={bottomRowClassName}
+      cardClassName={cardOverflowClassName}
+      value={value}
+      loading={loading}
+      responseError={responseError}
+    />
+  );
+
+  const progressCard = (
+    <InfoCard
+      title={t('workflow.progress')}
+      divider={false}
+      className={bottomRowClassName}
+      cardClassName={cardOverflowClassName}
+    >
+      <WorkflowProgress
+        workflowError={instance.error}
+        workflowNodes={instance.nodes}
+        workflowStatus={instance.state}
+      />
+    </InfoCard>
+  );
+
   return (
     <Content noPadding>
       <VariablesDialog
@@ -169,60 +230,37 @@ export const WorkflowInstancePageContent: React.FC<{
         instanceVariables={instanceVariables}
       />
       <Grid container spacing={2}>
-        <Grid item xs={6}>
-          <InfoCard
-            title={
-              <div className={classes.titleContainer}>
-                <Typography
-                  component="span"
-                  variant="h5"
-                  className={classes.detailsTitle}
-                >
-                  {t('common.details')}
-                </Typography>
-                {viewVariables}
-              </div>
-            }
-            divider={false}
-            className={classes.topRowCard}
-            cardClassName={classes.cardClassName}
-          >
-            <WorkflowRunDetails details={details} />
-          </InfoCard>
-        </Grid>
-
-        <Grid item xs={6}>
-          <WorkflowResult
-            className={classes.topRowCard}
-            cardClassName={classes.cardClassName}
-            instance={instance}
-          />
-        </Grid>
-
-        <Grid item xs={6}>
-          <WorkflowInputs
-            className={classes.bottomRowCard}
-            cardClassName={classes.cardClassName}
-            value={value}
-            loading={loading}
-            responseError={responseError}
-          />
-        </Grid>
-
-        <Grid item xs={6}>
-          <InfoCard
-            title={t('workflow.progress')}
-            divider={false}
-            className={classes.bottomRowCard}
-            cardClassName={classes.cardClassName}
-          >
-            <WorkflowProgress
-              workflowError={instance.error}
-              workflowNodes={instance.nodes}
-              workflowStatus={instance.state}
-            />
-          </InfoCard>
-        </Grid>
+        {isFixedHeightMode ? (
+          <>
+            <Grid item xs={6}>
+              {detailsCard}
+            </Grid>
+            <Grid item xs={6}>
+              {resultCard}
+            </Grid>
+            <Grid item xs={6}>
+              {inputsCard}
+            </Grid>
+            <Grid item xs={6}>
+              {progressCard}
+            </Grid>
+          </>
+        ) : (
+          <>
+            <Grid item xs={6}>
+              <Grid container spacing={2} direction="column">
+                <Grid item>{detailsCard}</Grid>
+                <Grid item>{inputsCard}</Grid>
+              </Grid>
+            </Grid>
+            <Grid item xs={6}>
+              <Grid container spacing={2} direction="column">
+                <Grid item>{resultCard}</Grid>
+                <Grid item>{progressCard}</Grid>
+              </Grid>
+            </Grid>
+          </>
+        )}
       </Grid>
     </Content>
   );

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useWorkflowInstanceCardHeightMode.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useWorkflowInstanceCardHeightMode.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+
+export type WorkflowInstanceCardHeightMode = 'fixed' | 'content';
+
+export function useWorkflowInstanceCardHeightMode(): WorkflowInstanceCardHeightMode {
+  const config = useApi(configApiRef);
+  const value = config.getOptionalString(
+    'orchestrator.workflowInstancePage.cardHeightMode',
+  );
+
+  if (value && value !== 'fixed' && value !== 'content') {
+    // eslint-disable-next-line no-console
+    console.warn(`Unknown cardHeightMode "${value}", falling back to "fixed"`);
+  }
+
+  return value === 'content' ? 'content' : 'fixed';
+}


### PR DESCRIPTION
Manual cherry-pick of 309547d

### **User description**
## Hey, I just made a Pull Request!

#### Fixes:

https://issues.redhat.com/browse/RHDHBUGS-2676

#### Summary
- add `orchestrator.workflowInstancePage.cardHeightMode` config (fixed vs content)
- introduce a hook to read the config and apply height/overflow styles
- update workflow instance page to respect the selected mode
- default behavior: if config is missing or invalid, use `fixed` (current layout)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
