### PR TITLE
feat(extensions): enforce collision policy for duplicate entity identities

### DIFF
--- a/workspaces/extensions/.changeset/clean-news-itch.md
+++ b/workspaces/extensions/.changeset/clean-news-itch.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions': minor
+---
+
+Enforce collision policy for duplicate entity identities

--- a/workspaces/extensions/examples/plugins/certified-plugin-2-by-vendor-a.yaml
+++ b/workspaces/extensions/examples/plugins/certified-plugin-2-by-vendor-a.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions.backstage.io/v1alpha1
 kind: Plugin
 metadata:
   namespace: extensions-plugin-demo
-  name: certified-plugin-1-by-vendor-a
+  name: certified-plugin-2-by-vendor-a
   title: Certified Plugin 2 by Vendor A
   description: This is a certified plugin example
   annotations:

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/README.md
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/README.md
@@ -59,6 +59,14 @@ extensions:
   directory: /path/to/custom/extensions
 ```
 
+### Collision behavior
+
+When multiple YAML sources define the same entity identity (`kind:namespace/name`), the provider handles collisions as follows:
+
+- If definitions are equivalent, it keeps the first definition and logs a warning.
+- If definitions conflict, it logs a warning and skips the conflicting definition.
+- Entities with the same `kind`/`name` but different namespaces are treated as distinct entities and are both ingested.
+
 ## Plugin configuration YAML Guide:
 
 This YAML file is used to add extensions plugin to the Software catalog in your backstage application.

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/report.api.md
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/report.api.md
@@ -27,7 +27,11 @@ import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
 export abstract class BaseEntityProvider<T extends Entity>
   implements EntityProvider
 {
-  constructor(taskRunner: SchedulerServiceTaskRunner, config?: Config);
+  constructor(
+    taskRunner: SchedulerServiceTaskRunner,
+    config?: Config,
+    logger?: LoggerService,
+  );
   // (undocumented)
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/module.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/module.ts
@@ -73,10 +73,10 @@ export const catalogModuleExtensions = createBackendModule({
         const catalogApi = new CatalogClient({ discoveryApi: discovery });
 
         catalog.addEntityProvider(
-          new ExtensionsPackageProvider(taskRunner, config),
+          new ExtensionsPackageProvider(taskRunner, config, logger),
         );
         catalog.addEntityProvider(
-          new ExtensionsPluginProvider(delayedTaskRunner, config),
+          new ExtensionsPluginProvider(delayedTaskRunner, config, logger),
         );
         // Disabling the collection provider as collections/all.yaml is already commented in RHDH 1.5 image.
         // catalog.addEntityProvider(

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.test.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
 import { BaseEntityProvider } from './BaseEntityProvider';
 import { JsonFileData } from '../types';
 
@@ -31,6 +34,13 @@ class TestEntityProvider extends BaseEntityProvider<Entity> {
 
 const taskRunner: SchedulerServiceTaskRunner = {
   run: jest.fn(async ({ fn }) => fn(new AbortController().signal)),
+};
+const logger: LoggerService = {
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
 };
 
 const createEntity = (overrides?: Partial<Entity>): Entity => ({
@@ -57,7 +67,7 @@ const createFileData = (
 
 describe('BaseEntityProvider collision policy', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
@@ -65,7 +75,7 @@ describe('BaseEntityProvider collision policy', () => {
   });
 
   it('keeps first definition when duplicate entities are equivalent', () => {
-    const provider = new TestEntityProvider(taskRunner);
+    const provider = new TestEntityProvider(taskRunner, undefined, logger);
     const duplicate = createEntity();
 
     const entities = provider.getEntities([
@@ -74,15 +84,15 @@ describe('BaseEntityProvider collision policy', () => {
     ]);
 
     expect(entities).toHaveLength(1);
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Skipping duplicate Extensions entity 'plugin/default/duplicate-plugin'",
+        "Skipping duplicate Extensions entity 'plugin:default/duplicate-plugin'",
       ),
     );
   });
 
-  it('throws when duplicate entities have conflicting definitions', () => {
-    const provider = new TestEntityProvider(taskRunner);
+  it('warns and skips when duplicate entities have conflicting definitions', () => {
+    const provider = new TestEntityProvider(taskRunner, undefined, logger);
     const firstEntity = createEntity({
       spec: { owner: 'owner-a' },
     });
@@ -90,18 +100,21 @@ describe('BaseEntityProvider collision policy', () => {
       spec: { owner: 'owner-b' },
     });
 
-    expect(() =>
-      provider.getEntities([
-        createFileData('/extensions/primary/plugin.yaml', firstEntity),
-        createFileData('/extensions/extra/community/plugin.yaml', secondEntity),
-      ]),
-    ).toThrow(
-      "Conflicting Extensions entities detected for 'plugin/default/duplicate-plugin'",
+    const entities = provider.getEntities([
+      createFileData('/extensions/primary/plugin.yaml', firstEntity),
+      createFileData('/extensions/extra/community/plugin.yaml', secondEntity),
+    ]);
+
+    expect(entities).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Conflicting Extensions entities detected for 'plugin:default/duplicate-plugin'",
+      ),
     );
   });
 
   it('keeps entities with same name when namespaces differ', () => {
-    const provider = new TestEntityProvider(taskRunner);
+    const provider = new TestEntityProvider(taskRunner, undefined, logger);
     const defaultNamespaceEntity = createEntity({
       metadata: { name: 'shared-name' },
     });

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.test.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+import { BaseEntityProvider } from './BaseEntityProvider';
+import { JsonFileData } from '../types';
+
+class TestEntityProvider extends BaseEntityProvider<Entity> {
+  getProviderName(): string {
+    return 'test-entity-provider';
+  }
+
+  getKind(): string {
+    return 'Plugin';
+  }
+}
+
+const taskRunner: SchedulerServiceTaskRunner = {
+  run: jest.fn(async ({ fn }) => fn()),
+};
+
+const createEntity = (overrides?: Partial<Entity>): Entity => ({
+  apiVersion: 'extensions.backstage.io/v1alpha1',
+  kind: 'Plugin',
+  metadata: {
+    name: 'duplicate-plugin',
+    ...overrides?.metadata,
+  },
+  spec: {
+    owner: 'test-owner',
+    ...(overrides?.spec as object),
+  },
+  ...overrides,
+});
+
+const createFileData = (
+  filePath: string,
+  entity: Entity,
+): JsonFileData<Entity> => ({
+  filePath,
+  content: entity,
+});
+
+describe('BaseEntityProvider collision policy', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps first definition when duplicate entities are equivalent', () => {
+    const provider = new TestEntityProvider(taskRunner);
+    const duplicate = createEntity();
+
+    const entities = provider.getEntities([
+      createFileData('/extensions/primary/plugin.yaml', duplicate),
+      createFileData('/extensions/extra/community/plugin.yaml', duplicate),
+    ]);
+
+    expect(entities).toHaveLength(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Skipping duplicate Extensions entity 'plugin/default/duplicate-plugin'",
+      ),
+    );
+  });
+
+  it('throws when duplicate entities have conflicting definitions', () => {
+    const provider = new TestEntityProvider(taskRunner);
+    const firstEntity = createEntity({
+      spec: { owner: 'owner-a' },
+    });
+    const secondEntity = createEntity({
+      spec: { owner: 'owner-b' },
+    });
+
+    expect(() =>
+      provider.getEntities([
+        createFileData('/extensions/primary/plugin.yaml', firstEntity),
+        createFileData('/extensions/extra/community/plugin.yaml', secondEntity),
+      ]),
+    ).toThrow(
+      "Conflicting Extensions entities detected for 'plugin/default/duplicate-plugin'",
+    );
+  });
+
+  it('keeps entities with same name when namespaces differ', () => {
+    const provider = new TestEntityProvider(taskRunner);
+    const defaultNamespaceEntity = createEntity({
+      metadata: { name: 'shared-name' },
+    });
+    const customNamespaceEntity = createEntity({
+      metadata: { name: 'shared-name', namespace: 'community' },
+    });
+
+    const entities = provider.getEntities([
+      createFileData(
+        '/extensions/primary/plugin-default.yaml',
+        defaultNamespaceEntity,
+      ),
+      createFileData(
+        '/extensions/extra/community/plugin-custom.yaml',
+        customNamespaceEntity,
+      ),
+    ]);
+
+    expect(entities).toHaveLength(2);
+  });
+});

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.test.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.test.ts
@@ -30,7 +30,7 @@ class TestEntityProvider extends BaseEntityProvider<Entity> {
 }
 
 const taskRunner: SchedulerServiceTaskRunner = {
-  run: jest.fn(async ({ fn }) => fn()),
+  run: jest.fn(async ({ fn }) => fn(new AbortController().signal)),
 };
 
 const createEntity = (overrides?: Partial<Entity>): Entity => ({

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   Entity,
+  stringifyEntityRef,
 } from '@backstage/catalog-model';
 import {
   EntityProvider,
@@ -39,26 +43,23 @@ export abstract class BaseEntityProvider<T extends Entity>
   private connection?: EntityProviderConnection;
   private taskRunner: SchedulerServiceTaskRunner;
   private config?: Config;
+  private logger?: LoggerService;
 
   private static readonly EXTENSIONS_DIRECTORY = '/extensions';
   private static readonly DEPRECATED_MARKETPLACE_DIRECTORY = '/marketplace';
 
-  constructor(taskRunner: SchedulerServiceTaskRunner, config?: Config) {
+  constructor(
+    taskRunner: SchedulerServiceTaskRunner,
+    config?: Config,
+    logger?: LoggerService,
+  ) {
     this.taskRunner = taskRunner;
     this.config = config;
+    this.logger = logger;
   }
 
   abstract getProviderName(): string;
   abstract getKind(): string;
-
-  private getEntityIdentity(entity: Entity): string {
-    const namespace = entity.metadata.namespace ?? 'default';
-    return [
-      entity.kind.toLocaleLowerCase('en-US'),
-      namespace.toLocaleLowerCase('en-US'),
-      entity.metadata.name.toLocaleLowerCase('en-US'),
-    ].join('/');
-  }
 
   private addProviderAnnotations(entity: T): T {
     return {
@@ -79,7 +80,7 @@ export abstract class BaseEntityProvider<T extends Entity>
       return [];
     }
 
-    const entitiesByIdentity = new Map<
+    const entitiesByEntityRef = new Map<
       string,
       { entity: T; filePath: string }
     >();
@@ -89,10 +90,14 @@ export abstract class BaseEntityProvider<T extends Entity>
         continue;
       }
 
-      const identity = this.getEntityIdentity(fileData.content);
-      const existing = entitiesByIdentity.get(identity);
+      const identity = stringifyEntityRef({
+        kind: fileData.content.kind,
+        namespace: fileData.content.metadata.namespace ?? 'default',
+        name: fileData.content.metadata.name,
+      }).toLocaleLowerCase('en-US');
+      const existing = entitiesByEntityRef.get(identity);
       if (!existing) {
-        entitiesByIdentity.set(identity, {
+        entitiesByEntityRef.set(identity, {
           entity: fileData.content,
           filePath: fileData.filePath,
         });
@@ -100,18 +105,19 @@ export abstract class BaseEntityProvider<T extends Entity>
       }
 
       if (isDeepStrictEqual(existing.entity, fileData.content)) {
-        console.warn(
+        this.logger?.warn(
           `Skipping duplicate Extensions entity '${identity}' from '${fileData.filePath}'. Keeping first definition from '${existing.filePath}'.`,
         );
         continue;
       }
 
-      throw new Error(
-        `Conflicting Extensions entities detected for '${identity}' in '${existing.filePath}' and '${fileData.filePath}'.`,
+      this.logger?.warn(
+        `Conflicting Extensions entities detected for '${identity}' in '${existing.filePath}' and '${fileData.filePath}'. Skipping conflicting definition from '${fileData.filePath}'.`,
       );
+      continue;
     }
 
-    return Array.from(entitiesByIdentity.values()).map(({ entity }) =>
+    return Array.from(entitiesByEntityRef.values()).map(({ entity }) =>
       this.addProviderAnnotations(entity),
     );
   }

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
@@ -172,7 +172,7 @@ export abstract class BaseEntityProvider<T extends Entity>
           }
         }
       } catch (error) {
-        console.warn(
+        this.logger?.warn(
           'Failed to read extensions directory from config, falling back to hardcoded fallbacks',
           error,
         );
@@ -192,7 +192,7 @@ export abstract class BaseEntityProvider<T extends Entity>
       }
     }
 
-    console.warn(
+    this.logger?.warn(
       `Extensions directory not found. Checked: configured directory "${BaseEntityProvider.EXTENSIONS_DIRECTORY}" and "${BaseEntityProvider.DEPRECATED_MARKETPLACE_DIRECTORY}"`,
     );
     return null;
@@ -210,7 +210,7 @@ export abstract class BaseEntityProvider<T extends Entity>
       try {
         yamlData = readYamlFiles(extensionsFilePath);
       } catch (error) {
-        console.error(error.message);
+        this.logger?.error(error.message);
       }
     }
 

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
@@ -43,7 +43,7 @@ export abstract class BaseEntityProvider<T extends Entity>
   private connection?: EntityProviderConnection;
   private taskRunner: SchedulerServiceTaskRunner;
   private config?: Config;
-  private logger?: LoggerService;
+  private readonly logger?: LoggerService;
 
   private static readonly EXTENSIONS_DIRECTORY = '/extensions';
   private static readonly DEPRECATED_MARKETPLACE_DIRECTORY = '/marketplace';
@@ -114,7 +114,6 @@ export abstract class BaseEntityProvider<T extends Entity>
       this.logger?.warn(
         `Conflicting Extensions entities detected for '${identity}' in '${existing.filePath}' and '${fileData.filePath}'. Skipping conflicting definition from '${fileData.filePath}'.`,
       );
-      continue;
     }
 
     return Array.from(entitiesByEntityRef.values()).map(({ entity }) =>

--- a/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
+++ b/workspaces/extensions/plugins/catalog-backend-module-extensions/src/providers/BaseEntityProvider.ts
@@ -28,6 +28,7 @@ import { readYamlFiles } from '../utils/file-utils';
 import { JsonFileData } from '../types';
 import path from 'path';
 import fs from 'fs';
+import { isDeepStrictEqual } from 'node:util';
 
 /**
  * @public
@@ -50,23 +51,69 @@ export abstract class BaseEntityProvider<T extends Entity>
   abstract getProviderName(): string;
   abstract getKind(): string;
 
+  private getEntityIdentity(entity: Entity): string {
+    const namespace = entity.metadata.namespace ?? 'default';
+    return [
+      entity.kind.toLocaleLowerCase('en-US'),
+      namespace.toLocaleLowerCase('en-US'),
+      entity.metadata.name.toLocaleLowerCase('en-US'),
+    ].join('/');
+  }
+
+  private addProviderAnnotations(entity: T): T {
+    return {
+      ...entity,
+      metadata: {
+        ...entity.metadata,
+        annotations: {
+          ...entity.metadata.annotations,
+          [ANNOTATION_LOCATION]: `file:${this.getProviderName()}`,
+          [ANNOTATION_ORIGIN_LOCATION]: `file:${this.getProviderName()}`,
+        },
+      },
+    };
+  }
+
   getEntities(allEntities: JsonFileData<T>[]): T[] {
     if (allEntities.length === 0) {
       return [];
     }
-    return allEntities
-      .filter(d => d.content.kind === this.getKind())
-      .map(file => ({
-        ...file.content,
-        metadata: {
-          ...file.content.metadata,
-          annotations: {
-            ...file.content.metadata.annotations,
-            [ANNOTATION_LOCATION]: `file:${this.getProviderName()}`,
-            [ANNOTATION_ORIGIN_LOCATION]: `file:${this.getProviderName()}`,
-          },
-        },
-      }));
+
+    const entitiesByIdentity = new Map<
+      string,
+      { entity: T; filePath: string }
+    >();
+
+    for (const fileData of allEntities) {
+      if (fileData.content.kind !== this.getKind()) {
+        continue;
+      }
+
+      const identity = this.getEntityIdentity(fileData.content);
+      const existing = entitiesByIdentity.get(identity);
+      if (!existing) {
+        entitiesByIdentity.set(identity, {
+          entity: fileData.content,
+          filePath: fileData.filePath,
+        });
+        continue;
+      }
+
+      if (isDeepStrictEqual(existing.entity, fileData.content)) {
+        console.warn(
+          `Skipping duplicate Extensions entity '${identity}' from '${fileData.filePath}'. Keeping first definition from '${existing.filePath}'.`,
+        );
+        continue;
+      }
+
+      throw new Error(
+        `Conflicting Extensions entities detected for '${identity}' in '${existing.filePath}' and '${fileData.filePath}'.`,
+      );
+    }
+
+    return Array.from(entitiesByIdentity.values()).map(({ entity }) =>
+      this.addProviderAnnotations(entity),
+    );
   }
 
   async connect(connection: EntityProviderConnection): Promise<void> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Add collision handling for extensions catalog entities in the backend provider by keying on normalized kind/namespace/name.
- Keep the first definition when duplicates are equivalent, and fail fast when duplicates with the same identity have conflicting content.
- Add targeted unit tests covering equivalent duplicates, conflicting duplicates, and same-name entities across different namespaces.

This change is being made as a result of [RHIDP-12376](https://redhat.atlassian.net/browse/RHIDP-12376). Multi-catalog ingestion can introduce duplicate entity identities; this change makes behaviour deterministic and prevents silent shadowing of conflicting definitions.

Manually validated runtime behavior in three scenarios:

1. equivalent duplicate -> warning + continue
2. conflicting duplicate -> provider error
3. same name with different namespace -> both accepted

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

## How to Test

Create a directory `/tmp/extensions-test`, with subdirectories `primary/catalog-entities/plugins` and `extra/community/catalog-entities/plugins`

For **case A** (equivalent duplicate), create an identical plugin yaml file on each path, for example:
`/tmp/extensions-collision-test/primary/catalog-entities/plugins/github.yaml` and `/tmp/extensions-collision-test/extra/community/catalog-entities/plugins/github.yaml` both containing

```
apiVersion: extensions.backstage.io/v1alpha1
kind: Plugin
metadata:
  name: github
spec:
  owner: redhat
 ```
 
 After running `yarn start-backend` you should see in the logs that the duplicate entity was skipped, with the first definition being kept. The backend continues successfully.

For **case B** (conflicting duplicate), update the `spec.owner` in `/tmp/extensions-collision-test/extra/community/catalog-entities/plugins/github.yaml` to `community` and restart the backend. You should see that the provider fails with a conflicting entities message surfaced in the logs.