### PR TITLE
fix(adoption-insights): normalize event timestamps to UTC and fix frontend date parsing

### DIFF
--- a/workspaces/adoption-insights/.changeset/four-areas-rush.md
+++ b/workspaces/adoption-insights/.changeset/four-areas-rush.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights-backend': patch
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+normalize event timestamps to UTC and fix frontend date parsing

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/models/Event.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/models/Event.ts
@@ -19,6 +19,7 @@ import {
   AnalyticsEvent,
   AnalyticsEventAttributes,
 } from '@backstage/core-plugin-api';
+import { normalizeToUTCISO } from '../utils/date';
 
 export type EventType = {
   user_ref: string;
@@ -49,8 +50,11 @@ export class Event {
     this.action = event.action;
     this.subject = event.subject;
     this.value = event.value;
-    this.created_at =
+    const rawTimestamp =
       (event.context?.timestamp as string) || new Date().toISOString();
+    this.created_at = normalizeToUTCISO(
+      typeof rawTimestamp === 'string' ? rawTimestamp : new Date(),
+    );
 
     // Handle type-based conversion
     this.context = isJson ? event.context : JSON.stringify(event.context ?? {});

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.test.ts
@@ -20,6 +20,7 @@ import {
   getDateGroupingType,
   getTimeZoneOffsetString,
   isSameMonth,
+  normalizeToUTCISO,
   toEndOfDayUTC,
   toStartOfDayUTC,
 } from './date';
@@ -108,6 +109,42 @@ describe('convertToTargetTimezone', () => {
     expect(convertToTargetTimezone('2025-03-02T18:00:00.000Z')).toBe(
       '2025-03-02T23:30:00.000+05:30',
     );
+  });
+});
+
+describe('normalizeToUTCISO', () => {
+  it('should return ISO string for Date input', () => {
+    const d = new Date('2026-03-11T16:17:46.540Z');
+    expect(normalizeToUTCISO(d)).toBe('2026-03-11T16:17:46.540Z');
+  });
+
+  it('should normalize ISO with Z to UTC ISO', () => {
+    expect(normalizeToUTCISO('2026-03-11T16:17:46.540Z')).toBe(
+      '2026-03-11T16:17:46.540Z',
+    );
+  });
+
+  it('should normalize ISO with offset to UTC ISO', () => {
+    expect(normalizeToUTCISO('2026-03-11T11:17:46.540-05:00')).toBe(
+      '2026-03-11T16:17:46.540Z',
+    );
+  });
+
+  it('should normalize "yyyy-MM-dd HH:mm:ss.SSS -0500" to UTC ISO', () => {
+    expect(normalizeToUTCISO('2026-03-11 11:17:46.540 -0500')).toBe(
+      '2026-03-11T16:17:46.540Z',
+    );
+  });
+
+  it('should normalize "yyyy-MM-dd HH:mm:ss -0500" to UTC ISO', () => {
+    expect(normalizeToUTCISO('2026-03-11 11:17:46 -0500')).toBe(
+      '2026-03-11T16:17:46.000Z',
+    );
+  });
+
+  it('should return original string when unparseable (no silent substitution with current time)', () => {
+    const unparseable = 'not-a-date';
+    expect(normalizeToUTCISO(unparseable)).toBe(unparseable);
   });
 });
 

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/src/utils/date.ts
@@ -56,6 +56,38 @@ export const hasZFormat = (dateStr: string): boolean => {
   return dateStr.includes('Z') || dateStr.includes('T');
 };
 
+/**
+ * Normalize any date string or Date to UTC ISO string (e.g. 2026-03-11T16:17:46.540Z).
+ * Use this before storing timestamps in the database so they are consistent.
+ */
+export const normalizeToUTCISO = (date: string | Date): string => {
+  if (date instanceof Date) {
+    return date.toISOString();
+  }
+  const s = String(date).trim();
+  // Luxon fromISO handles ISO with Z or offset (e.g. -05:00)
+  let dt = DateTime.fromISO(s, { setZone: true });
+  if (dt.isValid) {
+    return dt.toUTC().toISO() ?? s;
+  }
+  // Try "yyyy-MM-dd HH:mm:ss.SSS -0500" or "yyyy-MM-dd HH:mm:ss -0500" style
+  dt = DateTime.fromFormat(s, 'yyyy-MM-dd HH:mm:ss.SSS ZZZ', { setZone: true });
+  if (dt.isValid) {
+    return dt.toUTC().toISO() ?? s;
+  }
+  dt = DateTime.fromFormat(s, 'yyyy-MM-dd HH:mm:ss ZZZ', { setZone: true });
+  if (dt.isValid) {
+    return dt.toUTC().toISO() ?? s;
+  }
+  dt = DateTime.fromFormat(s, 'yyyy-MM-dd HH:mm:ss', { zone: 'UTC' });
+  if (dt.isValid) {
+    return dt.toISO() ?? s;
+  }
+  // Return original when unparseable: do not substitute current time, which would
+  // silently corrupt created_at and misplace events in partitions/date-range queries.
+  return s;
+};
+
 export const convertToTargetTimezone = (
   date: string | Date,
   timeZone: string = new Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/__tests__/utils.test.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/__tests__/utils.test.ts
@@ -53,6 +53,12 @@ describe('safeDate', () => {
     expect(result.toISOString()).toBe('2025-09-29T00:00:00.000Z');
   });
 
+  it('should normalize short offset -04 to -04:00 for parsing', () => {
+    const result = safeDate('2026-03-09T01:00:00-04');
+    expect(result).toBeInstanceOf(Date);
+    expect(result.toISOString()).toBe('2026-03-09T05:00:00.000Z');
+  });
+
   it('should handle invalid dates gracefully', () => {
     const result = safeDate('invalid-date');
     expect(result).toBeInstanceOf(Date);

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/utils/utils.ts
@@ -30,12 +30,18 @@ import { APIsViewOptions } from '../types';
 import { adoptionInsightsTranslationRef } from '../translations';
 
 /**
- * Parse date string and normalize timezone format.
- * Converts +00 timezone format to Z for better browser compatibility.
+ * Parse date string and normalize timezone format for browser compatibility.
+ * - Converts +00 at end to Z.
+ * - Expands short offset (e.g. -04 or +05) to -04:00 or +05:00 so Date parses reliably.
  */
 export const safeDate = (dateString: string): Date => {
-  const normalizedDate = dateString.replace(/\+00$/, 'Z');
-  return new Date(normalizedDate);
+  let normalized = dateString.replace(/\+00$/, 'Z');
+  // Short offset like -04 or +05 is not reliably parsed by Date; expand to -04:00 or +05:00.
+  // Only apply when string has a time part (T) so we don't change date-only strings like 2025-03-01.
+  if (normalized.includes('T')) {
+    normalized = normalized.replace(/([-+])(\d{2})$/g, '$1$2:00');
+  }
+  return new Date(normalized);
 };
 
 // =============================================================================


### PR DESCRIPTION


## Hey, I just made a Pull Request!


Fixes:

https://redhat.atlassian.net/browse/RHDHBUGS-2826


<img width="1656" height="955" alt="image" src="https://github.com/user-attachments/assets/c852c1d2-5a93-478a-9c96-5b15e04b4098" />

This PR introduces normalization of timestamps to UTC while storing in database and while parsing in the frontend.


## Steps to test:


**Without this PR changes, the following will break the UI**

1. Mock UseActiveUsers API  to return date strings with short offset (e.g. 2026-03-09T01:00:00-04)

```diff
diff --git a/workspaces/adoption-insights/plugins/adoption-insights/src/hooks/useActive
Users.tsx b/workspaces/adoption-insights/plugins/adoption-insights/src/hooks/useActiveU
sers.tsx
index 1da69628..9007a7c7 100644
--- a/workspaces/adoption-insights/plugins/adoption-insights/src/hooks/useActiveUsers.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/hooks/useActiveUsers.tsx
@@ -55,7 +55,17 @@ export const useActiveUsers = (): {
         grouping,
       })
       .then(response =>
-        setActiveUsers(response ?? { grouping: undefined, data: [] }),
+        setActiveUsers( {
+          "grouping": "weekly",
+          "data": [
+            {
+              "date": "2026-03-09T01:00:00-04",
+              "total_users": 2,
+              "new_users": 2,
+              "returning_users": 0
+            }
+          ]
+        }  ?? { grouping: undefined, data: [] }),
       );
   }, [api, startDateRange, endDateRange, grouping]);
  ```

2 .Visit adoption insights UI and notice that it breaks the user interface.



Note:  **with this PR changes it should NOT break the UI***




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
