### PR TITLE
fix(orchestrator): workflow start state might also be in the start.stateName variable when compiled and cloudevent input data should be one level deep

### DIFF
--- a/workspaces/orchestrator/.changeset/fast-pens-explode.md
+++ b/workspaces/orchestrator/.changeset/fast-pens-explode.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+fix: inputdata added to the cloudevent should be one level deep and not be inputData.workflowData

--- a/workspaces/orchestrator/.changeset/fast-pens-explode.md
+++ b/workspaces/orchestrator/.changeset/fast-pens-explode.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
 ---
 
-fix: inputdata added to the cloudevent should be one level deep and not be inputData.workflowData
+fix: input data added to the cloudevent should be one level deep and not be inputData.workflowData

--- a/workspaces/orchestrator/.changeset/five-shirts-lie.md
+++ b/workspaces/orchestrator/.changeset/five-shirts-lie.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+fix: workflow start state might also be in the start.stateName variable when compiled

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
@@ -277,7 +277,6 @@ describe('SonataFlowService', () => {
       expect(result?.id).toBe('12345');
     });
 
-
     it('should error on a bad connection', async () => {
       const kafkaServiceOptionsMock: OrchestratorKafkaServiceOptions = {
         clientId: 'kafkaClientId',

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
@@ -223,6 +223,54 @@ describe('SonataFlowService', () => {
       expect(result?.id).toEqual('12345');
     });
 
+    it('should pass data from workflowdata payload into the clouevent data', async () => {
+      const kafkaServiceOptionsMock: OrchestratorKafkaServiceOptions = {
+        clientId: 'kafkaClientId',
+        brokers: ['localhost:9091'],
+      };
+      const sonataFlowServiceWithKafka = new SonataFlowService(
+        dataIndexServiceMock,
+        loggerMock,
+        kafkaServiceOptionsMock,
+      );
+      const spy = jest
+        .spyOn(
+          sonataFlowServiceWithKafka.getOrchestratorKafkaImpl() as any,
+          'producer',
+        )
+        .mockImplementation(() => {
+          return {
+            connect: jest.fn(),
+            send: jest
+              .fn()
+              .mockImplementation(({ messages }: { messages: any }) => {
+                expect(messages[0].value).toContain(
+                  '"data":{"paramter1":"12345","lockid":"12345"}',
+                );
+                expect(messages[0].value).not.toContain('"isEvent": true');
+              }),
+            disconnect: jest.fn(),
+          };
+        });
+      const result =
+        await sonataFlowServiceWithKafka.executeWorkflowAsCloudEvent({
+          definitionId,
+          workflowSource: 'workflowSource',
+          workflowEventType: 'workflowEventType',
+          contextAttribute: 'lockid',
+          inputData: {
+            workflowdata: {
+              paramter1: '12345',
+              isEvent: true,
+            },
+          },
+        });
+      expect(spy).toHaveBeenCalled();
+      expect(result).toBeDefined();
+      expect(result?.id).toBeDefined();
+      expect(result?.id).toEqual('12345');
+    });
+
     it('should error on a bad connection', async () => {
       const kafkaServiceOptionsMock: OrchestratorKafkaServiceOptions = {
         clientId: 'kafkaClientId',

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
@@ -233,25 +233,20 @@ describe('SonataFlowService', () => {
         loggerMock,
         kafkaServiceOptionsMock,
       );
-      const spy = jest
+
+      const sendMock = jest.fn();
+
+      jest
         .spyOn(
           sonataFlowServiceWithKafka.getOrchestratorKafkaImpl() as any,
           'producer',
         )
-        .mockImplementation(() => {
-          return {
-            connect: jest.fn(),
-            send: jest
-              .fn()
-              .mockImplementation(({ messages }: { messages: any }) => {
-                expect(messages[0].value).toContain(
-                  '"data":{"paramter1":"12345","lockid":"12345"}',
-                );
-                expect(messages[0].value).not.toContain('"isEvent": true');
-              }),
-            disconnect: jest.fn(),
-          };
-        });
+        .mockImplementation(() => ({
+          connect: jest.fn(),
+          send: sendMock,
+          disconnect: jest.fn(),
+        }));
+
       const result =
         await sonataFlowServiceWithKafka.executeWorkflowAsCloudEvent({
           definitionId,
@@ -265,11 +260,23 @@ describe('SonataFlowService', () => {
             },
           },
         });
-      expect(spy).toHaveBeenCalled();
+
+      expect(sendMock).toHaveBeenCalled();
+
+      const { messages } = sendMock.mock.calls[0][0];
+      const parsed = JSON.parse(messages[0].value);
+
+      expect(parsed.data).toEqual({
+        paramter1: '12345',
+        lockid: '12345',
+      });
+
+      expect(parsed.isEvent).toBeUndefined();
+
       expect(result).toBeDefined();
-      expect(result?.id).toBeDefined();
-      expect(result?.id).toEqual('12345');
+      expect(result?.id).toBe('12345');
     });
+
 
     it('should error on a bad connection', async () => {
       const kafkaServiceOptionsMock: OrchestratorKafkaServiceOptions = {

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -140,14 +140,31 @@ export class SonataFlowService {
       throw new Error('No Orchestrator kafka implementation added');
     }
     const contextAttributeId = randomUUID();
-
+    // The data that needs to be part of the clouevent data is in the workflowdata key.
+    // We need to spread the workflowdata payload into the clouevent data,
+    // which is slighty different than a regular workflow execution.
+    // We also need to remove the isEvent value from the workflowdata payload.
+    const rawWorkflowdata = args.inputData?.workflowdata;
+    let workflowdataPayload: Record<string, unknown> = {};
+    if (
+      typeof rawWorkflowdata === 'object' &&
+      rawWorkflowdata !== null &&
+      !Array.isArray(rawWorkflowdata)
+    ) {
+      workflowdataPayload = {
+        ...(rawWorkflowdata as Record<string, unknown>),
+      };
+      if (workflowdataPayload.isEvent) {
+        delete workflowdataPayload.isEvent;
+      }
+    }
     const triggeringCloudEvent = new CloudEvent({
       datacontenttype: 'application/json',
       type: args.workflowEventType,
       source: args.workflowSource,
       [args.contextAttribute]: contextAttributeId,
       data: {
-        ...args.inputData,
+        ...workflowdataPayload,
         [args.contextAttribute]: contextAttributeId, // Need this to be able to correlate the workflow run somehow
       },
     });

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/test-utils.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/test-utils.ts
@@ -119,6 +119,45 @@ states:
   };
 }
 
+export function generateTestWorkflowInfoForEventypeNoStartStateNameStates(
+  id: string = 'test_workflowId',
+): WorkflowInfo {
+  return {
+    id: id,
+    source: `# yaml-language-server: $schema=https://raw.githubusercontent.com/serverlessworkflow/specification/refs/heads/0.8.x/schema/workflow.json
+id: lock-flow
+specVersion: "0.8"
+key: lock-flow
+version: "1.0.0"
+events:
+  - type: notify-event
+    kind: produced
+    name: notify-event
+    correlation:
+      - contextAttributeName: lockid
+functions:
+  - name: sysLog
+    type: custom
+    operation: sysout:INFO
+start:
+  stateName: listenToLock
+states:
+  - name: notifyLock
+    type: operation
+    actions:
+      - eventRef:
+          triggerEventRef: notify-event
+      - functionRef:
+          refName: sysLog
+          arguments:
+    transition: waitForRelease
+    end:
+      produceEvents:
+        - eventRef: released-event
+          data: '{test: "testYOOOOOOOOOOOOOOOO"}'`,
+  };
+}
+
 export function generateTestWorkflowInfoForEventypeNoEventRef(
   id: string = 'test_workflowId',
 ): WorkflowInfo {

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/v2.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/v2.test.ts
@@ -42,6 +42,7 @@ import {
   generateTestWorkflowInfoForEventype,
   generateTestWorkflowInfoForEventypeNoEventRef,
   generateTestWorkflowInfoForEventypeNoStartStateForEventRef,
+  generateTestWorkflowInfoForEventypeNoStartStateNameStates,
   generateTestWorkflowInfoForEventypeNoStartStates,
   generateTestWorkflowInfoForEventypeWithNoCorrelationContextAttribute,
   generateTestWorkflowOverview,
@@ -497,6 +498,38 @@ describe('executeWorkflow as event type', () => {
   it('executes a given workflow: event type, no start state error', async () => {
     // Arrange
     const workflowInfo = generateTestWorkflowInfoForEventypeNoStartStates();
+    (mockOrchestratorService.fetchWorkflowInfo as jest.Mock).mockResolvedValue(
+      workflowInfo,
+    );
+
+    const workflowData = {
+      customAttrib: 'My customAttrib',
+      isEvent: true,
+    };
+    // Act
+    try {
+      await v2.executeWorkflow(
+        {
+          inputData: workflowData,
+          targetEntity: 'someEntity',
+        },
+        workflowInfo.id,
+        'someUserEntity',
+        'someToken',
+      );
+    } catch (err) {
+      // Assert
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(err.message).toEqual(
+        'Error executing workflow with id test_workflowId, No States that match the start state',
+      );
+    }
+  });
+
+  it('executes a given workflow: event type, no start.stateName error', async () => {
+    // Arrange
+    const workflowInfo =
+      generateTestWorkflowInfoForEventypeNoStartStateNameStates();
     (mockOrchestratorService.fetchWorkflowInfo as jest.Mock).mockResolvedValue(
       workflowInfo,
     );

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/v2.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/v2.ts
@@ -219,7 +219,17 @@ export class V2 {
 
       // Parse the definition to find the start param then determine things from there
       // All workflows should have this start param
-      const start = parsedDefinitionSource.start;
+      /**
+       * When a workflow is compiled, the start value will look like this:
+       *
+       * start:
+       *   stateName: "Start State Name"
+       *
+       * Note: This doesn't matter if it is JSON or YAML.
+       * Need to test for both params since we need to be able to test.
+       */
+      const start =
+        parsedDefinitionSource.start?.stateName || parsedDefinitionSource.start;
 
       // Find the start state from the list of states
       const startState = parsedDefinitionSource.states.filter(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While i was testing the Emitting Cloud Events to Trigger workflows on an Openshift cluster,  using "compiled" workflows instead of running them in dev mode on my laptop, I ran into this error: "Error executing workflow with id lock-flow, No States that match the start state"

I discovered that the "start" parameter might also have another parameter in it that needs to be taken into account.

For example,  The previous code assumed that when parsing the source for the "start" param it would look like this:

```
id: lock-flow
name: Kafka and Cloud events demo
...
start: listenToLock
```
code example from here: https://github.com/masayag/poc-kafka-logic-operator/blob/main/callback-flow/src/main/resources/lock.sw.yaml

When i ran the "compiled" version of this workflow,  using the manifests that are generated when building the workflow, the source looks more like this:

```
start:
      stateName: listenToLock
```
code example from here: https://github.com/masayag/poc-kafka-logic-operator/blob/main/manifests/02-sonataflow_lock-flow.yaml


This code change checks for that "stateName" param and uses it if available, it not then falls back to just the "start" param

The other thing that I came across was when a workflow has input data from a form sent to it.  The inputData object will look like this:

```
{
  workflowData: {
    input1: Data,
    input2: moreData
  }
}
```
and the data section of the cloud event would look something like this: `data: { workflowData: {} }` which will error the workflow when the kafka message sends the data back.  The input data that is added to the data section of the cloudevent should just be the workflowData level and not the nested object.  I added that fix here too

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
