### PR TITLE
Skip SSO Authorization

### DIFF
--- a/workspaces/dcm/.changeset/swift-foxes-token.md
+++ b/workspaces/dcm/.changeset/swift-foxes-token.md
@@ -1,0 +1,10 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm-backend': patch
+---
+
+Fix 502 error when SSO credentials are not configured.
+
+The backend proxy now skips the SSO token exchange when `clientId` or
+`clientSecret` are absent, forwarding requests to the API gateway without
+an Authorization header instead of failing with "Failed to obtain upstream
+access token."

--- a/workspaces/dcm/Dockerfile
+++ b/workspaces/dcm/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM node:20-bookworm-slim AS build
+FROM node:22-bookworm-slim AS build
 
 RUN corepack enable
 
@@ -39,11 +39,11 @@ RUN yarn workspace app build
 RUN yarn workspace backend build
 
 # ── Stage 2: production image ─────────────────────────────────────────────────
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 RUN corepack enable \
     && apt-get update && apt-get install -y --no-install-recommends \
-    python3 make g++ \
+    python3 make g++ g++-13 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -60,7 +60,8 @@ RUN node -e " \
     if (pkg.scripts) pkg.scripts.postinstall = 'true'; \
     fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2)); \
     " \
-    && YARN_ENABLE_IMMUTABLE_INSTALLS=false \
+    && CXX=g++-13 \
+    YARN_ENABLE_IMMUTABLE_INSTALLS=false \
     YARN_CACHE_FOLDER=/root/.yarn/berry/cache \
     yarn workspaces focus --all --production \
     && rm -rf "$(yarn cache dir)"

--- a/workspaces/dcm/package.json
+++ b/workspaces/dcm/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "start": "concurrently -c auto -n \"fe,be\" -p \"{name}:{pid}\" \"yarn start-app\" \"yarn start-backend\"",
@@ -56,7 +56,7 @@
     "typescript": "~5.3.0"
   },
   "resolutions": {
-    "isolated-vm": "^6.0.1",
+    "isolated-vm": "6.0.2",
     "better-sqlite3": "^12.0.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/workspaces/dcm/package.json
+++ b/workspaces/dcm/package.json
@@ -56,6 +56,8 @@
     "typescript": "~5.3.0"
   },
   "resolutions": {
+    "isolated-vm": "^6.0.1",
+    "better-sqlite3": "^12.0.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "fsevents": "~2.3.2",

--- a/workspaces/dcm/plugins/dcm-backend/config.d.ts
+++ b/workspaces/dcm/plugins/dcm-backend/config.d.ts
@@ -42,13 +42,13 @@ export interface Config {
      *
      * @visibility secret
      */
-    clientId: string;
+    clientId?: string;
 
     /**
      * SSO client secret used to obtain a bearer token for upstream API calls.
      *
      * @visibility secret
      */
-    clientSecret: string;
+    clientSecret?: string;
   };
 }

--- a/workspaces/dcm/plugins/dcm-backend/src/routes/proxy.ts
+++ b/workspaces/dcm/plugins/dcm-backend/src/routes/proxy.ts
@@ -75,9 +75,15 @@ export function createDcmProxy(options: RouterOptions) {
     }
 
     const requestHeaders: Record<string, string> = {
-      Authorization: `Bearer ${tokenResult.accessToken}`,
       Accept: (req.headers.accept as string) || 'application/json',
     };
+
+    // Only attach the Authorization header when an SSO token was obtained.
+    // When clientId/clientSecret are not configured the token is empty and
+    // the request is forwarded without auth (open/unauthenticated gateway).
+    if (tokenResult.accessToken) {
+      requestHeaders.Authorization = `Bearer ${tokenResult.accessToken}`;
+    }
 
     // Forward Content-Type for requests that carry a body
     if (req.headers['content-type']) {

--- a/workspaces/dcm/plugins/dcm-backend/src/util/tokenUtil.ts
+++ b/workspaces/dcm/plugins/dcm-backend/src/util/tokenUtil.ts
@@ -51,12 +51,20 @@ export const getTokenFromApi = async (
     return cachedToken;
   }
 
+  const clientId = config.getOptionalString('dcm.clientId') ?? '';
+  const clientSecret = config.getOptionalString('dcm.clientSecret') ?? '';
+
+  if (!clientId || !clientSecret) {
+    logger.debug(
+      'DCM token: clientId/clientSecret not configured — skipping SSO token exchange',
+    );
+    return { accessToken: '', expiresAt: 0 };
+  }
+
   logger.info('DCM token: requesting new access token from SSO');
 
   const ssoBaseUrl =
     config.getOptionalString('dcm.ssoBaseUrl') ?? DEFAULT_SSO_BASE_URL;
-  const clientId = config.getString('dcm.clientId');
-  const clientSecret = config.getString('dcm.clientSecret');
 
   const tokenUrl = `${ssoBaseUrl}/auth/realms/redhat-external/protocol/openid-connect/token`;
   const body = new URLSearchParams({

--- a/workspaces/dcm/scripts/generate-image.sh
+++ b/workspaces/dcm/scripts/generate-image.sh
@@ -219,13 +219,13 @@ function backstage-image {
   "$_pocker" build \
     "${volume_args[@]+"${volume_args[@]}"}" \
     --tag "$image_tag" \
-    --tag "$REGISTRY_URL/$ORG_ID/$REPO:latest" \
+    --tag "$REGISTRY_URL/$ORG_ID/$REPO:main" \
     "$workspace_dir"
 
   if $do_push; then
     echo "Pushing $image_tag"
     "$_pocker" push "$image_tag"
-    "$_pocker" push "$REGISTRY_URL/$ORG_ID/$REPO:latest"
+    "$_pocker" push "$REGISTRY_URL/$ORG_ID/$REPO:main"
   else
     echo "Image built. Run with --push to push to the registry, or use:"
     echo "  $_pocker push $image_tag"

--- a/workspaces/dcm/yarn.lock
+++ b/workspaces/dcm/yarn.lock
@@ -17275,17 +17275,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^11.0.0":
-  version: 11.10.0
-  resolution: "better-sqlite3@npm:11.10.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10/5e4c7437c4fe6033335a79c82974d7ab29f33c51c36f48b73e87e087d21578468575de1c56a7badd4f76f17255e25abefddaeacf018e5eeb9e0cb8d6e3e4a5e1
-  languageName: node
-  linkType: hard
-
 "better-sqlite3@npm:^12.0.0":
   version: 12.6.2
   resolution: "better-sqlite3@npm:12.6.2"
@@ -17294,17 +17283,6 @@ __metadata:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
   checksum: 10/28600c06c03c33b027717f48d7208561d4a51d1fab48b4efb9041cafb9ca79568bc3a702835ad3bdd2b17189942745df22ed827be220254dd2a3928e257c138f
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10/06b3d95221071a06c2e22a9746d9b7049c0bce7962e5e3290ccf088fffbf4d4d52868f0d98b8ae2565fe33b1adab89823145f23c6f6eb63ecc4fc1b883f9082c
   languageName: node
   linkType: hard
 
@@ -24358,13 +24336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^5.0.1":
-  version: 5.0.4
-  resolution: "isolated-vm@npm:5.0.4"
+"isolated-vm@npm:^6.0.1":
+  version: 6.1.2
+  resolution: "isolated-vm@npm:6.1.2"
   dependencies:
     node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.2"
-  checksum: 10/f48e69ecf907645711d0a372cb6adb28cf72499e34b6e008ed597994bfd90d41dd11dc478a41fc21a25aaef424ab5a95a372286e4daf7f61e231d028c0fd64ec
+    node-gyp-build: "npm:^4.8.4"
+  checksum: 10/705c93375a6342d54d2381efebba45d965147d5a6e534dc5c1e622b625ad02ee8878cacd03a8fd09f9929a3fc2d039b26a900d976632b14a51a94005371ec1d9
   languageName: node
   linkType: hard
 
@@ -29705,7 +29683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.1.1, prebuild-install@npm:^7.1.2":
+"prebuild-install@npm:^7.1.1":
   version: 7.1.3
   resolution: "prebuild-install@npm:7.1.3"
   dependencies:

--- a/workspaces/dcm/yarn.lock
+++ b/workspaces/dcm/yarn.lock
@@ -24336,13 +24336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^6.0.1":
-  version: 6.1.2
-  resolution: "isolated-vm@npm:6.1.2"
+"isolated-vm@npm:6.0.2":
+  version: 6.0.2
+  resolution: "isolated-vm@npm:6.0.2"
   dependencies:
     node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.8.4"
-  checksum: 10/705c93375a6342d54d2381efebba45d965147d5a6e534dc5c1e622b625ad02ee8878cacd03a8fd09f9929a3fc2d039b26a900d976632b14a51a94005371ec1d9
+    prebuild-install: "npm:^7.1.3"
+  checksum: 10/74e97f13678023bf81141a6fb5c91bc179073a024e7f0a568af60d876b781b15b11e02d4012558e7d583e38a553ccccff70fd02645ed5d7bed2150dc3921fa64
   languageName: node
   linkType: hard
 
@@ -29683,7 +29683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.1.1":
+"prebuild-install@npm:^7.1.1, prebuild-install@npm:^7.1.3":
   version: 7.1.3
   resolution: "prebuild-install@npm:7.1.3"
   dependencies:


### PR DESCRIPTION
The backend proxy now skips the SSO token exchange when `clientId` or
`clientSecret` are absent, forwarding requests to the API gateway without
an Authorization header instead of failing with "Failed to obtain upstream
access token."