### PR TITLE
fix(orchestrator-form): Review step crash when form data is empty

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-review-empty-formdata.md
+++ b/workspaces/orchestrator/.changeset/fix-review-empty-formdata.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+---
+
+fix: avoid Review step crash when form data is empty (for example display-only `ActiveText` with no submitted values). `generateReviewTableData` returns `{}` instead of undefined, and `NestedReviewTable` handles missing data.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/NestedReviewTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/NestedReviewTable.tsx
@@ -123,9 +123,10 @@ export const NestedReviewTable: React.FC<NestedReviewTableProps> = ({
   data,
 }) => {
   const { classes } = useStyles();
+  const safeData = data ?? {};
 
   // Group top-level sections
-  const sections: [string, JsonValue][] = Object.entries(data).filter(
+  const sections: [string, JsonValue][] = Object.entries(safeData).filter(
     ([_, value]) => value !== undefined,
   ) as [string, JsonValue][];
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.test.ts
@@ -351,4 +351,21 @@ describe('mapSchemaToData', () => {
     const result = generateReviewTableData(schema, data);
     expect(result).toEqual(expectedResult);
   });
+
+  it('returns an empty object when form data is empty (e.g. display-only ActiveText)', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      title: 'Access request',
+      properties: {
+        infoMessage: {
+          type: 'string',
+          title: 'Info',
+          'ui:widget': 'ActiveText',
+        } as JSONSchema7,
+      },
+    };
+
+    const result = generateReviewTableData(schema, {});
+    expect(result).toEqual({});
+  });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
@@ -107,7 +107,8 @@ function generateReviewTableData(
     data,
     options?.includeHiddenFields ?? false,
   );
-  return result[''] as JsonObject;
+  const root = result[''] as JsonObject | undefined;
+  return root ?? {};
 }
 
 export default generateReviewTableData;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### PR description

#### Problem

On workflow execute, moving to the Review step could throw when formData was effectively empty—for example input schemas with only display-only ActiveText (no onChange, so nothing is submitted) or when every visible value is filtered out for review (e.g. `ui:hidden`). `generateReviewTableData` could return undefined, and `NestedReviewTable` called Object.entries on that value.

#### Solution

`generateReviewTableData`: always return a root payload object; use {} when the processed root is missing.
`NestedReviewTable`: treat missing data as {} so the table never receives undefined.

---------------

-----BEFORE-----

<img width="1204" height="741" alt="Screenshot 2026-04-20 at 5 05 50 PM" src="https://github.com/user-attachments/assets/6a775847-ed8f-409b-96e2-0186f35b65d7" />

---------------

----AFTER-----

<img width="1490" height="951" alt="Screenshot 2026-04-20 at 3 51 49 PM" src="https://github.com/user-attachments/assets/20fd925a-46e1-4d28-b8c6-8f4f694c2dc5" />

---------------

Use below schema for testing

```
{
  "$id": "classpath:/schemas/test-activetext-only-review.input-schema.json",
  "title": "IT Cluster Platform Access Request Input Schema",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "infoMessage": {
      "type": "string",
      "ui:widget": "ActiveText",
      "ui:props": {
        "ui:text": "User **$${{identityApi.displayName}}** will be added to the IT Cluster Platform users rover group and thus granted permissions to use the IT Cluster Platform plugin.\n\n**Note:** Group synchronization within IT Developer Hub can take up to an hour. If you experience permission issues after the workflow completes, please allow time for synchronization to complete."
      }
    }
  }
}
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
