### PR TITLE
fix(cost-management): set plugin versions to 2.0.2 for Tech Preview release

### DIFF
--- a/workspaces/cost-management/docs/dynamic-plugin.md
+++ b/workspaces/cost-management/docs/dynamic-plugin.md
@@ -5,11 +5,12 @@ Red Hat Developer Hub (RHDH) leverages dynamic plugins to efficiently deploy plu
 
 The procedure involves the following steps:
 
-1. Ensure you are familiar with the [Red Hat Developer Hub 1.8 configuration docs](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.8/html/configuring_red_hat_developer_hub/index) and [Red Hat Developer Hub 1.8 plugin installation guide](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.8/html/installing_and_viewing_plugins_in_red_hat_developer_hub/index)
+1. Ensure you are familiar with the Red Hat Developer Hub configuration docs and plugin installation guide. This plugin has been tested with RHDH 1.8 and 1.9.
 
    **Additional Resources:**
 
-   - For comprehensive RHDH documentation, visit: [Red Hat Developer Hub 1.8 Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.8/)
+   - [Red Hat Developer Hub 1.9 Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/)
+   - [Red Hat Developer Hub 1.8 Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.8/)
 
 2. The plugin consumes services from [Red Hat Hybrid Cloud Console](https://console.redhat.com/openshift/cost-management) for both OpenShift and Optimizations sections, therefore your clusters [must be configured to access cost management data and optimization recommendations](https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html/integrating_openshift_container_platform_data_into_cost_management/index).
    Copy and save the `CLIENT_ID` & `CLIENT_SECRET` from service account you created earlier with `Cost OpenShift Viewer` role. This will be needed during configuration step below.
@@ -33,7 +34,7 @@ The procedure involves the following steps:
    ```yaml
    # Add to dynamic-plugins-rhdh ConfigMap
 
-   - package: oci://quay.io/redhat-resource-optimization/dynamic-plugins:latest!red-hat-developer-hub-plugin-cost-management
+   - package: oci://quay.io/redhat-resource-optimization/dynamic-plugins:2.0.2!red-hat-developer-hub-plugin-cost-management
      disabled: false
      pluginConfig:
        dynamicPlugins:
@@ -64,7 +65,7 @@ The procedure involves the following steps:
                cost-management.openshift:
                  parent: cost-management
                  priority: 20
-   - package: oci://quay.io/redhat-resource-optimization/dynamic-plugins:latest!red-hat-developer-hub-plugin-cost-management-backend
+   - package: oci://quay.io/redhat-resource-optimization/dynamic-plugins:2.0.2!red-hat-developer-hub-plugin-cost-management-backend
      disabled: false
      pluginConfig:
        costManagement:

--- a/workspaces/cost-management/plugins/cost-management-common/package.json
+++ b/workspaces/cost-management/plugins/cost-management-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/plugin-cost-management-common",
   "description": "Common functionalities for the cost-management plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "backstage": {
     "pluginId": "cost-management",
     "pluginPackages": [

--- a/workspaces/cost-management/plugins/cost-management/package.json
+++ b/workspaces/cost-management/plugins/cost-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-hat-developer-hub/plugin-cost-management",
-  "version": "2.0.3-rc.4",
+  "version": "2.0.2",
   "backstage": {
     "pluginId": "cost-management",
     "pluginPackages": [
@@ -100,6 +100,5 @@
         "package.json"
       ]
     }
-  },
-  "stableVersion": "2.0.1"
+  }
 }


### PR DESCRIPTION
fix(cost-management): set plugin versions to 2.0.2 for Tech Preview release

The frontend version was accidentally bumped to 2.0.3-rc.4 in commit 7b7bab93b (permission fix). This sets all cost-management plugin versions to 2.0.2, which is the first official release of the restructured cost-management plugin (previously redhat-resource-optimization).

OCI images have been published to:
[quay.io/redhat-resource-optimization/dynamic-plugins](https://quay.io/repository/redhat-resource-optimization/dynamic-plugins?tab=tags)

Made-with: Cursor

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
