### PR TITLE
chore(orchestator): multiple dependency updates for CVE fixes (#2773)

### DIFF
--- a/workspaces/orchestrator/.changeset/nervous-eels-mate.md
+++ b/workspaces/orchestrator/.changeset/nervous-eels-mate.md
@@ -1,0 +1,8 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+fix: updating lodash for cve fixes

--- a/workspaces/orchestrator/plugins/orchestrator-backend/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/package.json
@@ -83,7 +83,7 @@
     "express-promise-router": "^4.1.1",
     "fs-extra": "^10.1.0",
     "isomorphic-git": "^1.23.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "luxon": "^3.7.2",
     "openapi-backend": "^5.10.5",
     "yn": "^5.0.0"

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
@@ -44,7 +44,7 @@
     "@rjsf/validator-ajv8": "^5.21.2",
     "json-schema": "^0.4.0",
     "json-schema-library": "^9.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "tss-react": "^4.9.18"
   },
   "peerDependencies": {

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/package.json
@@ -62,7 +62,7 @@
     "clsx": "^2.1.1",
     "json-schema": "^0.4.0",
     "jsonata": "^2.0.6",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "react-use": "^17.2.4",
     "tss-react": "^4.9.18"
   },

--- a/workspaces/orchestrator/plugins/orchestrator/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator/package.json
@@ -68,7 +68,7 @@
     "axios": "^1.15.0",
     "json-schema": "^0.4.0",
     "json-schema-library": "^9.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "luxon": "^3.7.2",
     "react-use": "^17.4.0",
     "swr": "^2.0.0",

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -12464,7 +12464,7 @@ __metadata:
     express-promise-router: ^4.1.1
     fs-extra: ^10.1.0
     isomorphic-git: ^1.23.0
-    lodash: ^4.17.21
+    lodash: ^4.18.1
     luxon: ^3.7.2
     openapi-backend: ^5.10.5
     prettier: 3.8.1
@@ -12534,7 +12534,7 @@ __metadata:
     "@types/react": ^18.2.58
     json-schema: ^0.4.0
     json-schema-library: ^9.0.0
-    lodash: ^4.17.21
+    lodash: ^4.18.1
     prettier: 3.8.1
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -12572,7 +12572,7 @@ __metadata:
     express: ^5.1.0
     json-schema: ^0.4.0
     jsonata: ^2.0.6
-    lodash: ^4.17.21
+    lodash: ^4.18.1
     msw: ^1.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
@@ -12630,7 +12630,7 @@ __metadata:
     axios: ^1.15.0
     json-schema: ^0.4.0
     json-schema-library: ^9.0.0
-    lodash: ^4.17.21
+    lodash: ^4.18.1
     luxon: ^3.7.2
     prettier: 3.8.1
     react: ^18.0.0
@@ -17076,14 +17076,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^6.12.2, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
   dependencies:
-    fast-deep-equal: ^3.1.1
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.4.1
-    uri-js: ^4.2.2
-  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+    fast-deep-equal: "npm:^3.1.1"
+    fast-json-stable-stringify: "npm:^2.0.0"
+    json-schema-traverse: "npm:^0.4.1"
+    uri-js: "npm:^4.2.2"
+  checksum: 7bb3ea97bb8af52521589079f427e799b6561acaa94f50e13410cb87588c51df8db1afe1157b3e48f1a829269adaa11116e0c2cafe2b998add1523789809a3c5
   languageName: node
   linkType: hard
 
@@ -27862,10 +27862,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.15.0, lodash@npm:^4.16.4, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.15, lodash@npm:~4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+"lodash@npm:^4.15.0, lodash@npm:^4.16.4, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 
@@ -27873,6 +27873,13 @@ __metadata:
   version: 2.4.2
   resolution: "lodash@npm:2.4.2"
   checksum: b18a5e5858091e2a0e6498e9f0efde559f64a2cc7adfa240c7da92930b7c734a9e52519101522e9fbd7acfcfb0ef682ce9b9cb668b5fea4809cb340435c1764d
+  languageName: node
+  linkType: hard
+
+"lodash@npm:~4.17.15, lodash@npm:~4.17.21":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
   languageName: node
   linkType: hard
 
@@ -31005,7 +31012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:8.3.0, path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.2.0":
+"path-to-regexp@npm:8.3.0":
   version: 8.3.0
   resolution: "path-to-regexp@npm:8.3.0"
   checksum: 73e0d3db449f9899692b10be8480bbcfa294fd575be2d09bce3e63f2f708d1fccd3aaa8591709f8b82062c528df116e118ff9df8f5c52ccc4c2443a90be73e10
@@ -31019,10 +31026,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.2.0":
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: c30fba443e413cc736b7b28056a4b60b537ae1caa80152da21e8093bd41deba7c408a4ac6f11a1bf594e089d8fd8d87ed31476c55c50983719fb355826370ade
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:~0.1.12":
-  version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12"
-  checksum: ab237858bee7b25ecd885189f175ab5b5161e7b712b360d44f5c4516b8d271da3e4bf7bf0a7b9153ecb04c7d90ce8ff5158614e1208819cf62bac2b08452722e
+  version: 0.1.13
+  resolution: "path-to-regexp@npm:0.1.13"
+  checksum: 0bf61c6068a0d92dbd3c2f4b24a9b8f153be2d8ec13c99bb7a45f31e5f7e153b91811e63b895ac9e0942ae16890ee15526e842f6f1b4920aa01335f94f6ce58e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
manual cherry-pick of PR #2773 

* fix: ran yarn up -R ajv.

fixes https://access.redhat.com/security/cve/cve-2025-69873

* fix: ran yarn up -R path-to-regexp

fixes https://access.redhat.com/security/cve/CVE-2026-4926

* fix: ran yarn up -R lodash

fixes: https://access.redhat.com/security/cve/CVE-2026-4800

* squash: add the changeset

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
