### PR TITLE
feat(x2a): log streaming and copy&paste without row numbers

### DIFF
--- a/workspaces/x2a/.changeset/pretty-planes-strive.md
+++ b/workspaces/x2a/.changeset/pretty-planes-strive.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+Stream logs in real-time as backend jobs produce them. Exclude row numbers from copy selection.

--- a/workspaces/x2a/packages/app/src/setupTests.ts
+++ b/workspaces/x2a/packages/app/src/setupTests.ts
@@ -27,6 +27,7 @@ const suppressPatterns = [
   'findDOMNode is deprecated', // @material-ui/core
   'validateDOMNesting', // React DOM nesting (e.g. div inside p from Typography)
   'Not implemented: HTMLCanvasElement.prototype.getContext', // JSDOM canvas
+  'DEPRECATION WARNING', // @backstage/frontend-plugin-api config.schema → configSchema
 ];
 const getMatchedPattern = (args: unknown[]): string | null => {
   const first = args[0];

--- a/workspaces/x2a/plugins/x2a-backend/src/plugin.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/plugin.test.ts
@@ -43,6 +43,7 @@ jest.mock('./services/makeK8sClient', () => ({
   makeK8sClient: jest.fn(() => ({
     coreV1Api: {},
     batchV1Api: {},
+    kubeConfig: { getCurrentCluster: () => ({ server: 'https://mock' }) },
   })),
 }));
 

--- a/workspaces/x2a/plugins/x2a-backend/src/router/jobs.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/jobs.test.ts
@@ -220,6 +220,54 @@ describe('createRouter – jobs (log)', () => {
       );
 
       it(
+        'should return 200 with empty body when streaming and kube has no log data yet (e.g. no pod or Pending)',
+        async () => {
+          await createTestJob(x2aDatabase, {
+            projectId: project.id,
+            moduleId: null,
+            phase: 'init',
+            status: 'running',
+            k8sJobName: 'init-k8s-job',
+          });
+          const mockGetJobLogs = jest.fn().mockResolvedValue('');
+          const app = await createApp(client, undefined, undefined, {
+            getJobLogs: mockGetJobLogs,
+          });
+          const response = await request(app)
+            .get(`/projects/${project.id}/log?streaming=true`)
+            .send();
+          expect(response.status).toBe(200);
+          expect(response.type).toBe('text/plain');
+          expect(response.text).toBe('');
+          expect(mockGetJobLogs).toHaveBeenCalledWith('init-k8s-job', true);
+        },
+        LONG_TEST_TIMEOUT,
+      );
+
+      it(
+        'should not call getJobLogs for streaming when init job has no k8sJobName yet',
+        async () => {
+          await createTestJob(x2aDatabase, {
+            projectId: project.id,
+            moduleId: null,
+            phase: 'init',
+            status: 'pending',
+          });
+          const mockGetJobLogs = jest.fn();
+          const app = await createApp(client, undefined, undefined, {
+            getJobLogs: mockGetJobLogs,
+          });
+          const response = await request(app)
+            .get(`/projects/${project.id}/log?streaming=true`)
+            .send();
+          expect(response.status).toBe(200);
+          expect(response.text).toBe('');
+          expect(mockGetJobLogs).not.toHaveBeenCalled();
+        },
+        LONG_TEST_TIMEOUT,
+      );
+
+      it(
         'should return 404 when no init job found for project',
         async () => {
           const app = await createApp(client);

--- a/workspaces/x2a/plugins/x2a-backend/src/router/jobs.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/jobs.ts
@@ -34,6 +34,7 @@ async function sendJobLogs(
   deps: Pick<RouterDeps, 'x2aDatabase' | 'kubeService' | 'logger'>,
 ): Promise<void> {
   const { x2aDatabase, kubeService, logger } = deps;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
 
   if (
     job.status === 'success' ||
@@ -43,7 +44,6 @@ async function sendJobLogs(
     logger.info(
       `Job ${job.id} is finished (status: ${job.status}), returning logs from database`,
     );
-    res.setHeader('Content-Type', 'text/plain');
     const log = await x2aDatabase.getJobLogs({ jobId: job.id });
     if (!log) {
       logger.error(`Log not found for a finished job ${job.id}`);
@@ -54,14 +54,15 @@ async function sendJobLogs(
 
   if (!job.k8sJobName) {
     logger.warn(`Job ${job.id} has no k8sJobName, returning empty logs`);
-    res.setHeader('Content-Type', 'text/plain');
     res.send('');
     return;
   }
 
   const logs = await kubeService.getJobLogs(job.k8sJobName, streaming);
-  res.setHeader('Content-Type', 'text/plain');
   if (streaming && typeof logs !== 'string') {
+    // Hints to proxies (e.g. nginx, OpenShift route) not to buffer the body.
+    res.setHeader('Cache-Control', 'no-store, no-transform, must-revalidate');
+    res.setHeader('X-Accel-Buffering', 'no');
     const stream = logs as Readable;
     stream.on('error', err => {
       logger.error(

--- a/workspaces/x2a/plugins/x2a-backend/src/router/jobsModuleLog.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/jobsModuleLog.test.ts
@@ -197,6 +197,57 @@ describe('createRouter – jobs (module log)', () => {
       );
 
       it(
+        'should return 200 with empty body when streaming and kube has no log data yet',
+        async () => {
+          await createTestJob(x2aDatabase, {
+            projectId: project.id,
+            moduleId: module.id,
+            phase: 'analyze',
+            status: 'running',
+            k8sJobName: 'test-k8s-job',
+          });
+          const mockGetJobLogs = jest.fn().mockResolvedValue('');
+          const app = await createApp(client, undefined, undefined, {
+            getJobLogs: mockGetJobLogs,
+          });
+          const response = await request(app)
+            .get(
+              `/projects/${project.id}/modules/${module.id}/log?phase=analyze&streaming=true`,
+            )
+            .send();
+          expect(response.status).toBe(200);
+          expect(response.text).toBe('');
+          expect(mockGetJobLogs).toHaveBeenCalledWith('test-k8s-job', true);
+        },
+        LONG_TEST_TIMEOUT,
+      );
+
+      it(
+        'should not call getJobLogs for module streaming when job has no k8sJobName yet',
+        async () => {
+          await createTestJob(x2aDatabase, {
+            projectId: project.id,
+            moduleId: module.id,
+            phase: 'publish',
+            status: 'pending',
+          });
+          const mockGetJobLogs = jest.fn();
+          const app = await createApp(client, undefined, undefined, {
+            getJobLogs: mockGetJobLogs,
+          });
+          const response = await request(app)
+            .get(
+              `/projects/${project.id}/modules/${module.id}/log?phase=publish&streaming=true`,
+            )
+            .send();
+          expect(response.status).toBe(200);
+          expect(response.text).toBe('');
+          expect(mockGetJobLogs).not.toHaveBeenCalled();
+        },
+        LONG_TEST_TIMEOUT,
+      );
+
+      it(
         'should return 400 when phase parameter is missing',
         async () => {
           const app = await createApp(client);

--- a/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.test.ts
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
+import { PassThrough } from 'node:stream';
 import { mockServices } from '@backstage/backend-test-utils';
 import { X2AConfig } from './types';
-import { KubeService } from './KubeService';
+import { KubeService, choosePodForJobLogs } from './KubeService';
 
-// Mock the Kubernetes client
+const mockK8sLogFn = jest.fn();
+jest.mock('@kubernetes/client-node', () => ({
+  Log: jest.fn().mockImplementation(() => ({ log: mockK8sLogFn })),
+}));
+
 const mockCoreV1Api = {
   createNamespacedSecret: jest.fn(),
   readNamespacedSecret: jest.fn(),
@@ -34,10 +39,15 @@ const mockBatchV1Api = {
   listNamespacedJob: jest.fn(),
 };
 
+const mockKubeConfig = {
+  getCurrentCluster: () => ({ server: 'https://mock.k8s.local' }),
+};
+
 jest.mock('./makeK8sClient', () => ({
   makeK8sClient: jest.fn(() => ({
     coreV1Api: mockCoreV1Api,
     batchV1Api: mockBatchV1Api,
+    kubeConfig: mockKubeConfig,
   })),
 }));
 
@@ -472,10 +482,25 @@ describe('KubeService', () => {
 
   describe('getJobLogs', () => {
     const jobName = 'job-x2a-init-abc123';
+    const runningPod = {
+      metadata: { name: 'job-x2a-init-abc123-pod' },
+      spec: { containers: [{ name: 'main' }] },
+      status: { phase: 'Running' as const },
+    };
+
+    beforeEach(() => {
+      mockK8sLogFn.mockImplementation(async (_ns, _pod, _c, stream) => {
+        (stream as PassThrough).end('ok');
+        return new globalThis.AbortController();
+      });
+    });
+    afterEach(() => {
+      mockK8sLogFn.mockReset();
+    });
 
     it('should retrieve logs from pod', async () => {
       mockCoreV1Api.listNamespacedPod.mockResolvedValue({
-        items: [{ metadata: { name: 'job-x2a-init-abc123-pod' } }],
+        items: [runningPod],
       });
       mockCoreV1Api.readNamespacedPodLog.mockResolvedValue('Job log output');
 
@@ -488,8 +513,10 @@ describe('KubeService', () => {
       expect(mockCoreV1Api.readNamespacedPodLog).toHaveBeenCalledWith({
         name: 'job-x2a-init-abc123-pod',
         namespace: 'test-namespace',
+        container: 'main',
         follow: false,
       });
+      expect(mockK8sLogFn).not.toHaveBeenCalled();
       expect(result).toBe('Job log output');
     });
 
@@ -501,20 +528,79 @@ describe('KubeService', () => {
       const result = await kubeService.getJobLogs(jobName);
 
       expect(result).toBe('');
+      expect(mockK8sLogFn).not.toHaveBeenCalled();
     });
 
-    it('should support streaming logs', async () => {
+    it('returns empty string for streaming when no pod exists yet (job scheduled, no list match)', async () => {
+      mockCoreV1Api.listNamespacedPod.mockResolvedValue({ items: [] });
+
+      const result = await kubeService.getJobLogs(jobName, true);
+
+      expect(result).toBe('');
+      expect(mockK8sLogFn).not.toHaveBeenCalled();
+    });
+
+    it('returns empty string for streaming when pod is still Pending (no log stream until Running)', async () => {
       mockCoreV1Api.listNamespacedPod.mockResolvedValue({
-        items: [{ metadata: { name: 'job-x2a-init-abc123-pod' } }],
+        items: [
+          {
+            metadata: { name: 'job-x2a-init-abc123-pod' },
+            spec: { containers: [{ name: 'main' }] },
+            status: { phase: 'Pending' },
+          },
+        ],
       });
-      mockCoreV1Api.readNamespacedPodLog.mockResolvedValue('Streaming logs');
 
+      const result = await kubeService.getJobLogs(jobName, true);
+
+      expect(result).toBe('');
+      expect(mockK8sLogFn).not.toHaveBeenCalled();
+    });
+
+    it('should use k8s Log (fetch stream) for follow logs, not buffered readNamespacedPodLog', async () => {
+      mockCoreV1Api.listNamespacedPod.mockResolvedValue({
+        items: [runningPod],
+      });
+      const result = await kubeService.getJobLogs(jobName, true);
+
+      expect(mockK8sLogFn).toHaveBeenCalledWith(
+        'test-namespace',
+        'job-x2a-init-abc123-pod',
+        'main',
+        expect.any(PassThrough),
+        { follow: true },
+      );
+      expect(mockCoreV1Api.readNamespacedPodLog).not.toHaveBeenCalled();
+      expect(result).toBeInstanceOf(PassThrough);
+    });
+
+    it('prefers the Running pod when Pending is listed first (K8s list order is not guaranteed)', async () => {
+      const pendingListedFirst = {
+        metadata: {
+          name: 'stale-pending',
+          creationTimestamp: '2024-01-01T12:05:00.000Z',
+        },
+        spec: { containers: [{ name: 'main' }] },
+        status: { phase: 'Pending' as const },
+      };
+      const actuallyRunning = {
+        metadata: {
+          name: 'workload-pod',
+          creationTimestamp: '2024-01-01T12:00:00.000Z',
+        },
+        spec: { containers: [{ name: 'main' }] },
+        status: { phase: 'Running' as const },
+      };
+      mockCoreV1Api.listNamespacedPod.mockResolvedValue({
+        items: [pendingListedFirst, actuallyRunning],
+      });
       await kubeService.getJobLogs(jobName, true);
-
-      expect(mockCoreV1Api.readNamespacedPodLog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          follow: true,
-        }),
+      expect(mockK8sLogFn).toHaveBeenCalledWith(
+        'test-namespace',
+        'workload-pod',
+        'main',
+        expect.any(PassThrough),
+        { follow: true },
       );
     });
 
@@ -547,12 +633,28 @@ describe('KubeService', () => {
 
     it('should throw on K8s API errors (e.g. pod not ready, network failure)', async () => {
       mockCoreV1Api.listNamespacedPod.mockResolvedValue({
-        items: [{ metadata: { name: 'job-x2a-init-abc123-pod' } }],
+        items: [runningPod],
       });
       const apiError = new Error('AnError');
       mockCoreV1Api.readNamespacedPodLog.mockRejectedValue(apiError);
 
       await expect(kubeService.getJobLogs(jobName)).rejects.toThrow(apiError);
+      expect(mockK8sLogFn).not.toHaveBeenCalled();
+    });
+
+    it('should return empty when pod has no container spec', async () => {
+      mockCoreV1Api.listNamespacedPod.mockResolvedValue({
+        items: [
+          {
+            metadata: { name: 'job-x2a-init-abc123-pod' },
+            spec: { containers: [] },
+          },
+        ],
+      });
+
+      const result = await kubeService.getJobLogs(jobName, true);
+      expect(result).toBe('');
+      expect(mockK8sLogFn).not.toHaveBeenCalled();
     });
 
     it('should throw when listNamespacedPod fails', async () => {
@@ -679,5 +781,96 @@ describe('KubeService', () => {
       jest.dontMock('node:fs');
       jest.resetModules();
     });
+  });
+});
+
+describe('choosePodForJobLogs', () => {
+  function makePod(name: string, phase: string, creationTimestamp?: string) {
+    return {
+      metadata: {
+        name,
+        ...(creationTimestamp
+          ? { creationTimestamp: new Date(creationTimestamp) }
+          : {}),
+      },
+      spec: { containers: [{ name: 'main' }] },
+      status: { phase },
+    };
+  }
+
+  it('returns undefined for an empty list', () => {
+    expect(choosePodForJobLogs([])).toBeUndefined();
+  });
+
+  it('returns the only pod when list has a single Running pod', () => {
+    const pod = makePod('pod-1', 'Running');
+    expect(choosePodForJobLogs([pod])).toBe(pod);
+  });
+
+  it('returns the only pod when list has a single Pending pod', () => {
+    const pod = makePod('pod-1', 'Pending');
+    expect(choosePodForJobLogs([pod])).toBe(pod);
+  });
+
+  it('prefers Running over Pending regardless of list order', () => {
+    const pending = makePod('pending-pod', 'Pending', '2024-01-01T12:05:00Z');
+    const running = makePod('running-pod', 'Running', '2024-01-01T12:00:00Z');
+    expect(choosePodForJobLogs([pending, running])?.metadata?.name).toBe(
+      'running-pod',
+    );
+    expect(choosePodForJobLogs([running, pending])?.metadata?.name).toBe(
+      'running-pod',
+    );
+  });
+
+  it('prefers Running over Succeeded', () => {
+    const succeeded = makePod('done-pod', 'Succeeded', '2024-01-01T12:00:00Z');
+    const running = makePod('running-pod', 'Running', '2024-01-01T12:01:00Z');
+    expect(choosePodForJobLogs([succeeded, running])?.metadata?.name).toBe(
+      'running-pod',
+    );
+  });
+
+  it('prefers non-Pending over Pending when no Running pod exists', () => {
+    const pending = makePod('pending-pod', 'Pending', '2024-01-01T12:05:00Z');
+    const succeeded = makePod('done-pod', 'Succeeded', '2024-01-01T12:00:00Z');
+    expect(choosePodForJobLogs([pending, succeeded])?.metadata?.name).toBe(
+      'done-pod',
+    );
+  });
+
+  it('picks the newest Running pod when multiple Running pods exist', () => {
+    const older = makePod('old-running', 'Running', '2024-01-01T12:00:00Z');
+    const newer = makePod('new-running', 'Running', '2024-01-01T12:05:00Z');
+    expect(choosePodForJobLogs([older, newer])?.metadata?.name).toBe(
+      'new-running',
+    );
+  });
+
+  it('falls back to newest Pending when all pods are Pending', () => {
+    const older = makePod('old-pending', 'Pending', '2024-01-01T12:00:00Z');
+    const newer = makePod('new-pending', 'Pending', '2024-01-01T12:05:00Z');
+    expect(choosePodForJobLogs([older, newer])?.metadata?.name).toBe(
+      'new-pending',
+    );
+  });
+
+  it('handles pods without creationTimestamp (treats as epoch 0)', () => {
+    const noTs = makePod('no-ts-pod', 'Running');
+    const withTs = makePod('ts-pod', 'Running', '2024-01-01T12:00:00Z');
+    expect(choosePodForJobLogs([noTs, withTs])?.metadata?.name).toBe('ts-pod');
+  });
+
+  it('handles Failed pod (non-Pending, non-Running)', () => {
+    const failed = makePod('failed-pod', 'Failed', '2024-01-01T12:00:00Z');
+    const pending = makePod('pending-pod', 'Pending', '2024-01-01T12:01:00Z');
+    expect(choosePodForJobLogs([pending, failed])?.metadata?.name).toBe(
+      'failed-pod',
+    );
+  });
+
+  it('handles string creationTimestamp (e.g. raw JSON from some clients)', () => {
+    const pod = makePod('str-ts-pod', 'Running', '2024-06-15T10:00:00Z');
+    expect(choosePodForJobLogs([pod])?.metadata?.name).toBe('str-ts-pod');
   });
 });

--- a/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/KubeService.ts
@@ -19,15 +19,20 @@ import {
   createServiceFactory,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { Log } from '@kubernetes/client-node';
 import type {
   CoreV1Api,
   BatchV1Api,
+  KubeConfig,
   V1OwnerReference,
   V1Pod,
   V1PodList,
   V1Secret,
   V1Job,
 } from '@kubernetes/client-node';
+
+import { PassThrough } from 'node:stream';
+import * as fs from 'node:fs';
 import {
   kubeServiceRef,
   type KubeServiceApi,
@@ -36,6 +41,8 @@ import {
   type GitRepo,
   type JobCreateParams,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-node';
+
+import { stringifyError } from '../utils';
 import { makeK8sClient } from './makeK8sClient';
 import { JobResourceBuilder } from './JobResourceBuilder';
 import type { X2AConfig } from './types';
@@ -52,9 +59,30 @@ import {
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_AUTHOR_EMAIL,
 } from './constants';
-import * as fs from 'node:fs';
 
-import { stringifyError } from '../utils';
+/**
+ * The API does not guarantee `items` order. Never use `items[0]`: a Pending
+ * placeholder can sort before a Running pod, which made us return no logs
+ * and/or tail the wrong pod.
+ *
+ * Priority: Running > any non-Pending (Succeeded/Failed) > Pending.
+ */
+export function choosePodForJobLogs(items: V1Pod[]): V1Pod | undefined {
+  const asTime = (p: V1Pod) => {
+    const ts = p.metadata?.creationTimestamp;
+    if (!ts) {
+      return 0;
+    }
+    return Date.parse(typeof ts === 'string' ? ts : ts.toISOString()) || 0;
+  };
+  const byNewest = [...items].sort((a, b) => asTime(b) - asTime(a));
+  const running = byNewest.find(p => p.status?.phase === 'Running');
+  if (running) {
+    return running;
+  }
+  const nonPending = byNewest.find(p => p.status?.phase !== 'Pending');
+  return nonPending ?? byNewest[0];
+}
 
 /**
  * Reads the namespace from the in-cluster service account
@@ -101,6 +129,7 @@ export class KubeService implements KubeServiceApi {
   readonly #logger: LoggerService;
   readonly #coreV1Api: CoreV1Api;
   readonly #batchV1Api: BatchV1Api;
+  readonly #kubeConfig: KubeConfig;
   readonly #config: X2AConfig;
   readonly #namespace: string;
 
@@ -116,15 +145,17 @@ export class KubeService implements KubeServiceApi {
     this.#namespace = config.kubernetes.namespace;
     this.#coreV1Api = null as any; // Initialized in initialize()
     this.#batchV1Api = null as any; // Initialized in initialize()
+    this.#kubeConfig = null as any; // Initialized in initialize()
   }
 
   private async initialize() {
-    const { coreV1Api, batchV1Api } = await makeK8sClient(
+    const { coreV1Api, batchV1Api, kubeConfig } = await makeK8sClient(
       this.#logger,
       this.#namespace,
     );
     (this.#coreV1Api as any) = coreV1Api;
     (this.#batchV1Api as any) = batchV1Api;
+    (this.#kubeConfig as any) = kubeConfig;
   }
 
   /**
@@ -381,7 +412,10 @@ export class KubeService implements KubeServiceApi {
         return '';
       }
 
-      const pod = pods.items[0];
+      const pod = choosePodForJobLogs(pods.items);
+      if (!pod) {
+        return '';
+      }
       const podName = pod?.metadata?.name;
       if (!podName) {
         // This can happen if a pod is in the process of being created but hasn't been
@@ -397,11 +431,35 @@ export class KubeService implements KubeServiceApi {
         return '';
       }
 
-      // Get logs from the pod
+      const containerName = pod.spec?.containers?.[0]?.name;
+      if (!containerName) {
+        this.#logger.warn(
+          `No container in pod to read logs for job: ${k8sJobName}`,
+        );
+        return '';
+      }
+
+      if (streaming) {
+        const pass = new PassThrough();
+        const k8sLog = new Log(this.#kubeConfig);
+        const logAbort: AbortController = await k8sLog.log(
+          this.#namespace,
+          podName,
+          containerName,
+          pass,
+          { follow: true },
+        );
+        pass.on('close', () => {
+          logAbort.abort();
+        });
+        return pass;
+      }
+
       const logs = await this.#coreV1Api.readNamespacedPodLog({
         name: podName,
         namespace: this.#namespace,
-        follow: streaming,
+        container: containerName,
+        follow: false,
       });
 
       return logs;

--- a/workspaces/x2a/plugins/x2a-backend/src/services/makeK8sClient.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/makeK8sClient.ts
@@ -15,7 +15,11 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
-import type { CoreV1Api, BatchV1Api } from '@kubernetes/client-node';
+import type {
+  CoreV1Api,
+  BatchV1Api,
+  KubeConfig,
+} from '@kubernetes/client-node';
 
 /**
  * Kubernetes API clients
@@ -23,6 +27,8 @@ import type { CoreV1Api, BatchV1Api } from '@kubernetes/client-node';
 export interface K8sClients {
   coreV1Api: CoreV1Api;
   batchV1Api: BatchV1Api;
+  /** Required for the `Log` helper (true streaming follow), which uses fetch + body.pipe. */
+  kubeConfig: KubeConfig;
 }
 
 /**
@@ -74,9 +80,10 @@ export const makeK8sClient = async (
 
   // Dynamic import of API classes to avoid ESM issues
   const { CoreV1Api, BatchV1Api } = await import('@kubernetes/client-node');
-  const clients = {
+  const clients: K8sClients = {
     coreV1Api: kc.makeApiClient(CoreV1Api),
     batchV1Api: kc.makeApiClient(BatchV1Api),
+    kubeConfig: kc,
   };
 
   // Test connection to the cluster. Fail fast...

--- a/workspaces/x2a/plugins/x2a/report.api.md
+++ b/workspaces/x2a/plugins/x2a/report.api.md
@@ -130,6 +130,7 @@ readonly "modulePage.phases.commitId": string;
 readonly "modulePage.phases.viewLog": string;
 readonly "modulePage.phases.hideLog": string;
 readonly "modulePage.phases.noLogsAvailable": string;
+readonly "modulePage.phases.logWaitingForStream": string;
 readonly "modulePage.phases.telemetry.title": string;
 readonly "modulePage.phases.telemetry.duration": string;
 readonly "modulePage.phases.telemetry.noTelemetryAvailable": string;

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.test.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.test.tsx
@@ -13,14 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import '../test-utils/webStreamsJestPolyfill';
 import { mockUseTranslation } from '../test-utils/mockTranslations';
+
+const mockProjectIdLogGet = jest.fn();
+const mockModulesModuleIdLogGet = jest.fn();
+const clientServiceMock = {
+  projectsProjectIdLogGet: mockProjectIdLogGet,
+  projectsProjectIdModulesModuleIdLogGet: mockModulesModuleIdLogGet,
+};
+
+function makeSuccessResponse(
+  buildBody: (
+    enc: globalThis.TextEncoder,
+  ) => globalThis.ReadableStream<Uint8Array>,
+) {
+  const te = new globalThis.TextEncoder();
+  const body = buildBody(te);
+  return {
+    ok: true,
+    status: 200,
+    body,
+    text: async () => '',
+  } as unknown as globalThis.Response;
+}
 
 jest.mock('../hooks/useTranslation', () => ({
   useTranslation: mockUseTranslation,
 }));
 
 jest.mock('../ClientService', () => ({
-  useClientService: () => ({}),
+  useClientService: () => clientServiceMock,
+}));
+
+jest.mock('@backstage/core-components', () => ({
+  LogViewer: ({ text }: { text: string }) => (
+    <div data-testid="log-viewer">{text}</div>
+  ),
+  Progress: () => <div data-testid="log-progress" />,
 }));
 
 jest.mock('./PhaseStatus', () => ({
@@ -38,11 +68,28 @@ jest.mock('./ItemField', () => ({
   ),
 }));
 
-import { render, screen, act } from '@testing-library/react';
-import { Job } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  Job,
+  POLLING_INTERVAL_MS,
+} from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 import { PhaseDetails } from './PhaseDetails';
 
+const baseJob: Job = {
+  id: 'job-1',
+  projectId: 'proj-1',
+  phase: 'analyze',
+  status: 'running',
+  k8sJobName: 'k8s-job-1',
+  startedAt: new Date('2024-01-01T12:00:00Z'),
+};
+
 describe('PhaseDetails', () => {
+  beforeEach(() => {
+    mockProjectIdLogGet.mockReset();
+    mockModulesModuleIdLogGet.mockReset();
+  });
   describe('duration field', () => {
     it('shows formatted duration when job has both startedAt and finishedAt', async () => {
       const phase: Job = {
@@ -111,6 +158,467 @@ describe('PhaseDetails', () => {
       const durationField = screen.getByTestId('item-field-Duration');
       expect(durationField.textContent).toContain('-');
       expect(durationField.textContent).not.toMatch(/\d+[smhd]/);
+    });
+  });
+
+  describe('log streaming', () => {
+    it('fetches module log with streaming: true and displays a single-chunk line', async () => {
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        makeSuccessResponse(
+          enc =>
+            new globalThis.ReadableStream({
+              start(c) {
+                c.enqueue(enc.encode('line1\n'));
+                c.close();
+              },
+            }),
+        ),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={baseJob}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      await waitFor(() => {
+        expect(mockModulesModuleIdLogGet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            path: { projectId: 'proj-1', moduleId: 'mod-1' },
+            query: { phase: 'analyze', streaming: true },
+          }),
+        );
+        expect(mockProjectIdLogGet).not.toHaveBeenCalled();
+      });
+
+      const viewer = await screen.findByTestId('log-viewer');
+      expect(viewer.textContent).toContain('line1');
+    });
+
+    it('uses projectsProjectIdLogGet for init phase with streaming: true', async () => {
+      const initJob: Job = { ...baseJob, phase: 'init' };
+      mockProjectIdLogGet.mockResolvedValue(
+        makeSuccessResponse(
+          enc =>
+            new globalThis.ReadableStream({
+              start(c) {
+                c.enqueue(enc.encode('init-log\n'));
+                c.close();
+              },
+            }),
+        ),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails phase={initJob} projectId="proj-1" phaseName="init" />,
+        );
+      });
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      await waitFor(() => {
+        expect(mockProjectIdLogGet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            path: { projectId: 'proj-1' },
+            query: { streaming: true },
+          }),
+        );
+        expect(mockModulesModuleIdLogGet).not.toHaveBeenCalled();
+      });
+
+      expect((await screen.findByTestId('log-viewer')).textContent).toContain(
+        'init-log',
+      );
+    });
+
+    it('aggregates text when the stream delivers multiple chunks', async () => {
+      const parts = ['A', 'B', 'C', '\nend'];
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        makeSuccessResponse(
+          enc =>
+            new globalThis.ReadableStream({
+              start(c) {
+                for (const p of parts) {
+                  c.enqueue(enc.encode(p));
+                }
+                c.close();
+              },
+            }),
+        ),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={baseJob}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      const viewer = await screen.findByTestId('log-viewer');
+      await waitFor(() => {
+        expect(viewer.textContent).toBe('ABC\nend');
+      });
+    });
+
+    it('shows logWaitingForStream (not noLogs) until the first byte arrives, then the log line', async () => {
+      let deliverChunk!: () => void;
+      const gate = new Promise<void>(r => {
+        deliverChunk = r;
+      });
+
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        makeSuccessResponse(enc => {
+          let delivered = false;
+          return new globalThis.ReadableStream({
+            async pull(controller) {
+              if (delivered) {
+                controller.close();
+              } else {
+                await gate;
+                controller.enqueue(enc.encode('pod started\n'));
+                delivered = true;
+              }
+            },
+          });
+        }),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={baseJob}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      const viewer = await screen.findByTestId('log-viewer');
+      expect(viewer.textContent).toContain(
+        'Waiting for log output from the cluster',
+      );
+      expect(viewer.textContent).not.toContain('No logs available');
+
+      await act(async () => {
+        deliverChunk();
+      });
+
+      await waitFor(() => {
+        expect(viewer.textContent).toContain('pod started');
+      });
+      expect(viewer.textContent).not.toContain('Waiting for log');
+    });
+
+    it('shows noLogsAvailable placeholder for empty log stream (finished job, no lines)', async () => {
+      const finishedJob: Job = {
+        ...baseJob,
+        status: 'success',
+        finishedAt: new Date('2024-01-01T12:05:00Z'),
+      };
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        makeSuccessResponse(
+          () =>
+            new globalThis.ReadableStream<Uint8Array>({
+              start(c) {
+                c.close();
+              },
+            }),
+        ),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={finishedJob}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      const viewer = await screen.findByTestId('log-viewer');
+      await waitFor(() => {
+        expect(viewer.textContent).toContain('No logs available');
+      });
+    });
+
+    it('retries fetching log when stream is empty and phase is running', async () => {
+      jest.useFakeTimers();
+
+      try {
+        mockModulesModuleIdLogGet
+          .mockResolvedValueOnce(
+            makeSuccessResponse(
+              () =>
+                new globalThis.ReadableStream<Uint8Array>({
+                  start(c) {
+                    c.close();
+                  },
+                }),
+            ),
+          )
+          .mockResolvedValueOnce(
+            makeSuccessResponse(
+              enc =>
+                new globalThis.ReadableStream({
+                  start(c) {
+                    c.enqueue(enc.encode('log appeared\n'));
+                    c.close();
+                  },
+                }),
+            ),
+          );
+
+        const user = userEvent.setup({
+          advanceTimers: jest.advanceTimersByTime,
+        });
+        await act(async () => {
+          render(
+            <PhaseDetails
+              phase={baseJob}
+              projectId="proj-1"
+              phaseName="analyze"
+              moduleId="mod-1"
+            />,
+          );
+        });
+        await act(async () => {
+          await user.click(screen.getByRole('button', { name: 'View Log' }));
+        });
+
+        const viewer = await screen.findByTestId('log-viewer');
+        await waitFor(() => {
+          expect(mockModulesModuleIdLogGet).toHaveBeenCalledTimes(1);
+        });
+        expect(viewer.textContent).toContain(
+          'Waiting for log output from the cluster',
+        );
+
+        await act(async () => {
+          jest.advanceTimersByTime(POLLING_INTERVAL_MS);
+        });
+
+        await waitFor(() => {
+          expect(mockModulesModuleIdLogGet).toHaveBeenCalledTimes(2);
+        });
+        await waitFor(() => {
+          expect(viewer.textContent).toContain('log appeared');
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('fetches log for a finished success phase the same way (one short response)', async () => {
+      const finished: Job = {
+        ...baseJob,
+        status: 'success',
+        finishedAt: new Date('2024-01-01T12:05:00Z'),
+      };
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        makeSuccessResponse(
+          enc =>
+            new globalThis.ReadableStream({
+              start(c) {
+                c.enqueue(enc.encode('captured in DB\n'));
+                c.close();
+              },
+            }),
+        ),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={finished}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      const viewer = await screen.findByTestId('log-viewer');
+      await waitFor(() => {
+        expect(viewer.textContent).toContain('captured in DB');
+      });
+    });
+
+    it('shows an error when the log request is not ok', async () => {
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        new globalThis.Response('permission denied', { status: 403 }),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={baseJob}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/permission denied/)).toBeInTheDocument();
+      });
+    });
+
+    it('stops retrying when phase transitions from running to success while stream is empty', async () => {
+      jest.useFakeTimers();
+
+      try {
+        mockModulesModuleIdLogGet.mockResolvedValue(
+          makeSuccessResponse(
+            () =>
+              new globalThis.ReadableStream<Uint8Array>({
+                start(c) {
+                  c.close();
+                },
+              }),
+          ),
+        );
+
+        const user = userEvent.setup({
+          advanceTimers: jest.advanceTimersByTime,
+        });
+        const { rerender } = await act(async () =>
+          render(
+            <PhaseDetails
+              phase={baseJob}
+              projectId="proj-1"
+              phaseName="analyze"
+              moduleId="mod-1"
+            />,
+          ),
+        );
+
+        await act(async () => {
+          await user.click(screen.getByRole('button', { name: 'View Log' }));
+        });
+
+        await waitFor(() => {
+          expect(mockModulesModuleIdLogGet).toHaveBeenCalledTimes(1);
+        });
+
+        const finishedJob: Job = {
+          ...baseJob,
+          status: 'success',
+          finishedAt: new Date('2024-01-01T12:05:00Z'),
+        };
+        await act(async () => {
+          rerender(
+            <PhaseDetails
+              phase={finishedJob}
+              projectId="proj-1"
+              phaseName="analyze"
+              moduleId="mod-1"
+            />,
+          );
+        });
+
+        // The already-scheduled retry fires once more (was queued before status changed).
+        await act(async () => {
+          jest.advanceTimersByTime(POLLING_INTERVAL_MS);
+        });
+        await waitFor(() => {
+          expect(mockModulesModuleIdLogGet).toHaveBeenCalledTimes(2);
+        });
+
+        // No further retries: phaseStatusRef is now 'success'.
+        await act(async () => {
+          jest.advanceTimersByTime(POLLING_INTERVAL_MS * 3);
+        });
+        expect(mockModulesModuleIdLogGet).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('aborts load when the log is hidden and does not surface AbortError in the UI', async () => {
+      const parts = ['a', 'b', 'c'];
+      let readCount = 0;
+      mockModulesModuleIdLogGet.mockResolvedValue(
+        makeSuccessResponse(
+          enc =>
+            new globalThis.ReadableStream({
+              pull(controller) {
+                if (readCount < parts.length) {
+                  controller.enqueue(enc.encode(parts[readCount]));
+                  readCount += 1;
+                } else {
+                  controller.close();
+                }
+              },
+            }),
+        ),
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={baseJob}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'View Log' }));
+      });
+      await screen.findByTestId('log-viewer');
+      await act(async () => {
+        await user.click(screen.getByRole('button', { name: 'Hide Log' }));
+      });
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', { name: 'Hide Log' }),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText(/AbortError/i)).toBeNull();
     });
   });
 });

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
-import useAsync from 'react-use/lib/useAsync';
+import { useCallback, useMemo, useState } from 'react';
 
 import { LogViewer, Progress } from '@backstage/core-components';
 import {
@@ -32,6 +31,7 @@ import {
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { useLogStream } from '../hooks/useLogStream';
 import { useClientService } from '../ClientService';
 import { ItemField } from './ItemField';
 import {
@@ -47,6 +47,12 @@ import { PhaseStatus } from './PhaseStatus';
 const useStyles = makeStyles(theme => ({
   buttonGroup: {
     gap: theme.spacing(1),
+  },
+  logViewerWrapper: {
+    height: 400,
+    '& a[role="row"]': {
+      userSelect: 'none',
+    },
   },
 }));
 
@@ -165,6 +171,7 @@ export const PhaseDetails = (
   } & OptionalModuleId,
 ) => {
   const { t } = useTranslation();
+  const classes = useStyles();
   const clientService = useClientService();
   const empty = t('module.phases.none');
   const [showLog, setShowLog] = useState(false);
@@ -179,31 +186,39 @@ export const PhaseDetails = (
 
   const canRunPhase = phase?.status !== 'running';
 
-  const {
-    value: logText,
-    loading: logLoading,
-    error: logError,
-  } = useAsync(async () => {
-    if (!showLog || !phase) {
-      return undefined;
-    }
+  const fetchLog = useCallback(
+    () =>
+      phaseName === 'init'
+        ? clientService.projectsProjectIdLogGet({
+            path: { projectId },
+            query: { streaming: true },
+          })
+        : clientService.projectsProjectIdModulesModuleIdLogGet({
+            path: { projectId, moduleId: moduleId as string },
+            query: { phase: phaseName as ModulePhase, streaming: true },
+          }),
+    [clientService, projectId, moduleId, phaseName],
+  );
 
-    if (phaseName === 'init') {
-      const response = await clientService.projectsProjectIdLogGet({
-        path: { projectId },
-        query: { streaming: false },
-      });
-      return await response.text();
-    }
+  const { logText, logStreamHasData, logLoading, logError } = useLogStream({
+    enabled: showLog && !!phase,
+    phaseId: phase?.id,
+    phaseStatus: phase?.status,
+    projectId,
+    moduleId,
+    phaseName,
+    fetchLog,
+  });
 
-    const response = await clientService.projectsProjectIdModulesModuleIdLogGet(
-      {
-        path: { projectId, moduleId: moduleId as string },
-        query: { phase: phaseName as ModulePhase, streaming: false },
-      },
-    );
-    return await response.text();
-  }, [showLog, phase?.id, projectId, moduleId]);
+  const logViewerText = useMemo((): string => {
+    if (logStreamHasData) {
+      return logText ?? '';
+    }
+    if (logLoading) {
+      return t('modulePage.phases.logWaitingForStream');
+    }
+    return logText || t('modulePage.phases.noLogsAvailable');
+  }, [logStreamHasData, logText, logLoading, t]);
 
   return (
     <Grid container direction="row" spacing={3}>
@@ -281,9 +296,9 @@ export const PhaseDetails = (
             <Typography color="error">{logError.message}</Typography>
           )}
           {logText !== undefined && (
-            <div style={{ height: 400 }}>
+            <div className={classes.logViewerWrapper}>
               <LogViewer
-                text={logText || t('modulePage.phases.noLogsAvailable')}
+                text={logViewerText}
                 onDownloadLog={() =>
                   downloadLogFile(logText || '', `${phaseName}-${projectId}`)
                 }

--- a/workspaces/x2a/plugins/x2a/src/components/phaseLogStream.test.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/phaseLogStream.test.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../test-utils/webStreamsJestPolyfill';
+
+import { readPlainTextResponseStream } from './phaseLogStream';
+
+const enc = new globalThis.TextEncoder();
+
+function makeJsonLikeResponse(overrides: {
+  ok?: boolean;
+  status?: number;
+  body?: globalThis.ReadableStream<Uint8Array> | null;
+  textImpl?: () => Promise<string>;
+}) {
+  const {
+    ok = true,
+    status = 200,
+    body,
+    textImpl = async () => '',
+  } = overrides;
+  if (!ok) {
+    return {
+      ok: false,
+      status: status,
+      text: textImpl,
+    } as globalThis.Response;
+  }
+  return {
+    ok: true,
+    status: 200,
+    body: body,
+    text: textImpl,
+  } as globalThis.Response;
+}
+
+describe('readPlainTextResponseStream', () => {
+  it('emits one chunk per enqueue for multiple small string parts', async () => {
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode('a'));
+        c.enqueue(enc.encode('b'));
+        c.enqueue(enc.encode('c'));
+        c.close();
+      },
+    });
+    const chunks: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => chunks.push(s),
+    });
+    expect(chunks.join('')).toBe('abc');
+  });
+
+  it('reconstructs multi-line and longer payloads across many chunks', async () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i}\n`);
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        for (const l of lines) {
+          c.enqueue(enc.encode(l));
+        }
+        c.close();
+      },
+    });
+    const out: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => out.push(s),
+    });
+    expect(out.join('')).toBe(lines.join(''));
+  });
+
+  it('decodes UTF-8 split across byte boundaries (multi-byte char)', async () => {
+    // '€' is UTF-8 E2 82 AC — split as 1 byte, then 2 bytes
+    const b = new Uint8Array([0xe2, 0x82, 0xac]);
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(b.slice(0, 1));
+        c.enqueue(b.slice(1, 3));
+        c.close();
+      },
+    });
+    const out: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => out.push(s),
+    });
+    expect(out.join('')).toBe('€');
+  });
+
+  it('decodes when the first bytes arrive on a later turn (e.g. k8s follow stream back-pressure)', async () => {
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        setTimeout(() => {
+          c.enqueue(enc.encode('ready\n'));
+          c.close();
+        }, 0);
+      },
+    });
+    const out: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => out.push(s),
+    });
+    expect(out.join('')).toBe('ready\n');
+  });
+
+  it('yields no chunks for an empty body stream (close without enqueue) - e.g. empty file', async () => {
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        c.close();
+      },
+    });
+    const chunks: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => chunks.push(s),
+    });
+    expect(chunks).toEqual([]);
+  });
+
+  it('handles single small chunk then immediate close (finished job, short DB log)', async () => {
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode('ok\n'));
+        c.close();
+      },
+    });
+    const chunks: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => chunks.push(s),
+    });
+    expect(chunks.join('')).toBe('ok\n');
+  });
+
+  it('falls back to response.text() when body is null (polyfill / no stream)', async () => {
+    const r = {
+      ok: true,
+      status: 200,
+      body: null,
+      text: async () => 'entire\nlog',
+    } as globalThis.Response;
+    const got: string[] = [];
+    await readPlainTextResponseStream(r, { onChunk: c => got.push(c) });
+    expect(got).toEqual(['entire\nlog']);
+  });
+
+  it('rejects on non-ok response and surfaces error body in message', async () => {
+    const r = new globalThis.Response('you shall not pass', { status: 404 });
+    await expect(
+      readPlainTextResponseStream(r, { onChunk: () => undefined }),
+    ).rejects.toThrow('you shall not pass');
+  });
+
+  it('rejects on non-ok when text() on error body fails', async () => {
+    const r = {
+      ok: false,
+      status: 500,
+      text: async () => {
+        throw new Error('read failed');
+      },
+    } as unknown as globalThis.Response;
+    await expect(
+      readPlainTextResponseStream(r, { onChunk: () => undefined }),
+    ).rejects.toThrow(/Log request failed \(500\)/);
+  });
+
+  it('throws DOMException(AbortError) if signal is already aborted before read', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode('x'));
+        c.close();
+      },
+    });
+    await expect(
+      readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+        signal: ac.signal,
+        onChunk: () => undefined,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('skips empty zero-length chunks (defensive, odd providers)', async () => {
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new Uint8Array(0));
+        c.enqueue(enc.encode('x'));
+        c.close();
+      },
+    });
+    const chunks: string[] = [];
+    await readPlainTextResponseStream(makeJsonLikeResponse({ body }), {
+      onChunk: s => chunks.push(s),
+    });
+    expect(chunks.join('')).toBe('x');
+  });
+
+  it('stops and rejects with AbortError when signal aborts after first chunk (mid stream)', async () => {
+    const ac = new AbortController();
+    const firstPull = { done: false };
+    const body = new globalThis.ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (firstPull.done) {
+          controller.enqueue(enc.encode('b'));
+          controller.close();
+        } else {
+          firstPull.done = true;
+          controller.enqueue(enc.encode('a'));
+        }
+      },
+    });
+    const chunks: string[] = [];
+    const err = await readPlainTextResponseStream(
+      makeJsonLikeResponse({ body }),
+      {
+        signal: ac.signal,
+        onChunk: s => {
+          chunks.push(s);
+          if (s === 'a') {
+            ac.abort();
+          }
+        },
+      },
+    ).then(
+      () => null,
+      e => e,
+    );
+    expect(err).toMatchObject({ name: 'AbortError' });
+    expect(chunks.join('')).toBe('a');
+  });
+});

--- a/workspaces/x2a/plugins/x2a/src/components/phaseLogStream.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/phaseLogStream.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Reads a fetch Response body as `text/plain` and invokes `onChunk` for each
+ * decoded segment. If `body` is missing, falls back to `response.text()`.
+ */
+export async function readPlainTextResponseStream(
+  response: Response,
+  options: {
+    signal?: AbortSignal;
+    onChunk: (chunk: string) => void;
+  },
+): Promise<void> {
+  if (!response.ok) {
+    const errBody = await response.text().catch(() => '');
+    throw new Error(errBody || `Log request failed (${response.status})`);
+  }
+
+  if (!response.body) {
+    options.onChunk(await response.text());
+    return;
+  }
+
+  if (options.signal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
+
+  const streamDecoder = new TextDecoder();
+  const reader = response.body.getReader();
+
+  const abort = () => {
+    reader.cancel().catch(() => undefined);
+  };
+  if (options.signal) {
+    options.signal.addEventListener('abort', abort, { once: true });
+  }
+
+  try {
+    for (;;) {
+      if (options.signal?.aborted) {
+        throw new DOMException('Aborted', 'AbortError');
+      }
+      const { done, value } = await reader.read();
+      if (done) {
+        const tail = streamDecoder.decode();
+        if (tail) {
+          options.onChunk(tail);
+        }
+        break;
+      }
+      if (value && value.length > 0) {
+        options.onChunk(streamDecoder.decode(value, { stream: true }));
+      }
+    }
+  } finally {
+    options.signal?.removeEventListener('abort', abort);
+    reader.releaseLock();
+  }
+}

--- a/workspaces/x2a/plugins/x2a/src/hooks/useLogStream.ts
+++ b/workspaces/x2a/plugins/x2a/src/hooks/useLogStream.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { POLLING_INTERVAL_MS } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+import { readPlainTextResponseStream } from '../components/phaseLogStream';
+
+export interface UseLogStreamResult {
+  logText?: string;
+  logStreamHasData: boolean;
+  logLoading: boolean;
+  logError?: Error;
+}
+
+/**
+ * Streams plain-text logs from the backend into React state.
+ *
+ * The caller provides a `fetchLog` callback that returns a `Response`.
+ * The hook reads its body as a stream, appending chunks to `logText`.
+ * When `enabled` flips to `false` (or on unmount), the stream is aborted.
+ */
+export function useLogStream(params: {
+  enabled: boolean;
+  phaseId?: string;
+  phaseStatus?: string;
+  projectId: string;
+  moduleId?: string;
+  phaseName: string;
+  fetchLog: () => Promise<Response>;
+}): UseLogStreamResult {
+  const {
+    enabled,
+    phaseId,
+    phaseStatus,
+    projectId,
+    moduleId,
+    phaseName,
+    fetchLog,
+  } = params;
+
+  const fetchRef = useRef(fetchLog);
+  fetchRef.current = fetchLog;
+
+  const phaseStatusRef = useRef(phaseStatus);
+  phaseStatusRef.current = phaseStatus;
+
+  const [logText, setLogText] = useState<string | undefined>(undefined);
+  const [logStreamHasData, setLogStreamHasData] = useState(false);
+  const [logLoading, setLogLoading] = useState(false);
+  const [logError, setLogError] = useState<Error | undefined>(undefined);
+  const [retryCounter, setRetryCounter] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || !phaseId) {
+      setLogText(undefined);
+      setLogStreamHasData(false);
+      setLogError(undefined);
+      setLogLoading(false);
+      return undefined;
+    }
+
+    const ac = new AbortController();
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+    let receivedData = false;
+    let hadError = false;
+
+    setLogText('');
+    setLogStreamHasData(false);
+    setLogError(undefined);
+    setLogLoading(true);
+
+    (async () => {
+      try {
+        const response = await fetchRef.current();
+        if (cancelled) {
+          return;
+        }
+        await readPlainTextResponseStream(response, {
+          signal: ac.signal,
+          onChunk: chunk => {
+            if (cancelled) {
+              return;
+            }
+            receivedData = true;
+            setLogStreamHasData(true);
+            setLogText(prev => (prev ?? '') + chunk);
+          },
+        });
+      } catch (e) {
+        if (
+          cancelled ||
+          (e instanceof DOMException && e.name === 'AbortError') ||
+          ac.signal.aborted
+        ) {
+          return;
+        }
+        hadError = true;
+        setLogError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (!cancelled && !ac.signal.aborted) {
+          if (
+            !receivedData &&
+            !hadError &&
+            phaseStatusRef.current === 'running'
+          ) {
+            retryTimeout = setTimeout(() => {
+              if (!cancelled) {
+                setRetryCounter(prev => prev + 1);
+              }
+            }, POLLING_INTERVAL_MS);
+          } else {
+            setLogLoading(false);
+          }
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      ac.abort();
+      if (retryTimeout !== undefined) clearTimeout(retryTimeout);
+    };
+  }, [enabled, phaseId, projectId, moduleId, phaseName, retryCounter]);
+
+  return { logText, logStreamHasData, logLoading, logError };
+}

--- a/workspaces/x2a/plugins/x2a/src/test-utils/webStreamsJestPolyfill.ts
+++ b/workspaces/x2a/plugins/x2a/src/test-utils/webStreamsJestPolyfill.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* Test env: polyfill Web Streams in Jest when globals are missing. */
+/* eslint-disable no-restricted-imports */
+import { TextDecoder, TextEncoder } from 'node:util';
+import { ReadableStream } from 'node:stream/web';
+/* eslint-enable no-restricted-imports */
+
+if ((globalThis as { TextDecoder?: unknown }).TextDecoder === undefined) {
+  (globalThis as { TextDecoder: unknown }).TextDecoder = TextDecoder;
+}
+if ((globalThis as { TextEncoder?: unknown }).TextEncoder === undefined) {
+  (globalThis as { TextEncoder: unknown }).TextEncoder = TextEncoder;
+}
+if ((globalThis as { ReadableStream?: unknown }).ReadableStream === undefined) {
+  (globalThis as { ReadableStream: unknown }).ReadableStream = ReadableStream;
+}

--- a/workspaces/x2a/plugins/x2a/src/translations/de.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/de.ts
@@ -176,6 +176,8 @@ const x2aPluginTranslationDe = createTranslationMessages({
     'modulePage.phases.viewLog': 'Log anzeigen',
     'modulePage.phases.hideLog': 'Log ausblenden',
     'modulePage.phases.noLogsAvailable': 'Noch keine Logs verfügbar...',
+    'modulePage.phases.logWaitingForStream':
+      'Warte auf Log-Ausgabe vom Cluster...',
     'modulePage.phases.telemetry.title': 'Telemetrie',
     'modulePage.phases.telemetry.noTelemetryAvailable':
       'Keine Telemetrie verfügbar',

--- a/workspaces/x2a/plugins/x2a/src/translations/es.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/es.ts
@@ -177,6 +177,8 @@ const x2aPluginTranslationEs = createTranslationMessages({
     'modulePage.phases.viewLog': 'Ver registro',
     'modulePage.phases.hideLog': 'Ocultar registro',
     'modulePage.phases.noLogsAvailable': 'Aún no hay registros disponibles...',
+    'modulePage.phases.logWaitingForStream':
+      'Esperando la salida de registro del clúster...',
     'modulePage.phases.telemetry.title': 'Telemetría',
     'modulePage.phases.telemetry.noTelemetryAvailable':
       'No hay telemetría disponible',

--- a/workspaces/x2a/plugins/x2a/src/translations/fr.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/fr.ts
@@ -178,6 +178,8 @@ const x2aPluginTranslationFr = createTranslationMessages({
     'modulePage.phases.hideLog': 'Masquer le journal',
     'modulePage.phases.noLogsAvailable':
       'Aucun journal disponible pour le moment...',
+    'modulePage.phases.logWaitingForStream':
+      'En attente des journaux du cluster...',
     'modulePage.phases.telemetry.title': 'Télémétrie',
     'modulePage.phases.telemetry.noTelemetryAvailable':
       'Aucune télémétrie disponible',

--- a/workspaces/x2a/plugins/x2a/src/translations/it.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/it.ts
@@ -179,6 +179,8 @@ const x2aPluginTranslationIt = createTranslationMessages({
     'modulePage.phases.viewLog': 'Visualizza log',
     'modulePage.phases.hideLog': 'Nascondi log',
     'modulePage.phases.noLogsAvailable': 'Nessun log disponibile ancora...',
+    'modulePage.phases.logWaitingForStream':
+      "In attesa dell'output di log dal cluster...",
     'modulePage.phases.telemetry.title': 'Telemetria',
     'modulePage.phases.telemetry.noTelemetryAvailable':
       'Nessuna telemetria disponibile',

--- a/workspaces/x2a/plugins/x2a/src/translations/ref.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/ref.ts
@@ -122,6 +122,7 @@ export const x2aPluginMessages = {
       viewLog: 'View Log',
       hideLog: 'Hide Log',
       noLogsAvailable: 'No logs available yet...',
+      logWaitingForStream: 'Waiting for log output from the cluster...',
       telemetry: {
         title: 'Telemetry',
         noTelemetryAvailable: 'No telemetry available',


### PR DESCRIPTION
Fixes: FLPATH-4087

Stream logs in real-time as backend jobs produce them.

Exclude row numbers from copy selection.
