### PR TITLE
chore(x2a): project name and short id used in target repo

### DIFF
--- a/workspaces/x2a/.changeset/afraid-papers-change.md
+++ b/workspaces/x2a/.changeset/afraid-papers-change.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+Move project directory naming logic from bash to TypeScript Project value object

--- a/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.test.ts
@@ -680,6 +680,7 @@ describe('JobResourceBuilder', () => {
             { name: 'PHASE', value: 'init' },
             { name: 'PROJECT_ID', value: 'proj-123' },
             { name: 'PROJECT_NAME', value: 'Test Project' },
+            { name: 'PROJECT_DIR', value: 'test-project-proj-1' },
             { name: 'JOB_ID', value: 'job-123' },
             { name: 'USER', value: 'user:default/test' },
             {

--- a/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts
@@ -19,6 +19,7 @@ import { V1Job, V1OwnerReference, V1Secret } from '@kubernetes/client-node';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { X2AConfig } from '../../config';
+import { Project } from './Project';
 import { JobCreateParams, AAPCredentials, GitRepo } from './types';
 
 /**
@@ -202,6 +203,7 @@ export class JobResourceBuilder {
    * @returns V1Job resource ready to be created in Kubernetes
    */
   static buildJobSpec(params: JobCreateParams, config: X2AConfig): V1Job {
+    const project = new Project(params.projectId, params.projectName);
     const shortId = crypto.randomBytes(4).toString('hex');
     const jobName = `job-x2a-${params.phase}-${shortId}`;
     const projectSecretName = `x2a-project-secret-${params.projectId}`;
@@ -302,6 +304,10 @@ export class JobResourceBuilder {
                   {
                     name: 'PROJECT_NAME',
                     value: params.projectName,
+                  },
+                  {
+                    name: 'PROJECT_DIR',
+                    value: project.dirName,
                   },
                   {
                     name: 'JOB_ID',

--- a/workspaces/x2a/plugins/x2a-backend/src/services/Project.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/Project.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project } from './Project';
+
+describe('Project', () => {
+  const uuid = '0d52e6f4-1a2b-3c4d-5e6f-7a8b9c0d1e2f';
+
+  describe('projectId', () => {
+    it('returns the raw project ID', () => {
+      const project = new Project(uuid, 'My Project');
+      expect(project.projectId).toBe(uuid);
+    });
+  });
+
+  describe('shortId', () => {
+    it('returns the first 6 characters of the UUID', () => {
+      const project = new Project(uuid, 'My Project');
+      expect(project.shortId).toBe('0d52e6');
+    });
+  });
+
+  describe('baseName', () => {
+    it('lowercases and sanitizes a normal name', () => {
+      const project = new Project(uuid, 'My Chef Migration');
+      expect(project.baseName).toBe('my-chef-migration');
+    });
+
+    it('replaces special characters with dashes', () => {
+      const project = new Project(uuid, 'project@name#with$special!chars');
+      expect(project.baseName).toBe('project-name-with-special-chars');
+    });
+
+    it('collapses consecutive dashes', () => {
+      const project = new Project(uuid, 'my---project---name');
+      expect(project.baseName).toBe('my-project-name');
+    });
+
+    it('removes leading and trailing dashes', () => {
+      const project = new Project(uuid, '---my-project---');
+      expect(project.baseName).toBe('my-project');
+    });
+
+    it('truncates to 64 characters', () => {
+      const longName = 'a'.repeat(100);
+      const project = new Project(uuid, longName);
+      expect(project.baseName).toBe('a'.repeat(64));
+    });
+
+    it('removes trailing dash created by truncation', () => {
+      // 63 chars of 'a' + '-' + more chars = truncation at 64 leaves trailing dash
+      const name = `${'a'.repeat(63)}-bbbbb`;
+      const project = new Project(uuid, name);
+      expect(project.baseName).toBe('a'.repeat(63));
+      expect(project.baseName.endsWith('-')).toBe(false);
+    });
+
+    it('falls back to "project" when name sanitizes to empty', () => {
+      const project = new Project(uuid, '!!!@@@###');
+      expect(project.baseName).toBe('project');
+    });
+
+    it('falls back to "project" for empty string', () => {
+      const project = new Project(uuid, '');
+      expect(project.baseName).toBe('project');
+    });
+
+    it('handles unicode characters', () => {
+      const project = new Project(uuid, 'проект-миграции');
+      // All non-ascii chars become dashes, collapse to empty after trimming
+      expect(project.baseName).toBe('project');
+    });
+
+    it('preserves numbers', () => {
+      const project = new Project(uuid, 'migration-2024-v3');
+      expect(project.baseName).toBe('migration-2024-v3');
+    });
+  });
+
+  describe('dirName', () => {
+    it('combines baseName and shortId', () => {
+      const project = new Project(uuid, 'My Chef Migration');
+      expect(project.dirName).toBe('my-chef-migration-0d52e6');
+    });
+
+    it('uses fallback name for empty sanitized name', () => {
+      const project = new Project(uuid, '!!!');
+      expect(project.dirName).toBe('project-0d52e6');
+    });
+
+    it('handles very long names with truncation', () => {
+      const longName = 'a'.repeat(100);
+      const project = new Project(uuid, longName);
+      expect(project.dirName).toBe(`${'a'.repeat(64)}-0d52e6`);
+      // total length: 64 + 1 + 6 = 71
+      expect(project.dirName.length).toBe(71);
+    });
+  });
+
+  describe('ReDoS protection', () => {
+    it('handles adversarial input in under 100ms', () => {
+      // Craft a string that could cause catastrophic backtracking with naive regex
+      const adversarial =
+        '-'.repeat(1000) + 'a'.repeat(1000) + '-'.repeat(1000);
+      const start = Date.now();
+      const project = new Project(uuid, adversarial);
+      expect(project.baseName).toBeDefined();
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(100);
+    });
+  });
+});

--- a/workspaces/x2a/plugins/x2a-backend/src/services/Project.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/Project.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const MAX_BASE_NAME_LENGTH = 64;
+const SHORT_ID_LENGTH = 6;
+const DEFAULT_BASE_NAME = 'project';
+
+/**
+ * Value Object that encapsulates project naming and directory conventions.
+ *
+ * All sanitization and truncation logic lives here so that consumers
+ * (K8s job specs, bash scripts, etc.) receive a safe, pre-computed name.
+ */
+export class Project {
+  constructor(
+    private readonly id: string,
+    private readonly projectName: string,
+  ) {}
+
+  /** Raw project ID (UUID) */
+  get projectId(): string {
+    return this.id;
+  }
+
+  /** First 6 characters of the project UUID */
+  get shortId(): string {
+    return this.id.substring(0, SHORT_ID_LENGTH);
+  }
+
+  /**
+   * Sanitized project name suitable for use as a directory component.
+   *
+   * Rules:
+   *  - Lowercased
+   *  - Non-alphanumeric characters (except dash) replaced with dash
+   *  - Consecutive dashes collapsed
+   *  - Leading/trailing dashes removed
+   *  - Truncated to 64 characters
+   *  - Falls back to "project" if empty after sanitization
+   *
+   * Uses manual iteration for trimming to prevent ReDoS (O(n) guaranteed).
+   */
+  get baseName(): string {
+    let sanitized = this.projectName
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-{2,}/g, '-');
+
+    // Remove leading dashes (manual iteration — O(n), no ReDoS)
+    let start = 0;
+    while (start < sanitized.length && sanitized[start] === '-') {
+      start++;
+    }
+    sanitized = sanitized.substring(start);
+
+    // Remove trailing dashes (manual iteration — O(n), no ReDoS)
+    let end = sanitized.length;
+    while (end > 0 && sanitized[end - 1] === '-') {
+      end--;
+    }
+    sanitized = sanitized.substring(0, end);
+
+    // Truncate to max length
+    sanitized = sanitized.substring(0, MAX_BASE_NAME_LENGTH);
+
+    // Remove any trailing dash created by truncation
+    while (sanitized.length > 0 && sanitized[sanitized.length - 1] === '-') {
+      sanitized = sanitized.substring(0, sanitized.length - 1);
+    }
+
+    return sanitized || DEFAULT_BASE_NAME;
+  }
+
+  /** Directory name for the target repo: `<baseName>-<shortId>` */
+  get dirName(): string {
+    return `${this.baseName}-${this.shortId}`;
+  }
+}

--- a/workspaces/x2a/plugins/x2a-backend/src/services/types.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/types.ts
@@ -47,7 +47,7 @@ export interface JobCreateParams {
   projectId: string;
   projectName: string;
   /**
-   * Project abbreviation - used for directory naming in target repository
+   * Project abbreviation
    */
   projectAbbrev: string;
   phase: MigrationPhase;

--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -235,9 +235,7 @@ git_clone_repos
 # Define paths
 TARGET_BASE="/workspace/target"
 SOURCE_BASE="/workspace/source"
-SANITIZED_NAME=$(echo "${PROJECT_NAME}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
-SHORT_UUID="${PROJECT_ID:0:6}"
-PROJECT_DIR="${SANITIZED_NAME}-${SHORT_UUID}"
+# PROJECT_DIR is pre-computed by the backend (sanitized name + short UUID)
 PROJECT_PATH="${TARGET_BASE}/${PROJECT_DIR}"
 
 # Create project directory in target

--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -122,7 +122,7 @@ cleanup() {
     # Sanitize secrets from output files before committing
     sanitize_secrets "${PROJECT_PATH:-/workspace/target}"
 
-    git add "${PROJECT_DIR:-${PROJECT_ID}.${PROJECT_ABBREV}}" 2>/dev/null || git add -A || true
+    git add "${PROJECT_DIR}" 2>/dev/null || git add -A || true
     git commit -m "x2a: ${PHASE} phase for ${MODULE_NAME:-project}
 
 Phase: ${PHASE}
@@ -203,7 +203,7 @@ trap 'TERMINATED=true' SIGTERM SIGINT
 # │   ├── [source code]    # Original Chef/Puppet/etc code
 # │   └── [x2a outputs]    # x2a tool writes here (migration-plan.md, etc)
 # └── target/              # Cloned target repo (output, committed to git)
-#     └── [PROJECT_ID].[PROJECT_ABBREV]/
+#     └── [SANITIZED_NAME]-[SHORT_UUID]/   # e.g. my-chef-migration-0d52e6
 #         ├── migration-plan.md
 #         └── modules/[MODULE_NAME]/
 #             ├── migration-plan-{module_name}.md
@@ -235,7 +235,9 @@ git_clone_repos
 # Define paths
 TARGET_BASE="/workspace/target"
 SOURCE_BASE="/workspace/source"
-PROJECT_DIR="${PROJECT_ID}.${PROJECT_ABBREV}"
+SANITIZED_NAME=$(echo "${PROJECT_NAME}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+SHORT_UUID="${PROJECT_ID:0:6}"
+PROJECT_DIR="${SANITIZED_NAME}-${SHORT_UUID}"
 PROJECT_PATH="${TARGET_BASE}/${PROJECT_DIR}"
 
 # Create project directory in target


### PR DESCRIPTION
instead of a long UUID representing a project in the target repo, now a combination of a sanitzed project name + UUID[0:6] chars will be used. This will enhance user experience

related to https://redhat.atlassian.net/browse/FLPATH-4020