### PR TITLE
fix(lightspeed): added empty state for unconfigured LLM

### DIFF
--- a/workspaces/lightspeed/.changeset/weak-rocks-sort.md
+++ b/workspaces/lightspeed/.changeset/weak-rocks-sort.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Add an empty state for unconfigured LLM.

--- a/workspaces/lightspeed/e2e-tests/lightspeed.ui.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.ui.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { test, expect, Page } from '@playwright/test';
-import { models } from './fixtures/responses';
+import { modelBaseUrl, models } from './fixtures/responses';
 import { openLightspeed } from './utils/testHelper';
 import {
   openChatbot,
@@ -45,6 +45,7 @@ import {
 import { LightspeedMessages, evaluateMessage } from './utils/translations';
 import { runAccessibilityTests } from './utils/accessibility';
 import { bootstrapLightspeedE2ePage } from './utils/lightspeedE2eSetup';
+import { mockModels, mockShields } from './utils/devMode';
 
 test.describe('Lightspeed UI', () => {
   let translations: LightspeedMessages;
@@ -116,6 +117,30 @@ test.describe('Lightspeed UI', () => {
     ).toContainText(translations['chatbox.welcome.description']);
 
     await runAccessibilityTests(sharedPage, testInfo);
+  });
+
+  test('Validate Empty State', async () => {
+    await sharedPage.unroute(`${modelBaseUrl}/v1/shields`);
+    await sharedPage.unroute(`${modelBaseUrl}/v1/models`);
+    await mockShields(sharedPage, []);
+    await mockModels(sharedPage, []);
+
+    await sharedPage.goto('/lightspeed');
+    await sharedPage
+      .getByTestId('lightspeed-lcore-not-configured')
+      .waitFor({ state: 'visible' });
+
+    await expect(
+      sharedPage.getByLabel(translations['lcore.notConfigured.title']),
+    ).toMatchAriaSnapshot(`
+    - region "${translations['lcore.notConfigured.title']}":
+      - heading "${translations['lcore.notConfigured.title']}" [level=2]
+      - paragraph: ${translations['lcore.notConfigured.description']}
+      - link "${translations['lcore.notConfigured.developerLightspeedDocs']}":
+        - /url: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/developer-lightspeed#proc-installing-and-configuring-lightspeed_developer-lightspeed
+      - link "${translations['lcore.notConfigured.backendDocs']}":
+        - /url: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md
+    `);
   });
 
   test('Verify disclaimer to be visible', async () => {

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -258,18 +258,10 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'permission.subject.plugin': string;
     readonly 'permission.subject.notebooks': string;
     readonly 'permission.notebooks.goBack': string;
-    readonly 'lcore.notConfigured.title': string;
-    readonly 'lcore.notConfigured.description': string;
-    readonly 'lcore.notConfigured.developerLightspeedDocs': string;
-    readonly 'lcore.notConfigured.backendDocs': string;
-    readonly 'lcore.loadError.title': string;
-    readonly 'lcore.loadError.description': string;
     readonly 'footer.accuracy.label': string;
     readonly 'common.cancel': string;
     readonly 'common.close': string;
     readonly 'common.readMore': string;
-    readonly 'common.retry': string;
-    readonly 'common.loading': string;
     readonly 'common.noSearchResults': string;
     readonly 'menu.newConversation': string;
     readonly 'chatbox.header.title': string;

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -260,7 +260,7 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'permission.notebooks.goBack': string;
     readonly 'lcore.notConfigured.title': string;
     readonly 'lcore.notConfigured.description': string;
-    readonly 'lcore.notConfigured.llamaStackDocs': string;
+    readonly 'lcore.notConfigured.developerLightspeedDocs': string;
     readonly 'lcore.notConfigured.backendDocs': string;
     readonly 'lcore.loadError.title': string;
     readonly 'lcore.loadError.description': string;

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -258,10 +258,17 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'permission.subject.plugin': string;
     readonly 'permission.subject.notebooks': string;
     readonly 'permission.notebooks.goBack': string;
+    readonly 'lcore.notConfigured.title': string;
+    readonly 'lcore.notConfigured.description': string;
+    readonly 'lcore.notConfigured.llamaStackDocs': string;
+    readonly 'lcore.notConfigured.backendDocs': string;
+    readonly 'lcore.loadError.title': string;
+    readonly 'lcore.loadError.description': string;
     readonly 'footer.accuracy.label': string;
     readonly 'common.cancel': string;
     readonly 'common.close': string;
     readonly 'common.readMore': string;
+    readonly 'common.retry': string;
     readonly 'common.noSearchResults': string;
     readonly 'menu.newConversation': string;
     readonly 'chatbox.header.title': string;

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -269,6 +269,7 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'common.close': string;
     readonly 'common.readMore': string;
     readonly 'common.retry': string;
+    readonly 'common.loading': string;
     readonly 'common.noSearchResults': string;
     readonly 'menu.newConversation': string;
     readonly 'chatbox.header.title': string;

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -258,10 +258,18 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'permission.subject.plugin': string;
     readonly 'permission.subject.notebooks': string;
     readonly 'permission.notebooks.goBack': string;
+    readonly 'lcore.notConfigured.title': string;
+    readonly 'lcore.notConfigured.description': string;
+    readonly 'lcore.notConfigured.developerLightspeedDocs': string;
+    readonly 'lcore.notConfigured.backendDocs': string;
+    readonly 'lcore.loadError.title': string;
+    readonly 'lcore.loadError.description': string;
     readonly 'footer.accuracy.label': string;
     readonly 'common.cancel': string;
     readonly 'common.close': string;
     readonly 'common.readMore': string;
+    readonly 'common.retry': string;
+    readonly 'common.loading': string;
     readonly 'common.noSearchResults': string;
     readonly 'menu.newConversation': string;
     readonly 'chatbox.header.title': string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -135,6 +135,13 @@ const useStyles = makeStyles(theme => ({
   errorContainer: {
     padding: theme.spacing(3),
   },
+  drawerFileDropZone: {
+    gap: 0,
+    rowGap: 0,
+    columnGap: 0,
+    '--pf-v6-c-multiple-file-upload--Gap': '0',
+    '--pf-v5-c-multiple-file-upload--Gap': '0',
+  },
   headerMenu: {
     // align hamburger icon with title
     '& .pf-v6-c-button': {
@@ -1577,6 +1584,7 @@ export const LightspeedChat = ({
             }
             drawerContent={
               <FileDropZone
+                className={classes.drawerFileDropZone}
                 onFileDrop={(e, data) => handleAttach(data, e)}
                 displayMode={ChatbotDisplayMode.embedded}
                 infoText={t('chatbox.fileUpload.infoText')}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
@@ -31,6 +31,11 @@ import { useTranslation } from '../hooks/useTranslation';
 import queryClient from '../utils/queryClient';
 import FileAttachmentContextProvider from './AttachmentContext';
 import { LightspeedChat } from './LightSpeedChat';
+import {
+  LcoreNotConfiguredEmptyState,
+  LightspeedChatModelsLoading,
+  ModelsLoadErrorEmptyState,
+} from './LightspeedChatModelsState';
 import PermissionRequiredState from './PermissionRequiredState';
 
 const THEME_DARK = 'dark';
@@ -48,7 +53,12 @@ const LightspeedChatContainerInner = () => {
 
   const identityApi = useApi(identityApiRef);
 
-  const { data: models } = useAllModels();
+  const {
+    data: models,
+    isLoading: modelsLoading,
+    isError: modelsError,
+    refetch: refetchModels,
+  } = useAllModels();
 
   const { allowed: hasViewAccess, loading } = useLightspeedViewPermission();
 
@@ -157,6 +167,18 @@ const LightspeedChatContainerInner = () => {
         }
       />
     );
+  }
+
+  if (modelsLoading) {
+    return <LightspeedChatModelsLoading />;
+  }
+
+  if (modelsError) {
+    return <ModelsLoadErrorEmptyState onRetry={() => refetchModels()} />;
+  }
+
+  if (modelsItems.length === 0) {
+    return <LcoreNotConfiguredEmptyState />;
   }
 
   return (

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
@@ -147,7 +147,10 @@ const LightspeedChatContainerInner = () => {
   }, [selectedModel, selectedProvider]);
 
   if (loading) {
-    return null;
+    // Never return null inside the overlay modal: PatternFly's focus-trap requires at least
+    // one tabbable node (e.g. after removing the modal close button). Locale switches can
+    // briefly re-enter this loading state.
+    return <LightspeedChatModelsLoading />;
   }
 
   if (!hasViewAccess) {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
@@ -173,7 +173,10 @@ const LightspeedChatContainerInner = () => {
     return <LightspeedChatModelsLoading />;
   }
 
-  if (modelsError) {
+  // TanStack Query can keep the last successful `data` while `isError` is true after a
+  // failed refetch. Prefer showing chat when we still have LLM rows; only use the full-page
+  // error state when there is nothing usable to render.
+  if (modelsError && modelsItems.length === 0) {
     return <ModelsLoadErrorEmptyState onRetry={() => refetchModels()} />;
   }
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
@@ -28,7 +28,8 @@ import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 
 import { useTranslation } from '../hooks/useTranslation';
 
-const LLAMA_STACK_DOCS_URL = 'https://github.com/llamastack/llama-stack';
+const LLAMA_STACK_CONFIGURE_DOCS_URL =
+  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/developer-lightspeed#proc-installing-and-configuring-lightspeed_developer-lightspeed';
 const LIGHTSPEED_BACKEND_README_URL =
   'https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md';
 
@@ -145,9 +146,9 @@ export const LcoreNotConfiguredEmptyState = () => {
             color="primary"
             target="_blank"
             rel="noopener noreferrer"
-            href={LLAMA_STACK_DOCS_URL}
+            href={LLAMA_STACK_CONFIGURE_DOCS_URL}
           >
-            {t('lcore.notConfigured.llamaStackDocs')} &nbsp;{' '}
+            {t('lcore.notConfigured.developerLightspeedDocs')} &nbsp;{' '}
             <OpenInNewIcon fontSize="small" aria-hidden />
           </Button>
           <Link

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { Box, Button, CircularProgress, Typography } from '@material-ui/core';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Link,
+  Typography,
+} from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -66,10 +72,17 @@ const useStyles = makeStyles(theme =>
     },
     actions: {
       display: 'flex',
-      flexWrap: 'wrap',
+      flexDirection: 'column',
+      alignItems: 'center',
       gap: theme.spacing(1.5),
-      justifyContent: 'center',
       marginTop: theme.spacing(1),
+    },
+    backendLink: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      fontSize: theme.typography.body1.fontSize,
+      fontWeight: 500,
     },
   }),
 );
@@ -79,9 +92,16 @@ const useStyles = makeStyles(theme =>
  */
 export const LightspeedChatModelsLoading = () => {
   const classes = useStyles();
+  const { t } = useTranslation();
   return (
-    <div className={classes.root} data-testid="lightspeed-models-loading">
-      <CircularProgress aria-label="Loading models" />
+    <div
+      className={classes.root}
+      data-testid="lightspeed-models-loading"
+      role="status"
+      aria-busy="true"
+      aria-label={t('common.loading')}
+    >
+      <CircularProgress aria-hidden />
     </div>
   );
 };
@@ -130,16 +150,17 @@ export const LcoreNotConfiguredEmptyState = () => {
             {t('lcore.notConfigured.llamaStackDocs')} &nbsp;{' '}
             <OpenInNewIcon fontSize="small" aria-hidden />
           </Button>
-          <Button
-            variant="outlined"
+          <Link
+            className={classes.backendLink}
+            component="a"
             color="primary"
+            href={LIGHTSPEED_BACKEND_README_URL}
             target="_blank"
             rel="noopener noreferrer"
-            href={LIGHTSPEED_BACKEND_README_URL}
           >
-            {t('lcore.notConfigured.backendDocs')} &nbsp;{' '}
+            {t('lcore.notConfigured.backendDocs')}
             <OpenInNewIcon fontSize="small" aria-hidden />
-          </Button>
+          </Link>
         </Box>
       </Box>
     </div>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box, Button, CircularProgress, Typography } from '@material-ui/core';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
+
+import { useTranslation } from '../hooks/useTranslation';
+
+const LLAMA_STACK_DOCS_URL = 'https://github.com/llamastack/llama-stack';
+const LIGHTSPEED_BACKEND_README_URL =
+  'https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md';
+
+const useStyles = makeStyles(theme =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      boxSizing: 'border-box',
+      width: '100%',
+      maxWidth: '100%',
+      minWidth: 0,
+      minHeight: '100%',
+      height: '100%',
+      flex: '1 1 auto',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: theme.spacing(4, 2),
+      backgroundColor: theme.palette.background.default,
+    },
+    panel: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      textAlign: 'center',
+      width: '100%',
+      maxWidth: 440,
+      gap: theme.spacing(2),
+    },
+    emptyStateIcon: {
+      fontSize: 64,
+      color: theme.palette.text.secondary,
+    },
+    errorIcon: {
+      fontSize: 64,
+      color: theme.palette.warning.main,
+    },
+    description: {
+      lineHeight: 1.5,
+      color: theme.palette.text.secondary,
+    },
+    actions: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1.5),
+      justifyContent: 'center',
+      marginTop: theme.spacing(1),
+    },
+  }),
+);
+
+/**
+ * Shown while the models list is loading for an authorized user.
+ */
+export const LightspeedChatModelsLoading = () => {
+  const classes = useStyles();
+  return (
+    <div className={classes.root} data-testid="lightspeed-models-loading">
+      <CircularProgress aria-label="Loading models" />
+    </div>
+  );
+};
+
+/**
+ * Shown when LCORE / Llama Stack is up but no LLM models are registered.
+ */
+export const LcoreNotConfiguredEmptyState = () => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  return (
+    <div className={classes.root} data-testid="lightspeed-lcore-not-configured">
+      <Box
+        className={classes.panel}
+        component="section"
+        aria-labelledby="lightspeed-lcore-empty-title"
+      >
+        <SmartToyOutlinedIcon
+          className={classes.emptyStateIcon}
+          aria-hidden
+          focusable={false}
+        />
+        <Typography
+          id="lightspeed-lcore-empty-title"
+          variant="h5"
+          component="h2"
+        >
+          {t('lcore.notConfigured.title')}
+        </Typography>
+        <Typography
+          variant="body1"
+          component="p"
+          className={classes.description}
+        >
+          {t('lcore.notConfigured.description')}
+        </Typography>
+        <Box className={classes.actions}>
+          <Button
+            variant="contained"
+            color="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={LLAMA_STACK_DOCS_URL}
+          >
+            {t('lcore.notConfigured.llamaStackDocs')} &nbsp;{' '}
+            <OpenInNewIcon fontSize="small" aria-hidden />
+          </Button>
+          <Button
+            variant="outlined"
+            color="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={LIGHTSPEED_BACKEND_README_URL}
+          >
+            {t('lcore.notConfigured.backendDocs')} &nbsp;{' '}
+            <OpenInNewIcon fontSize="small" aria-hidden />
+          </Button>
+        </Box>
+      </Box>
+    </div>
+  );
+};
+
+type ModelsLoadErrorEmptyStateProps = {
+  onRetry: () => void;
+};
+
+/**
+ * Shown when the models API fails (distinct from “no models configured”).
+ */
+export const ModelsLoadErrorEmptyState = ({
+  onRetry,
+}: ModelsLoadErrorEmptyStateProps) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  return (
+    <div className={classes.root} data-testid="lightspeed-models-load-error">
+      <Box
+        className={classes.panel}
+        component="section"
+        aria-labelledby="lightspeed-models-error-title"
+      >
+        <ErrorOutlineIcon
+          className={classes.errorIcon}
+          aria-hidden
+          focusable={false}
+        />
+        <Typography
+          id="lightspeed-models-error-title"
+          variant="h5"
+          component="h2"
+        >
+          {t('lcore.loadError.title')}
+        </Typography>
+        <Typography
+          variant="body1"
+          component="p"
+          className={classes.description}
+        >
+          {t('lcore.loadError.description')}
+        </Typography>
+        <Box className={classes.actions}>
+          <Button variant="contained" color="primary" onClick={() => onRetry()}>
+            {t('common.retry')}
+          </Button>
+        </Box>
+      </Box>
+    </div>
+  );
+};

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -54,7 +54,8 @@ export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => {
         <ChatbotModal
           isOpen
           displayMode={contextValue.displayMode}
-          onClose={closeChatbot}
+          disableFocusTrap
+          onEscapePress={() => closeChatbot()}
           ouiaId="LightspeedChatbotModal"
           aria-labelledby="lightspeed-chatpopup-modal"
           className={classes.chatbotModal}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedDrawerProvider.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedDrawerProvider.test.tsx
@@ -35,13 +35,15 @@ jest.mock('@patternfly/chatbot', () => {
     ChatbotModal: ({
       children,
       onClose,
+      onEscapePress,
       displayMode,
       className,
       ouiaId,
       'aria-labelledby': ariaLabelledBy,
     }: {
       children: React.ReactNode;
-      onClose: () => void;
+      onClose?: () => void;
+      onEscapePress?: () => void;
       displayMode: ChatbotDisplayMode;
       className?: string;
       ouiaId?: string;
@@ -54,9 +56,20 @@ jest.mock('@patternfly/chatbot', () => {
         data-display-mode={displayMode}
         className={className}
       >
-        <button type="button" data-testid="modal-close" onClick={onClose}>
-          Close
-        </button>
+        {onClose ? (
+          <button type="button" data-testid="modal-close" onClick={onClose}>
+            Close
+          </button>
+        ) : null}
+        {onEscapePress ? (
+          <button
+            type="button"
+            data-testid="modal-escape-close"
+            onClick={() => onEscapePress()}
+          >
+            Escape close
+          </button>
+        ) : null}
         {children}
       </div>
     ),
@@ -172,7 +185,7 @@ describe('LightspeedDrawerProvider', () => {
     expect(screen.getByTestId('lightspeed-chat-container')).toBeInTheDocument();
   });
 
-  it('wires ChatbotModal onClose to closeChatbot from the hook', async () => {
+  it('wires ChatbotModal onEscapePress to closeChatbot from the hook', async () => {
     const user = userEvent.setup();
     const closeChatbot = jest.fn();
     mockUseLightspeedProviderState.mockReturnValue({
@@ -187,7 +200,7 @@ describe('LightspeedDrawerProvider', () => {
       </LightspeedDrawerProvider>,
     );
 
-    await user.click(screen.getByTestId('modal-close'));
+    await user.click(screen.getByTestId('modal-escape-close'));
     expect(closeChatbot).toHaveBeenCalledTimes(1);
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -229,6 +229,11 @@ describe('LightspeedPage', () => {
     expect(
       screen.getByRole('heading', { name: 'Connect an LLM to get started' }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Lightspeed requires a registered LLM. Contact your organization's platform administrator to complete the setup.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it('should show models load error state with retry', async () => {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -266,6 +266,41 @@ describe('LightspeedPage', () => {
     expect(refetch).toHaveBeenCalled();
   });
 
+  it('should show chat when models query errored but cached LLM data exists', async () => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    const { useAllModels } = require('../../hooks/useAllModels');
+    (useAllModels as jest.Mock).mockReturnValue({
+      data: [
+        {
+          provider_resource_id: 'cached-model',
+          provider_id: 'provider-1',
+          model_type: 'llm',
+        },
+      ],
+      isLoading: false,
+      isError: true,
+      refetch: jest.fn(),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, identityApi],
+          [lightspeedApiRef, mockLightspeedApi],
+        ]}
+      >
+        <LightspeedPage />
+      </TestApiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('LightspeedChat')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId('lightspeed-models-load-error'),
+    ).not.toBeInTheDocument();
+  });
+
   describe('localStorage model persistence', () => {
     const LAST_SELECTED_MODEL_KEY = 'lastSelectedModel';
     const mockModels = [

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -68,9 +68,7 @@ jest.mock('@mui/material', () => ({
 }));
 
 jest.mock('../../hooks/useAllModels', () => ({
-  useAllModels: jest.fn().mockResolvedValue({
-    data: [],
-  }),
+  useAllModels: jest.fn(),
 }));
 
 jest.mock('../../hooks/useTranslation', () => ({
@@ -84,6 +82,19 @@ const mockUsePermission = usePermission as jest.MockedFunction<
 describe('LightspeedPage', () => {
   beforeEach(() => {
     localStorage.clear();
+    const { useAllModels } = require('../../hooks/useAllModels');
+    (useAllModels as jest.Mock).mockReturnValue({
+      data: [
+        {
+          provider_resource_id: 'model-1',
+          provider_id: 'provider-1',
+          model_type: 'llm',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
   });
 
   it('should not display chatbot if permission checks are in loading phase', async () => {
@@ -165,6 +176,96 @@ describe('LightspeedPage', () => {
     );
   });
 
+  it('should show a loading state while models are fetched', async () => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    const { useAllModels } = require('../../hooks/useAllModels');
+    (useAllModels as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, identityApi],
+          [lightspeedApiRef, mockLightspeedApi],
+        ]}
+      >
+        <LightspeedPage />
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByTestId('lightspeed-models-loading')).toBeInTheDocument();
+  });
+
+  it('should show LCORE not configured empty state when no LLM models', async () => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    const { useAllModels } = require('../../hooks/useAllModels');
+    (useAllModels as jest.Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, identityApi],
+          [lightspeedApiRef, mockLightspeedApi],
+        ]}
+      >
+        <LightspeedPage />
+      </TestApiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('lightspeed-lcore-not-configured'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole('heading', { name: 'Configure an LLM for Lightspeed' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should show models load error state with retry', async () => {
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    const refetch = jest.fn();
+    const { useAllModels } = require('../../hooks/useAllModels');
+    (useAllModels as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, identityApi],
+          [lightspeedApiRef, mockLightspeedApi],
+        ]}
+      >
+        <LightspeedPage />
+      </TestApiProvider>,
+    );
+
+    expect(
+      screen.getByTestId('lightspeed-models-load-error'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Could not load models' }),
+      ).toBeInTheDocument();
+    });
+
+    screen.getByRole('button', { name: 'Try again' }).click();
+    expect(refetch).toHaveBeenCalled();
+  });
+
   describe('localStorage model persistence', () => {
     const LAST_SELECTED_MODEL_KEY = 'lastSelectedModel';
     const mockModels = [
@@ -193,6 +294,7 @@ describe('LightspeedPage', () => {
         isLoading: false,
         isError: false,
         error: null,
+        refetch: jest.fn(),
       });
     });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -227,7 +227,7 @@ describe('LightspeedPage', () => {
       ).toBeInTheDocument();
     });
     expect(
-      screen.getByRole('heading', { name: 'Configure an LLM for Lightspeed' }),
+      screen.getByRole('heading', { name: 'Connect an LLM to get started' }),
     ).toBeInTheDocument();
   });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useLightspeedProviderState.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useLightspeedProviderState.test.tsx
@@ -183,6 +183,27 @@ describe('useLightspeedProviderState', () => {
       );
       expect(mockOpenDrawer).toHaveBeenCalledWith(LIGHTSPEED_APP_DRAWER_ID);
     });
+
+    it('opens FAB in overlay when persisted mode is embedded', async () => {
+      displayModeSettingsRef.displayMode = ChatbotDisplayMode.embedded;
+
+      renderWithRouter(['/catalog']);
+
+      screen.getByTestId('toggle-button').click();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('is-open')).toHaveTextContent('open');
+      });
+
+      expect(screen.getByTestId('display-mode')).toHaveTextContent(
+        ChatbotDisplayMode.default,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-modal-flag')).toHaveTextContent(
+          'yes',
+        );
+      });
+    });
   });
 
   describe('closing chatbot', () => {

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useLightspeedProviderState.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useLightspeedProviderState.test.tsx
@@ -298,5 +298,26 @@ describe('useLightspeedProviderState', () => {
         );
       });
     });
+
+    it('uses overlay when leaving /lightspeed while fullscreen preference is persisted', async () => {
+      displayModeSettingsRef.displayMode = ChatbotDisplayMode.embedded;
+
+      renderWithRouter(['/lightspeed']);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('display-mode')).toHaveTextContent(
+          ChatbotDisplayMode.embedded,
+        );
+        expect(screen.getByTestId('is-open')).toHaveTextContent('open');
+      });
+
+      screen.getByTestId('go-catalog').click();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('display-mode')).toHaveTextContent(
+          ChatbotDisplayMode.default,
+        );
+      });
+    });
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useLightspeedProviderState.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useLightspeedProviderState.test.tsx
@@ -184,7 +184,7 @@ describe('useLightspeedProviderState', () => {
       expect(mockOpenDrawer).toHaveBeenCalledWith(LIGHTSPEED_APP_DRAWER_ID);
     });
 
-    it('opens FAB in overlay when persisted mode is embedded', async () => {
+    it('opens chatbot in persisted fullscreen (embedded) by navigating to /lightspeed', async () => {
       displayModeSettingsRef.displayMode = ChatbotDisplayMode.embedded;
 
       renderWithRouter(['/catalog']);
@@ -196,13 +196,9 @@ describe('useLightspeedProviderState', () => {
       });
 
       expect(screen.getByTestId('display-mode')).toHaveTextContent(
-        ChatbotDisplayMode.default,
+        ChatbotDisplayMode.embedded,
       );
-      await waitFor(() => {
-        expect(screen.getByTestId('overlay-modal-flag')).toHaveTextContent(
-          'yes',
-        );
-      });
+      expect(screen.getByTestId('overlay-modal-flag')).toHaveTextContent('no');
     });
   });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedProviderState.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedProviderState.ts
@@ -112,21 +112,14 @@ export function useLightspeedProviderState(): {
       if (!dockedAfterLeavingFullscreenRef.current) {
         closeDrawer(LIGHTSPEED_APP_DRAWER_ID);
       }
-    } else if (
-      persistedDisplayMode === ChatbotDisplayMode.embedded &&
-      !isOpen
-    ) {
+    } else if (persistedDisplayMode === ChatbotDisplayMode.embedded) {
+      // Off /lightspeed there is no fullscreen surface; use overlay so FAB stays available.
+      // (Persisted preference remains "fullscreen" for the next open.)
       setDisplayModeState(ChatbotDisplayMode.default);
     } else {
       setDisplayModeState(persistedDisplayMode);
     }
-  }, [
-    closeDrawer,
-    conversationId,
-    isLightspeedRoute,
-    isOpen,
-    persistedDisplayMode,
-  ]);
+  }, [closeDrawer, conversationId, isLightspeedRoute, persistedDisplayMode]);
 
   useEffect(() => {
     if (

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedProviderState.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedProviderState.ts
@@ -132,7 +132,14 @@ export function useLightspeedProviderState(): {
 
   const openChatbot = useCallback(() => {
     openedViaFABRef.current = true;
-    const modeToUse = persistedDisplayMode || ChatbotDisplayMode.default;
+    const rawMode = persistedDisplayMode || ChatbotDisplayMode.default;
+    // Full-page (/lightspeed) mode is tied to the route, not the FAB. If the user last used
+    // fullscreen there, persisted mode can still be "embedded" — opening from the FAB should
+    // use the compact overlay instead unless they chose docked.
+    const modeToUse =
+      rawMode === ChatbotDisplayMode.embedded
+        ? ChatbotDisplayMode.default
+        : rawMode;
     setDisplayModeState(modeToUse);
 
     if (modeToUse === ChatbotDisplayMode.docked) {
@@ -141,18 +148,8 @@ export function useLightspeedProviderState(): {
       closeDrawer(LIGHTSPEED_APP_DRAWER_ID);
     }
 
-    if (modeToUse === ChatbotDisplayMode.embedded) {
-      navigate(lightspeedRoutePath(currentConversationIdState));
-    }
-
     setIsOpen(true);
-  }, [
-    closeDrawer,
-    currentConversationIdState,
-    navigate,
-    openDrawer,
-    persistedDisplayMode,
-  ]);
+  }, [closeDrawer, openDrawer, persistedDisplayMode]);
 
   const closeChatbot = useCallback(() => {
     dockedAfterLeavingFullscreenRef.current = false;

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedProviderState.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useLightspeedProviderState.ts
@@ -112,12 +112,21 @@ export function useLightspeedProviderState(): {
       if (!dockedAfterLeavingFullscreenRef.current) {
         closeDrawer(LIGHTSPEED_APP_DRAWER_ID);
       }
-    } else if (persistedDisplayMode === ChatbotDisplayMode.embedded) {
+    } else if (
+      persistedDisplayMode === ChatbotDisplayMode.embedded &&
+      !isOpen
+    ) {
       setDisplayModeState(ChatbotDisplayMode.default);
     } else {
       setDisplayModeState(persistedDisplayMode);
     }
-  }, [closeDrawer, conversationId, isLightspeedRoute, persistedDisplayMode]);
+  }, [
+    closeDrawer,
+    conversationId,
+    isLightspeedRoute,
+    isOpen,
+    persistedDisplayMode,
+  ]);
 
   useEffect(() => {
     if (
@@ -133,23 +142,34 @@ export function useLightspeedProviderState(): {
   const openChatbot = useCallback(() => {
     openedViaFABRef.current = true;
     const rawMode = persistedDisplayMode || ChatbotDisplayMode.default;
-    // Full-page (/lightspeed) mode is tied to the route, not the FAB. If the user last used
-    // fullscreen there, persisted mode can still be "embedded" — opening from the FAB should
-    // use the compact overlay instead unless they chose docked.
-    const modeToUse =
-      rawMode === ChatbotDisplayMode.embedded
-        ? ChatbotDisplayMode.default
-        : rawMode;
-    setDisplayModeState(modeToUse);
 
-    if (modeToUse === ChatbotDisplayMode.docked) {
+    if (rawMode === ChatbotDisplayMode.embedded) {
+      if (!isLightspeedRoute) {
+        navigate(lightspeedRoutePath(currentConversationIdState));
+      }
+      setDisplayModeState(ChatbotDisplayMode.embedded);
+      closeDrawer(LIGHTSPEED_APP_DRAWER_ID);
+      setIsOpen(true);
+      return;
+    }
+
+    setDisplayModeState(rawMode);
+
+    if (rawMode === ChatbotDisplayMode.docked) {
       openDrawer(LIGHTSPEED_APP_DRAWER_ID);
     } else {
       closeDrawer(LIGHTSPEED_APP_DRAWER_ID);
     }
 
     setIsOpen(true);
-  }, [closeDrawer, openDrawer, persistedDisplayMode]);
+  }, [
+    closeDrawer,
+    currentConversationIdState,
+    isLightspeedRoute,
+    navigate,
+    openDrawer,
+    persistedDisplayMode,
+  ]);
 
   const closeChatbot = useCallback(() => {
     dockedAfterLeavingFullscreenRef.current = false;

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -142,11 +142,11 @@ const lightspeedTranslationDe = createTranslationMessages({
     'permission.subject.plugin': 'das Lightspeed-Plugin',
     'permission.subject.notebooks': 'die Lightspeed-Notizbücher',
     'permission.notebooks.goBack': 'Zurück',
-    'lcore.notConfigured.title': 'LLM für Lightspeed konfigurieren',
+    'lcore.notConfigured.title': 'Verbinden Sie ein LLM, um zu starten',
     'lcore.notConfigured.description':
-      'LCORE und Llama Stack können ohne Sprachmodell laufen. Registrieren Sie ein OpenAI-kompatibles LLM in Ihrer Llama Stack-Bereitstellung (oder schließen Sie die LCORE-Modellkonfiguration ab) und laden Sie diese Seite neu.',
-    'lcore.notConfigured.llamaStackDocs': 'Llama Stack-Dokumentation',
-    'lcore.notConfigured.backendDocs': 'Lightspeed-Backend-README',
+      'Um die KI-Funktionen von Lightspeed zu nutzen, müssen Sie ein OpenAI-kompatibles LLM in Ihrer Llama Stack-Bereitstellung registrieren.',
+    'lcore.notConfigured.llamaStackDocs': 'Llama Stack konfigurieren',
+    'lcore.notConfigured.backendDocs': 'Lightspeed-Backend einrichten',
     'lcore.loadError.title': 'Modelle konnten nicht geladen werden',
     'lcore.loadError.description':
       'Das Lightspeed-Backend hat keine Modellliste zurückgegeben. Prüfen Sie, ob der Dienst läuft und erreichbar ist, und versuchen Sie es erneut.',
@@ -160,6 +160,7 @@ const lightspeedTranslationDe = createTranslationMessages({
     'common.close': 'Schließen',
     'common.readMore': 'Mehr lesen',
     'common.retry': 'Erneut versuchen',
+    'common.loading': 'Wird geladen',
     'common.noSearchResults': 'Keine Ergebnisse, die der Suche entsprechen',
     'menu.newConversation': 'Neuer Chat',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -142,6 +142,14 @@ const lightspeedTranslationDe = createTranslationMessages({
     'permission.subject.plugin': 'das Lightspeed-Plugin',
     'permission.subject.notebooks': 'die Lightspeed-Notizbücher',
     'permission.notebooks.goBack': 'Zurück',
+    'lcore.notConfigured.title': 'LLM für Lightspeed konfigurieren',
+    'lcore.notConfigured.description':
+      'LCORE und Llama Stack können ohne Sprachmodell laufen. Registrieren Sie ein OpenAI-kompatibles LLM in Ihrer Llama Stack-Bereitstellung (oder schließen Sie die LCORE-Modellkonfiguration ab) und laden Sie diese Seite neu.',
+    'lcore.notConfigured.llamaStackDocs': 'Llama Stack-Dokumentation',
+    'lcore.notConfigured.backendDocs': 'Lightspeed-Backend-README',
+    'lcore.loadError.title': 'Modelle konnten nicht geladen werden',
+    'lcore.loadError.description':
+      'Das Lightspeed-Backend hat keine Modellliste zurückgegeben. Prüfen Sie, ob der Dienst läuft und erreichbar ist, und versuchen Sie es erneut.',
     'disclaimer.withValidation':
       'Diese Funktion nutzt KI-Technologie. Geben Sie bei Ihrer Eingabe keine persönlichen oder sonstigen sensiblen Informationen an. Interaktionen können dazu genutzt werden, die Produkte oder Dienstleistungen von Red Hat zu verbessern.',
     'disclaimer.withoutValidation':
@@ -151,6 +159,7 @@ const lightspeedTranslationDe = createTranslationMessages({
     'common.cancel': 'Abbrechen',
     'common.close': 'Schließen',
     'common.readMore': 'Mehr lesen',
+    'common.retry': 'Erneut versuchen',
     'common.noSearchResults': 'Keine Ergebnisse, die der Suche entsprechen',
     'menu.newConversation': 'Neuer Chat',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -144,8 +144,9 @@ const lightspeedTranslationDe = createTranslationMessages({
     'permission.notebooks.goBack': 'Zurück',
     'lcore.notConfigured.title': 'Verbinden Sie ein LLM, um zu starten',
     'lcore.notConfigured.description':
-      'Um die KI-Funktionen von Lightspeed zu nutzen, müssen Sie ein OpenAI-kompatibles LLM in Ihrer Llama Stack-Bereitstellung registrieren.',
-    'lcore.notConfigured.llamaStackDocs': 'Llama Stack konfigurieren',
+      'Lightspeed erfordert ein registriertes LLM. Wenden Sie sich an den Plattformadministrator Ihrer Organisation, um die Einrichtung abzuschließen.',
+    'lcore.notConfigured.developerLightspeedDocs':
+      'Developer Lightspeed wird konfiguriert',
     'lcore.notConfigured.backendDocs': 'Lightspeed-Backend einrichten',
     'lcore.loadError.title': 'Modelle konnten nicht geladen werden',
     'lcore.loadError.description':

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -142,6 +142,14 @@ const lightspeedTranslationEs = createTranslationMessages({
     'permission.subject.plugin': 'el plugin de Lightspeed',
     'permission.subject.notebooks': 'los cuadernos de Lightspeed',
     'permission.notebooks.goBack': 'Volver',
+    'lcore.notConfigured.title': 'Configurar un LLM para Lightspeed',
+    'lcore.notConfigured.description':
+      'LCORE y Llama Stack pueden ejecutarse sin un modelo de lenguaje. Registre un LLM compatible con OpenAI en su despliegue de Llama Stack (o complete la configuración del modelo en LCORE) y vuelva a cargar esta página.',
+    'lcore.notConfigured.llamaStackDocs': 'Documentación de Llama Stack',
+    'lcore.notConfigured.backendDocs': 'README del backend de Lightspeed',
+    'lcore.loadError.title': 'No se pudieron cargar los modelos',
+    'lcore.loadError.description':
+      'El backend de Lightspeed no devolvió una lista de modelos. Compruebe que el servicio está en ejecución y es accesible, e inténtelo de nuevo.',
     'disclaimer.withValidation':
       'Esta funcionalidad utiliza tecnología de IA. No incluya información personal ni otros datos confidenciales en la entrada. Las interacciones pueden utilizarse para mejorar los productos o servicios de Red Hat.',
     'disclaimer.withoutValidation':
@@ -151,6 +159,7 @@ const lightspeedTranslationEs = createTranslationMessages({
     'common.cancel': 'Cancelar',
     'common.close': 'Cerrar',
     'common.readMore': 'Leer más',
+    'common.retry': 'Volver a intentar',
     'common.noSearchResults': 'Ningún resultado coincide con la búsqueda',
     'menu.newConversation': 'Nuevo chat',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -142,11 +142,12 @@ const lightspeedTranslationEs = createTranslationMessages({
     'permission.subject.plugin': 'el plugin de Lightspeed',
     'permission.subject.notebooks': 'los cuadernos de Lightspeed',
     'permission.notebooks.goBack': 'Volver',
-    'lcore.notConfigured.title': 'Configurar un LLM para Lightspeed',
+    'lcore.notConfigured.title': 'Conecte un LLM para empezar',
     'lcore.notConfigured.description':
-      'LCORE y Llama Stack pueden ejecutarse sin un modelo de lenguaje. Registre un LLM compatible con OpenAI en su despliegue de Llama Stack (o complete la configuración del modelo en LCORE) y vuelva a cargar esta página.',
-    'lcore.notConfigured.llamaStackDocs': 'Documentación de Llama Stack',
-    'lcore.notConfigured.backendDocs': 'README del backend de Lightspeed',
+      'Para usar las funciones de IA de Lightspeed, debe registrar un LLM compatible con OpenAI en su despliegue de Llama Stack.',
+    'lcore.notConfigured.llamaStackDocs': 'Configurar Llama Stack',
+    'lcore.notConfigured.backendDocs':
+      'Configuración del backend de Lightspeed',
     'lcore.loadError.title': 'No se pudieron cargar los modelos',
     'lcore.loadError.description':
       'El backend de Lightspeed no devolvió una lista de modelos. Compruebe que el servicio está en ejecución y es accesible, e inténtelo de nuevo.',
@@ -160,6 +161,7 @@ const lightspeedTranslationEs = createTranslationMessages({
     'common.close': 'Cerrar',
     'common.readMore': 'Leer más',
     'common.retry': 'Volver a intentar',
+    'common.loading': 'Cargando',
     'common.noSearchResults': 'Ningún resultado coincide con la búsqueda',
     'menu.newConversation': 'Nuevo chat',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -144,8 +144,9 @@ const lightspeedTranslationEs = createTranslationMessages({
     'permission.notebooks.goBack': 'Volver',
     'lcore.notConfigured.title': 'Conecte un LLM para empezar',
     'lcore.notConfigured.description':
-      'Para usar las funciones de IA de Lightspeed, debe registrar un LLM compatible con OpenAI en su despliegue de Llama Stack.',
-    'lcore.notConfigured.llamaStackDocs': 'Configurar Llama Stack',
+      'Lightspeed requiere un LLM registrado. Póngase en contacto con el administrador de la plataforma de su organización para completar la configuración.',
+    'lcore.notConfigured.developerLightspeedDocs':
+      'Configurando Developer Lightspeed',
     'lcore.notConfigured.backendDocs':
       'Configuración del backend de Lightspeed',
     'lcore.loadError.title': 'No se pudieron cargar los modelos',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -139,6 +139,14 @@ const lightspeedTranslationFr = createTranslationMessages({
     'permission.subject.plugin': 'le plugin Lightspeed',
     'permission.subject.notebooks': 'les carnets Lightspeed',
     'permission.notebooks.goBack': 'Retour',
+    'lcore.notConfigured.title': 'Configurer un LLM pour Lightspeed',
+    'lcore.notConfigured.description':
+      'LCORE et Llama Stack peuvent fonctionner sans modèle de langage. Enregistrez un LLM compatible OpenAI dans votre déploiement Llama Stack (ou terminez la configuration du modèle LCORE), puis rechargez cette page.',
+    'lcore.notConfigured.llamaStackDocs': 'Documentation Llama Stack',
+    'lcore.notConfigured.backendDocs': 'README du backend Lightspeed',
+    'lcore.loadError.title': 'Impossible de charger les modèles',
+    'lcore.loadError.description':
+      "Le backend Lightspeed n'a pas renvoyé de liste de modèles. Vérifiez que le service est démarré et joignable, puis réessayez.",
     'permission.required.description':
       "Pour afficher <subject/>, veuillez contacter votre administrateur pour qu'il vous donne la permission <permissions/>.",
     'disclaimer.withValidation':
@@ -150,6 +158,7 @@ const lightspeedTranslationFr = createTranslationMessages({
     'common.cancel': 'Annuler',
     'common.close': 'Fermer',
     'common.readMore': 'En savoir plus',
+    'common.retry': 'Réessayer',
     'common.noSearchResults': 'Aucun résultat ne correspond à cette demande',
     'menu.newConversation': 'Nouvelle Conversation',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -139,11 +139,11 @@ const lightspeedTranslationFr = createTranslationMessages({
     'permission.subject.plugin': 'le plugin Lightspeed',
     'permission.subject.notebooks': 'les carnets Lightspeed',
     'permission.notebooks.goBack': 'Retour',
-    'lcore.notConfigured.title': 'Configurer un LLM pour Lightspeed',
+    'lcore.notConfigured.title': 'Connectez un LLM pour commencer',
     'lcore.notConfigured.description':
-      'LCORE et Llama Stack peuvent fonctionner sans modèle de langage. Enregistrez un LLM compatible OpenAI dans votre déploiement Llama Stack (ou terminez la configuration du modèle LCORE), puis rechargez cette page.',
-    'lcore.notConfigured.llamaStackDocs': 'Documentation Llama Stack',
-    'lcore.notConfigured.backendDocs': 'README du backend Lightspeed',
+      "Pour utiliser les fonctionnalités d'IA de Lightspeed, vous devez enregistrer un LLM compatible OpenAI dans votre déploiement Llama Stack.",
+    'lcore.notConfigured.llamaStackDocs': 'Configurer Llama Stack',
+    'lcore.notConfigured.backendDocs': 'Configuration du backend Lightspeed',
     'lcore.loadError.title': 'Impossible de charger les modèles',
     'lcore.loadError.description':
       "Le backend Lightspeed n'a pas renvoyé de liste de modèles. Vérifiez que le service est démarré et joignable, puis réessayez.",
@@ -159,6 +159,7 @@ const lightspeedTranslationFr = createTranslationMessages({
     'common.close': 'Fermer',
     'common.readMore': 'En savoir plus',
     'common.retry': 'Réessayer',
+    'common.loading': 'Chargement',
     'common.noSearchResults': 'Aucun résultat ne correspond à cette demande',
     'menu.newConversation': 'Nouvelle Conversation',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -141,8 +141,9 @@ const lightspeedTranslationFr = createTranslationMessages({
     'permission.notebooks.goBack': 'Retour',
     'lcore.notConfigured.title': 'Connectez un LLM pour commencer',
     'lcore.notConfigured.description':
-      "Pour utiliser les fonctionnalités d'IA de Lightspeed, vous devez enregistrer un LLM compatible OpenAI dans votre déploiement Llama Stack.",
-    'lcore.notConfigured.llamaStackDocs': 'Configurer Llama Stack',
+      "Lightspeed nécessite un LLM enregistré. Contactez l'administrateur de la plateforme de votre organisation pour finaliser la configuration.",
+    'lcore.notConfigured.developerLightspeedDocs':
+      'Configuration de Developer Lightspeed',
     'lcore.notConfigured.backendDocs': 'Configuration du backend Lightspeed',
     'lcore.loadError.title': 'Impossible de charger les modèles',
     'lcore.loadError.description':

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -143,6 +143,14 @@ const lightspeedTranslationIt = createTranslationMessages({
     'permission.subject.plugin': 'il plugin Lightspeed',
     'permission.subject.notebooks': 'i quaderni Lightspeed',
     'permission.notebooks.goBack': 'Torna indietro',
+    'lcore.notConfigured.title': 'Configura un LLM per Lightspeed',
+    'lcore.notConfigured.description':
+      'LCORE e Llama Stack possono essere avviati senza un modello linguistico. Registra un LLM compatibile con OpenAI nella distribuzione Llama Stack (o completa la configurazione del modello LCORE), quindi ricarica questa pagina.',
+    'lcore.notConfigured.llamaStackDocs': 'Documentazione di Llama Stack',
+    'lcore.notConfigured.backendDocs': 'README del backend Lightspeed',
+    'lcore.loadError.title': 'Impossibile caricare i modelli',
+    'lcore.loadError.description':
+      'Il backend Lightspeed non ha restituito un elenco di modelli. Verifica che il servizio sia in esecuzione e raggiungibile, quindi riprova.',
     'disclaimer.withValidation':
       'Questa funzione utilizza una tecnologia AI. Non includere nei dati immessi informazioni personali o altre informazioni sensibili. Le interazioni possono essere utilizzate per migliorare i prodotti o i servizi Red Hat.',
     'disclaimer.withoutValidation':
@@ -152,6 +160,7 @@ const lightspeedTranslationIt = createTranslationMessages({
     'common.cancel': 'Cancella',
     'common.close': 'Chiudi',
     'common.readMore': 'Per saperne di più',
+    'common.retry': 'Riprova',
     'common.noSearchResults': 'Nessun risultato corrisponde alla ricerca',
     'menu.newConversation': 'Nuova chat',
     'chatbox.header.title': 'Sviluppatore Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -145,8 +145,9 @@ const lightspeedTranslationIt = createTranslationMessages({
     'permission.notebooks.goBack': 'Torna indietro',
     'lcore.notConfigured.title': 'Collega un LLM per iniziare',
     'lcore.notConfigured.description':
-      'Per usare le funzionalità di intelligenza artificiale di Lightspeed, devi registrare un LLM compatibile con OpenAI nella tua distribuzione Llama Stack.',
-    'lcore.notConfigured.llamaStackDocs': 'Configura Llama Stack',
+      "Lightspeed richiede un LLM registrato. Contattare l'amministratore della piattaforma dell'organizzazione per completare la configurazione.",
+    'lcore.notConfigured.developerLightspeedDocs':
+      'Configurazione di Developer Lightspeed',
     'lcore.notConfigured.backendDocs': 'Configurazione backend Lightspeed',
     'lcore.loadError.title': 'Impossibile caricare i modelli',
     'lcore.loadError.description':

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -143,11 +143,11 @@ const lightspeedTranslationIt = createTranslationMessages({
     'permission.subject.plugin': 'il plugin Lightspeed',
     'permission.subject.notebooks': 'i quaderni Lightspeed',
     'permission.notebooks.goBack': 'Torna indietro',
-    'lcore.notConfigured.title': 'Configura un LLM per Lightspeed',
+    'lcore.notConfigured.title': 'Collega un LLM per iniziare',
     'lcore.notConfigured.description':
-      'LCORE e Llama Stack possono essere avviati senza un modello linguistico. Registra un LLM compatibile con OpenAI nella distribuzione Llama Stack (o completa la configurazione del modello LCORE), quindi ricarica questa pagina.',
-    'lcore.notConfigured.llamaStackDocs': 'Documentazione di Llama Stack',
-    'lcore.notConfigured.backendDocs': 'README del backend Lightspeed',
+      'Per usare le funzionalità di intelligenza artificiale di Lightspeed, devi registrare un LLM compatibile con OpenAI nella tua distribuzione Llama Stack.',
+    'lcore.notConfigured.llamaStackDocs': 'Configura Llama Stack',
+    'lcore.notConfigured.backendDocs': 'Configurazione backend Lightspeed',
     'lcore.loadError.title': 'Impossibile caricare i modelli',
     'lcore.loadError.description':
       'Il backend Lightspeed non ha restituito un elenco di modelli. Verifica che il servizio sia in esecuzione e raggiungibile, quindi riprova.',
@@ -161,6 +161,7 @@ const lightspeedTranslationIt = createTranslationMessages({
     'common.close': 'Chiudi',
     'common.readMore': 'Per saperne di più',
     'common.retry': 'Riprova',
+    'common.loading': 'Caricamento in corso',
     'common.noSearchResults': 'Nessun risultato corrisponde alla ricerca',
     'menu.newConversation': 'Nuova chat',
     'chatbox.header.title': 'Sviluppatore Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -141,11 +141,11 @@ const lightspeedTranslationJa = createTranslationMessages({
     'permission.subject.plugin': 'Lightspeed プラグイン',
     'permission.subject.notebooks': 'Lightspeed ノートブック',
     'permission.notebooks.goBack': '戻る',
-    'lcore.notConfigured.title': 'Lightspeed 用に LLM を構成する',
+    'lcore.notConfigured.title': 'LLM に接続して始める',
     'lcore.notConfigured.description':
-      'LCORE と Llama Stack は言語モデルなしで起動できます。Llama Stack のデプロイに OpenAI 互換の LLM を登録するか（LCORE のモデル構成を完了するか）してから、このページを再読み込みしてください。',
-    'lcore.notConfigured.llamaStackDocs': 'Llama Stack ドキュメント',
-    'lcore.notConfigured.backendDocs': 'Lightspeed バックエンドの README',
+      'Lightspeed の AI 機能を使用するには、Llama Stack のデプロイに OpenAI 互換の LLM を登録する必要があります。',
+    'lcore.notConfigured.llamaStackDocs': 'Llama Stack を構成',
+    'lcore.notConfigured.backendDocs': 'Lightspeed バックエンドのセットアップ',
     'lcore.loadError.title': 'モデルを読み込めませんでした',
     'lcore.loadError.description':
       'Lightspeed バックエンドがモデル一覧を返しませんでした。サービスが実行中で到達可能か確認してから、もう一度お試しください。',
@@ -159,6 +159,7 @@ const lightspeedTranslationJa = createTranslationMessages({
     'common.close': '閉じる',
     'common.readMore': 'さらに表示する',
     'common.retry': '再試行',
+    'common.loading': '読み込み中',
     'common.noSearchResults': '検索に一致する結果がありません',
     'menu.newConversation': '新しいチャット',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -143,8 +143,9 @@ const lightspeedTranslationJa = createTranslationMessages({
     'permission.notebooks.goBack': '戻る',
     'lcore.notConfigured.title': 'LLM に接続して始める',
     'lcore.notConfigured.description':
-      'Lightspeed の AI 機能を使用するには、Llama Stack のデプロイに OpenAI 互換の LLM を登録する必要があります。',
-    'lcore.notConfigured.llamaStackDocs': 'Llama Stack を構成',
+      'Lightspeed を使用するには登録済みの LLM が必要です。セットアップを完了するには、組織のプラットフォーム管理者にお問い合わせください。',
+    'lcore.notConfigured.developerLightspeedDocs':
+      'Developer Lightspeed を構成中',
     'lcore.notConfigured.backendDocs': 'Lightspeed バックエンドのセットアップ',
     'lcore.loadError.title': 'モデルを読み込めませんでした',
     'lcore.loadError.description':

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -141,6 +141,14 @@ const lightspeedTranslationJa = createTranslationMessages({
     'permission.subject.plugin': 'Lightspeed プラグイン',
     'permission.subject.notebooks': 'Lightspeed ノートブック',
     'permission.notebooks.goBack': '戻る',
+    'lcore.notConfigured.title': 'Lightspeed 用に LLM を構成する',
+    'lcore.notConfigured.description':
+      'LCORE と Llama Stack は言語モデルなしで起動できます。Llama Stack のデプロイに OpenAI 互換の LLM を登録するか（LCORE のモデル構成を完了するか）してから、このページを再読み込みしてください。',
+    'lcore.notConfigured.llamaStackDocs': 'Llama Stack ドキュメント',
+    'lcore.notConfigured.backendDocs': 'Lightspeed バックエンドの README',
+    'lcore.loadError.title': 'モデルを読み込めませんでした',
+    'lcore.loadError.description':
+      'Lightspeed バックエンドがモデル一覧を返しませんでした。サービスが実行中で到達可能か確認してから、もう一度お試しください。',
     'disclaimer.withValidation':
       'この機能は AI テクノロジーを使用します。入力内容に個人情報やその他の機密情報を含めないでください。やり取りの内容は、Red Hat の製品やサービスを改善するために使用される場合があります。',
     'disclaimer.withoutValidation':
@@ -150,6 +158,7 @@ const lightspeedTranslationJa = createTranslationMessages({
     'common.cancel': 'キャンセル',
     'common.close': '閉じる',
     'common.readMore': 'さらに表示する',
+    'common.retry': '再試行',
     'common.noSearchResults': '検索に一致する結果がありません',
     'menu.newConversation': '新しいチャット',
     'chatbox.header.title': 'Developer Lightspeed',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -145,6 +145,16 @@ export const lightspeedMessages = {
   'permission.subject.notebooks': 'the Lightspeed notebooks',
   'permission.notebooks.goBack': 'Go back',
 
+  // LCORE / LLM (no models registered)
+  'lcore.notConfigured.title': 'Configure an LLM for Lightspeed',
+  'lcore.notConfigured.description':
+    'LCORE and Llama Stack can run without a language model. Register an OpenAI-compatible LLM with your Llama Stack deployment (or finish LCORE model configuration), then reload this page.',
+  'lcore.notConfigured.llamaStackDocs': 'Llama Stack documentation',
+  'lcore.notConfigured.backendDocs': 'Lightspeed backend README',
+  'lcore.loadError.title': 'Could not load models',
+  'lcore.loadError.description':
+    'The Lightspeed backend did not return a model list. Check that the service is running and reachable, then try again.',
+
   // Disclaimers
   'disclaimer.withValidation':
     "This feature uses AI technology. Do not include any personal information or any other sensitive information in your input. Interactions may be used to improve Red Hat's products or services.",
@@ -158,6 +168,7 @@ export const lightspeedMessages = {
   'common.cancel': 'Cancel',
   'common.close': 'Close',
   'common.readMore': 'Read more',
+  'common.retry': 'Try again',
   'common.noSearchResults': 'No result matches the search',
 
   // Menu items

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -148,8 +148,9 @@ export const lightspeedMessages = {
   // LCORE / LLM (no models registered)
   'lcore.notConfigured.title': 'Connect an LLM to get started',
   'lcore.notConfigured.description':
-    "To use Lightspeed's AI capabilities, you'll need to register an OpenAI-compatible LLM with your Llama Stack deployment.",
-  'lcore.notConfigured.llamaStackDocs': 'Configure Llama Stack',
+    "Lightspeed requires a registered LLM. Contact your organization's platform administrator to complete the setup.",
+  'lcore.notConfigured.developerLightspeedDocs':
+    'Configuring Developer Lightspeed',
   'lcore.notConfigured.backendDocs': 'Lightspeed Backend Setup',
   'lcore.loadError.title': 'Could not load models',
   'lcore.loadError.description':

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -146,11 +146,11 @@ export const lightspeedMessages = {
   'permission.notebooks.goBack': 'Go back',
 
   // LCORE / LLM (no models registered)
-  'lcore.notConfigured.title': 'Configure an LLM for Lightspeed',
+  'lcore.notConfigured.title': 'Connect an LLM to get started',
   'lcore.notConfigured.description':
-    'LCORE and Llama Stack can run without a language model. Register an OpenAI-compatible LLM with your Llama Stack deployment (or finish LCORE model configuration), then reload this page.',
-  'lcore.notConfigured.llamaStackDocs': 'Llama Stack documentation',
-  'lcore.notConfigured.backendDocs': 'Lightspeed backend README',
+    "To use Lightspeed's AI capabilities, you'll need to register an OpenAI-compatible LLM with your Llama Stack deployment.",
+  'lcore.notConfigured.llamaStackDocs': 'Configure Llama Stack',
+  'lcore.notConfigured.backendDocs': 'Lightspeed Backend Setup',
   'lcore.loadError.title': 'Could not load models',
   'lcore.loadError.description':
     'The Lightspeed backend did not return a model list. Check that the service is running and reachable, then try again.',
@@ -169,6 +169,7 @@ export const lightspeedMessages = {
   'common.close': 'Close',
   'common.readMore': 'Read more',
   'common.retry': 'Try again',
+  'common.loading': 'Loading',
   'common.noSearchResults': 'No result matches the search',
 
   // Menu items


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
For [RHIDP-12816](https://redhat.atlassian.net/browse/RHIDP-12816)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

**Test steps:**

1. In `run.yaml` comment out your provider config in the inference array, for example:
```
providers:
  ...
  inference:
    - config:
        api_token: ${env.VLLM_API_KEY:=}
        base_url: ${env.VLLM_URL:=}
        max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
        network:
          tls:
            verify: ${env.VLLM_TLS_VERIFY:=true}
      provider_id: ${env.ENABLE_VLLM:+vllm}
      provider_type: remote::vllm
    # - config:
    #     base_url: ${env.OLLAMA_URL:=http://localhost:11434/v1}
    #   provider_id: ${env.ENABLE_OLLAMA:+ollama}
    #   provider_type: remote::vllm
    ...
```
2. Remove local persistence (matches whatever paths you have in `storage.backend` in your `run.yaml`)

```
rm -f /tmp/kvstore.db /tmp/sql_store.db
```

3. Restart Llama Stack and LCS


**Screenshot(updated on 4/20):**

<img width="3024" height="1652" alt="image" src="https://github.com/user-attachments/assets/85bccd2f-9eb9-420a-9358-e173ab6173ae" />

