### PR TITLE
fix(x2a): remove blockOwnerDeletion on jobs

### DIFF
--- a/workspaces/x2a/.changeset/shaky-beers-hug.md
+++ b/workspaces/x2a/.changeset/shaky-beers-hug.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+Removed blockOwnerDeletion: true from the ownerReference in KubeService.ts. This field is unnecessary for our use case - it only controls whether the garbage collector should block deletion of the owner (Job) until the dependent (Secret) is removed first.

--- a/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.test.ts
@@ -410,7 +410,6 @@ describe('JobResourceBuilder', () => {
       kind: 'Job',
       name: 'job-x2a-init-abc123',
       uid: 'test-uid-123',
-      blockOwnerDeletion: true,
     };
 
     it('should include source repository credentials', () => {

--- a/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.test.ts
@@ -285,7 +285,6 @@ describe('KubeService', () => {
                   kind: 'Job',
                   name: expect.stringMatching(/^job-x2a-init-/),
                   uid: 'uid-123',
-                  blockOwnerDeletion: true,
                 }),
               ],
             }),
@@ -361,7 +360,6 @@ describe('KubeService', () => {
         kind: 'Job',
         name: expect.stringMatching(/^job-x2a-init-/),
         uid: 'uid-456',
-        blockOwnerDeletion: true,
       });
     });
 

--- a/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.ts
@@ -287,7 +287,6 @@ export class KubeService {
       kind: 'Job',
       name: k8sJobName,
       uid: jobUid,
-      blockOwnerDeletion: true,
     };
 
     try {


### PR DESCRIPTION
Removed `blockOwnerDeletion: true` from the ownerReference in KubeService.ts.

This field is unnecessary for our use case, it only controls whether the garbage collector should block deletion of the owner (Job) until the dependent (Secret) is removed first.

Avoids following error on trigerring init-phase:
```
{"error":{"name":"Error","message":"HTTP-Code: 403\nMessage: Unknown API Status Code!\nBody: \"{\\\"kind\\\":\\\"Status\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"metadata\\\":{},\\\"status\\\":\\\"Failure\\\",\\\"message\\\":\\\"secrets \\\\\\\"x2a-job-secret-init-2bbdf196-34c8-41dd-a17e-9b24c1df38f3\\\\\\\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , \\\\u003cnil\\\\u003e\\\",\\\"reason\\\":\\\"Forbidden\\\",\\\"details\\\":{\\\"name\\\":\\\"x2a-job-secret-init-2bbdf196-34c8-41dd-a17e-9b24c1df38f3\\\",\\\"kind\\\":\\\"secrets\\\"},\\\"code\\\":403}\\n\"\nHeaders: {\"audit-id\":\"44a0a81f-c326-4949-a85f-0a62830f5e38\",\"cache-control\":\"no-cache, private\",\"connection\":\"close\",\"content-length\":\"410\",\"content-type\":\"application/json\",\"date\":\"Mon, 13 Apr 2026 12:15:00 GMT\",\"strict-transport-security\":\"max-age=31536000; includeSubDomains; preload\",\"x-kubernetes-pf-flowschema-uid\":\"f71a491c-86bb-483c-ab65-249b469d7d90\",\"x-kubernetes-pf-prioritylevel-uid\":\"e8e0c1c6-adbf-4b0f-a98b-766d18459f16\"}","code":403,"body":"{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"secrets \\\"x2a-job-secret-init-2bbdf196-34c8-41dd-a17e-9b24c1df38f3\\\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , \\u003cnil\\u003e\",\"reason\":\"Forbidden\",\"details\":{\"name\":\"x2a-job-secret-init-2bbdf196-34c8-41dd-a17e-9b24c1df38f3\",\"kind\":\"secrets\"},\"code\":403}\n","headers":{"audit-id":"44a0a81f-c326-4949-a85f-0a62830f5e38","cache-control":"no-cache, private","connection":"close","content-length":"410","content-type":"application/json","date":"Mon, 13 Apr 2026 12:15:00 GMT","strict-transport-security":"max-age=31536000; includeSubDomains; preload","x-kubernetes-pf-flowschema-uid":"f71a491c-86bb-483c-ab65-249b469d7d90","x-kubernetes-pf-prioritylevel-uid":"e8e0c1c6-adbf-4b0f-a98b-766d18459f16"}},"request":{"method":"POST","url":"/projects/d0df0423-d88e-4ba5-b6e3-2c0e7a0b6264/run"},"response":{"statusCode":500}}
```