### PR TITLE
fix(orchestrator): makes the bodyParser limit configurable. (#2802)

### DIFF
--- a/workspaces/orchestrator/.changeset/purple-eagles-share.md
+++ b/workspaces/orchestrator/.changeset/purple-eagles-share.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+fix: add configurable bodyParser limit

--- a/workspaces/orchestrator/.changeset/strong-pillows-yawn.md
+++ b/workspaces/orchestrator/.changeset/strong-pillows-yawn.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+---
+
+chore: add new config value for contentLengthLimit

--- a/workspaces/orchestrator/app-config.yaml
+++ b/workspaces/orchestrator/app-config.yaml
@@ -147,6 +147,8 @@ catalog:
 dynamicPlugins:
   frontend: {}
 orchestrator:
+  # Uncomment to set the content length limit for the requests. Defaults to 102400 bytes (100kb)
+  # contentLengthLimit: 10mb
   # Uncomment and configure to use the log viewer
   # workflowLogProvider:
   #   loki:

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/router.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/router.ts
@@ -201,7 +201,18 @@ export async function createBackendRouter(
   const permissionsIntegrationRouter = createPermissionIntegrationRouter({
     permissions: orchestratorPermissions,
   });
-  router.use(express.json());
+  const contentLengthLimit = config.getOptionalString(
+    'orchestrator.contentLengthLimit',
+  );
+  /**
+   * Set the content length limit for the requests.
+   * Defaults to 102400 bytes (100kb)
+   *
+   * There is a possiblity that some workflows will have a very large payload, which could cause a 413 error.
+   * Increasing this value will allow larger payloads to be processed.
+   *
+   */
+  router.use(express.json({ limit: contentLengthLimit }));
   router.use(permissionsIntegrationRouter);
   router.use('/workflows', express.text());
   router.get('/health', (_, response) => {

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -19,6 +19,11 @@ export interface Config {
    * Configuration for the Orchestrator plugin.
    */
   orchestrator?: {
+    /**
+     * Set the content length limit for the requests.
+     * Defaults to 102400 bytes (100kb)
+     */
+    contentLengthLimit?: string;
     sonataFlowService: {
       /**
        * Base URL of the Sonata Flow service.


### PR DESCRIPTION
Cherry pick of PR https://github.com/redhat-developer/rhdh-plugins/pull/2802

Related to JIRA https://redhat.atlassian.net/browse/RHDHSUPP-362


* fix(orchestrator): makes the bodyParser limit configurable.

A customer was having an issue where the workflows content length was over the 100kb limit.  This adds a configurable value to make the content lenght larger

fixes: https://redhat.atlassian.net/browse/RHDHSUPP-351

* squash: add changeset

* squash: add changeset

* squash: add the contentLengthLimit to the common config

* squash: only add to the global

* squash: add comment

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
