### PR TITLE
[Konflux] add wildcard and glob pattern support for applications filter

### DIFF
--- a/workspaces/konflux/.changeset/dark-ads-hear.md
+++ b/workspaces/konflux/.changeset/dark-ads-hear.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-konflux-backend': patch
+---
+
+Feat: add wildcard (_) and glob pattern support (e.g. my-app-_, \*-backend) for the applications field in konflux-ci.dev/clusters annotation.
+Feat: allow omitting applications to fetch all applications from a namespace.

--- a/workspaces/konflux/.changeset/gold-regions-design.md
+++ b/workspaces/konflux/.changeset/gold-regions-design.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-konflux': patch
+---
+
+Docs: document wildcard and glob pattern usage with examples and YAML quoting note.

--- a/workspaces/konflux/plugins/konflux-backend/src/helpers/__tests__/kubernetes.test.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/helpers/__tests__/kubernetes.test.ts
@@ -261,6 +261,74 @@ describe('kubernetes', () => {
       expect(result).toHaveLength(1);
       expect(result[0].metadata?.name).toBe('app1');
     });
+
+    it('should filter applications using glob pattern with prefix', () => {
+      const items = [
+        createMockApplication('my-app-frontend'),
+        createMockApplication('my-app-backend'),
+        createMockApplication('other-app'),
+      ];
+      const result = filterResourcesByApplication(items, 'applications', [
+        'my-app-*',
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0].metadata?.name).toBe('my-app-frontend');
+      expect(result[1].metadata?.name).toBe('my-app-backend');
+    });
+
+    it('should filter applications using glob pattern with suffix', () => {
+      const items = [
+        createMockApplication('my-app-backend'),
+        createMockApplication('other-backend'),
+        createMockApplication('my-app-frontend'),
+      ];
+      const result = filterResourcesByApplication(items, 'applications', [
+        '*-backend',
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0].metadata?.name).toBe('my-app-backend');
+      expect(result[1].metadata?.name).toBe('other-backend');
+    });
+
+    it('should filter applications using glob pattern with contains', () => {
+      const items = [
+        createMockApplication('my-api-service'),
+        createMockApplication('other-app'),
+        createMockApplication('test-api-backend'),
+      ];
+      const result = filterResourcesByApplication(items, 'applications', [
+        '*-api-*',
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0].metadata?.name).toBe('my-api-service');
+      expect(result[1].metadata?.name).toBe('test-api-backend');
+    });
+
+    it('should filter with mix of exact and glob patterns', () => {
+      const items = [
+        createMockApplication('my-app-frontend'),
+        createMockApplication('my-app-backend'),
+        createMockApplication('special-app'),
+        createMockApplication('other-app'),
+      ];
+      const result = filterResourcesByApplication(items, 'applications', [
+        'my-app-*',
+        'special-app',
+      ]);
+      expect(result).toHaveLength(3);
+    });
+
+    it('should filter components using glob pattern', () => {
+      const items = [
+        createMockComponent('comp1', 'my-app-frontend'),
+        createMockComponent('comp2', 'my-app-backend'),
+        createMockComponent('comp3', 'other-app'),
+      ];
+      const result = filterResourcesByApplication(items, 'components', [
+        'my-app-*',
+      ]);
+      expect(result).toHaveLength(2);
+    });
   });
 
   describe('createResourceWithClusterInfo', () => {

--- a/workspaces/konflux/plugins/konflux-backend/src/helpers/__tests__/label-selector.test.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/helpers/__tests__/label-selector.test.ts
@@ -144,5 +144,45 @@ describe('label-selector', () => {
 
       expect(result).toBe(`${PipelineRunLabel.APPLICATION}=app1`);
     });
+
+    it('should skip application label selector when wildcard is used', () => {
+      const combination = createMockCombination({ applications: ['*'] });
+      const filters = createMockFilters();
+
+      const result = buildLabelSelector('pipelineruns', combination, filters);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should only include component filter when wildcard is used with component', () => {
+      const combination = createMockCombination({ applications: ['*'] });
+      const filters = createMockFilters({ component: 'comp1' });
+
+      const result = buildLabelSelector('pipelineruns', combination, filters);
+
+      expect(result).toBe(`${PipelineRunLabel.COMPONENT}=comp1`);
+    });
+
+    it('should skip application label selector when glob pattern is used', () => {
+      const combination = createMockCombination({
+        applications: ['app-*'],
+      });
+      const filters = createMockFilters();
+
+      const result = buildLabelSelector('pipelineruns', combination, filters);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should skip application label selector when mix of exact and glob patterns', () => {
+      const combination = createMockCombination({
+        applications: ['app1', '*-backend'],
+      });
+      const filters = createMockFilters();
+
+      const result = buildLabelSelector('pipelineruns', combination, filters);
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/workspaces/konflux/plugins/konflux-backend/src/helpers/config.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/helpers/config.ts
@@ -118,18 +118,13 @@ const extractComponentConfigsFromEntities = async (
       if (clustersParsedYaml) {
         const subcomponentName = e.metadata.name;
         clustersParsedYaml.forEach(clusterConfig => {
-          // filter out invalid configs (missing required field)
-          if (
-            clusterConfig.cluster &&
-            clusterConfig.namespace &&
-            clusterConfig.applications &&
-            clusterConfig.applications.length > 0
-          ) {
+          // filter out invalid configs (missing required fields)
+          if (clusterConfig.cluster && clusterConfig.namespace) {
             subcomponentConfigs.push({
               subcomponent: subcomponentName,
               cluster: clusterConfig.cluster,
               namespace: clusterConfig.namespace,
-              applications: clusterConfig.applications,
+              applications: clusterConfig.applications || [],
             });
           }
         });

--- a/workspaces/konflux/plugins/konflux-backend/src/helpers/kubernetes.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/helpers/kubernetes.ts
@@ -19,7 +19,29 @@ import {
 } from '@red-hat-developer-hub/backstage-plugin-konflux-common';
 
 /**
- * Filter resources by application names
+ * Convert a glob pattern (e.g. "app-*", "*api*") to a RegExp
+ */
+const globToRegex = (pattern: string): RegExp => {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const regexStr = escaped.replace(/\*/g, '.*');
+  return new RegExp(`^${regexStr}$`);
+};
+
+/**
+ * Check if a name matches any of the given application patterns.
+ * Supports exact matches and glob patterns with "*".
+ */
+export const matchesApplicationPattern = (
+  name: string,
+  patterns: string[],
+): boolean => {
+  return patterns.some(pattern =>
+    pattern.includes('*') ? globToRegex(pattern).test(name) : pattern === name,
+  );
+};
+
+/**
+ * Filter resources by application names or glob patterns
  */
 export const filterResourcesByApplication = (
   items: K8sResourceCommonWithClusterInfo[],
@@ -39,14 +61,21 @@ export const filterResourcesByApplication = (
     const applicationName = getApplicationFromResource(item);
     switch (resourceType) {
       case 'applications':
-        return applicationNames.includes(item.metadata?.name || '');
+        return matchesApplicationPattern(
+          item.metadata?.name || '',
+          applicationNames,
+        );
       case 'components':
-        return applicationNames.includes(
+        return matchesApplicationPattern(
           (item.spec?.application as string) || '',
+          applicationNames,
         );
       case 'releases':
       case 'pipelineruns':
-        return applicationNames.includes(applicationName || '');
+        return matchesApplicationPattern(
+          applicationName || '',
+          applicationNames,
+        );
       default:
         return true;
     }

--- a/workspaces/konflux/plugins/konflux-backend/src/helpers/label-selector.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/helpers/label-selector.ts
@@ -34,11 +34,12 @@ export const buildLabelSelector = (
 
   const labelSelectors: string[] = [];
 
-  // Add application filter
-  if (
-    combination.applications?.length &&
-    combination.applications?.length > 0
-  ) {
+  // Add application filter (skip if no applications or any contain glob patterns)
+  const hasWildcard =
+    !combination.applications?.length ||
+    combination.applications.some(app => app.includes('*'));
+
+  if (!hasWildcard) {
     if (combination.applications.length === 1) {
       labelSelectors.push(
         `${PipelineRunLabel.APPLICATION}=${combination.applications[0]}`,

--- a/workspaces/konflux/plugins/konflux-backend/src/services/__tests__/konflux-service.test.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/services/__tests__/konflux-service.test.ts
@@ -949,7 +949,9 @@ describe('KonfluxService', () => {
       mockDetermineClusterNamespaceCombinations.mockResolvedValue([
         combination,
       ]);
-      mockBuildLabelSelector.mockReturnValue('app=app1'); // label selector available
+      mockBuildLabelSelector.mockReturnValue(
+        'appstudio.openshift.io/application=app1',
+      ); // label selector includes application filter
       mockResourceFetcher.fetchFromSource.mockResolvedValue({
         items: [resource1],
         newPaginationState: {},

--- a/workspaces/konflux/plugins/konflux-backend/src/services/konflux-service.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/services/konflux-service.ts
@@ -29,6 +29,7 @@ import {
   PAGINATION_CONFIG,
   ClusterError,
   GroupVersionKind,
+  PipelineRunLabel,
 } from '@red-hat-developer-hub/backstage-plugin-konflux-common';
 
 import { Entity } from '@backstage/catalog-model';
@@ -606,12 +607,13 @@ export class KonfluxService {
     filters: Filters | undefined,
     labelSelector: string | undefined,
   ): K8sResourceCommonWithClusterInfo[] {
-    const needsInMemoryFiltering = !labelSelector;
+    const applicationHandledByLabelSelector =
+      labelSelector?.includes(PipelineRunLabel.APPLICATION) ?? false;
     const fetchesAllApplications =
       !combination.applications?.length ||
       combination.applications.includes('*');
 
-    if (!needsInMemoryFiltering || fetchesAllApplications) {
+    if (applicationHandledByLabelSelector || fetchesAllApplications) {
       return items;
     }
 

--- a/workspaces/konflux/plugins/konflux-backend/src/services/konflux-service.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/services/konflux-service.ts
@@ -607,8 +607,11 @@ export class KonfluxService {
     labelSelector: string | undefined,
   ): K8sResourceCommonWithClusterInfo[] {
     const needsInMemoryFiltering = !labelSelector;
+    const fetchesAllApplications =
+      !combination.applications?.length ||
+      combination.applications.includes('*');
 
-    if (!needsInMemoryFiltering || !combination.applications?.length) {
+    if (!needsInMemoryFiltering || fetchesAllApplications) {
       return items;
     }
 

--- a/workspaces/konflux/plugins/konflux/README.md
+++ b/workspaces/konflux/plugins/konflux/README.md
@@ -83,6 +83,40 @@ annotations:
         - application-2
 ```
 
+To fetch all applications from a namespace, you can either omit the `applications` field or use a wildcard:
+
+```yaml
+annotations:
+  konflux-ci.dev/clusters: |
+    - cluster: cluster-name
+      namespace: namespace-name
+      applications:
+        - "*"
+```
+
+Glob patterns are also supported for partial matching:
+
+```yaml
+annotations:
+  konflux-ci.dev/clusters: |
+    - cluster: cluster-name
+      namespace: namespace-name
+      applications:
+        - "my-app-*"
+        - "*-backend"
+```
+
+> **Note:** Patterns starting with `*` (e.g., `*-backend`) **must be quoted** in YAML. An unquoted `*` at the start of a value is interpreted as a YAML alias reference, which will cause a parsing error. Always use quotes: `"*-backend"`, not `*-backend`.
+
+Or simply omit `applications` to fetch everything:
+
+```yaml
+annotations:
+  konflux-ci.dev/clusters: |
+    - cluster: cluster-name
+      namespace: namespace-name
+```
+
 ### 2. Resource Fetching Flow
 
 ```
@@ -387,6 +421,24 @@ metadata:
         namespace: namespace2
         applications:
           - app3
+spec:
+  subcomponentOf: my-component
+  type: service
+---
+# Subcomponent C - all applications from a namespace (wildcard)
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: my-component-subcomponent-c
+  description: Subcomponent C
+  title: Subcomponent C
+  annotations:
+    konflux-ci.dev/overview: 'true'
+    konflux-ci.dev/konflux: 'true'
+    konflux-ci.dev/ci: 'true'
+    konflux-ci.dev/clusters: |
+      - cluster: cluster3
+        namespace: namespace3
 spec:
   subcomponentOf: my-component
   type: service


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Description

In this PR we're updating the Konflux plugin, allowing the `applications` field in `konflux-ci.dev/clusters` annotation config to use wildcards `(*)` and `glob patterns` (e.g. `my-app-*`, `*-backend`).

Omitting `applications` fetches all applications from the namespace.

**Fixes https://redhat.atlassian.net/browse/KFLUXUI-1177**

## How to test it?

You can test locally by updating your Backstage component/entity config, playing around with the `konflux-ci.dev/clusters` annotation and checking different variations of the `applications` usage. Examples:

- current behavior still works (manually specifying each application):

```yaml
    konflux-ci.dev/clusters: |
      - cluster: stone-stg-rh01
        namespace: rh-ee-rgalvao-tenant
        applications:
          - application-a
          - application-b

```

- fetch all applications by omitting applications field:

```yaml
    konflux-ci.dev/clusters: |
      - cluster: stone-stg-rh01
        namespace: rh-ee-rgalvao-tenant

```

- fetch all applications by using wildcard (`*`):

```yaml
    konflux-ci.dev/clusters: |
      - cluster: stone-stg-rh01
        namespace: rh-ee-rgalvao-tenant
        applications:
          - "*"
```

- use glob patterns:

```yaml
    konflux-ci.dev/clusters: |
      - cluster: stone-stg-rh01
        namespace: rh-ee-rgalvao-tenant
        applications:
          - application-*
          - "*-123".   # patterns starting with * must be quoted
```

## Visual references

In the screen-recording below I'm showing how it works with the examples mentioned above.


https://github.com/user-attachments/assets/389cb413-d860-4d66-98c3-011d4751b435



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
