### PR TITLE
chore(scorecard): log metric provider errors

### DIFF
--- a/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts
@@ -181,6 +181,12 @@ export class PullMetricsByProviderTask implements SchedulerTask {
             } catch (error) {
               // status is intentionally omitted — a calculation failure produces a NULL status
               // in the database, which sorts last when sortBy=status is used
+              logger.warn(
+                `Failed to calculate metric for entity ${stringifyEntityRef(
+                  entity,
+                )}: ${error}`,
+                error instanceof Error ? error : undefined,
+              );
               return {
                 catalog_entity_ref: stringifyEntityRef(entity),
                 metric_id: this.providerId,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Logs a warning when a metric provider fails for an entity. Wdyt? :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
