### PR TITLE
fix(scorecard): status icon rendering issue in cluster env

### DIFF
--- a/workspaces/scorecard/.changeset/many-frogs-count.md
+++ b/workspaces/scorecard/.changeset/many-frogs-count.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-scorecard': patch
 ---
 
-Fix status icon rendering issue in cluster environment
+Removed Backstage registration requirement for default Scorecard icons

--- a/workspaces/scorecard/.changeset/many-frogs-count.md
+++ b/workspaces/scorecard/.changeset/many-frogs-count.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': patch
+---
+
+Fix status icon rendering issue in cluster environment

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardIcon/ScorecardIcon.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardIcon/ScorecardIcon.tsx
@@ -16,7 +16,18 @@
 import { useApp } from '@backstage/core-plugin-api';
 import Box from '@mui/material/Box';
 import MuiIcon from '@mui/material/Icon';
+import type { SvgIconComponent } from '@mui/icons-material';
 import type { SxProps, Theme } from '@mui/material/styles';
+
+import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
+import WarningAmber from '@mui/icons-material/WarningAmber';
+import DangerousOutlined from '@mui/icons-material/DangerousOutlined';
+
+const builtInIcons: Record<string, SvgIconComponent> = {
+  scorecardSuccessStatusIcon: CheckCircleOutline,
+  scorecardWarningStatusIcon: WarningAmber,
+  scorecardErrorStatusIcon: DangerousOutlined,
+};
 
 /**
  * @public
@@ -40,7 +51,7 @@ export const ScorecardIcon = ({
     return null;
   }
 
-  const SystemIcon = app.getSystemIcon(icon);
+  const SystemIcon = app.getSystemIcon(icon) ?? builtInIcons[icon];
   if (SystemIcon) {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', ...sx }}>

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardIcon/ScorecardIcon.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardIcon/ScorecardIcon.tsx
@@ -18,15 +18,16 @@ import Box from '@mui/material/Box';
 import MuiIcon from '@mui/material/Icon';
 import type { SvgIconComponent } from '@mui/icons-material';
 import type { SxProps, Theme } from '@mui/material/styles';
-
-import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
-import WarningAmber from '@mui/icons-material/WarningAmber';
-import DangerousOutlined from '@mui/icons-material/DangerousOutlined';
+import {
+  ScorecardSuccessStatusIcon,
+  ScorecardWarningStatusIcon,
+  ScorecardErrorStatusIcon,
+} from '../..';
 
 const builtInIcons: Record<string, SvgIconComponent> = {
-  scorecardSuccessStatusIcon: CheckCircleOutline,
-  scorecardWarningStatusIcon: WarningAmber,
-  scorecardErrorStatusIcon: DangerousOutlined,
+  scorecardSuccessStatusIcon: ScorecardSuccessStatusIcon,
+  scorecardWarningStatusIcon: ScorecardWarningStatusIcon,
+  scorecardErrorStatusIcon: ScorecardErrorStatusIcon,
 };
 
 /**

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardIcon/__tests__/ScorecardIcon.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardIcon/__tests__/ScorecardIcon.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+
+import { ScorecardIcon } from '../ScorecardIcon';
+
+const mockGetSystemIcon = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApp: () => ({
+    getSystemIcon: mockGetSystemIcon,
+  }),
+}));
+
+describe('ScorecardIcon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null for empty icon string', () => {
+    const { container } = render(<ScorecardIcon icon="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should use system icon when registered', () => {
+    const MockIcon = (props: any) => (
+      <span data-testid="system-icon" {...props} />
+    );
+    mockGetSystemIcon.mockReturnValue(MockIcon);
+
+    const { getByTestId } = render(
+      <ScorecardIcon icon="scorecardSuccessStatusIcon" />,
+    );
+
+    expect(mockGetSystemIcon).toHaveBeenCalledWith(
+      'scorecardSuccessStatusIcon',
+    );
+    expect(getByTestId('system-icon')).toBeInTheDocument();
+  });
+
+  it('should fall back to built-in icon when system icon is not registered', () => {
+    mockGetSystemIcon.mockReturnValue(undefined);
+
+    const { container } = render(
+      <ScorecardIcon icon="scorecardSuccessStatusIcon" />,
+    );
+
+    expect(mockGetSystemIcon).toHaveBeenCalledWith(
+      'scorecardSuccessStatusIcon',
+    );
+    expect(
+      container.querySelector('[data-testid="CheckCircleOutlineIcon"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('should fall back to built-in warning icon', () => {
+    mockGetSystemIcon.mockReturnValue(undefined);
+
+    const { container } = render(
+      <ScorecardIcon icon="scorecardWarningStatusIcon" />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="WarningAmberIcon"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('should fall back to built-in error icon', () => {
+    mockGetSystemIcon.mockReturnValue(undefined);
+
+    const { container } = render(
+      <ScorecardIcon icon="scorecardErrorStatusIcon" />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="DangerousOutlinedIcon"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('should prefer system icon over built-in icon', () => {
+    const OverrideIcon = (props: any) => (
+      <span data-testid="override-icon" {...props} />
+    );
+    mockGetSystemIcon.mockReturnValue(OverrideIcon);
+
+    const { getByTestId, container } = render(
+      <ScorecardIcon icon="scorecardSuccessStatusIcon" />,
+    );
+
+    expect(getByTestId('override-icon')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-testid="CheckCircleOutlineIcon"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render URL-based icon as image', () => {
+    mockGetSystemIcon.mockReturnValue(undefined);
+
+    const { container } = render(
+      <ScorecardIcon icon="https://example.com/icon.png" />,
+    );
+
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img?.getAttribute('src')).toBe('https://example.com/icon.png');
+  });
+
+  it('should render unknown icon string as Material Design ligature', () => {
+    mockGetSystemIcon.mockReturnValue(undefined);
+
+    const { container } = render(<ScorecardIcon icon="settings" />);
+
+    const muiIcon = container.querySelector('.material-icons-outlined');
+    expect(muiIcon).toBeInTheDocument();
+    expect(muiIcon?.textContent).toBe('settings');
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix: https://redhat.atlassian.net/browse/RHDHBUGS-2996

Issue:
While testing the Scorecard plugin in the cluster environment, status icons are not rendering correctly. The same functionality works as expected in the local development environment.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
