### PR TITLE
feat(x2a): allow downloading logs from Logviewer

### DIFF
--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
@@ -36,6 +36,7 @@ import { useClientService } from '../ClientService';
 import { ItemField } from './ItemField';
 import {
   canCancelPhase,
+  downloadLogFile,
   formatDuration,
   humanizeDate,
   secondsBetween,
@@ -283,6 +284,9 @@ export const PhaseDetails = (
             <div style={{ height: 400 }}>
               <LogViewer
                 text={logText || t('modulePage.phases.noLogsAvailable')}
+                onDownloadLog={() =>
+                  downloadLogFile(logText || '', `${phaseName}-${projectId}`)
+                }
               />
             </div>
           )}

--- a/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.test.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { downloadLogFile } from './downloadLogFile';
+
+describe('downloadLogFile', () => {
+  let createObjectURLMock: jest.Mock;
+  let revokeObjectURLMock: jest.Mock;
+  let anchorClickMock: jest.Mock;
+
+  beforeEach(() => {
+    createObjectURLMock = jest.fn().mockReturnValue('blob:mock-url');
+    revokeObjectURLMock = jest.fn();
+    URL.createObjectURL = createObjectURLMock;
+    URL.revokeObjectURL = revokeObjectURLMock;
+
+    anchorClickMock = jest.fn();
+    jest.spyOn(document, 'createElement').mockReturnValue({
+      set href(_: string) {},
+      set download(_: string) {},
+      click: anchorClickMock,
+    } as unknown as HTMLAnchorElement);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates a blob with the provided text', () => {
+    downloadLogFile('log content', 'test');
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(expect.any(Blob));
+  });
+
+  it('triggers a download with the correct filename', () => {
+    const setDownloadSpy = jest.fn();
+    jest.spyOn(document, 'createElement').mockReturnValue({
+      set href(_: string) {},
+      set download(val: string) {
+        setDownloadSpy(val);
+      },
+      click: anchorClickMock,
+    } as unknown as HTMLAnchorElement);
+
+    downloadLogFile('log content', 'analyze-proj-1');
+
+    expect(setDownloadSpy).toHaveBeenCalledWith('analyze-proj-1.log');
+  });
+
+  it('clicks the anchor to trigger download', () => {
+    downloadLogFile('log content', 'test');
+
+    expect(anchorClickMock).toHaveBeenCalled();
+  });
+
+  it('revokes the object URL after download', () => {
+    downloadLogFile('log content', 'test');
+
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url');
+  });
+});

--- a/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.test.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.test.ts
@@ -22,6 +22,7 @@ describe('downloadLogFile', () => {
   let anchorClickMock: jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     createObjectURLMock = jest.fn().mockReturnValue('blob:mock-url');
     revokeObjectURLMock = jest.fn();
     URL.createObjectURL = createObjectURLMock;
@@ -36,6 +37,7 @@ describe('downloadLogFile', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -69,6 +71,8 @@ describe('downloadLogFile', () => {
   it('revokes the object URL after download', () => {
     downloadLogFile('log content', 'test');
 
+    expect(revokeObjectURLMock).not.toHaveBeenCalled();
+    jest.runAllTimers();
     expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url');
   });
 });

--- a/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './buildArtifactUrl';
-export * from './extractResponseError';
-export * from './buildRepoBranchUrl';
-export * from './formatRelativeTime';
-export * from './humanizeArtifactType';
-export * from './humanizeDate';
-export * from './getLastPhaseReached';
-export * from './getNextPhase';
-export * from './canRunNextPhase';
-export * from './canCancelPhase';
-export * from './downloadLogFile';
-export * from './hasPhasePrerequisites';
-export * from './areEligibleModulesToRun';
-export * from './isEligibleForRetriggerInit';
+
+export const downloadLogFile = (text: string, name: string): void => {
+  const blob = new Blob([text], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `${name}.log`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};

--- a/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/downloadLogFile.ts
@@ -21,5 +21,5 @@ export const downloadLogFile = (text: string, name: string): void => {
   anchor.href = url;
   anchor.download = `${name}.log`;
   anchor.click();
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 };


### PR DESCRIPTION
Copy is a bit hard, and It's good to have a way to donwload logs on the phases.

<img width="1560" height="332" alt="image" src="https://github.com/user-attachments/assets/1947d74b-1b5b-4abf-b0f5-88b17050b5b6" />


FIX: FLPATH-3559
