### PR TITLE
fix(x2a): resolve isolated-vm to v6 for Node 24 CI

### DIFF
--- a/workspaces/x2a/package.json
+++ b/workspaces/x2a/package.json
@@ -55,6 +55,7 @@
     "typescript": "^5.9.0"
   },
   "resolutions": {
+    "isolated-vm": "^6.0.1",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@backstage/backend-plugin-api": "1.5.0",

--- a/workspaces/x2a/yarn.lock
+++ b/workspaces/x2a/yarn.lock
@@ -24116,13 +24116,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^5.0.1":
-  version: 5.0.4
-  resolution: "isolated-vm@npm:5.0.4"
+"isolated-vm@npm:^6.0.1":
+  version: 6.1.2
+  resolution: "isolated-vm@npm:6.1.2"
   dependencies:
     node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.2"
-  checksum: 10c0/3576ac27a907d2cd100590276fb31870eb702a0e7aeb43d6cdd8b76f57264211983ff6b8e6815f86c8376377fedb5cf22e94e663171935e04e2e96bffd944ca9
+    node-gyp-build: "npm:^4.8.4"
+  checksum: 10c0/2209032b8296e6af49250f7e04ab904e9c331bbbf1bdf8eeca78e32ed6bd98c84ced42b785127f0f2828a1c5e66d82cb2bf1459e973620e19b485c5a00252e98
   languageName: node
   linkType: hard
 
@@ -29785,7 +29785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.1.1, prebuild-install@npm:^7.1.2":
+"prebuild-install@npm:^7.1.1":
   version: 7.1.3
   resolution: "prebuild-install@npm:7.1.3"
   dependencies:


### PR DESCRIPTION
Add yarn resolution for isolated-vm ^6.0.1 so build succeeds on Node 24.

Transitive dependency from @backstage/plugin-scaffolder-backend 3.0.2 still declares isolated-vm ^5 but this version fails to compile against current headers (C++20 required).


