### PR TITLE
feat(orchestrator): add custom review page API support

### DIFF
--- a/workspaces/orchestrator/.changeset/custom-review-page-api.md
+++ b/workspaces/orchestrator/.changeset/custom-review-page-api.md
@@ -1,0 +1,20 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-api': minor
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': minor
+---
+
+Add custom review page API support
+
+**Custom Review Page API:**
+
+- Add `ReviewComponentProps` type to define props for custom review components
+- Add optional `getReviewComponent()` method to `OrchestratorFormApi` interface
+- Update `OrchestratorForm` to support custom review page components from plugins
+- Add `CustomReviewPage` example component in orchestrator-form-widgets plugin
+- Falls back to default review page when `getReviewComponent()` returns `undefined`
+
+**Documentation:**
+
+- Update `extensibleForm.md` with custom review page implementation guide
+- Add example showing how to implement and use custom review components

--- a/workspaces/orchestrator/.changeset/custom-review-page-api.md
+++ b/workspaces/orchestrator/.changeset/custom-review-page-api.md
@@ -11,7 +11,8 @@ Add custom review page API support
 - Add `ReviewComponentProps` type to define props for custom review components
 - Add optional `getReviewComponent()` method to `OrchestratorFormApi` interface
 - Update `OrchestratorForm` to support custom review page components from plugins
-- Add `CustomReviewPage` example component in orchestrator-form-widgets plugin
+- Add `CustomReviewPage` example component in orchestrator-form-widgets plugin (aligned with `ReviewStep`: `generateReviewTableData`, hidden-fields toggle, `NestedReviewTable`)
+- Export `generateReviewTableData`, `schemaHasUiHiddenFields`, and `NestedReviewTable` from orchestrator-form-react for custom review implementations
 - Falls back to default review page when `getReviewComponent()` returns `undefined`
 
 **Documentation:**

--- a/workspaces/orchestrator/docs/extensibleForm.md
+++ b/workspaces/orchestrator/docs/extensibleForm.md
@@ -9,6 +9,7 @@ This decorator supports overriding a selected set of [react-json-schema-form pro
   - **Asynchronous Validation** via the `getExtraErrors` property, for validations requiring backend calls.
 - **Custom Components:** Replace default form components by overriding the `widgets` property.
 - **Interdependent Field Values:** Manage complex inter-field dependencies using the `onChange` and `formData` properties.
+- **Custom Review Page:** Replace the default review page with a custom component via the `getReviewComponent` method.
 
 The custom decorator is delivered via a factory method that leverages a [Backstage utility API](https://backstage.io/docs/api/utility-apis) provided by the orchestrator.
 To trigger the desired behavior, the workflow schema should include custom UI properties.
@@ -57,6 +58,62 @@ The most simple implementation of the API is the default one - adds no extra log
 See [its sources](../plugins/orchestrator-form-api/src/DefaultFormApi.tsx).
 
 More complex example is [the FormWidgetsApi provided by orchestrator-form-widgets plugin](../plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx).
+
+### Custom Review Page Component
+
+You can provide a custom review page component to replace the default review step. This is useful when you want to customize how the form data is displayed before submission.
+
+#### Review Component Props
+
+The custom review component receives the following props:
+
+```typescript
+export type ReviewComponentProps = {
+  /** Whether the workflow execution is in progress */
+  busy: boolean;
+  /** The JSON Schema for the workflow form */
+  schema: JSONSchema7;
+  /** The form data to be reviewed before submission */
+  data: JsonObject;
+  /** Callback to execute the workflow */
+  handleExecute: () => void;
+};
+```
+
+#### Example Implementation
+
+A complete example implementation is available at:
+[`plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx`](../plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx)
+
+This example shows:
+
+- How to structure a custom review component
+- Handling of form data display with proper formatting
+- Integration with Material-UI components
+- Flattening nested objects for better readability
+- Proper button states during execution
+
+#### How to Use in Your Plugin
+
+```typescript
+import { CustomReviewPage } from './components/CustomReviewPage';
+
+class MyFormApi implements OrchestratorFormApi {
+  getFormDecorator(): OrchestratorFormDecorator {
+    // ... your decorator implementation
+  }
+
+  getReviewComponent() {
+    // Return your custom component
+    return CustomReviewPage;
+
+    // Or return undefined to use the default review page
+    // return undefined;
+  }
+}
+```
+
+**Note:** By default, `getReviewComponent()` returns `undefined`, which uses the built-in default review page. To enable a custom review page, return your custom component from this method.
 
 ### Plugin Creation Example
 

--- a/workspaces/orchestrator/docs/extensibleForm.md
+++ b/workspaces/orchestrator/docs/extensibleForm.md
@@ -87,7 +87,7 @@ export type ReviewComponentProps = {
 A complete example implementation is available at:
 [`plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx`](../plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx)
 
-> **Not a blind drop-in:** Older or minimal examples may only restyle raw `data`. For parity with the built-in [`ReviewStep`](../plugins/orchestrator-form-react/src/components/ReviewStep.tsx), a custom review should use **`generateReviewTableData`** from `@red-hat-developer-hub/backstage-plugin-orchestrator-form-react` (respects `ui:hidden`, password masking, and nesting) and, when the schema uses hidden fields, the same **“show hidden parameters”** pattern as `ReviewStep` (see **`schemaHasUiHiddenFields`** in that package). You can also render the structured output with **`NestedReviewTable`** if you want the default table layout without copying markup.
+> **Not a blind drop-in:** Older or minimal examples may only restyle raw `data`. For parity with the built-in [`ReviewStep`](../plugins/orchestrator-form-react/src/components/ReviewStep.tsx), a custom review should use **`generateReviewTableData`** from `@red-hat-developer-hub/backstage-plugin-orchestrator-form-react` (respects `ui:hidden`, password masking, and nesting) and, when the schema uses hidden fields, the same **“show hidden parameters”** pattern as `ReviewStep` (see **`schemaHasUiHiddenFields`** and **`ReviewHiddenParametersAlert`** in that package). You can also render the structured output with **`NestedReviewTable`** if you want the default table layout without copying markup.
 
 This example shows:
 

--- a/workspaces/orchestrator/docs/extensibleForm.md
+++ b/workspaces/orchestrator/docs/extensibleForm.md
@@ -75,6 +75,8 @@ export type ReviewComponentProps = {
   schema: JSONSchema7;
   /** The form data to be reviewed before submission */
   data: JsonObject;
+  /** Return to the previous wizard step (same as the default review page) */
+  handleBack: () => void;
   /** Callback to execute the workflow */
   handleExecute: () => void;
 };
@@ -85,13 +87,15 @@ export type ReviewComponentProps = {
 A complete example implementation is available at:
 [`plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx`](../plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx)
 
+> **Not a blind drop-in:** Older or minimal examples may only restyle raw `data`. For parity with the built-in [`ReviewStep`](../plugins/orchestrator-form-react/src/components/ReviewStep.tsx), a custom review should use **`generateReviewTableData`** from `@red-hat-developer-hub/backstage-plugin-orchestrator-form-react` (respects `ui:hidden`, password masking, and nesting) and, when the schema uses hidden fields, the same **“show hidden parameters”** pattern as `ReviewStep` (see **`schemaHasUiHiddenFields`** in that package). You can also render the structured output with **`NestedReviewTable`** if you want the default table layout without copying markup.
+
 This example shows:
 
 - How to structure a custom review component
-- Handling of form data display with proper formatting
+- Using `generateReviewTableData`, `schemaHasUiHiddenFields`, and `NestedReviewTable` for behavior aligned with `ReviewStep`
 - Integration with Material-UI components
-- Flattening nested objects for better readability
 - Proper button states during execution
+- Back navigation via the `handleBack` prop
 
 #### How to Use in Your Plugin
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -29,7 +29,8 @@ export type FormDecoratorProps = Pick<
 
 // @public
 export interface OrchestratorFormApi {
-  getFormDecorator(): OrchestratorFormDecorator;
+    getFormDecorator(): OrchestratorFormDecorator;
+    getReviewComponent?(): React.ComponentType<ReviewComponentProps> | undefined;
 }
 
 // @public
@@ -66,6 +67,14 @@ export type OrchestratorFormSchemaUpdater = (
 ) => void;
 
 // @public
+export type ReviewComponentProps = {
+    busy: boolean;
+    schema: JSONSchema7;
+    data: JsonObject;
+    handleExecute: () => void;
+};
+
+// @public
 export type SchemaChunksResponse = {
   [key: string]: JsonObject;
 };
@@ -77,7 +86,7 @@ export const useOrchestratorFormApiOrDefault: () => OrchestratorFormApi;
 
 // Warnings were encountered during analysis:
 //
-// src/api.d.ts:100:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
+// src/api.d.ts:123:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/report.api.md
@@ -29,8 +29,8 @@ export type FormDecoratorProps = Pick<
 
 // @public
 export interface OrchestratorFormApi {
-    getFormDecorator(): OrchestratorFormDecorator;
-    getReviewComponent?(): React.ComponentType<ReviewComponentProps> | undefined;
+  getFormDecorator(): OrchestratorFormDecorator;
+  getReviewComponent?(): React.ComponentType<ReviewComponentProps> | undefined;
 }
 
 // @public
@@ -68,10 +68,11 @@ export type OrchestratorFormSchemaUpdater = (
 
 // @public
 export type ReviewComponentProps = {
-    busy: boolean;
-    schema: JSONSchema7;
-    data: JsonObject;
-    handleExecute: () => void;
+  busy: boolean;
+  schema: JSONSchema7;
+  data: JsonObject;
+  handleBack: () => void;
+  handleExecute: () => void;
 };
 
 // @public
@@ -86,7 +87,7 @@ export const useOrchestratorFormApiOrDefault: () => OrchestratorFormApi;
 
 // Warnings were encountered during analysis:
 //
-// src/api.d.ts:123:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
+// src/api.d.ts:125:22 - (ae-undocumented) Missing documentation for "useOrchestratorFormApiOrDefault".
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
@@ -118,6 +118,23 @@ export type OrchestratorFormSchemaUpdater = (
 
 /**
  * @public
+ * ReviewComponentProps
+ *
+ * Type definition for properties passed to a custom review page component.
+ */
+export type ReviewComponentProps = {
+  /** Whether the workflow execution is in progress */
+  busy: boolean;
+  /** The JSON Schema for the workflow form */
+  schema: JSONSchema7;
+  /** The form data to be reviewed before submission */
+  data: JsonObject;
+  /** Callback to execute the workflow */
+  handleExecute: () => void;
+};
+
+/**
+ * @public
  * OrchestratorFormApi
  * API to be implemented by factory in a custom plugin
  */
@@ -137,6 +154,14 @@ export interface OrchestratorFormApi {
    * return the form decorator
    */
   getFormDecorator(): OrchestratorFormDecorator;
+
+  /**
+   * @public
+   * getReviewComponent
+   * return a custom review page component to replace the default review step
+   * @returns A React component that accepts ReviewComponentProps, or undefined to use the default review page
+   */
+  getReviewComponent?(): React.ComponentType<ReviewComponentProps> | undefined;
 }
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/api.ts
@@ -129,6 +129,8 @@ export type ReviewComponentProps = {
   schema: JSONSchema7;
   /** The form data to be reviewed before submission */
   data: JsonObject;
+  /** Go back to the previous wizard step (same behavior as the default review page) */
+  handleBack: () => void;
   /** Callback to execute the workflow */
   handleExecute: () => void;
 };

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/src/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/src/index.ts
@@ -22,4 +22,5 @@ export type {
   OrchestratorFormSchemaUpdater,
   SchemaChunksResponse,
   OrchestratorFormContextProps,
+  ReviewComponentProps,
 } from './api';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
@@ -63,6 +63,17 @@ export type OrchestratorFormProps = {
 };
 
 // @public
+export const ReviewHiddenParametersAlert: (
+  input: ReviewHiddenParametersAlertProps,
+) => JSX_2.Element;
+
+// @public (undocumented)
+export type ReviewHiddenParametersAlertProps = {
+  showHiddenFields: boolean;
+  onShowHiddenFieldsChange: (includeHidden: boolean) => void;
+};
+
+// @public
 export function schemaHasUiHiddenFields(schema: JSONSchema7): boolean;
 
 // @public
@@ -87,6 +98,7 @@ export const useTranslation: () => {
 
 // Warnings were encountered during analysis:
 //
+// src/components/ReviewHiddenParametersAlert.d.ts:4:1 - (ae-undocumented) Missing documentation for "ReviewHiddenParametersAlertProps".
 // src/hooks/useTranslation.d.ts:1:1 - (ae-undocumented) Missing documentation for "TranslationFunction".
 // src/hooks/useTranslation.d.ts:2:22 - (ae-undocumented) Missing documentation for "useTranslation".
 ```

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
@@ -8,7 +8,17 @@ import type { JSONSchema7 } from 'json-schema';
 import { JsonValue } from '@backstage/types';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
+
+// @public
+export function generateReviewTableData(
+  schema: JSONSchema7,
+  data: JsonObject,
+  options?: {
+    includeHiddenFields?: boolean;
+  },
+): JsonObject;
 
 // @public
 export type HiddenCondition =
@@ -31,6 +41,14 @@ export interface HiddenConditionObject {
 }
 
 // @public
+export const NestedReviewTable: React_2.FC<NestedReviewTableProps>;
+
+// @public
+export interface NestedReviewTableProps {
+  data: JsonObject;
+}
+
+// @public
 export const OrchestratorForm: (input: OrchestratorFormProps) => JSX_2.Element;
 
 // @public
@@ -43,6 +61,9 @@ export type OrchestratorFormProps = {
   initialFormData: JsonObject;
   t: TranslationFunction;
 };
+
+// @public
+export function schemaHasUiHiddenFields(schema: JSONSchema7): boolean;
 
 // @public
 export const SubmitButton: (input: {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/NestedReviewTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/NestedReviewTable.tsx
@@ -57,7 +57,13 @@ const useStyles = makeStyles()(theme => ({
   },
 }));
 
-interface NestedReviewTableProps {
+/**
+ * Props for `NestedReviewTable`.
+ *
+ * @public
+ */
+export interface NestedReviewTableProps {
+  /** Structured review payload (typically from `generateReviewTableData`). */
   data: JsonObject;
 }
 
@@ -108,6 +114,11 @@ const RenderNestedData: React.FC<{ data: JsonObject; classes: any }> = ({
   );
 };
 
+/**
+ * Renders nested review key/value sections (structure matches `generateReviewTableData` output).
+ *
+ * @public
+ */
 export const NestedReviewTable: React.FC<NestedReviewTableProps> = ({
   data,
 }) => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Fragment, useCallback, useMemo, useState } from 'react';
+import { ComponentType, Fragment, useCallback, useMemo, useState } from 'react';
 
 import { JsonObject } from '@backstage/types';
 
@@ -25,6 +25,7 @@ import get from 'lodash/get';
 
 import {
   OrchestratorFormContextProps,
+  ReviewComponentProps,
   useOrchestratorFormApiOrDefault,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
@@ -32,7 +33,10 @@ import { TranslationFunction } from '../hooks/useTranslation';
 import extractStaticDefaults from '../utils/extractStaticDefaults';
 import generateUiSchema from '../utils/generateUiSchema';
 import { omitFromWorkflowInput, pruneFormData } from '../utils/pruneFormData';
-import { StepperContextProvider } from '../utils/StepperContext';
+import {
+  StepperContextProvider,
+  useStepperContext,
+} from '../utils/StepperContext';
 import OrchestratorFormWrapper from './OrchestratorFormWrapper';
 import ReviewStep from './ReviewStep';
 import SingleStepForm from './SingleStepForm';
@@ -99,6 +103,34 @@ const removeHiddenSteps = (schema: JSONSchema7): JSONSchema7 => {
   }
 
   return schema;
+};
+
+type ReviewStepHostProps = {
+  ReviewComponent: ComponentType<ReviewComponentProps>;
+  busy: boolean;
+  schema: JSONSchema7;
+  data: JsonObject;
+  handleExecute: () => void;
+};
+
+/** Supplies `handleBack` from stepper context to the default or custom review component. */
+const ReviewStepHost = ({
+  ReviewComponent,
+  busy,
+  schema,
+  data,
+  handleExecute,
+}: ReviewStepHostProps) => {
+  const { handleBack } = useStepperContext();
+  return (
+    <ReviewComponent
+      busy={busy}
+      schema={schema}
+      data={data}
+      handleBack={handleBack}
+      handleExecute={handleExecute}
+    />
+  );
 };
 
 /**
@@ -179,10 +211,10 @@ const OrchestratorForm = ({
   }, [orchestratorFormApi]);
 
   const reviewStep = useMemo(() => {
-    // Use custom review component if provided, otherwise use default
     const ReviewComponent = CustomReviewComponent || ReviewStep;
     return (
-      <ReviewComponent
+      <ReviewStepHost
+        ReviewComponent={ReviewComponent}
         data={prunedFormData}
         schema={schema}
         busy={isExecuting}

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -23,7 +23,10 @@ import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 
-import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import {
+  OrchestratorFormContextProps,
+  useOrchestratorFormApiOrDefault,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
 import { TranslationFunction } from '../hooks/useTranslation';
 import extractStaticDefaults from '../utils/extractStaticDefaults';
@@ -169,17 +172,30 @@ const OrchestratorForm = ({
     return generateUiSchema(schema, isMultiStep);
   }, [schema, isMultiStep]);
 
+  // Get custom review component from API if available
+  const orchestratorFormApi = useOrchestratorFormApiOrDefault();
+  const CustomReviewComponent = useMemo(() => {
+    return orchestratorFormApi.getReviewComponent?.();
+  }, [orchestratorFormApi]);
+
   const reviewStep = useMemo(() => {
+    // Use custom review component if provided, otherwise use default
+    const ReviewComponent = CustomReviewComponent || ReviewStep;
     return (
-      <ReviewStep
+      <ReviewComponent
         data={prunedFormData}
         schema={schema}
         busy={isExecuting}
         handleExecute={_handleExecute}
-        // no schema update here
       />
     );
-  }, [prunedFormData, schema, isExecuting, _handleExecute]);
+  }, [
+    CustomReviewComponent,
+    prunedFormData,
+    schema,
+    isExecuting,
+    _handleExecute,
+  ]);
 
   return (
     <StepperContextProvider reviewStep={reviewStep} t={t}>

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewHiddenParametersAlert.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewHiddenParametersAlert.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Alert from '@mui/material/Alert';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
+
+import { useTranslation } from '../hooks/useTranslation';
+
+const useStyles = makeStyles()(theme => ({
+  hiddenFieldsAlert: {
+    marginBottom: theme.spacing(2),
+  },
+  hiddenFieldsAction: {
+    marginLeft: theme.spacing(2),
+  },
+  hiddenFieldsText: {
+    fontSize: theme.typography.body1.fontSize,
+  },
+}));
+
+/**
+ * @public
+ */
+export type ReviewHiddenParametersAlertProps = {
+  /** When true, `ui:hidden` fields are included in the review table. */
+  showHiddenFields: boolean;
+  /** Invoked when the user toggles “show hidden parameters”. */
+  onShowHiddenFieldsChange: (includeHidden: boolean) => void;
+};
+
+/**
+ * Info alert and switch to include `ui:hidden` fields in the review table (shared by default and custom review UIs).
+ *
+ * @public
+ */
+export const ReviewHiddenParametersAlert = ({
+  showHiddenFields,
+  onShowHiddenFieldsChange,
+}: ReviewHiddenParametersAlertProps) => {
+  const { t } = useTranslation();
+  const { classes } = useStyles();
+
+  return (
+    <Alert
+      severity="info"
+      className={classes.hiddenFieldsAlert}
+      action={
+        <FormControlLabel
+          className={classes.hiddenFieldsAction}
+          control={
+            <Switch
+              checked={showHiddenFields}
+              onChange={event => onShowHiddenFieldsChange(event.target.checked)}
+              color="primary"
+            />
+          }
+          label={
+            <Typography className={classes.hiddenFieldsText}>
+              {t('reviewStep.showHiddenParameters')}
+            </Typography>
+          }
+        />
+      }
+    >
+      <Typography className={classes.hiddenFieldsText}>
+        {t('reviewStep.hiddenFieldsNote')}
+      </Typography>
+    </Alert>
+  );
+};

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
@@ -19,13 +19,9 @@ import { useMemo, useState } from 'react';
 import { Content } from '@backstage/core-components';
 import { JsonObject } from '@backstage/types';
 
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
-import Switch from '@mui/material/Switch';
-import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 
 import { ReviewComponentProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
@@ -34,6 +30,7 @@ import { useTranslation } from '../hooks/useTranslation';
 import generateReviewTableData from '../utils/generateReviewTableData';
 import { schemaHasUiHiddenFields } from '../utils/schemaHasUiHiddenFields';
 import NestedReviewTable from './NestedReviewTable';
+import { ReviewHiddenParametersAlert } from './ReviewHiddenParametersAlert';
 import SubmitButton from './SubmitButton';
 
 const useStyles = makeStyles()(theme => ({
@@ -59,15 +56,6 @@ const useStyles = makeStyles()(theme => ({
         justifyContent: 'left',
       },
     },
-  },
-  hiddenFieldsAlert: {
-    marginBottom: theme.spacing(2),
-  },
-  hiddenFieldsAction: {
-    marginLeft: theme.spacing(2),
-  },
-  hiddenFieldsText: {
-    fontSize: theme.typography.body1.fontSize,
   },
 }));
 
@@ -96,33 +84,10 @@ const ReviewStep = ({
     <Content noPadding>
       <Paper square elevation={0} className={classes.paper}>
         {showHiddenFieldsNote && (
-          <Alert
-            severity="info"
-            className={classes.hiddenFieldsAlert}
-            action={
-              <FormControlLabel
-                className={classes.hiddenFieldsAction}
-                control={
-                  <Switch
-                    checked={showHiddenFields}
-                    onChange={event =>
-                      setShowHiddenFields(event.target.checked)
-                    }
-                    color="primary"
-                  />
-                }
-                label={
-                  <Typography className={classes.hiddenFieldsText}>
-                    {t('reviewStep.showHiddenParameters')}
-                  </Typography>
-                }
-              />
-            }
-          >
-            <Typography className={classes.hiddenFieldsText}>
-              {t('reviewStep.hiddenFieldsNote')}
-            </Typography>
-          </Alert>
+          <ReviewHiddenParametersAlert
+            showHiddenFields={showHiddenFields}
+            onShowHiddenFieldsChange={setShowHiddenFields}
+          />
         )}
         <NestedReviewTable data={displayData} />
         <Box mb={4} />

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/ReviewStep.tsx
@@ -26,13 +26,13 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
-import type { JSONSchema7 } from 'json-schema';
-import { get } from 'lodash';
 import { makeStyles } from 'tss-react/mui';
+
+import { ReviewComponentProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
 import { useTranslation } from '../hooks/useTranslation';
 import generateReviewTableData from '../utils/generateReviewTableData';
-import { useStepperContext } from '../utils/StepperContext';
+import { schemaHasUiHiddenFields } from '../utils/schemaHasUiHiddenFields';
 import NestedReviewTable from './NestedReviewTable';
 import SubmitButton from './SubmitButton';
 
@@ -71,59 +71,16 @@ const useStyles = makeStyles()(theme => ({
   },
 }));
 
-/**
- * Recursively checks if the schema contains any fields with ui:hidden property
- */
-const hasHiddenFields = (schema: JSONSchema7): boolean => {
-  if (typeof schema === 'boolean') {
-    return false;
-  }
-
-  // Check if this schema itself is hidden
-  if (get(schema, 'ui:hidden')) {
-    return true;
-  }
-
-  // Check properties
-  if (schema.properties) {
-    for (const prop of Object.values(schema.properties)) {
-      if (typeof prop !== 'boolean' && hasHiddenFields(prop)) {
-        return true;
-      }
-    }
-  }
-
-  // Check items (for arrays)
-  if (schema.items && typeof schema.items !== 'boolean') {
-    if (Array.isArray(schema.items)) {
-      for (const item of schema.items) {
-        if (typeof item !== 'boolean' && hasHiddenFields(item)) {
-          return true;
-        }
-      }
-    } else if (hasHiddenFields(schema.items)) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
 const ReviewStep = ({
   busy,
   schema,
   data,
+  handleBack,
   handleExecute,
-}: {
-  busy: boolean;
-  schema: JSONSchema7;
-  data: JsonObject;
-  handleExecute: () => void;
-}) => {
+}: ReviewComponentProps) => {
   const { t } = useTranslation();
 
   const { classes } = useStyles();
-  const { handleBack } = useStepperContext();
   const [showHiddenFields, setShowHiddenFields] = useState(false);
   const displayData = useMemo<JsonObject>(() => {
     return generateReviewTableData(schema, data, {
@@ -132,7 +89,7 @@ const ReviewStep = ({
   }, [schema, data, showHiddenFields]);
 
   const showHiddenFieldsNote = useMemo(() => {
-    return hasHiddenFields(schema);
+    return schemaHasUiHiddenFields(schema);
   }, [schema]);
 
   return (

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/index.ts
@@ -16,4 +16,6 @@
 
 export type { OrchestratorFormProps } from './OrchestratorForm';
 export { default as OrchestratorForm } from './OrchestratorForm';
+export type { NestedReviewTableProps } from './NestedReviewTable';
+export { NestedReviewTable } from './NestedReviewTable';
 export { default as SubmitButton } from './SubmitButton';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/index.ts
@@ -18,4 +18,6 @@ export type { OrchestratorFormProps } from './OrchestratorForm';
 export { default as OrchestratorForm } from './OrchestratorForm';
 export type { NestedReviewTableProps } from './NestedReviewTable';
 export { NestedReviewTable } from './NestedReviewTable';
+export type { ReviewHiddenParametersAlertProps } from './ReviewHiddenParametersAlert';
+export { ReviewHiddenParametersAlert } from './ReviewHiddenParametersAlert';
 export { default as SubmitButton } from './SubmitButton';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/index.ts
@@ -24,9 +24,12 @@
 // that are useful to other plugins or modules.
 
 export * from './components';
+export type { NestedReviewTableProps } from './components/NestedReviewTable';
 export * from './hooks';
 export type {
   HiddenCondition,
   HiddenConditionObject,
   HiddenConditionComposite,
 } from './types/HiddenCondition';
+export { default as generateReviewTableData } from './utils/generateReviewTableData';
+export { schemaHasUiHiddenFields } from './utils/schemaHasUiHiddenFields';

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/index.ts
@@ -25,6 +25,7 @@
 
 export * from './components';
 export type { NestedReviewTableProps } from './components/NestedReviewTable';
+export type { ReviewHiddenParametersAlertProps } from './components/ReviewHiddenParametersAlert';
 export * from './hooks';
 export type {
   HiddenCondition,

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
@@ -88,6 +88,12 @@ export function processSchema(
   return { [name]: value };
 }
 
+/**
+ * Builds review display data from form values and schema (respects `ui:hidden`, passwords, nesting).
+ * Pair with `schemaHasUiHiddenFields` and a user toggle when you need parity with the default review step.
+ *
+ * @public
+ */
 function generateReviewTableData(
   schema: JSONSchema7,
   data: JsonObject,

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/schemaHasUiHiddenFields.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/schemaHasUiHiddenFields.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { JSONSchema7 } from 'json-schema';
+import { get } from 'lodash';
+
+/**
+ * Returns true when the schema tree contains any `ui:hidden` marker (static or conditional),
+ * matching how the default review step decides to show the hidden-fields notice.
+ *
+ * @public
+ */
+export function schemaHasUiHiddenFields(schema: JSONSchema7): boolean {
+  if (typeof schema === 'boolean') {
+    return false;
+  }
+
+  if (get(schema, 'ui:hidden')) {
+    return true;
+  }
+
+  if (schema.properties) {
+    for (const prop of Object.values(schema.properties)) {
+      if (typeof prop !== 'boolean' && schemaHasUiHiddenFields(prop)) {
+        return true;
+      }
+    }
+  }
+
+  if (schema.items && typeof schema.items !== 'boolean') {
+    if (Array.isArray(schema.items)) {
+      for (const item of schema.items) {
+        if (typeof item !== 'boolean' && schemaHasUiHiddenFields(item)) {
+          return true;
+        }
+      }
+    } else if (schemaHasUiHiddenFields(schema.items)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/package.json
@@ -71,6 +71,7 @@
     "@mui/styles": "5.18.0",
     "@red-hat-developer-hub/backstage-plugin-orchestrator-common": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-orchestrator-form-api": "workspace:^",
+    "@red-hat-developer-hub/backstage-plugin-orchestrator-form-react": "workspace:^",
     "@rjsf/material-ui": "^5.21.2",
     "@rjsf/utils": "^5.21.2",
     "clsx": "^2.1.1",

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.tsx
@@ -68,4 +68,12 @@ export class FormWidgetsApi implements OrchestratorFormApi {
       };
     };
   };
+
+  getReviewComponent: OrchestratorFormApi['getReviewComponent'] = () => {
+    // Return undefined to use the default review page
+    // To use a custom review page, return your custom component here
+    // Example: return CustomReviewPage;
+    // See: plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
+    return undefined;
+  };
 }

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * EXAMPLE: Custom Review Page Component
+ *
+ * This is a reference implementation showing how to create a custom review page.
+ * It is NOT actively used by default - the default review page is used instead.
+ *
+ * To use this custom review page:
+ * 1. Import this component in FormWidgetsApi.tsx
+ * 2. Return it from the getReviewComponent() method:
+ *
+ *    getReviewComponent() {
+ *      return CustomReviewPage;
+ *    }
+ *
+ * Or create your own custom review component following this pattern.
+ *
+ * See docs/extensibleForm.md for more details.
+ */
+
+import React, { useMemo } from 'react';
+import { Content } from '@backstage/core-components';
+import { ReviewComponentProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import { makeStyles } from 'tss-react/mui';
+
+const useStyles = makeStyles()(theme => ({
+  paper: {
+    padding: theme.spacing(3),
+  },
+  header: {
+    marginBottom: theme.spacing(3),
+    paddingBottom: theme.spacing(2),
+    borderBottom: `2px solid ${theme.palette.primary.main}`,
+  },
+  section: {
+    marginBottom: theme.spacing(2),
+  },
+  label: {
+    fontWeight: 600,
+    color: theme.palette.text.secondary,
+    marginRight: theme.spacing(1),
+  },
+  value: {
+    color: theme.palette.text.primary,
+  },
+  row: {
+    display: 'flex',
+    padding: theme.spacing(1.5, 0),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(4),
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  customBadge: {
+    marginLeft: theme.spacing(1),
+  },
+}));
+
+const renderValue = (value: any): React.ReactNode => {
+  if (value === null || value === undefined) {
+    return (
+      <Typography variant="body2" color="textSecondary">
+        N/A
+      </Typography>
+    );
+  }
+  if (typeof value === 'object') {
+    return (
+      <Typography
+        variant="body2"
+        component="pre"
+        sx={{ whiteSpace: 'pre-wrap' }}
+      >
+        {JSON.stringify(value, null, 2)}
+      </Typography>
+    );
+  }
+  return <Typography variant="body2">{String(value)}</Typography>;
+};
+
+/**
+ * Custom review page component with enhanced styling
+ * This demonstrates how to create a custom review page for the orchestrator form
+ */
+export const CustomReviewPage: React.FC<ReviewComponentProps> = ({
+  data,
+  schema: _schema,
+  busy,
+  handleExecute,
+}) => {
+  const { classes } = useStyles();
+
+  const flattenedData = useMemo(() => {
+    const result: Array<{ key: string; value: any; path: string }> = [];
+
+    const flatten = (obj: any, prefix = '', displayPrefix = '') => {
+      Object.entries(obj).forEach(([key, value]) => {
+        const newPath = prefix ? `${prefix}.${key}` : key;
+        const newDisplayPrefix = displayPrefix
+          ? `${displayPrefix} > ${key}`
+          : key;
+
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          flatten(value, newPath, newDisplayPrefix);
+        } else {
+          result.push({ key: newDisplayPrefix, value, path: newPath });
+        }
+      });
+    };
+
+    flatten(data);
+    return result;
+  }, [data]);
+
+  return (
+    <Content noPadding>
+      <Paper elevation={0} className={classes.paper}>
+        <Box className={classes.header}>
+          <Typography variant="h5" component="h2">
+            🎨 Custom Review Page
+            <Chip
+              label="CUSTOM"
+              color="primary"
+              size="small"
+              className={classes.customBadge}
+            />
+          </Typography>
+          <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+            This is a custom review page component provided via the
+            OrchestratorFormApi plugin system
+          </Typography>
+        </Box>
+
+        <Box className={classes.section}>
+          <Typography variant="h6" gutterBottom>
+            Review Your Information
+          </Typography>
+          <Typography variant="body2" color="textSecondary" gutterBottom>
+            Please review the information below before submitting the workflow
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 3 }}>
+          {flattenedData.map(({ key, value }) => (
+            <Box key={key} className={classes.row}>
+              <Typography className={classes.label} sx={{ minWidth: '200px' }}>
+                {key}:
+              </Typography>
+              <Box className={classes.value} sx={{ flex: 1 }}>
+                {renderValue(value)}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+
+        <Box className={classes.footer}>
+          <Button variant="outlined" disabled={busy}>
+            Back
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleExecute}
+            disabled={busy}
+          >
+            {busy ? 'Executing...' : 'Run Workflow'}
+          </Button>
+        </Box>
+      </Paper>
+    </Content>
+  );
+};

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
@@ -20,6 +20,9 @@
  * This is a reference implementation showing how to create a custom review page.
  * It is NOT actively used by default - the default review page is used instead.
  *
+ * It follows the same data rules as the built-in `ReviewStep`: `generateReviewTableData`
+ * for display (including `ui:hidden` handling) and the optional hidden-fields toggle.
+ *
  * To use this custom review page:
  * 1. Import this component in FormWidgetsApi.tsx
  * 2. Return it from the getReviewComponent() method:
@@ -28,19 +31,29 @@
  *      return CustomReviewPage;
  *    }
  *
- * Or create your own custom review component following this pattern.
+ * Or create your own custom component following this pattern.
  *
  * See docs/extensibleForm.md for more details.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Content } from '@backstage/core-components';
+import { JsonObject } from '@backstage/types';
 import { ReviewComponentProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import {
+  generateReviewTableData,
+  NestedReviewTable,
+  schemaHasUiHiddenFields,
+  useTranslation,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Paper from '@mui/material/Paper';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 
 const useStyles = makeStyles()(theme => ({
@@ -55,19 +68,6 @@ const useStyles = makeStyles()(theme => ({
   section: {
     marginBottom: theme.spacing(2),
   },
-  label: {
-    fontWeight: 600,
-    color: theme.palette.text.secondary,
-    marginRight: theme.spacing(1),
-  },
-  value: {
-    color: theme.palette.text.primary,
-  },
-  row: {
-    display: 'flex',
-    padding: theme.spacing(1.5, 0),
-    borderBottom: `1px solid ${theme.palette.divider}`,
-  },
   footer: {
     display: 'flex',
     justifyContent: 'flex-end',
@@ -79,63 +79,42 @@ const useStyles = makeStyles()(theme => ({
   customBadge: {
     marginLeft: theme.spacing(1),
   },
+  hiddenFieldsAlert: {
+    marginBottom: theme.spacing(2),
+  },
+  hiddenFieldsAction: {
+    marginLeft: theme.spacing(2),
+  },
+  hiddenFieldsText: {
+    fontSize: theme.typography.body1.fontSize,
+  },
 }));
 
-const renderValue = (value: any): React.ReactNode => {
-  if (value === null || value === undefined) {
-    return (
-      <Typography variant="body2" color="textSecondary">
-        N/A
-      </Typography>
-    );
-  }
-  if (typeof value === 'object') {
-    return (
-      <Typography
-        variant="body2"
-        component="pre"
-        sx={{ whiteSpace: 'pre-wrap' }}
-      >
-        {JSON.stringify(value, null, 2)}
-      </Typography>
-    );
-  }
-  return <Typography variant="body2">{String(value)}</Typography>;
-};
-
 /**
- * Custom review page component with enhanced styling
- * This demonstrates how to create a custom review page for the orchestrator form
+ * Custom review page component with enhanced styling.
+ * Uses the same review data pipeline as the default `ReviewStep` for predictable behavior.
  */
 export const CustomReviewPage: React.FC<ReviewComponentProps> = ({
   data,
-  schema: _schema,
+  schema,
   busy,
+  handleBack,
   handleExecute,
 }) => {
+  const { t } = useTranslation();
   const { classes } = useStyles();
+  const [showHiddenFields, setShowHiddenFields] = useState(false);
 
-  const flattenedData = useMemo(() => {
-    const result: Array<{ key: string; value: any; path: string }> = [];
+  const displayData = useMemo<JsonObject>(() => {
+    return generateReviewTableData(schema, data, {
+      includeHiddenFields: showHiddenFields,
+    });
+  }, [schema, data, showHiddenFields]);
 
-    const flatten = (obj: any, prefix = '', displayPrefix = '') => {
-      Object.entries(obj).forEach(([key, value]) => {
-        const newPath = prefix ? `${prefix}.${key}` : key;
-        const newDisplayPrefix = displayPrefix
-          ? `${displayPrefix} > ${key}`
-          : key;
-
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-          flatten(value, newPath, newDisplayPrefix);
-        } else {
-          result.push({ key: newDisplayPrefix, value, path: newPath });
-        }
-      });
-    };
-
-    flatten(data);
-    return result;
-  }, [data]);
+  const showHiddenFieldsNote = useMemo(
+    () => schemaHasUiHiddenFields(schema),
+    [schema],
+  );
 
   return (
     <Content noPadding>
@@ -165,22 +144,43 @@ export const CustomReviewPage: React.FC<ReviewComponentProps> = ({
           </Typography>
         </Box>
 
+        {showHiddenFieldsNote && (
+          <Alert
+            severity="info"
+            className={classes.hiddenFieldsAlert}
+            action={
+              <FormControlLabel
+                className={classes.hiddenFieldsAction}
+                control={
+                  <Switch
+                    checked={showHiddenFields}
+                    onChange={event =>
+                      setShowHiddenFields(event.target.checked)
+                    }
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography className={classes.hiddenFieldsText}>
+                    {t('reviewStep.showHiddenParameters')}
+                  </Typography>
+                }
+              />
+            }
+          >
+            <Typography className={classes.hiddenFieldsText}>
+              {t('reviewStep.hiddenFieldsNote')}
+            </Typography>
+          </Alert>
+        )}
+
         <Box sx={{ mt: 3 }}>
-          {flattenedData.map(({ key, value }) => (
-            <Box key={key} className={classes.row}>
-              <Typography className={classes.label} sx={{ minWidth: '200px' }}>
-                {key}:
-              </Typography>
-              <Box className={classes.value} sx={{ flex: 1 }}>
-                {renderValue(value)}
-              </Box>
-            </Box>
-          ))}
+          <NestedReviewTable data={displayData} />
         </Box>
 
         <Box className={classes.footer}>
-          <Button variant="outlined" disabled={busy}>
-            Back
+          <Button variant="outlined" onClick={handleBack} disabled={busy}>
+            {t('common.back')}
           </Button>
           <Button
             variant="contained"
@@ -188,7 +188,7 @@ export const CustomReviewPage: React.FC<ReviewComponentProps> = ({
             onClick={handleExecute}
             disabled={busy}
           >
-            {busy ? 'Executing...' : 'Run Workflow'}
+            {busy ? 'Executing...' : t('common.run')}
           </Button>
         </Box>
       </Paper>

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/components/CustomReviewPage.tsx
@@ -43,16 +43,14 @@ import { ReviewComponentProps } from '@red-hat-developer-hub/backstage-plugin-or
 import {
   generateReviewTableData,
   NestedReviewTable,
+  ReviewHiddenParametersAlert,
   schemaHasUiHiddenFields,
   useTranslation,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
-import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 
@@ -78,15 +76,6 @@ const useStyles = makeStyles()(theme => ({
   },
   customBadge: {
     marginLeft: theme.spacing(1),
-  },
-  hiddenFieldsAlert: {
-    marginBottom: theme.spacing(2),
-  },
-  hiddenFieldsAction: {
-    marginLeft: theme.spacing(2),
-  },
-  hiddenFieldsText: {
-    fontSize: theme.typography.body1.fontSize,
   },
 }));
 
@@ -145,33 +134,10 @@ export const CustomReviewPage: React.FC<ReviewComponentProps> = ({
         </Box>
 
         {showHiddenFieldsNote && (
-          <Alert
-            severity="info"
-            className={classes.hiddenFieldsAlert}
-            action={
-              <FormControlLabel
-                className={classes.hiddenFieldsAction}
-                control={
-                  <Switch
-                    checked={showHiddenFields}
-                    onChange={event =>
-                      setShowHiddenFields(event.target.checked)
-                    }
-                    color="primary"
-                  />
-                }
-                label={
-                  <Typography className={classes.hiddenFieldsText}>
-                    {t('reviewStep.showHiddenParameters')}
-                  </Typography>
-                }
-              />
-            }
-          >
-            <Typography className={classes.hiddenFieldsText}>
-              {t('reviewStep.hiddenFieldsNote')}
-            </Typography>
-          </Alert>
+          <ReviewHiddenParametersAlert
+            showHiddenFields={showHiddenFields}
+            onShowHiddenFieldsChange={setShowHiddenFields}
+          />
         )}
 
         <Box sx={{ mt: 3 }}>

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -123,11 +123,11 @@ const _default: OverridableFrontendPlugin<
         defaultGroup?: [Error: `Use the 'group' param instead`];
         group?:
           | (
+              | 'operation'
               | 'overview'
               | 'documentation'
               | 'development'
               | 'deployment'
-              | 'operation'
               | 'observability'
             )
           | (string & {});

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -123,11 +123,11 @@ const _default: OverridableFrontendPlugin<
         defaultGroup?: [Error: `Use the 'group' param instead`];
         group?:
           | (
-              | 'operation'
               | 'overview'
               | 'documentation'
               | 'development'
               | 'deployment'
+              | 'operation'
               | 'observability'
             )
           | (string & {});

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -12833,6 +12833,7 @@ __metadata:
     "@mui/styles": "npm:5.18.0"
     "@red-hat-developer-hub/backstage-plugin-orchestrator-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-orchestrator-form-api": "workspace:^"
+    "@red-hat-developer-hub/backstage-plugin-orchestrator-form-react": "workspace:^"
     "@rjsf/material-ui": "npm:^5.21.2"
     "@rjsf/utils": "npm:^5.21.2"
     "@testing-library/jest-dom": "npm:^6.0.0"


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Story: https://redhat.atlassian.net/browse/RHIDP-13037


**Custom Review Page API:**

- Add `ReviewComponentProps` type to define props for custom review components
- Add optional `getReviewComponent()` method to `OrchestratorFormApi` interface
- Update `OrchestratorForm` to support custom review page components from plugins
- Add `CustomReviewPage` example component in orchestrator-form-widgets plugin
- Falls back to default review page when `getReviewComponent()` returns `undefined`

**Documentation:**

- Update `extensibleForm.md` with custom review page implementation guide



--------Custom review page-----

<img width="1506" height="915" alt="Screenshot 2026-04-14 at 11 50 05 AM" src="https://github.com/user-attachments/assets/e2f12365-33ca-45c5-b03e-ea53dfaea515" />


--------------------
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)


