### PR TITLE
fix(theme): add missing font css reference so that the Red Hat font is used again

### DIFF
--- a/workspaces/theme/.changeset/spotty-jeans-begin.md
+++ b/workspaces/theme/.changeset/spotty-jeans-begin.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Add missing font css reference so that the Red Hat font is used again.

--- a/workspaces/theme/plugins/theme/knip-report.md
+++ b/workspaces/theme/plugins/theme/knip-report.md
@@ -5,6 +5,6 @@
 | Name                        | Location          | Severity |
 | :-------------------------- | :---------------- | :------- |
 | @testing-library/user-event | package.json:75:6 | error    |
-| @backstage/core-app-api     | package.json:59:6 | error    |
+| @backstage/core-app-api     | package.json:61:6 | error    |
 | msw                         | package.json:76:6 | error    |
 

--- a/workspaces/theme/plugins/theme/package.json
+++ b/workspaces/theme/plugins/theme/package.json
@@ -20,7 +20,9 @@
       "@red-hat-developer-hub/backstage-plugin-theme"
     ]
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "exports": {
     ".": "./src/index.ts",
     "./alpha": "./src/alpha/index.ts",
@@ -61,8 +63,6 @@
     "@backstage/core-plugin-api": "^1.12.4",
     "@backstage/dev-utils": "^1.1.21",
     "@backstage/frontend-defaults": "^0.5.0",
-    "@backstage/frontend-plugin-api": "^0.15.1",
-    "@backstage/plugin-app-react": "^0.2.1",
     "@backstage/plugin-user-settings": "^0.9.1",
     "@backstage/test-utils": "^1.7.16",
     "@backstage/theme": "^0.7.2",
@@ -98,6 +98,8 @@
     "@divyanshiGupta"
   ],
   "dependencies": {
+    "@backstage/frontend-plugin-api": "^0.15.1",
+    "@backstage/plugin-app-react": "^0.2.1",
     "@mui/icons-material": "^5.17.1"
   }
 }

--- a/workspaces/theme/plugins/theme/src/alpha/index.ts
+++ b/workspaces/theme/plugins/theme/src/alpha/index.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import { createFrontendModule } from '@backstage/frontend-plugin-api';
-import { ThemeBlueprint } from '@backstage/plugin-app-react';
-import { getAllThemes } from '../themes';
-
 /**
  * RHDH themes as NFS extensions (ThemeBlueprint).
  * Only the app can register ThemeBlueprint; we use the same theme definitions
@@ -25,6 +21,14 @@ import { getAllThemes } from '../themes';
  *
  * @packageDocumentation
  */
+
+import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import { ThemeBlueprint } from '@backstage/plugin-app-react';
+
+import '../assets/fonts/font.min.css';
+
+import { getAllThemes } from '../themes';
+
 const rhdhThemeExtensions = getAllThemes().map(appTheme =>
   ThemeBlueprint.make({
     name: appTheme.id,

--- a/workspaces/theme/plugins/theme/src/index.ts
+++ b/workspaces/theme/plugins/theme/src/index.ts
@@ -17,6 +17,8 @@
 export { default as LightIcon } from '@mui/icons-material/WbSunnyRounded';
 export { default as DarkIcon } from '@mui/icons-material/Brightness2Rounded';
 
+import './assets/fonts/font.min.css';
+
 export * from './hooks';
 export * from './themes';
 export { LogoFull, LogoIcon } from './components';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://redhat.atlassian.net/browse/RHDHBUGS-2469

The difference is small of course... Checkout the a in example... ;)

| What | Before | After |
| --- | --- | --- |
| NFS | <img width="1204" height="745" alt="nfs-before" src="https://github.com/user-attachments/assets/bcedab11-1a6c-4674-bc32-166370e7c31a" /> | <img width="1204" height="745" alt="nfs-after" src="https://github.com/user-attachments/assets/ce02d7f3-31ca-42da-95bb-800de5397af5" /> |
| Legacy | <img width="1204" height="745" alt="legacy-before" src="https://github.com/user-attachments/assets/c30d3f49-7900-4d75-9dc5-36a99d6d68a3" /> | <img width="1204" height="745" alt="legacy-after" src="https://github.com/user-attachments/assets/4c3a48b7-98fa-4e01-b577-681fcfc93ea8" /> |

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
