### PR TITLE
feat(lightspeed): add dedicated route for individual notebook view

### DIFF
--- a/workspaces/lightspeed/.changeset/dedicated-notebook-route.md
+++ b/workspaces/lightspeed/.changeset/dedicated-notebook-route.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': minor
+---
+
+Add dedicated route for individual notebook view (/lightspeed/notebooks/:notebookId).

--- a/workspaces/lightspeed/.changeset/dedicated-notebook-route.md
+++ b/workspaces/lightspeed/.changeset/dedicated-notebook-route.md
@@ -1,6 +1,5 @@
 ---
 '@red-hat-developer-hub/backstage-plugin-lightspeed': minor
-'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': minor
 ---
 
 Add dedicated route for individual notebook view (/lightspeed/notebooks/:notebookId).

--- a/workspaces/lightspeed/plugins/lightspeed/report.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report.api.md
@@ -52,6 +52,7 @@ export const lightspeedPlugin: BackstagePlugin<
       PathParams<'/conversation/:conversationId'>
     >;
     lightspeedNotebooks: SubRouteRef<undefined>;
+    lightspeedNotebookView: SubRouteRef<PathParams<'/notebooks/:notebookId'>>;
   },
   {},
   {}

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/NotebooksApiClient.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/NotebooksApiClient.ts
@@ -135,6 +135,17 @@ export class NotebooksApiClient implements NotebooksAPI {
     return response?.sessions ?? [];
   }
 
+  async getSession(sessionId: string) {
+    const baseUrl = await this.getBaseUrl();
+    const response = await this.fetchJson<SessionResponse>(
+      `${baseUrl}/v1/sessions/${encodeURIComponent(sessionId)}`,
+    );
+    if (!response.session) {
+      throw new Error(response.error ?? 'Session not found');
+    }
+    return response.session;
+  }
+
   async renameSession(sessionId: string, name: string) {
     const baseUrl = await this.getBaseUrl();
     await this.fetchJson(

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/__tests__/NotebooksApiClient.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/__tests__/NotebooksApiClient.test.ts
@@ -45,7 +45,7 @@ describe('NotebooksApiClient', () => {
   describe('getBaseUrl', () => {
     it('should return the correct base URL', async () => {
       const baseUrl = await client.getBaseUrl();
-      expect(baseUrl).toBe('http://localhost:7007/api/lightspeed/ai-notebooks');
+      expect(baseUrl).toBe('http://localhost:7007/api/lightspeed/notebooks');
       expect(mockConfigApi.getString).toHaveBeenCalledWith('backend.baseUrl');
     });
   });
@@ -72,7 +72,7 @@ describe('NotebooksApiClient', () => {
 
       expect(result).toEqual(mockSession);
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test-123',
+        'http://localhost:7007/api/lightspeed/notebooks/v1/sessions/vs_test-123',
         expect.objectContaining({
           headers: { 'Content-Type': 'application/json' },
         }),
@@ -95,7 +95,7 @@ describe('NotebooksApiClient', () => {
       await client.getSession('vs_test/special?chars');
 
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test%2Fspecial%3Fchars',
+        'http://localhost:7007/api/lightspeed/notebooks/v1/sessions/vs_test%2Fspecial%3Fchars',
         expect.any(Object),
       );
     });
@@ -162,7 +162,7 @@ describe('NotebooksApiClient', () => {
 
       expect(result).toEqual(mockSessions);
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions',
+        'http://localhost:7007/api/lightspeed/notebooks/v1/sessions',
         expect.any(Object),
       );
     });
@@ -196,7 +196,7 @@ describe('NotebooksApiClient', () => {
 
       expect(result).toEqual(mockSession);
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions',
+        'http://localhost:7007/api/lightspeed/notebooks/v1/sessions',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({
@@ -233,7 +233,7 @@ describe('NotebooksApiClient', () => {
       await client.renameSession('vs_test-123', 'New Name');
 
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test-123',
+        'http://localhost:7007/api/lightspeed/notebooks/v1/sessions/vs_test-123',
         expect.objectContaining({
           method: 'PUT',
           body: JSON.stringify({ name: 'New Name' }),
@@ -252,7 +252,7 @@ describe('NotebooksApiClient', () => {
       await client.deleteSession('vs_test-123');
 
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test-123',
+        'http://localhost:7007/api/lightspeed/notebooks/v1/sessions/vs_test-123',
         expect.objectContaining({
           method: 'DELETE',
         }),

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/__tests__/NotebooksApiClient.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/__tests__/NotebooksApiClient.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigApi, FetchApi } from '@backstage/core-plugin-api';
+
+import { NotebooksApiClient } from '../NotebooksApiClient';
+
+describe('NotebooksApiClient', () => {
+  let mockConfigApi: jest.Mocked<ConfigApi>;
+  let mockFetchApi: jest.Mocked<FetchApi>;
+  let client: NotebooksApiClient;
+
+  beforeEach(() => {
+    mockConfigApi = {
+      getString: jest.fn().mockReturnValue('http://localhost:7007'),
+    } as unknown as jest.Mocked<ConfigApi>;
+
+    mockFetchApi = {
+      fetch: jest.fn(),
+    } as unknown as jest.Mocked<FetchApi>;
+
+    client = new NotebooksApiClient({
+      configApi: mockConfigApi,
+      fetchApi: mockFetchApi,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getBaseUrl', () => {
+    it('should return the correct base URL', async () => {
+      const baseUrl = await client.getBaseUrl();
+      expect(baseUrl).toBe('http://localhost:7007/api/lightspeed/ai-notebooks');
+      expect(mockConfigApi.getString).toHaveBeenCalledWith('backend.baseUrl');
+    });
+  });
+
+  describe('getSession', () => {
+    it('should return session data when API call succeeds', async () => {
+      const mockSession = {
+        session_id: 'vs_test-123',
+        name: 'Test Notebook',
+        metadata: { conversation_id: 'conv-456' },
+      };
+
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            session: mockSession,
+            message: 'Session retrieved successfully',
+          }),
+        ),
+      } as unknown as Response);
+
+      const result = await client.getSession('vs_test-123');
+
+      expect(result).toEqual(mockSession);
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test-123',
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('should encode special characters in session ID', async () => {
+      const mockSession = {
+        session_id: 'vs_test/special?chars',
+        name: 'Test Notebook',
+      };
+
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify({ session: mockSession })),
+      } as unknown as Response);
+
+      await client.getSession('vs_test/special?chars');
+
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test%2Fspecial%3Fchars',
+        expect.any(Object),
+      );
+    });
+
+    it('should throw error when session is not found', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify({ error: 'Session not found' })),
+      } as unknown as Response);
+
+      await expect(client.getSession('vs_invalid')).rejects.toThrow(
+        'Session not found',
+      );
+    });
+
+    it('should throw error when response has no session', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({ message: 'Success but no session' }),
+          ),
+      } as unknown as Response);
+
+      await expect(client.getSession('vs_test-123')).rejects.toThrow(
+        'Session not found',
+      );
+    });
+
+    it('should throw error with custom error message from response', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify({ error: 'Custom error message' })),
+      } as unknown as Response);
+
+      await expect(client.getSession('vs_test-123')).rejects.toThrow(
+        'Custom error message',
+      );
+    });
+  });
+
+  describe('listSessions', () => {
+    it('should return sessions when API call succeeds', async () => {
+      const mockSessions = [
+        { session_id: 'vs_1', name: 'Notebook 1' },
+        { session_id: 'vs_2', name: 'Notebook 2' },
+      ];
+
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify({ sessions: mockSessions })),
+      } as unknown as Response);
+
+      const result = await client.listSessions();
+
+      expect(result).toEqual(mockSessions);
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions',
+        expect.any(Object),
+      );
+    });
+
+    it('should return empty array when sessions is undefined', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue(JSON.stringify({})),
+      } as unknown as Response);
+
+      const result = await client.listSessions();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('createSession', () => {
+    it('should create and return session', async () => {
+      const mockSession = {
+        session_id: 'vs_new-123',
+        name: 'New Notebook',
+      };
+
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify({ session: mockSession })),
+      } as unknown as Response);
+
+      const result = await client.createSession('New Notebook', 'Description');
+
+      expect(result).toEqual(mockSession);
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            name: 'New Notebook',
+            description: 'Description',
+          }),
+        }),
+      );
+    });
+
+    it('should throw error when creation fails', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({ error: 'Failed to create session' }),
+          ),
+      } as unknown as Response);
+
+      await expect(client.createSession('New Notebook')).rejects.toThrow(
+        'Failed to create session',
+      );
+    });
+  });
+
+  describe('renameSession', () => {
+    it('should rename session successfully', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue(''),
+      } as unknown as Response);
+
+      await client.renameSession('vs_test-123', 'New Name');
+
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test-123',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ name: 'New Name' }),
+        }),
+      );
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('should delete session successfully', async () => {
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue(''),
+      } as unknown as Response);
+
+      await client.deleteSession('vs_test-123');
+
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/lightspeed/ai-notebooks/v1/sessions/vs_test-123',
+        expect.objectContaining({
+          method: 'DELETE',
+        }),
+      );
+    });
+  });
+});

--- a/workspaces/lightspeed/plugins/lightspeed/src/api/notebooksApi.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/api/notebooksApi.ts
@@ -33,6 +33,7 @@ export type NotebooksAPI = {
     description?: string,
   ) => Promise<NotebookSession>;
   listSessions: () => Promise<NotebookSession[]>;
+  getSession: (sessionId: string) => Promise<NotebookSession>;
   renameSession: (sessionId: string, name: string) => Promise<void>;
   deleteSession: (sessionId: string) => Promise<void>;
   uploadDocument: (

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -87,6 +87,7 @@ import {
   useLastOpenedConversation,
   useLightspeedDeletePermission,
   useLightspeedNotebooksPermission,
+  useNotebookSession,
   useNotebookSessions,
   usePinnedChatsSettings,
   useSortSettings,
@@ -475,11 +476,13 @@ export const LightspeedChat = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const notebooksRouteMatch = useMatch('/lightspeed/notebooks');
+  const notebookViewRouteMatch = useMatch('/lightspeed/notebooks/:notebookId');
+  const routeNotebookId = notebookViewRouteMatch?.params?.notebookId;
   const user = useBackstageUserIdentity();
   const [filterValue, setFilterValue] = useState<string>('');
   const [announcement, setAnnouncement] = useState<string>('');
   const [activeTab, setActiveTab] = useState<number>(
-    notebooksRouteMatch ? 1 : 0,
+    notebooksRouteMatch || notebookViewRouteMatch ? 1 : 0,
   );
   const { allowed: hasNotebooksAccess, loading: notebooksPermissionLoading } =
     useLightspeedNotebooksPermission();
@@ -496,6 +499,29 @@ export const LightspeedChat = ({
   const [activeNotebook, setActiveNotebook] = useState<NotebookSession | null>(
     null,
   );
+  const {
+    data: routeNotebook,
+    isLoading: routeNotebookLoading,
+    isError: routeNotebookError,
+  } = useNotebookSession(routeNotebookId);
+
+  useEffect(() => {
+    if (routeNotebookId && routeNotebook && !routeNotebookLoading) {
+      setActiveNotebook(routeNotebook);
+    } else if (routeNotebookId && routeNotebookError) {
+      navigate('/lightspeed/notebooks', { replace: true });
+    } else if (!routeNotebookId && notebooksRouteMatch) {
+      setActiveNotebook(null);
+    }
+  }, [
+    routeNotebookId,
+    routeNotebook,
+    routeNotebookLoading,
+    routeNotebookError,
+    notebooksRouteMatch,
+    navigate,
+  ]);
+
   const [notebookAlerts, setNotebookAlerts] = useState<Partial<AlertProps>[]>(
     [],
   );
@@ -560,16 +586,16 @@ export const LightspeedChat = ({
       { name: UNTITLED_NOTEBOOK_NAME },
       {
         onSuccess: (session: NotebookSession) => {
-          setActiveNotebook(session);
+          navigate(`/lightspeed/notebooks/${session.session_id}`);
         },
       },
     );
-  }, [createNotebookMutation]);
+  }, [createNotebookMutation, navigate]);
 
   const handleCloseNotebook = useCallback(() => {
-    setActiveNotebook(null);
+    navigate('/lightspeed/notebooks');
     refetchNotebooks();
-  }, [refetchNotebooks]);
+  }, [navigate, refetchNotebooks]);
 
   const handleRemoveNotebookAlert = (key: React.Key) => {
     setNotebookAlerts(prevAlerts =>
@@ -1668,7 +1694,9 @@ export const LightspeedChat = ({
               classes={classes}
               openNotebookMenuId={openNotebookMenuId}
               setOpenNotebookMenuId={setOpenNotebookMenuId}
-              onSelectNotebook={setActiveNotebook}
+              onSelectNotebook={(notebook: NotebookSession) =>
+                navigate(`/lightspeed/notebooks/${notebook.session_id}`)
+              }
               onRename={setRenameNotebookId}
               onDelete={setDeleteNotebookId}
               onCreateNotebook={handleCreateNotebook}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/Router.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/Router.tsx
@@ -30,6 +30,7 @@ export const Router = () => {
         element={<LightspeedPage />}
       />
       <Route path="/notebooks" element={<LightspeedPage />} />
+      <Route path="/notebooks/:notebookId" element={<LightspeedPage />} />
     </Routes>
   );
 };

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -81,6 +81,14 @@ jest.mock('../../hooks/notebooks/useNotebookSessions', () => ({
   }),
 }));
 
+jest.mock('../../hooks/notebooks/useNotebookSession', () => ({
+  useNotebookSession: jest.fn().mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 jest.mock('../../hooks/useFeedbackActions', () => ({
   useFeedbackActions: jest.fn().mockReturnValue([]),
 }));

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useNotebookSession.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useNotebookSession.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi } from '@backstage/core-plugin-api';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useNotebookSession } from '../notebooks/useNotebookSession';
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: jest.fn(),
+}));
+
+const mockGetSession = jest.fn();
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children?: React.ReactNode }): any => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useNotebookSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+    (useApi as jest.Mock).mockReturnValue({
+      getSession: mockGetSession,
+    });
+  });
+
+  it('should fetch session data when sessionId is provided', async () => {
+    const mockSession = {
+      session_id: 'vs_test-123',
+      name: 'Test Notebook',
+      metadata: { conversation_id: 'conv-456' },
+    };
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useNotebookSession('vs_test-123'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockSession);
+    expect(mockGetSession).toHaveBeenCalledWith('vs_test-123');
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not fetch when sessionId is undefined', async () => {
+    const { result } = renderHook(() => useNotebookSession(undefined), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch when sessionId is empty string', async () => {
+    const { result } = renderHook(() => useNotebookSession(''), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('should handle error when session fetch fails', async () => {
+    mockGetSession.mockRejectedValue(new Error('Session not found'));
+
+    const { result } = renderHook(() => useNotebookSession('vs_invalid'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Session not found');
+  });
+
+  it('should return session with metadata containing conversation_id', async () => {
+    const mockSession = {
+      session_id: 'vs_test-123',
+      name: 'Test Notebook',
+      metadata: {
+        conversation_id: 'conv-abc123',
+        other_field: 'value',
+      },
+    };
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useNotebookSession('vs_test-123'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.metadata?.conversation_id).toBe('conv-abc123');
+  });
+
+  it('should refetch when sessionId changes', async () => {
+    const mockSession1 = { session_id: 'vs_1', name: 'Notebook 1' };
+    const mockSession2 = { session_id: 'vs_2', name: 'Notebook 2' };
+
+    mockGetSession
+      .mockResolvedValueOnce(mockSession1)
+      .mockResolvedValueOnce(mockSession2);
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => useNotebookSession(sessionId),
+      {
+        wrapper,
+        initialProps: { sessionId: 'vs_1' },
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockSession1);
+
+    rerender({ sessionId: 'vs_2' });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockSession2));
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/index.ts
@@ -26,6 +26,7 @@ export * from './useLightspeedDeletePermission';
 export * from './notebooks/useLightspeedNotebooksPermission';
 export * from './useLightspeedViewPermission';
 export * from './useDisplayModeSettings';
+export * from './notebooks/useNotebookSession';
 export * from './notebooks/useNotebookSessions';
 export * from './usePinnedChatsSettings';
 export * from './notebooks/useRenameNotebook';

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/notebooks/useNotebookSession.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/notebooks/useNotebookSession.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi } from '@backstage/core-plugin-api';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { notebooksApiRef } from '../../api/notebooksApi';
+import { NotebookSession } from '../../types';
+
+export const useNotebookSession = (
+  sessionId?: string,
+): UseQueryResult<NotebookSession, Error> => {
+  const notebooksApi = useApi(notebooksApiRef);
+  return useQuery({
+    queryKey: ['notebooks', 'session', sessionId],
+    queryFn: async () => {
+      return await notebooksApi.getSession(sessionId!);
+    },
+    enabled: Boolean(sessionId),
+    staleTime: 1000 * 60,
+  });
+};

--- a/workspaces/lightspeed/plugins/lightspeed/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/plugin.ts
@@ -35,6 +35,7 @@ import { NotebooksApiClient } from './api/NotebooksApiClient';
 import {
   addConversationRouteRef,
   notebooksRouteRef,
+  notebookViewRouteRef,
   rootRouteRef,
 } from './routes';
 
@@ -48,6 +49,7 @@ export const lightspeedPlugin = createPlugin({
     root: rootRouteRef,
     lightspeedConversation: addConversationRouteRef,
     lightspeedNotebooks: notebooksRouteRef,
+    lightspeedNotebookView: notebookViewRouteRef,
   },
   apis: [
     createApiFactory({

--- a/workspaces/lightspeed/plugins/lightspeed/src/routes.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/routes.ts
@@ -31,3 +31,9 @@ export const notebooksRouteRef = createSubRouteRef({
   parent: rootRouteRef,
   path: '/notebooks',
 });
+
+export const notebookViewRouteRef = createSubRouteRef({
+  id: 'lightspeed-notebook-view',
+  parent: rootRouteRef,
+  path: '/notebooks/:notebookId',
+});


### PR DESCRIPTION
## Description
- Add dedicated route `/lightspeed/notebooks/:notebookId` so that refreshing the page while viewing a notebook preserves the view

## Fixes
- Fixed https://redhat.atlassian.net/browse/RHDHBUGS-2986

## UI after changes


https://github.com/user-attachments/assets/28179543-73d8-4b3e-bb3c-af30147a1c73


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
