### PR TITLE
fix(scorecard): fix race condition

### DIFF
--- a/workspaces/scorecard/packages/app/e2e-tests/pages/CatalogPage.ts
+++ b/workspaces/scorecard/packages/app/e2e-tests/pages/CatalogPage.ts
@@ -47,6 +47,7 @@ export class CatalogPage {
 
   async openCatalog() {
     await this.page.getByRole('link', { name: 'Catalog', exact: true }).click();
+    await this.page.getByTestId('user-picker-all').getByText('All').click();
   }
 
   async openComponent(componentName: string) {


### PR DESCRIPTION
### Summary
Stabilize scorecard e2e by explicitly setting the Catalog entity picker to "All" in `openCatalog()`, removing a race between navigation and the user-picker being ready.

### Solution
In `CatalogPage.openCatalog()`, after clicking the Catalog nav link we now wait for and click the "All" option in the user-picker:

```ts
await this.page.getByTestId('user-picker-all').getByText('All').click();
```

This:

- Ensures the user-picker has rendered and is interactive before the test continues.
- Puts the Catalog in a known state (filter = "All") so later steps (e.g. search, open component) behave consistently.
- Eliminates the race between "Catalog opened" and "user-picker ready / filter applied", so the suite passes reliably on CI.

