### PR TITLE
fix(adoption-insights): update permission page documentation link to product docs

### DIFF
--- a/workspaces/adoption-insights/.changeset/orange-falcons-shake.md
+++ b/workspaces/adoption-insights/.changeset/orange-falcons-shake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+The Adoption Insights "Missing Permission" page was linking to GitHub repository documentation. This has been updated to point to the official Red Hat Developer Hub product documentation instead.

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/PermissionRequiredState.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/PermissionRequiredState.tsx
@@ -47,7 +47,7 @@ const PermissionRequiredState = () => {
             variant="outlined"
             color="primary"
             target="_blank"
-            href="https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/adoption-insights/plugins/adoption-insights/README.md#permission-framework-support"
+            href="https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/adoption_insights_in_red_hat_developer_hub/assembly-adoption-insights#proc-customize-adoption-insights_title-adoption-insights"
           >
             {t('common.readMore')} &nbsp; <OpenInNewIcon />
           </Button>

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/__tests__/PermissionRequiredState.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/__tests__/PermissionRequiredState.test.tsx
@@ -64,7 +64,7 @@ describe('PermissionRequiredState', () => {
     expect(readMoreLink).toBeInTheDocument();
     expect(readMoreLink).toHaveAttribute(
       'href',
-      'https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/adoption-insights/plugins/adoption-insights/README.md#permission-framework-support',
+      'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/adoption_insights_in_red_hat_developer_hub/assembly-adoption-insights#proc-customize-adoption-insights_title-adoption-insights',
     );
 
     // OpenInNewIcon


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Fix: https://redhat.atlassian.net/browse/RHDHBUGS-2204

### Description
- Updated the documentation link shown on the Adoption Insights "Missing Permission" page.
- Previously, it redirected users to GitHub repository docs, which is not appropriate for product usage. 
- The link now points to the official Red Hat Developer Hub product documentation.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
