### PR TITLE
fix(x2a): report git clone and init-phase errors to the UI

### DIFF
--- a/workspaces/x2a/.changeset/rich-meals-tan.md
+++ b/workspaces/x2a/.changeset/rich-meals-tan.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+Bugfix - failures in git clone and init-phase are propagated to the UI.

--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -23,7 +23,11 @@ report_result() {
     url="${url}&moduleId=${MODULE_ID}"
   fi
 
-  local cmd=(uv run app.py report --url "${url}" --job-id "${JOB_ID}" --source-dir "${SOURCE_BASE}")
+  local cmd=(uv run app.py report --url "${url}" --job-id "${JOB_ID}")
+
+  if [ -n "${SOURCE_BASE:-}" ]; then
+    cmd+=(--source-dir "${SOURCE_BASE}")
+  fi
 
   for artifact in "${ARTIFACTS[@]}"; do
     cmd+=(--artifacts "${artifact}")


### PR DESCRIPTION
Fixes: FLPATH-3435
Requires: https://github.com/x2ansible/x2a-convertor/pull/153

The SOURCE_BASE does not need to be known for early steps.