### PR TITLE
fix(orchestrator): preserve nested extraErrors and async validation errors

### DIFF
--- a/workspaces/orchestrator/.changeset/sharp-dots-sing.md
+++ b/workspaces/orchestrator/.changeset/sharp-dots-sing.md
@@ -1,0 +1,10 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+---
+
+Fix multi-step workflow forms dropping or misplacing async validation errors and deep nested field paths.
+
+- @red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets: Fix safeSet deep paths and sequential async validation in getExtraErrors.
+
+- @red-hat-developer-hub/backstage-plugin-orchestrator-form-react: Wrap extraErrors with the active step key so RJSF matches the root schema.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -35,6 +35,7 @@ import {
 import { useTranslation } from '../hooks/useTranslation';
 import { getActiveStepKey } from '../utils/getSortedStepEntries';
 import { useStepperContext } from '../utils/StepperContext';
+import { toRootExtraErrors } from '../utils/toRootExtraErrors';
 import useValidator from '../utils/useValidator';
 import { AuthRequester } from './AuthRequester';
 import HiddenObjectFieldTemplate from './HiddenObjectFieldTemplate';
@@ -102,15 +103,7 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
           extraErrorsUiSchema,
         );
 
-        if (activeKey) {
-          setExtraErrors(
-            _extraErrors?.[activeKey]
-              ? (_extraErrors[activeKey] as ErrorSchema<JsonObject>)
-              : undefined,
-          );
-        } else {
-          setExtraErrors(_extraErrors);
-        }
+        setExtraErrors(toRootExtraErrors(activeKey, _extraErrors));
       } catch (err) {
         _validationError = err as Error;
       } finally {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/toRootExtraErrors.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/toRootExtraErrors.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ERRORS_KEY } from '@rjsf/utils';
+
+import { toRootExtraErrors } from './toRootExtraErrors';
+
+describe('toRootExtraErrors', () => {
+  it('returns undefined when extraErrors is undefined', () => {
+    expect(toRootExtraErrors('my-step', undefined)).toBeUndefined();
+  });
+
+  it('returns extraErrors unchanged when activeKey is undefined', () => {
+    const tree = { a: { [ERRORS_KEY]: ['x'] } };
+    expect(toRootExtraErrors(undefined, tree)).toBe(tree);
+  });
+
+  it('wraps the active step slice so RJSF receives root-shaped errors', () => {
+    const inner = {
+      xParams: {
+        fieldA: { [ERRORS_KEY]: ['invalid A'] },
+        fieldB: { [ERRORS_KEY]: ['invalid B'] },
+      },
+    };
+    const fromGetExtraErrors = {
+      'my-solution': inner,
+    };
+    expect(toRootExtraErrors('my-solution', fromGetExtraErrors)).toEqual({
+      'my-solution': inner,
+    });
+  });
+
+  it('returns undefined when the active step has no errors in the tree', () => {
+    expect(
+      toRootExtraErrors('missing-step', {
+        'other-step': { [ERRORS_KEY]: ['e'] },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/toRootExtraErrors.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/toRootExtraErrors.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import { ErrorSchema } from '@rjsf/utils';
+
+/**
+ * RJSF `extraErrors` must match the root `schema.properties` shape. For
+ * multi-step forms, `getExtraErrors` returns a tree keyed by step name; pass
+ * `activeKey` so the slice is wrapped again for the root form.
+ */
+export function toRootExtraErrors(
+  activeKey: string | undefined,
+  extraErrors: ErrorSchema<JsonObject> | undefined,
+): ErrorSchema<JsonObject> | undefined {
+  if (!extraErrors) {
+    return undefined;
+  }
+  if (!activeKey) {
+    return extraErrors;
+  }
+  const slice = extraErrors[activeKey];
+  if (!slice) {
+    return undefined;
+  }
+  return { [activeKey]: slice } as ErrorSchema<JsonObject>;
+}

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/safeSet.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/safeSet.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ERRORS_KEY } from '@rjsf/utils';
+
+import { safeSet } from './safeSet';
+import { JsonObject } from '@backstage/types/index';
+
+describe('safeSet', () => {
+  it('splits only on the first dot so deep paths (e.g. step.x.y) are not truncated', () => {
+    // `String.prototype.split(".", 2)` truncates remainder (e.g. "a.b.c" -> ["a","b"]);
+    // paths with three or more segments must recurse on `a` + `b.c`, not `a` + `b` only.
+    const errors: JsonObject = {};
+    safeSet(errors, 'a.b.c.d', { [ERRORS_KEY]: ['deep'] });
+    expect(errors).toEqual({
+      a: {
+        b: {
+          c: {
+            d: {
+              [ERRORS_KEY]: ['deep'],
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('sets a single-segment path', () => {
+    const errors: JsonObject = {};
+    safeSet(errors, 'onlyKey', { [ERRORS_KEY]: ['msg'] });
+    expect(errors).toEqual({ onlyKey: { [ERRORS_KEY]: ['msg'] } });
+  });
+
+  it('merges sibling leaf paths under a shared prefix when applied sequentially', () => {
+    const errors: JsonObject = {};
+    safeSet(errors, 'my-solution.xParams.fieldA', {
+      [ERRORS_KEY]: ['a'],
+    });
+    safeSet(errors, 'my-solution.xParams.fieldB', {
+      [ERRORS_KEY]: ['b'],
+    });
+    safeSet(errors, 'my-solution.xParams.fieldC', {
+      [ERRORS_KEY]: ['c'],
+    });
+    expect(errors).toEqual({
+      'my-solution': {
+        xParams: {
+          fieldA: { [ERRORS_KEY]: ['a'] },
+          fieldB: { [ERRORS_KEY]: ['b'] },
+          fieldC: { [ERRORS_KEY]: ['c'] },
+        },
+      },
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/safeSet.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/safeSet.ts
@@ -21,12 +21,14 @@ export const safeSet: (
   path: string,
   value: JsonValue,
 ) => void = (errors, path, value) => {
-  const steps = path.split('.', 2);
-  if (steps.length === 1) {
-    errors[steps[0]] = value;
+  const dot = path.indexOf('.');
+  if (dot === -1) {
+    errors[path] = value;
   } else {
-    const safeObject = (errors[steps[0]] ?? {}) as JsonObject;
-    errors[steps[0]] = safeObject;
-    safeSet(safeObject, steps[1], value);
+    const head = path.slice(0, dot);
+    const rest = path.slice(dot + 1);
+    const safeObject = (errors[head] ?? {}) as JsonObject;
+    errors[head] = safeObject;
+    safeSet(safeObject, rest, value);
   }
 };

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { JsonObject } from '@backstage/types';
+import { ERRORS_KEY } from '@rjsf/utils';
+
+import { useGetExtraErrors } from './useGetExtraErrors';
+
+jest.mock('./evaluateTemplate', () => ({
+  evaluateTemplateString: jest
+    .fn()
+    .mockResolvedValue('https://example.com/validate'),
+}));
+
+jest.mock('./useRequestInit', () => ({
+  getRequestInit: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('./useTemplateUnitEvaluator', () => ({
+  useTemplateUnitEvaluator: jest.fn(() => async () => undefined),
+}));
+
+const mockFetch = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: (ref: unknown) => {
+      if (ref === actual.fetchApiRef) {
+        return { fetch: mockFetch };
+      }
+      throw new Error(
+        `useGetExtraErrors.test: unmocked api ref: ${String(ref)}`,
+      );
+    },
+  };
+});
+
+describe('useGetExtraErrors', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('aggregates async validation errors for all nested fields under a shared path prefix', async () => {
+    let fetchCall = 0;
+    mockFetch.mockImplementation(async () => {
+      const n = ++fetchCall;
+      return {
+        status: 422,
+        json: async () => ({ issues: [`validation failed for request ${n}`] }),
+      };
+    });
+
+    const { result } = renderHook(() => useGetExtraErrors());
+
+    const uiSchema: JsonObject = {
+      'my-solution': {
+        xParams: {
+          fieldA: {
+            'ui:widget': 'ActiveTextInput',
+            'ui:props': { 'validate:url': 'https://example.com/validate' },
+          },
+          fieldB: {
+            'ui:widget': 'ActiveTextInput',
+            'ui:props': { 'validate:url': 'https://example.com/validate' },
+          },
+          fieldC: {
+            'ui:widget': 'ActiveTextInput',
+            'ui:props': { 'validate:url': 'https://example.com/validate' },
+          },
+        },
+      },
+    };
+
+    const formData: JsonObject = {
+      'my-solution': {
+        xParams: {
+          fieldA: '',
+          fieldB: '',
+          fieldC: '',
+        },
+      },
+    };
+
+    const errors = await result.current(formData, uiSchema);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(errors).toEqual({
+      'my-solution': {
+        xParams: {
+          fieldA: {
+            [ERRORS_KEY]: ['validation failed for request 1'],
+          },
+          fieldB: {
+            [ERRORS_KEY]: ['validation failed for request 2'],
+          },
+          fieldC: {
+            [ERRORS_KEY]: ['validation failed for request 3'],
+          },
+        },
+      },
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
@@ -143,7 +143,12 @@ export const useGetExtraErrors = () => {
       '',
     );
 
-    await Promise.all(promises);
+    // Run sequentially so concurrent async callbacks cannot interleave
+    // `safeSet` mutations on the shared `errors` object (lost updates under
+    // the same path prefix, e.g. `step.xParams.fieldA` vs `fieldB`).
+    for (const p of promises) {
+      await p;
+    }
     return errors;
   };
 };


### PR DESCRIPTION
##  Preserve nested extraErrors and async validation errors
**Fixes:**
https://redhat.atlassian.net/browse/RHDHBUGS-2970

Fixes cases where only one of several backend validation errors appeared for multi-step workflows, or errors did not show inline on nested fields under a wizard step.

**Changes included in the PR:**

- `safeSet` builds the correct nested error tree for dotted paths.
- Sequential await avoids losing updates when multiple fields validate async.
- `toRootExtraErrors` ensures extraErrors passed to the root form match schema.properties (step keys), so RJSF + `StepperObjectField` show inline errors correctly.

```mermaid
flowchart LR
  A["Deep nested paths<br/>e.g. step.x.y.z"] -->|safeSet fix| B["Correct error tree<br/>built recursively"]
  C["Concurrent async<br/>validation calls"] -->|sequential await| D["All errors preserved<br/>no lost updates"]
  E["getExtraErrors<br/>returns step-keyed tree"] -->|toRootExtraErrors| F["Root-shaped errors<br/>for RJSF + StepperObjectField"]
  B --> G["Multi-step forms<br/>show all inline errors"]
  D --> G
  F --> G
```


### How to test 


**1. Add the Backstage proxy** so the browser does not call `127.0.0.1:7070` directly. Merge under `proxy:` in `app-config.yaml` or `app-config.local.yaml`:

```yaml
proxy:
  endpoints:
    '/local-validation-mock':
      target: 'http://127.0.0.1:7070'
      changeOrigin: true
      allowedMethods: ['GET', 'POST', 'OPTIONS']
      allowedHeaders: ['Content-Type', 'Accept', 'Authorization']
```


**2. Run a mock validation HTTP server** on `127.0.0.1:7070` that answers **POST** to paths like `/validate/fieldA` with **422** and a JSON body such as `{ "validation": ["…"] }`. Save the script below to any path (e.g. `mock-validation-server.cjs` in your workspace) and run:

<details>
<summary>Example mock server - `mock-validation-server.cjs`. (Node.js)</summary>

```js
const http = require('http');
const PORT = Number(process.env.PORT || 7070);
const server = http.createServer((req, res) => {
  if (req.method !== 'POST') {
    res.writeHead(405, { 'Content-Type': 'application/json' });
    res.end(JSON.stringify({ validation: ['Method not allowed'] }));
    return;
  }
  const path = req.url || '';
  const m = path.match(/\/validate\/([^/?]+)/);
  const field = m ? m[1] : 'unknown';
  let body = '';
  req.on('data', c => {
    body += c;
  });
  req.on('end', () => {
    res.writeHead(422, { 'Content-Type': 'application/json' });
    res.end(
      JSON.stringify({
        validation: [`Mock validation failed for "${field}"`],
      }),
    );
  });
});
server.listen(PORT, '127.0.0.1', () =>
  console.log(`mock listening on http://127.0.0.1:${PORT}`),
);
```

</details>


```bash
node mock-validation-server.cjs
```


**3. Register the workflow and input schema** using the YAML/JSON in the collapsible sections below. **`validate:url`** must use the proxy, e.g. `$${{backend.baseUrl}}/api/proxy/local-validation-mock/validate/fieldA` (and `fieldB`, `fieldC`), not `http://127.0.0.1:7070/...` directly (avoids CORS).

<details>
<summary>Workflow definition (reference)</summary>

```yaml
id: extra-errors-repro
version: '0.1'
specVersion: '0.8'
name: Extra errors reproduction (nested validate:url)
description: >-
  Demo workflow with a single wizard step property (my-solution), nested xParams, and
  three ActiveTextInput fields using validate:url for async backend validation.
dataInputSchema: schemas/extra-errors-repro__main-schema.json
start: Finish
functions:
  - name: noop
    type: custom
    operation: sysout
states:
  - name: Finish
    type: operation
    actions:
      - name: noopAction
        functionRef:
          refName: noop
          arguments:
            message: '"ok"'
    end:
      terminate: true
```

</details>

<details>
<summary>Input schema JSON (reference)</summary>

```json
{
  "$id": "classpath:/schemas/extra-errors-repro__main-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Extra errors reproduction",
  "type": "object",
  "properties": {
    "my-solution": {
      "type": "object",
      "title": "Solution step",
      "properties": {
        "workflowParams": {
          "type": "object",
          "title": "Workflow params (hidden)",
          "ui:hidden": true,
          "additionalProperties": true
        },
        "xParams": {
          "type": "object",
          "title": "Cross parameters",
          "required": ["fieldA", "fieldB", "fieldC"],
          "properties": {
            "fieldA": {
              "type": "string",
              "title": "Field A",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:url": "$${{backend.baseUrl}}/api/proxy/local-validation-mock/validate/fieldA",
                "validate:method": "POST",
                "validate:body": { "field": "fieldA" }
              }
            },
            "fieldB": {
              "type": "string",
              "title": "Field B",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:url": "$${{backend.baseUrl}}/api/proxy/local-validation-mock/validate/fieldB",
                "validate:method": "POST",
                "validate:body": { "field": "fieldB" }
              }
            },
            "fieldC": {
              "type": "string",
              "title": "Field C",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:url": "$${{backend.baseUrl}}/api/proxy/local-validation-mock/validate/fieldC",
                "validate:method": "POST",
                "validate:body": { "field": "fieldC" }
              }
            }
          }
        }
      }
    }
  },
  "required": ["my-solution"]
}
```

</details>

---

**4. Run the app** and open **Execute workflow** for `extra-errors-repro`.

**5. What to verify**

- Leave **fieldA / fieldB / fieldC** empty.
- **Submit** or **Next** so `getExtraErrors` runs (three `validate:url` requests).
- **Expected:** Three **422** responses in the network trace and **three** distinct error messages in the UI (not a single one). Inline errors should appear under each field when the step is visible.

**Before:**

<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/080a7f16-f29a-43ae-9981-4aca34c51944" />

---

**After:**

<img width="2000" height="1300" alt="image" src="https://github.com/user-attachments/assets/9bfddd41-e45a-44c7-b7d1-26ac8f3570a3" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
