### PR TITLE
fix(theme): active sidebar nav link styles using aria-current under BackstageSidebar drawer

### DIFF
--- a/workspaces/theme/.changeset/loud-glasses-perform.md
+++ b/workspaces/theme/.changeset/loud-glasses-perform.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+style the active sidebar nav link (a[aria-current="page"]) so selected colors match the resolved navigation shell

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -634,6 +634,15 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           '& hr': {
             backgroundColor: general.sidebarDividerColor,
           },
+          '#rhdh-sidebar-layout & a[aria-current="page"], & a[aria-current="page"]':
+            {
+              background: `${sidebarItemInteractionBackgroundColor} !important`,
+              backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,
+              color: `${navigationSelectedColor} !important`,
+              '& .MuiTypography-root': {
+                color: 'inherit !important',
+              },
+            },
           '& [class*="BackstageSidebarItem-selected-"][class*="BackstageSidebarItem-root-"]':
             {
               backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,


### PR DESCRIPTION

## Hey, I just made a Pull Request!

https://redhat.atlassian.net/browse/RHDHBUGS-2981

Adds theme overrides on the BackstageSidebar drawer so the current route’s nav link (a[aria-current="page"]) uses the resolved sidebar interaction background and selected text color, with a #rhdh-sidebar-layout scope for higher specificity when that layout wrapper is used. Nested MuiTypography labels inherit the link color.



<img width="1919" height="775" alt="image" src="https://github.com/user-attachments/assets/c0814435-3dfa-412a-bf8b-4230e3881033" />


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
