### PR TITLE
chore: automate workspace labels for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,68 @@
+workspace/adoption-insights:
+  - 'Workspace\\s*adoption-insights'
+
+workspace/ai-integrations:
+  - 'Workspace\\s*ai-integrations'
+
+workspace/app-defaults:
+  - 'Workspace\\s*app-defaults'
+
+workspace/augment:
+  - 'Workspace\\s*augment'
+
+workspace/bulk-import:
+  - 'Workspace\\s*bulk-import'
+
+workspace/cost-management:
+  - 'Workspace\\s*cost-management'
+
+workspace/dcm:
+  - 'Workspace\\s*dcm'
+
+workspace/extensions:
+  - 'Workspace\\s*extensions'
+
+workspace/global-floating-action-button:
+  - 'Workspace\\s*global-floating-action-button'
+
+workspace/global-header:
+  - 'Workspace\\s*global-header'
+
+workspace/homepage:
+  - 'Workspace\\s*homepage'
+
+workspace/konflux:
+  - 'Workspace\\s*konflux'
+
+workspace/lightspeed:
+  - 'Workspace\\s*lightspeed'
+
+workspace/mcp-integrations:
+  - 'Workspace\\s*mcp-integrations'
+
+workspace/noop:
+  - 'Workspace\\s*noop'
+
+workspace/orchestrator:
+  - 'Workspace\\s*orchestrator'
+
+workspace/quickstart:
+  - 'Workspace\\s*quickstart'
+
+workspace/repo-tools:
+  - 'Workspace\\s*repo-tools'
+
+workspace/sandbox:
+  - 'Workspace\\s*sandbox'
+
+workspace/scorecard:
+  - 'Workspace\\s*scorecard'
+
+workspace/theme:
+  - 'Workspace\\s*theme'
+
+workspace/translations:
+  - 'Workspace\\s*translations'
+
+workspace/x2a:
+  - 'Workspace\\s*x2a'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,91 @@
+workspace/adoption-insights:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/adoption-insights/**']
+
+workspace/ai-integrations:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/ai-integrations/**']
+
+workspace/app-defaults:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/app-defaults/**']
+
+workspace/augment:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/augment/**']
+
+workspace/bulk-import:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/bulk-import/**']
+
+workspace/cost-management:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/cost-management/**']
+
+workspace/dcm:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/dcm/**']
+
+workspace/extensions:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/extensions/**']
+
+workspace/global-floating-action-button:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/global-floating-action-button/**']
+
+workspace/global-header:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/global-header/**']
+
+workspace/homepage:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/homepage/**']
+
+workspace/konflux:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/konflux/**']
+
+workspace/lightspeed:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/lightspeed/**']
+
+workspace/mcp-integrations:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/mcp-integrations/**']
+
+workspace/noop:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/noop/**']
+
+workspace/orchestrator:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/orchestrator/**']
+
+workspace/quickstart:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/quickstart/**']
+
+workspace/repo-tools:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/repo-tools/**']
+
+workspace/sandbox:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/sandbox/**']
+
+workspace/scorecard:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/scorecard/**']
+
+workspace/theme:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/theme/**']
+
+workspace/translations:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/translations/**']
+
+workspace/x2a:
+  - changed-files:
+      - any-glob-to-any-file: ['workspaces/x2a/**']

--- a/.github/workflows/add-workspace-label.yml
+++ b/.github/workflows/add-workspace-label.yml
@@ -11,15 +11,13 @@ on:
       - synchronize
       - reopened
 
-permissions:
-  issues: write
-  contents: read
-  pull-requests: write
-
 jobs:
   triage-issues:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
@@ -34,6 +32,9 @@ jobs:
 
   label-prs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1

--- a/.github/workflows/add-workspace-label.yml
+++ b/.github/workflows/add-workspace-label.yml
@@ -1,0 +1,18 @@
+# PR-only workspace path labels (workspace/<dir>) for search and triage.
+# Based on: https://github.com/backstage/community-plugins/blob/main/.github/workflows/add-workspace-label.yml
+name: Add Workspace Label to PRs
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/pr-labeler.yml

--- a/.github/workflows/add-workspace-label.yml
+++ b/.github/workflows/add-workspace-label.yml
@@ -1,18 +1,46 @@
 # PR-only workspace path labels (workspace/<dir>) for search and triage.
 # Based on: https://github.com/backstage/community-plugins/blob/main/.github/workflows/add-workspace-label.yml
-name: Add Workspace Label to PRs
+name: Add workspace labels to PRs
+
 on:
+  issues:
+    types: [opened, edited]
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions:
-  pull-requests: write
+  issues: write
   contents: read
+  pull-requests: write
 
 jobs:
+  triage-issues:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 #v3.4
+        with:
+          configuration-path: .github/labeler.yml
+          enable-versioned-regex: 0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   label-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           configuration-path: .github/pr-labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-workspace-label.yml
+++ b/.github/workflows/add-workspace-label.yml
@@ -1,4 +1,4 @@
-# PR-only workspace path labels (workspace/<dir>) for search and triage.
+# PR and issue workspace path labels (workspace/<dir>) for search and triage.
 # Based on: https://github.com/backstage/community-plugins/blob/main/.github/workflows/add-workspace-label.yml
 name: Add workspace labels to PRs
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds automated PR labeling based on modified workspaces. This change introduces a workflow that monitors file changes and applies relevant workspace labels automatically. This ensures better visibility into which parts of the monorepo are being affected without requiring manual tagging by the author. 

This automation does not dynamically create labels in the repository settings. Will need to be some manual effort but if everyone agrees with these changes, I can go in and begin the process.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
