### PR TITLE
[Konflux] Fix Latest Releases not shown when applications field is omitted or uses wildcard patterns.

### DIFF
--- a/workspaces/konflux/.changeset/ready-clowns-juggle.md
+++ b/workspaces/konflux/.changeset/ready-clowns-juggle.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-konflux-backend': patch
+'@red-hat-developer-hub/backstage-plugin-konflux-common': patch
+'@red-hat-developer-hub/backstage-plugin-konflux': patch
+---
+
+Bump Backstage dependencies from 1.45.2 to 1.49.4 to align with RHDH 1.10. Fix Latest Releases not shown when applications field is omitted or uses wildcard patterns.

--- a/workspaces/konflux/plugins/konflux-backend/src/helpers/kubernetes.ts
+++ b/workspaces/konflux/plugins/konflux-backend/src/helpers/kubernetes.ts
@@ -16,29 +16,8 @@
 import {
   getApplicationFromResource,
   K8sResourceCommonWithClusterInfo,
+  matchesApplicationPattern,
 } from '@red-hat-developer-hub/backstage-plugin-konflux-common';
-
-/**
- * Convert a glob pattern (e.g. "app-*", "*api*") to a RegExp
- */
-const globToRegex = (pattern: string): RegExp => {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
-  const regexStr = escaped.replace(/\*/g, '.*');
-  return new RegExp(`^${regexStr}$`);
-};
-
-/**
- * Check if a name matches any of the given application patterns.
- * Supports exact matches and glob patterns with "*".
- */
-export const matchesApplicationPattern = (
-  name: string,
-  patterns: string[],
-): boolean => {
-  return patterns.some(pattern =>
-    pattern.includes('*') ? globToRegex(pattern).test(name) : pattern === name,
-  );
-};
 
 /**
  * Filter resources by application names or glob patterns

--- a/workspaces/konflux/plugins/konflux-common/report.api.md
+++ b/workspaces/konflux/plugins/konflux-common/report.api.md
@@ -88,6 +88,9 @@ export function getSubcomponentsWithFallback(
 ): Entity[];
 
 // @public
+export const globToRegex: (pattern: string) => RegExp;
+
+// @public
 export type GroupVersionKind = GroupVersionKind_2;
 
 // @public (undocumented)
@@ -179,6 +182,12 @@ export interface KonfluxConfig {
 export const konfluxResourceModels: {
   [key: string]: GroupVersionKind_2;
 };
+
+// @public
+export const matchesApplicationPattern: (
+  name: string,
+  patterns: string[],
+) => boolean;
 
 // @public (undocumented)
 export enum ModelsPlural {

--- a/workspaces/konflux/plugins/konflux-common/src/__tests__/patterns.test.ts
+++ b/workspaces/konflux/plugins/konflux-common/src/__tests__/patterns.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { globToRegex, matchesApplicationPattern } from '../patterns';
+
+describe('globToRegex', () => {
+  it('should match exact string when no wildcard', () => {
+    const regex = globToRegex('my-app');
+    expect(regex.test('my-app')).toBe(true);
+    expect(regex.test('my-app-extra')).toBe(false);
+    expect(regex.test('prefix-my-app')).toBe(false);
+  });
+
+  it('should match prefix wildcard', () => {
+    const regex = globToRegex('my-app-*');
+    expect(regex.test('my-app-frontend')).toBe(true);
+    expect(regex.test('my-app-backend')).toBe(true);
+    expect(regex.test('my-app-')).toBe(true);
+    expect(regex.test('other-app')).toBe(false);
+  });
+
+  it('should match suffix wildcard', () => {
+    const regex = globToRegex('*-backend');
+    expect(regex.test('my-app-backend')).toBe(true);
+    expect(regex.test('other-backend')).toBe(true);
+    expect(regex.test('backend')).toBe(false);
+    expect(regex.test('my-app-frontend')).toBe(false);
+  });
+
+  it('should match contains wildcard', () => {
+    const regex = globToRegex('*-api-*');
+    expect(regex.test('my-api-service')).toBe(true);
+    expect(regex.test('test-api-backend')).toBe(true);
+    expect(regex.test('my-app')).toBe(false);
+  });
+
+  it('should match all with single wildcard', () => {
+    const regex = globToRegex('*');
+    expect(regex.test('anything')).toBe(true);
+    expect(regex.test('')).toBe(true);
+  });
+
+  it('should escape regex special characters', () => {
+    const regex = globToRegex('my.app*');
+    expect(regex.test('my.app-frontend')).toBe(true);
+    expect(regex.test('myXapp-frontend')).toBe(false);
+  });
+});
+
+describe('matchesApplicationPattern', () => {
+  it('should match exact names', () => {
+    expect(matchesApplicationPattern('app1', ['app1', 'app2'])).toBe(true);
+    expect(matchesApplicationPattern('app3', ['app1', 'app2'])).toBe(false);
+  });
+
+  it('should match glob patterns', () => {
+    expect(matchesApplicationPattern('my-app-frontend', ['my-app-*'])).toBe(
+      true,
+    );
+    expect(matchesApplicationPattern('other-app', ['my-app-*'])).toBe(false);
+  });
+
+  it('should match mix of exact and glob patterns', () => {
+    expect(
+      matchesApplicationPattern('special-app', ['my-app-*', 'special-app']),
+    ).toBe(true);
+    expect(
+      matchesApplicationPattern('my-app-backend', ['my-app-*', 'special-app']),
+    ).toBe(true);
+    expect(
+      matchesApplicationPattern('other-app', ['my-app-*', 'special-app']),
+    ).toBe(false);
+  });
+
+  it('should return false for empty patterns', () => {
+    expect(matchesApplicationPattern('app1', [])).toBe(false);
+  });
+
+  it('should be case sensitive', () => {
+    expect(matchesApplicationPattern('App1', ['app1'])).toBe(false);
+  });
+});

--- a/workspaces/konflux/plugins/konflux-common/src/index.ts
+++ b/workspaces/konflux/plugins/konflux-common/src/index.ts
@@ -85,3 +85,5 @@ export { PipelineRunLabel } from './pipeline-runs';
 export { getApplicationFromResource } from './resources';
 
 export { getSubcomponentsWithFallback, getSubcomponentNames } from './entities';
+
+export { globToRegex, matchesApplicationPattern } from './patterns';

--- a/workspaces/konflux/plugins/konflux-common/src/patterns.ts
+++ b/workspaces/konflux/plugins/konflux-common/src/patterns.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Convert a glob pattern (e.g. "app-*", "*api*") to a RegExp.
+ * Only supports `*` as a wildcard character.
+ *
+ * @public
+ */
+export const globToRegex = (pattern: string): RegExp => {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const regexStr = escaped.replace(/\*/g, '.*');
+  return new RegExp(`^${regexStr}$`);
+};
+
+/**
+ * Check if a name matches any of the given application patterns.
+ * Supports exact matches and glob patterns with "*".
+ *
+ * @public
+ */
+export const matchesApplicationPattern = (
+  name: string,
+  patterns: string[],
+): boolean => {
+  return patterns.some(pattern =>
+    pattern.includes('*') ? globToRegex(pattern).test(name) : pattern === name,
+  );
+};

--- a/workspaces/konflux/plugins/konflux/src/components/List/LatestReleasesList/utils.ts
+++ b/workspaces/konflux/plugins/konflux/src/components/List/LatestReleasesList/utils.ts
@@ -16,6 +16,7 @@
 
 import {
   getApplicationFromResource,
+  matchesApplicationPattern,
   ReleaseResource,
   SubcomponentClusterConfig,
 } from '@red-hat-developer-hub/backstage-plugin-konflux-common';
@@ -40,16 +41,19 @@ export const getLatestRelease = (
       config.namespace === namespace,
   );
 
-  // get all applications from matching configs
-  const appNames = new Set(
-    matchingConfigs.flatMap(config => config.applications),
+  // get all application patterns from matching configs
+  const appPatterns = matchingConfigs.flatMap(
+    config => config.applications ?? [],
   );
+  const fetchesAll = appPatterns.length === 0 || appPatterns.includes('*');
 
   const filteredReleases = releases.filter(release => {
     const applicationName = getApplicationFromResource(release) || '';
+    const matchesApp =
+      fetchesAll || matchesApplicationPattern(applicationName, appPatterns);
     return (
       release.subcomponent?.name === subcomponent &&
-      appNames.has(applicationName) &&
+      matchesApp &&
       release.cluster.name === cluster &&
       release.metadata?.namespace === namespace
     );

--- a/workspaces/konflux/plugins/konflux/src/hooks/useEntitiesKonfluxConfig.ts
+++ b/workspaces/konflux/plugins/konflux/src/hooks/useEntitiesKonfluxConfig.ts
@@ -50,17 +50,12 @@ export const useEntitiesKonfluxConfig = ():
           const subcomponentName = e.metadata.name;
           clustersParsedYaml.forEach(clusterConfig => {
             // filter out invalid configs (missing required fields)
-            if (
-              clusterConfig.cluster &&
-              clusterConfig.namespace &&
-              clusterConfig.applications &&
-              clusterConfig.applications.length > 0
-            ) {
+            if (clusterConfig.cluster && clusterConfig.namespace) {
               subcomponentConfigs.push({
                 subcomponent: subcomponentName,
                 cluster: clusterConfig.cluster,
                 namespace: clusterConfig.namespace,
-                applications: clusterConfig.applications,
+                applications: clusterConfig.applications || [],
               });
             }
           });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Description

In this PR we're fixing a bug where the "Latest Releases" card (shown in Overview tab) was not showing any release when the `applications` field was omitted or used wildcard patterns.


Fixes https://redhat.atlassian.net/browse/KFLUXUI-1230

### How to test it?

- create a backstage entity/component in which the `konflux-ci.dev/clusters` either have an `applications` field that uses wildcard patterns or ommit the `applications` field. Example:
```yaml
kind: Component
apiVersion: backstage.io/v1alpha1
metadata:
  name: component-1
  description: Component 1
  title: Component 1
  annotations:
    konflux-ci.dev/overview: 'true'
    konflux-ci.dev/konflux: 'true'
    konflux-ci.dev/ci: 'true'
    konflux-ci.dev/clusters: |
      - cluster: <your-cluster>
        namespace: <your-namespace>
spec:
  type: service
  lifecycle: experimental
  owner: user:guest
``` 
- navigate to `Overview` tab
- notice that now the `Konflux Latest Releases` UI component should show the latest release given your config
- :coffee:

### Visual references

Before:

https://github.com/user-attachments/assets/956b0407-865d-480a-8bcc-19659baa8974

After:

https://github.com/user-attachments/assets/29073189-f010-4a20-bcf4-3017da75e9fc


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
