### PR TITLE
feat(orchestrator): Run as Event for Kafka-configured workflows

### DIFF
--- a/workspaces/orchestrator/.changeset/run-as-event-kafka.md
+++ b/workspaces/orchestrator/.changeset/run-as-event-kafka.md
@@ -1,0 +1,8 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-api': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+---
+
+Add Run as Event when `orchestrator.kafka` is configured: send `isEvent` with execute input, redirect to workflow runs with a notice when the response id is `kafkaEvent`.

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -79,6 +79,30 @@ export interface Config {
       url: string;
     };
     /**
+     * Kafka configuration for event-triggered workflows (KafkaJS-style).
+     * When present, the UI can show actions such as "Run as Event".
+     * @visibility frontend
+     */
+    kafka?: {
+      /**
+       * Logical identifier of the Kafka client application.
+       * @see https://kafka.js.org/docs/configuration#client-id
+       * @visibility frontend
+       */
+      clientId: string;
+      /**
+       * Kafka broker addresses (`host:port`).
+       * @visibility frontend
+       */
+      brokers: string[];
+      /**
+       * Log level for orchestrator Kafka services. Defaults to INFO (4); e.g. use 5 for DEBUG.
+       * @see https://kafka.js.org/docs/configuration#logging
+       * @visibility frontend
+       */
+      logLevel?: number;
+    };
+    /**
      * Configuration for the workflow log provider.
      * If configured, the "View Logs" button will be shown in the workflow instance results.
      * @visibility frontend

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -90,7 +90,7 @@ export const useOrchestratorFormApiOrDefault: () => OrchestratorFormApi;
 
 // Warnings were encountered during analysis:
 //
-// src/api.d.ts:125:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
+// src/api.d.ts:131:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -73,6 +73,9 @@ export type ReviewComponentProps = {
   data: JsonObject;
   handleBack: () => void;
   handleExecute: () => void;
+  executeLabel?: string;
+  handleExecuteAsEvent?: () => void;
+  executeAsEventLabel?: string;
 };
 
 // @public

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
@@ -133,6 +133,12 @@ export type ReviewComponentProps = {
   handleBack: () => void;
   /** Callback to execute the workflow */
   handleExecute: () => void;
+  /** Label for the primary execute button (default review UI falls back to translated "Run") */
+  executeLabel?: string;
+  /** Optional second action to execute as an event-style (e.g. Kafka) workflow */
+  handleExecuteAsEvent?: () => void;
+  /** Label for the event execute control when `handleExecuteAsEvent` is set */
+  executeAsEventLabel?: string;
 };
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
@@ -58,8 +58,11 @@ export type OrchestratorFormProps = {
   setAuthTokenDescriptors: OrchestratorFormContextProps['setAuthTokenDescriptors'];
   isExecuting: boolean;
   handleExecute: (parameters: JsonObject) => Promise<void>;
+  handleExecuteAsEvent?: (parameters: JsonObject) => Promise<void>;
   initialFormData: JsonObject;
   t: TranslationFunction;
+  executeLabel?: string;
+  executeAsEventLabel?: string;
 };
 
 // @public

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -59,8 +59,11 @@ export type OrchestratorFormProps = {
   setAuthTokenDescriptors: OrchestratorFormContextProps['setAuthTokenDescriptors'];
   isExecuting: boolean;
   handleExecute: (parameters: JsonObject) => Promise<void>;
+  handleExecuteAsEvent?: (parameters: JsonObject) => Promise<void>;
   initialFormData: JsonObject;
   t: TranslationFunction;
+  executeLabel?: string;
+  executeAsEventLabel?: string;
 };
 
 /**
@@ -111,6 +114,9 @@ type ReviewStepHostProps = {
   schema: JSONSchema7;
   data: JsonObject;
   handleExecute: () => void;
+  executeLabel?: string;
+  handleExecuteAsEvent?: () => void;
+  executeAsEventLabel?: string;
 };
 
 /** Supplies `handleBack` from stepper context to the default or custom review component. */
@@ -120,6 +126,9 @@ const ReviewStepHost = ({
   schema,
   data,
   handleExecute,
+  executeLabel,
+  handleExecuteAsEvent,
+  executeAsEventLabel,
 }: ReviewStepHostProps) => {
   const { handleBack } = useStepperContext();
   return (
@@ -129,6 +138,9 @@ const ReviewStepHost = ({
       data={data}
       handleBack={handleBack}
       handleExecute={handleExecute}
+      executeLabel={executeLabel}
+      handleExecuteAsEvent={handleExecuteAsEvent}
+      executeAsEventLabel={executeAsEventLabel}
     />
   );
 };
@@ -141,10 +153,13 @@ const OrchestratorForm = ({
   schema: rawSchema,
   updateSchema,
   handleExecute,
+  handleExecuteAsEvent,
   isExecuting,
   initialFormData,
   setAuthTokenDescriptors,
   t,
+  executeLabel,
+  executeAsEventLabel,
 }: OrchestratorFormProps) => {
   // Extract static defaults from fetch:response:default in schema and merge with initialFormData
   // This ensures defaults are available before widgets render
@@ -192,6 +207,11 @@ const OrchestratorForm = ({
     // Use pruned data for execution to avoid submitting stale properties
     handleExecute(workflowInputData);
   }, [workflowInputData, handleExecute]);
+  const _handleExecuteAsEvent = useCallback(() => {
+    if (handleExecuteAsEvent) {
+      handleExecuteAsEvent(workflowInputData);
+    }
+  }, [workflowInputData, handleExecuteAsEvent]);
 
   const onSubmit = useCallback(
     (_formData: JsonObject) => {
@@ -219,6 +239,11 @@ const OrchestratorForm = ({
         schema={schema}
         busy={isExecuting}
         handleExecute={_handleExecute}
+        executeLabel={executeLabel}
+        handleExecuteAsEvent={
+          handleExecuteAsEvent ? _handleExecuteAsEvent : undefined
+        }
+        executeAsEventLabel={executeAsEventLabel}
       />
     );
   }, [
@@ -227,6 +252,10 @@ const OrchestratorForm = ({
     schema,
     isExecuting,
     _handleExecute,
+    executeLabel,
+    handleExecuteAsEvent,
+    _handleExecuteAsEvent,
+    executeAsEventLabel,
   ]);
 
   return (

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
@@ -37,6 +37,9 @@ const useStyles = makeStyles()(theme => ({
   backButton: {
     marginRight: theme.spacing(1),
   },
+  executeAsEventButton: {
+    marginLeft: theme.spacing(2),
+  },
   footer: {
     display: 'flex',
     flexDirection: 'row',
@@ -65,6 +68,9 @@ const ReviewStep = ({
   data,
   handleBack,
   handleExecute,
+  executeLabel,
+  handleExecuteAsEvent,
+  executeAsEventLabel,
 }: ReviewComponentProps) => {
   const { t } = useTranslation();
 
@@ -104,8 +110,21 @@ const ReviewStep = ({
             submitting={busy}
             focusOnMount
           >
-            {t('common.run')}
+            {executeLabel ?? t('common.run')}
           </SubmitButton>
+          {handleExecuteAsEvent && executeAsEventLabel && (
+            <Button
+              variant="contained"
+              color="primary"
+              type="button"
+              onClick={handleExecuteAsEvent}
+              disabled={busy}
+              className={classes.executeAsEventButton}
+              disableRipple
+            >
+              {executeAsEventLabel}
+            </Button>
+          )}
         </div>
       </Paper>
     </Content>

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -256,6 +256,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'table.headers.lastRunStatus': string;
     readonly 'table.headers.workflowName': string;
     readonly 'table.actions.run': string;
+    readonly 'table.actions.runAsEvent': string;
     readonly 'table.actions.viewRuns': string;
     readonly 'table.actions.viewInputSchema': string;
     readonly 'table.filters.status': string;
@@ -313,6 +314,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'run.status.workflowIsRunning': string;
     readonly 'run.status.noAdditionalInfo': string;
     readonly 'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete': string;
+    readonly 'run.messages.eventTriggered': string;
     readonly 'run.pageTitle': string;
     readonly 'run.variables': string;
     readonly 'run.inputs': string;
@@ -349,6 +351,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.messages.userNotAuthorizedExecute': string;
     readonly 'workflow.messages.workflowDown': string;
     readonly 'workflow.buttons.run': string;
+    readonly 'workflow.buttons.runAsEvent': string;
     readonly 'workflow.buttons.running': string;
     readonly 'workflow.buttons.runWorkflow': string;
     readonly 'workflow.buttons.runAgain': string;

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -51,6 +51,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'table.headers.lastRunStatus': string;
     readonly 'table.headers.workflowName': string;
     readonly 'table.actions.run': string;
+    readonly 'table.actions.runAsEvent': string;
     readonly 'table.actions.viewRuns': string;
     readonly 'table.actions.viewInputSchema': string;
     readonly 'table.filters.status': string;
@@ -108,6 +109,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'run.status.workflowIsRunning': string;
     readonly 'run.status.noAdditionalInfo': string;
     readonly 'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete': string;
+    readonly 'run.messages.eventTriggered': string;
     readonly 'run.pageTitle': string;
     readonly 'run.variables': string;
     readonly 'run.inputs': string;
@@ -144,6 +146,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.messages.userNotAuthorizedExecute': string;
     readonly 'workflow.messages.workflowDown': string;
     readonly 'workflow.buttons.run': string;
+    readonly 'workflow.buttons.runAsEvent': string;
     readonly 'workflow.buttons.running': string;
     readonly 'workflow.buttons.runWorkflow': string;
     readonly 'workflow.buttons.runAgain': string;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -45,14 +45,18 @@ import {
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
 
 import { orchestratorApiRef } from '../../api';
+import { useKafkaEnabled } from '../../hooks/useKafkaEnabled';
 import { useOrchestratorAuth } from '../../hooks/useOrchestratorAuth';
 import { useTranslation } from '../../hooks/useTranslation';
 import {
   entityInstanceRouteRef,
+  entityWorkflowRouteRef,
   executeWorkflowRouteRef,
   workflowInstanceRouteRef,
+  workflowRunsRouteRef,
 } from '../../routes';
 import { getErrorObject } from '../../utils/ErrorUtils';
+import { buildUrl } from '../../utils/UrlUtils';
 import { BaseOrchestratorPage } from '../ui/BaseOrchestratorPage';
 import MissingSchemaNotice from './MissingSchemaNotice';
 import { mergeQueryParamsIntoFormData } from './queryParamsToFormData';
@@ -68,10 +72,13 @@ export const ExecuteWorkflowPage = () => {
   const [isExecuting, setIsExecuting] = useState(false);
   const [updateError, setUpdateError] = useState<Error>();
   const [instanceId] = useQueryParamState<string>(QUERY_PARAM_INSTANCE_ID);
+  const kafkaEnabled = useKafkaEnabled();
 
   const navigate = useNavigate();
   const instanceLink = useRouteRef(workflowInstanceRouteRef);
   const entityInstanceLink = useRouteRef(entityInstanceRouteRef);
+  const entityWorkflowLink = useRouteRef(entityWorkflowRouteRef);
+  const workflowRunsLink = useRouteRef(workflowRunsRouteRef);
   const {
     value,
     loading,
@@ -116,18 +123,28 @@ export const ExecuteWorkflowPage = () => {
 
   const [kind, namespace, name] = targetEntity?.split(/[:\/]/) || [];
 
-  const handleExecute = useCallback(
-    async (parameters: JsonObject) => {
+  const executeWorkflow = useCallback(
+    async (parameters: JsonObject, isEvent: boolean) => {
       setUpdateError(undefined);
       try {
         setIsExecuting(true);
         const authTokens = await authenticate(authTokenDescriptors);
+        const executeParameters = isEvent
+          ? { ...parameters, isEvent: true }
+          : parameters;
         const response = await orchestratorApi.executeWorkflow({
           workflowId,
-          parameters,
+          parameters: executeParameters,
           authTokens,
           targetEntity: targetEntity ?? undefined,
         });
+        if (response.data.id === 'kafkaEvent') {
+          const redirectUrl = targetEntity
+            ? entityWorkflowLink({ namespace, kind, name, workflowId })
+            : workflowRunsLink({ workflowId });
+          navigate(buildUrl(redirectUrl, { eventTriggered: 'true' }));
+          return;
+        }
         const url = targetEntity
           ? entityInstanceLink({
               namespace,
@@ -153,10 +170,24 @@ export const ExecuteWorkflowPage = () => {
       authenticate,
       targetEntity,
       entityInstanceLink,
+      entityWorkflowLink,
+      workflowRunsLink,
       kind,
       namespace,
       name,
     ],
+  );
+  const handleExecute = useCallback(
+    async (parameters: JsonObject) => {
+      await executeWorkflow(parameters, false);
+    },
+    [executeWorkflow],
+  );
+  const handleExecuteAsEvent = useCallback(
+    async (parameters: JsonObject) => {
+      await executeWorkflow(parameters, true);
+    },
+    [executeWorkflow],
   );
 
   const error = responseError || workflowNameError;
@@ -185,14 +216,27 @@ export const ExecuteWorkflowPage = () => {
                 schema={schema}
                 updateSchema={updateSchema}
                 handleExecute={handleExecute}
+                handleExecuteAsEvent={
+                  kafkaEnabled ? handleExecuteAsEvent : undefined
+                }
                 isExecuting={isExecuting}
                 initialFormData={initialFormData}
                 setAuthTokenDescriptors={setAuthTokenDescriptors}
                 t={t as unknown as TranslationFunction}
+                executeLabel={t('common.run')}
+                executeAsEventLabel={
+                  kafkaEnabled ? t('workflow.buttons.runAsEvent') : undefined
+                }
               />
             ) : (
               <MissingSchemaNotice
                 handleExecute={handleExecute}
+                handleExecuteAsEvent={
+                  kafkaEnabled ? handleExecuteAsEvent : undefined
+                }
+                executeAsEventLabel={
+                  kafkaEnabled ? t('workflow.buttons.runAsEvent') : undefined
+                }
                 isExecuting={isExecuting}
               />
             )}

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/MissingSchemaNotice.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/MissingSchemaNotice.tsx
@@ -18,6 +18,8 @@ import type { JsonObject } from '@backstage/types';
 
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 
 import { SubmitButton } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
@@ -27,9 +29,13 @@ import { useTranslation } from '../../hooks/useTranslation';
 const MissingSchemaNotice = ({
   isExecuting,
   handleExecute,
+  handleExecuteAsEvent,
+  executeAsEventLabel,
 }: {
   isExecuting: boolean;
   handleExecute: (parameters: JsonObject) => Promise<void>;
+  handleExecuteAsEvent?: (parameters: JsonObject) => Promise<void>;
+  executeAsEventLabel?: string;
 }) => {
   const { t } = useTranslation();
   return (
@@ -45,12 +51,33 @@ const MissingSchemaNotice = ({
         </Alert>
       </Grid>
       <Grid item xs={12}>
-        <SubmitButton
-          submitting={isExecuting}
-          handleClick={() => handleExecute({})}
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 2,
+            alignItems: 'center',
+          }}
         >
-          Run
-        </SubmitButton>
+          <SubmitButton
+            submitting={isExecuting}
+            handleClick={() => handleExecute({})}
+          >
+            {t('common.run')}
+          </SubmitButton>
+          {handleExecuteAsEvent && executeAsEventLabel && (
+            <Button
+              variant="contained"
+              color="primary"
+              type="button"
+              onClick={() => handleExecuteAsEvent({})}
+              disabled={isExecuting}
+              disableRipple
+            >
+              {executeAsEventLabel}
+            </Button>
+          )}
+        </Box>
       </Grid>
     </Grid>
   );

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import {
   ErrorPanel,
@@ -29,7 +30,8 @@ import {
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
 
-import Grid from '@mui/material/Grid';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import TablePagination from '@mui/material/TablePagination';
 
 import {
@@ -74,6 +76,20 @@ const makeSelectItemsFromProcessInstanceValues = (t: any): SelectItem[] => [
 
 export const WorkflowRunsTabContent = () => {
   const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const eventTriggered = searchParams.get('eventTriggered') === 'true';
+  const [showEventAlert, setShowEventAlert] = useState(eventTriggered);
+
+  useEffect(() => {
+    setShowEventAlert(eventTriggered);
+  }, [eventTriggered]);
+
+  const handleCloseEventAlert = () => {
+    setShowEventAlert(false);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('eventTriggered');
+    setSearchParams(nextParams, { replace: true });
+  };
 
   const statuses = makeSelectItemsFromProcessInstanceValues(t);
   const started = [
@@ -355,87 +371,120 @@ export const WorkflowRunsTabContent = () => {
   return error ? (
     <ErrorPanel error={error} />
   ) : (
-    <Grid container item xs={12} spacing={2}>
-      <Grid item>
-        <Selector
-          label={t('table.filters.status')}
-          items={statuses}
-          onChange={value_ => {
-            setStatusSelectorValue(value_);
-            setPage(0);
-          }}
-          selected={statusSelectorValue}
-        />
-        <Selector
-          label={t('table.filters.started')}
-          items={started}
-          onChange={value_ => {
-            setStartedSelectorValue(value_);
-            setPage(0);
-          }}
-          selected={startedSelectorValue}
-        />
-      </Grid>
-      <Grid item xs style={{ flexGrow: 1 }}>
-        <InfoCard
-          noPadding
-          title={
-            workflowId ? (
-              <Trans
-                message="table.title.allWorkflowRuns"
-                params={{ count: data.length }}
-              />
-            ) : (
-              <Trans
-                message="table.title.allRuns"
-                params={{ count: data.length }}
-              />
-            )
-          }
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        width: '100%',
+        maxWidth: '100%',
+      }}
+    >
+      {showEventAlert && (
+        <Alert
+          severity="info"
+          onClose={handleCloseEventAlert}
+          sx={{ width: '100%', boxSizing: 'border-box' }}
         >
-          <OverrideBackstageTable
-            removeOutline
-            isLoading={loading}
-            columns={columns}
-            data={data}
-            options={{
-              paging: false,
+          {t('run.messages.eventTriggered')}
+        </Alert>
+      )}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: 'flex-start',
+          gap: 2,
+          width: '100%',
+        }}
+      >
+        <Box sx={{ flexShrink: 0 }}>
+          <Selector
+            label={t('table.filters.status')}
+            items={statuses}
+            onChange={value_ => {
+              setStatusSelectorValue(value_);
+              setPage(0);
             }}
-            onOrderChange={(
-              orderBy_: number,
-              orderDirection_: 'asc' | 'desc',
-            ) => {
-              const field = columns[orderBy_].field;
-              if (!field) {
-                throw new Error(`Failed to find column number ${orderBy_}`);
-              }
-              setOrderByField(field);
-              setOrderDirection(orderDirection_);
-            }}
-            components={{
-              Toolbar: () => <></>, // this removes the search filter, which isn't applicable for most fields
-            }}
+            selected={statusSelectorValue}
           />
-          {enablePaging && (
-            <TablePagination
-              component="div"
-              count={-1}
-              page={page}
-              onPageChange={(_, page_) => setPage(page_)}
-              onRowsPerPageChange={e => {
-                setPageSize(parseInt(e.target.value, 10));
-                setPage(0);
+          <Selector
+            label={t('table.filters.started')}
+            items={started}
+            onChange={value_ => {
+              setStartedSelectorValue(value_);
+              setPage(0);
+            }}
+            selected={startedSelectorValue}
+          />
+        </Box>
+        <Box
+          sx={{
+            flex: '1 1 auto',
+            minWidth: 0,
+            width: { xs: '100%', sm: 'auto' },
+          }}
+        >
+          <InfoCard
+            noPadding
+            title={
+              workflowId ? (
+                <Trans
+                  message="table.title.allWorkflowRuns"
+                  params={{ count: data.length }}
+                />
+              ) : (
+                <Trans
+                  message="table.title.allRuns"
+                  params={{ count: data.length }}
+                />
+              )
+            }
+          >
+            <OverrideBackstageTable
+              removeOutline
+              isLoading={loading}
+              columns={columns}
+              data={data}
+              options={{
+                paging: false,
               }}
-              rowsPerPage={pageSize}
-              labelDisplayedRows={({ from }) => {
-                return `${from}-${from + data.length - 1}`;
+              onOrderChange={(
+                orderBy_: number,
+                orderDirection_: 'asc' | 'desc',
+              ) => {
+                const field = columns[orderBy_].field;
+                if (!field) {
+                  throw new Error(`Failed to find column number ${orderBy_}`);
+                }
+                setOrderByField(field);
+                setOrderDirection(orderDirection_);
               }}
-              rowsPerPageOptions={[5, 10, 20]}
-              nextIconButtonProps={{ disabled: !hasNextPage }}
+              components={{
+                Toolbar: () => <></>, // this removes the search filter, which isn't applicable for most fields
+              }}
             />
-          )}
-        </InfoCard>
-      </Grid>
-    </Grid>
+            {enablePaging && (
+              <TablePagination
+                component="div"
+                count={-1}
+                page={page}
+                onPageChange={(_, page_) => setPage(page_)}
+                onRowsPerPageChange={e => {
+                  setPageSize(parseInt(e.target.value, 10));
+                  setPage(0);
+                }}
+                rowsPerPage={pageSize}
+                labelDisplayedRows={({ from }) => {
+                  return `${from}-${from + data.length - 1}`;
+                }}
+                rowsPerPageOptions={[5, 10, 20]}
+                nextIconButtonProps={{ disabled: !hasNextPage }}
+              />
+            )}
+          </InfoCard>
+        </Box>
+      </Box>
+    </Box>
   );
 };

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
@@ -165,17 +165,23 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
     [definitionRunsLink, navigate],
   );
 
+  const buildExecuteUrl = useCallback(
+    (workflowId: string) => {
+      const baseUrl = executeWorkflowLink({ workflowId });
+      const params = new URLSearchParams();
+      if (entityRef) {
+        params.set('targetEntity', entityRef);
+      }
+      const query = params.toString();
+      return query ? `${baseUrl}?${query}` : baseUrl;
+    },
+    [executeWorkflowLink, entityRef],
+  );
   const handleExecute = useCallback(
     (rowData: FormattedWorkflowOverview) => {
-      if (entityRef) {
-        navigate(
-          `${executeWorkflowLink({ workflowId: rowData.id })}?targetEntity=${entityRef}`,
-        );
-      } else {
-        navigate(executeWorkflowLink({ workflowId: rowData.id }));
-      }
+      navigate(buildExecuteUrl(rowData.id));
     },
-    [executeWorkflowLink, navigate, entityRef],
+    [buildExecuteUrl, navigate],
   );
 
   const canExecuteWorkflow = useCallback(

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/RunButton.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/RunButton.tsx
@@ -43,12 +43,17 @@ export const RunButton = ({
   const { workflowId } = useRouteRefParams(workflowRouteRef);
   const navigate = useNavigate();
   const executeWorkflowLink = useRouteRef(executeWorkflowRouteRef);
+  const buildExecuteUrl = () => {
+    const baseUrl = executeWorkflowLink({ workflowId });
+    const params = new URLSearchParams();
+    if (entityRef) {
+      params.set('targetEntity', entityRef);
+    }
+    const query = params.toString();
+    return query ? `${baseUrl}?${query}` : baseUrl;
+  };
   const handleExecute = () => {
-    navigate(
-      entityRef
-        ? `${executeWorkflowLink({ workflowId })}?targetEntity=${entityRef}`
-        : executeWorkflowLink({ workflowId }),
-    );
+    navigate(buildExecuteUrl());
   };
 
   const { loading: loadingPermission, allowed: canRun } =
@@ -65,7 +70,7 @@ export const RunButton = ({
   }
 
   return (
-    <Grid item container justifyContent="flex-end" xs={12} spacing={2}>
+    <Grid item container justifyContent="flex-end" xs={12}>
       <Grid item>
         {loadingPermission ? (
           <Skeleton variant="text" width="5rem" />

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/WorkflowPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/WorkflowPage.tsx
@@ -82,7 +82,9 @@ export const WorkflowPage = () => {
           >
             <Grid container spacing={2}>
               <RunButton isAvailable={workflowOverviewDTO?.data.isAvailable} />
-              <WorkflowRunsTabContent />
+              <Grid item xs={12}>
+                <WorkflowRunsTabContent />
+              </Grid>
             </Grid>
           </TabbedLayout.Route>
         </TabbedLayout>

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useKafkaEnabled.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useKafkaEnabled.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+
+export function useKafkaEnabled(): boolean {
+  const config = useApi(configApiRef);
+  const kafkaConfig = config.getOptionalConfig('orchestrator.kafka');
+  return !!kafkaConfig;
+}

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -33,6 +33,7 @@ const orchestratorTranslationDe = createTranslationMessages({
     'table.title.workflows': 'Workflows',
     'table.title.allRuns': 'Alle Ausführungen ({{count}})',
     'table.actions.run': 'Ausführung',
+    'table.actions.runAsEvent': 'Als Ereignis ausführen',
     'table.actions.viewRuns': 'Ausführungen anzeigen',
     'table.actions.viewInputSchema': 'Eingabeschema anzeigen',
     'table.status.running': 'Wird ausgeführt',
@@ -65,6 +66,7 @@ const orchestratorTranslationDe = createTranslationMessages({
       'Erneuter Auslöser fehlgeschlagen: {{reason}}',
     'workflow.errors.abortFailedWithReason':
       'Abbruch fehlgeschlagen: {{reason}}',
+    'workflow.buttons.runAsEvent': 'Als Ereignis ausführen',
     'run.title': 'Workflow ausführen',
     'run.pageTitle': 'Ausführung von {{processName}}',
     'run.variables': 'Ausführungsvariablen',
@@ -86,6 +88,8 @@ const orchestratorTranslationDe = createTranslationMessages({
     'run.status.completedWithMessage':
       'Ausführung {{time}} mit folgender Nachricht abgeschlossen',
     'run.status.failedAt': 'Ausführung ist fehlgeschlagen {{time}}',
+    'run.messages.eventTriggered':
+      'Ein Ereignis wurde gesendet, um diesen Workflow zu starten. Es wird angezeigt, sobald die Ausführung beginnt.',
     'run.viewVariables': 'Variablen anzeigen',
     'run.suggestedNextWorkflow': 'Vorgeschlagener nächster Workflow',
     'run.suggestedNextWorkflows': 'Empfohlene nächste Workflows',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -33,6 +33,7 @@ const orchestratorTranslationEs = createTranslationMessages({
     'table.title.workflows': 'Flujos de trabajo',
     'table.title.allRuns': 'Todas las ejecuciones ({{count}})',
     'table.actions.run': 'Ejecutar',
+    'table.actions.runAsEvent': 'Ejecutar como evento',
     'table.actions.viewRuns': 'Ver ejecuciones',
     'table.actions.viewInputSchema': 'Ver esquema de entrada',
     'table.status.running': 'En ejecución',
@@ -63,6 +64,7 @@ const orchestratorTranslationEs = createTranslationMessages({
       'ID de ejecución copiado en el portapapeles',
     'workflow.errors.retriggerFailed': 'Error al reactivar: {{reason}}',
     'workflow.errors.abortFailedWithReason': 'Error al cancelar: {{reason}}',
+    'workflow.buttons.runAsEvent': 'Ejecutar como evento',
     'run.title': 'Ejecutar flujo de trabajo',
     'run.pageTitle': 'Ejecución de {{processName}}',
     'run.variables': 'Variables de ejecución',
@@ -84,6 +86,8 @@ const orchestratorTranslationEs = createTranslationMessages({
     'run.status.completedWithMessage':
       'Ejecución completada {{time}} con mensaje',
     'run.status.failedAt': 'La ejecución falló {{time}}',
+    'run.messages.eventTriggered':
+      'Se envió un evento para activar este flujo de trabajo. Aparecerá cuando comience la ejecución.',
     'run.viewVariables': 'Ver variables',
     'run.suggestedNextWorkflow': 'Próximo flujo de trabajo sugerido',
     'run.suggestedNextWorkflows': 'Próximos flujos de trabajo sugeridos',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -44,6 +44,7 @@ const orchestratorTranslationFr = createTranslationMessages({
     'table.headers.lastRunStatus': 'Statut de la dernière exécution',
     'table.headers.workflowName': 'Nom du flux de travail',
     'table.actions.run': 'Exécution',
+    'table.actions.runAsEvent': "Exécuter en tant qu'événement",
     'table.actions.viewRuns': 'Voir les exécutions',
     'table.actions.viewInputSchema': "Afficher le schéma d'entrée",
     'table.status.running': "En cours d'exécution",
@@ -85,6 +86,7 @@ const orchestratorTranslationFr = createTranslationMessages({
     'workflow.messages.workflowDown':
       "Le flux de travail est actuellement en panne ou dans un état d'erreur. L'exécuter maintenant peut échouer ou produire des résultats inattendus.",
     'workflow.buttons.run': 'Exécution',
+    'workflow.buttons.runAsEvent': "Exécuter en tant qu'événement",
     'workflow.buttons.runWorkflow': 'Exécuter le flux de travail',
     'workflow.buttons.runAgain': 'Courir à nouveau',
     'workflow.buttons.running': "En cours d'exécution",
@@ -109,6 +111,8 @@ const orchestratorTranslationFr = createTranslationMessages({
     'run.status.completed': 'Exécution terminée',
     'run.status.failed': "L'exécution a échoué {{time}}",
     'run.status.failedAt': "L'exécution a échoué {{time}}",
+    'run.messages.eventTriggered':
+      "Un événement a été envoyé pour déclencher ce workflow. Il apparaîtra une fois l'exécution commencée.",
     'run.status.aborted': "L'exécution a été interrompue",
     'run.status.completedWithMessage':
       'Exécution terminée {{time}} avec message',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -45,6 +45,7 @@ const orchestratorTranslationIt = createTranslationMessages({
     'table.headers.lastRunStatus': "Stato dell'ultima esecuzione",
     'table.headers.workflowName': 'Nome flusso di lavoro',
     'table.actions.run': 'Esecuzione',
+    'table.actions.runAsEvent': 'Esegui come evento',
     'table.actions.viewRuns': 'Visualizza esecuzioni',
     'table.actions.viewInputSchema': 'Visualizza schema di input',
     'table.status.running': 'In esecuzione',
@@ -86,6 +87,7 @@ const orchestratorTranslationIt = createTranslationMessages({
     'workflow.messages.workflowDown':
       "Al momento lo stato del flusso di lavoro è inattivo o in errore. L'esecuzione potrebbe non riuscire o produrre risultati imprevisti.",
     'workflow.buttons.run': 'Esecuzione',
+    'workflow.buttons.runAsEvent': 'Esegui come evento',
     'workflow.buttons.runWorkflow': 'Esegui flusso di lavoro',
     'workflow.buttons.runAgain': 'Esegui di nuovo',
     'workflow.buttons.running': 'Esecuzione in corso...',
@@ -110,6 +112,8 @@ const orchestratorTranslationIt = createTranslationMessages({
     'run.status.completed': 'Esecuzione completata',
     'run.status.failed': 'Esecuzione non riuscita {{time}}',
     'run.status.failedAt': 'Esecuzione non riuscita {{time}}',
+    'run.messages.eventTriggered':
+      "È stato inviato un evento per attivare questo flusso di lavoro. Apparirà quando l'esecuzione inizierà.",
     'run.status.aborted': 'Esecuzione interrotta',
     'run.status.completedWithMessage':
       'Esecuzione completata {{time}} con messaggio',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
@@ -44,6 +44,7 @@ const orchestratorTranslationJa = createTranslationMessages({
     'table.headers.lastRunStatus': '最終実行のステータス',
     'table.headers.workflowName': 'ワークフロー名',
     'table.actions.run': '実行',
+    'table.actions.runAsEvent': 'イベントとして実行',
     'table.actions.viewRuns': '実行の表示',
     'table.actions.viewInputSchema': '入力スキーマの表示',
     'table.status.running': '実行中',
@@ -85,6 +86,7 @@ const orchestratorTranslationJa = createTranslationMessages({
     'workflow.messages.workflowDown':
       'ワークフローは現在停止しているかエラー状態です。今実行すると、失敗や予期しない結果が生じる可能性があります。',
     'workflow.buttons.run': '実行',
+    'workflow.buttons.runAsEvent': 'イベントとして実行',
     'workflow.buttons.runWorkflow': 'ワークフローの実行',
     'workflow.buttons.runAgain': '再実行',
     'workflow.buttons.running': '実行中...',
@@ -107,6 +109,8 @@ const orchestratorTranslationJa = createTranslationMessages({
       '実行はすでに完了しているため、中止することはできません。',
     'run.status.completed': '実行は完了しました',
     'run.status.failed': '実行は {{time}} に失敗しました',
+    'run.messages.eventTriggered':
+      'このワークフローを起動するためのイベントが送信されました。実行が開始すると一覧に表示されます。',
     'run.status.aborted': '実行は中止されました',
     'run.status.completedWithMessage':
       '実行は {{time}} に完了しました。メッセージ:',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -47,6 +47,7 @@ export const orchestratorMessages = {
     },
     actions: {
       run: 'Run',
+      runAsEvent: 'Run as Event',
       viewRuns: 'View runs',
       viewInputSchema: 'View input schema',
     },
@@ -102,6 +103,7 @@ export const orchestratorMessages = {
     },
     buttons: {
       run: 'Run',
+      runAsEvent: 'Run as Event',
       runWorkflow: 'Run workflow',
       runAgain: 'Run again',
       running: 'Running...',
@@ -146,6 +148,10 @@ export const orchestratorMessages = {
         'The workflow provided no additional info about the status.',
       resultsWillBeDisplayedHereOnceTheRunIsComplete:
         'Results will be displayed here once the run is complete.',
+    },
+    messages: {
+      eventTriggered:
+        'An event was sent to trigger this workflow. It will appear once the run starts.',
     },
     retrigger: 'Retrigger',
     viewVariables: 'View variables',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Story:

https://redhat.atlassian.net/browse/RHIDP-9144

### Summary:

Users can trigger workflows as an event from the RHDH orchestrator UI when orchestrator.kafka is present in app config. The flow mirrors Run, but the execute request includes isEvent: true in the input payload so the platform/backend can treat it as an event-style trigger (e.g. CloudEvent → Kafka).

When the execute API returns an instance id of kafkaEvent (async / delayed start), the UI does not open a single instance page. It navigates to the workflow runs view and shows an informational message that an event was sent and the run will appear in the list once it starts.


https://github.com/user-attachments/assets/5d90c7e6-a611-4a8c-87be-a45a7ee5682c


https://github.com/user-attachments/assets/a243c357-32f1-440b-8da2-c448e6275c69


https://github.com/user-attachments/assets/2715d566-ad56-48d2-a1c9-20f7f01ad835

<img width="1505" height="699" alt="Screenshot 2026-04-13 at 12 17 26 PM" src="https://github.com/user-attachments/assets/f355ad75-fd0e-4ec1-99ab-76eee12af6ba" />


### How to test

**- Config**

  - In app config, add an orchestrator.kafka block (clientId, brokers, optional logLevel) so the frontend gate is on.
  - Restart the app so config is picked up.
  - Run as Event visibility

**- Open a workflow’s Execute page.**

  - Confirm Run as Event appears next to Run on the review step (multi-step) or equivalent for single-step + Missing schema flow.
  - Remove or comment out orchestrator.kafka, restart, and confirm Run as Event is hidden.

**- Payload**

  - Use browser devtools (network tab) on execute.
  - Click Run as Event and confirm the execute request body includes isEvent: true inside inputData (alongside your form fields).

**- kafkaEvent redirect and message (needs backend returning that id, or a temporary test shim):**

  - After execute, if the API returns id: kafkaEvent, the app should land on the workflow runs list (or entity-scoped runs view) with the event triggered info alert.
  - Dismissing the alert should remove eventTriggered from the URL.

**- Normal run unchanged**

  - Run (without event) should still navigate to the instance page when a real instance id is returned.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
