### PR TITLE
fix(cost-management): bump plugin versions to 2.1.0 for RHDH 1.10 Tech Preview

### DIFF
--- a/workspaces/cost-management/plugins/cost-management-backend/package.json
+++ b/workspaces/cost-management/plugins/cost-management-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-hat-developer-hub/plugin-cost-management-backend",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "backstage": {
     "pluginId": "cost-management",
     "pluginPackages": [

--- a/workspaces/cost-management/plugins/cost-management-common/package.json
+++ b/workspaces/cost-management/plugins/cost-management-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/plugin-cost-management-common",
   "description": "Common functionalities for the cost-management plugin",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "backstage": {
     "pluginId": "cost-management",
     "pluginPackages": [

--- a/workspaces/cost-management/plugins/cost-management/package.json
+++ b/workspaces/cost-management/plugins/cost-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-hat-developer-hub/plugin-cost-management",
-  "version": "2.0.3-rc.4",
+  "version": "2.1.0",
   "backstage": {
     "pluginId": "cost-management",
     "pluginPackages": [
@@ -100,6 +100,5 @@
         "package.json"
       ]
     }
-  },
-  "stableVersion": "2.0.1"
+  }
 }


### PR DESCRIPTION
fix(cost-management): bump plugin versions to 2.1.0 for RHDH 1.10 Tech Preview

Align all cost-management plugin package versions to 2.1.0, targeting RHDH 1.10. This release includes Backstage 1.49.4 upgrade, 8 CVE remediations

OCI images published to quay.io/redhat-resource-optimization/dynamic-plugins:2.1.0

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
