### PR TITLE
fix(x2a): split flow for branch creation in x2a job script

### DIFF
--- a/workspaces/x2a/.changeset/real-heads-sin.md
+++ b/workspaces/x2a/.changeset/real-heads-sin.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+Fix git push for new target branches by tracking branch creation state

--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -10,6 +10,7 @@ ARTIFACTS=()
 PUSH_FAILED=""
 TERMINATED=false
 COMMIT_ID=""
+TARGET_BRANCH_IS_NEW=false
 
 # Path where x2a-convertor writes error details on failure
 export X2A_ERROR_FILE="/tmp/x2a-error.txt"
@@ -148,12 +149,22 @@ Job: ${JOB_ID}
 
 Co-Authored-By: ${GIT_AUTHOR_NAME} <${GIT_AUTHOR_EMAIL}>
 " || true
-    git_target_repo pull --rebase origin "${TARGET_REPO_BRANCH}" 2>/dev/null || true
-    COMMIT_ID=$(git rev-parse HEAD 2>/dev/null || echo "")
-    if ! git_target_repo push origin "${TARGET_REPO_BRANCH}"; then
-      PUSH_FAILED="Failed to push to ${TARGET_REPO_URL} branch ${TARGET_REPO_BRANCH}"
-      echo "ERROR: ${PUSH_FAILED}"
+
+    if [ "${TARGET_BRANCH_IS_NEW}" = "true" ]; then
+      # New branch — no remote tracking branch to rebase against
+      if ! git_target_repo push -u origin "${TARGET_REPO_BRANCH}"; then
+        PUSH_FAILED="Failed to push new branch '${TARGET_REPO_BRANCH}' to ${TARGET_REPO_URL}"
+        echo "ERROR: ${PUSH_FAILED}"
+      fi
+    else
+      # Existing branch — rebase on remote changes before pushing
+      git_target_repo pull --rebase origin "${TARGET_REPO_BRANCH}" 2>/dev/null || true
+      if ! git_target_repo push origin "${TARGET_REPO_BRANCH}"; then
+        PUSH_FAILED="Failed to push to ${TARGET_REPO_URL} branch ${TARGET_REPO_BRANCH}"
+        echo "ERROR: ${PUSH_FAILED}"
+      fi
     fi
+    COMMIT_ID=$(git rev-parse HEAD 2>/dev/null || echo "")
   fi
 
   if [ "$TERMINATED" = true ]; then
@@ -178,13 +189,14 @@ git_clone_repos() {
   if git_target_repo clone --depth=1 --single-branch \
       --branch="${TARGET_REPO_BRANCH}" "${TARGET_REPO_URL}" /workspace/target 2>/dev/null; then
     # Repo and branch exist — cloned successfully
-    :
+    TARGET_BRANCH_IS_NEW=false
   elif git_target_repo clone --depth=1 \
       "${TARGET_REPO_URL}" /workspace/target 2>/dev/null; then
     # Repo exists but branch doesn't — create target branch locally
     echo "Branch '${TARGET_REPO_BRANCH}' not found on remote, creating it"
     cd /workspace/target
     git checkout -b "${TARGET_REPO_BRANCH}"
+    TARGET_BRANCH_IS_NEW=true
   else
     # Repo doesn't exist or can't be accessed — init empty
     echo "Target repo doesn't exist, initializing empty repo"
@@ -193,6 +205,7 @@ git_clone_repos() {
     git init
     git checkout -b "${TARGET_REPO_BRANCH}"
     git remote add origin "${TARGET_REPO_URL}"
+    TARGET_BRANCH_IS_NEW=true
   fi
 
   ERROR_MESSAGE=""


### PR DESCRIPTION
 ## Summary                                                                                                                                                      
  - Fixes git push failures when the target branch doesn't exist on the remote yet                                                                                
  - Tracks whether the target branch was newly created (`TARGET_BRANCH_IS_NEW` flag) during `git_clone_repos`                                                     
  - When the branch is new, uses `git push -u origin` instead of attempting `git pull --rebase` first (which fails because there's no upstream tracking branch)   
  - When the branch already exists, preserves the existing rebase-then-push behavior        