### PR TITLE
fix(orchestrator): simplify workflows tab layout

### DIFF
--- a/workspaces/orchestrator/.changeset/workflows-tab-simplify-layout.md
+++ b/workspaces/orchestrator/.changeset/workflows-tab-simplify-layout.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Simplify workflows tab layout by rendering `WorkflowsTable` directly inside `Content` instead of an extra MUI `Grid` wrapper.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.tsx
@@ -23,8 +23,6 @@ import {
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
-import Grid from '@mui/material/Grid';
-
 import { WorkflowOverviewDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 
 import { orchestratorApiRef } from '../../api';
@@ -65,13 +63,7 @@ export const WorkflowsTabContent = ({
     <Content noPadding>
       {loading ? <Progress /> : null}
       {error ? <ResponseErrorPanel error={error} /> : null}
-      {isReady ? (
-        <Grid container direction="column">
-          <Grid item xs={12}>
-            <WorkflowsTable items={value ?? []} />
-          </Grid>
-        </Grid>
-      ) : null}
+      {isReady ? <WorkflowsTable items={value ?? []} /> : null}
     </Content>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Fixes:

https://redhat.atlassian.net/browse/RHDHBUGS-2690

This change removes the redundant MUI Grid wrapper around WorkflowsTable in WorkflowsTabContent, so the table renders directly inside Content. Behaviour should be unchanged; the layout is simpler and avoids an unnecessary layout component.

----------------------

-----BEFORE----

<img width="962" height="957" alt="Screenshot 2026-04-15 at 5 27 32 PM" src="https://github.com/user-attachments/assets/6bd11fb4-2553-4a85-a23b-15b52beb00a6" />

----------------------

-----AFTER----

<img width="961" height="956" alt="Screenshot 2026-04-15 at 5 26 08 PM" src="https://github.com/user-attachments/assets/f68e5a62-f1f8-485d-b9c4-6a25361d913c" />
<img width="962" height="947" alt="Screenshot 2026-04-15 at 5 25 56 PM" src="https://github.com/user-attachments/assets/38ad2fb4-faed-4b74-9530-6ca8829cb488" />

----------------------


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
