### PR TITLE
feat(coverage): add Codecov integration with per-workspace flags (RHIDP-11862)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,8 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
-          directory: ./workspaces/${{ matrix.workspace }}
+          files: workspaces/${{ matrix.workspace }}/plugins/**/coverage/lcov.info
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,11 @@ jobs:
         run: yarn backstage-cli repo fix --check --publish
 
       - name: test changed packages
+        id: tests
         run: yarn test:all --maxWorkers=3
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
         with:
           flags: ${{ matrix.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
       - name: test changed packages
         run: yarn test:all --maxWorkers=3
 
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        with:
+          flags: ${{ matrix.workspace }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: install playwright
         if: ${{ hashFiles(format('workspaces/{0}/playwright.config.ts', matrix.workspace)) != '' }}
         run: yarn playwright install --with-deps chromium chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
+          directory: ./workspaces/${{ matrix.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -1,0 +1,88 @@
+# Codecov baseline coverage for redhat-developer/rhdh-plugins
+#
+# Feature umbrella: RHDHPLAN-851
+# Epic: RHIDP-11862 — Unit Test Coverage for RHDH Plugins Repository
+#
+# Runs the test suite for every workspace on push to main and uploads
+# coverage to Codecov. This establishes the per-workspace baselines that
+# Codecov uses to calculate coverage deltas in PRs (via carryforward).
+#
+# PR-level coverage is handled by the upload step in ci.yml; this
+# workflow only covers push events so the two never duplicate work.
+
+name: Coverage Baseline
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  list-workspaces:
+    name: Discover workspaces
+    runs-on: ubuntu-latest
+    outputs:
+      workspaces: ${{ steps.list.outputs.workspaces }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: List all workspaces
+        id: list
+        run: |
+          WORKSPACES=$(ls -d workspaces/*/ 2>/dev/null | sed 's|workspaces/||;s|/$||' | grep -v '^\.' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "workspaces=$WORKSPACES" >> "$GITHUB_OUTPUT"
+
+  coverage:
+    name: Coverage — ${{ matrix.workspace }}
+    runs-on: ubuntu-latest
+    needs: list-workspaces
+    strategy:
+      matrix:
+        workspace: ${{ fromJSON(needs.list-workspaces.outputs.workspaces) }}
+      fail-fast: false
+    defaults:
+      run:
+        working-directory: ./workspaces/${{ matrix.workspace }}
+
+    env:
+      CI: true
+      NODE_OPTIONS: --max-old-space-size=8192
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run tests with coverage
+        id: tests
+        run: yarn test:all --maxWorkers=3
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        with:
+          flags: ${{ matrix.workspace }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -84,6 +84,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
-          directory: ./workspaces/${{ matrix.workspace }}
+          files: workspaces/${{ matrix.workspace }}/plugins/**/coverage/lcov.info
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -84,5 +84,6 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
+          directory: ./workspaces/${{ matrix.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -32,7 +32,7 @@ coverage:
         informational: true
 
 comment:
-  layout: "header, diff, flags, components, footer"
+  layout: "header, diff, flags, footer"
   behavior: default
   require_changes: false
   show_carryforward_flags: true
@@ -50,8 +50,8 @@ ignore:
   - "**/build/**"
   - "**/node_modules/**"
   - "**/playwright.config.ts"
-  - "scripts/**"
-  - "docs/**"
+  - "**/scripts/**"
+  - "**/docs/**"
 
 flag_management:
   default_rules:

--- a/codecov.yml
+++ b/codecov.yml
@@ -49,6 +49,7 @@ ignore:
   - "**/dist/**"
   - "**/build/**"
   - "**/node_modules/**"
+  - "**/setupTests.*"
   - "**/playwright.config.ts"
   - "**/scripts/**"
   - "**/docs/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,11 +25,15 @@ coverage:
         threshold: 100%
         informational: true
         only_pulls: false
+        paths:
+          - "workspaces/*/plugins/*/src/**"
     patch:
       default:
         target: auto
         threshold: 100%
         informational: true
+        paths:
+          - "workspaces/*/plugins/*/src/**"
 
 comment:
   layout: "header, diff, flags, footer"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,65 @@
+# Codecov configuration for redhat-developer/rhdh-plugins
+# Reference: https://docs.codecov.com/docs/codecov-yaml
+#
+# Feature umbrella: RHDHPLAN-851
+# Epic: RHIDP-11862 — Unit Test Coverage for RHDH Plugins Repository
+#
+# Each workspace uploads coverage with its own flag (e.g., lightspeed,
+# orchestrator). Flags are created dynamically by the upload step in CI;
+# default_rules apply to all of them automatically.
+
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 100%
+        informational: true
+        only_pulls: false
+    patch:
+      default:
+        target: auto
+        threshold: 100%
+        informational: true
+
+comment:
+  layout: "header, diff, flags, components, footer"
+  behavior: default
+  require_changes: false
+  show_carryforward_flags: true
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/index.ts"
+  - "**/__fixtures__/**"
+  - "**/__tests__/**"
+  - "**/__mocks__/**"
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/node_modules/**"
+  - "**/playwright.config.ts"
+  - "scripts/**"
+  - "docs/**"
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 100%
+      - type: patch
+        target: auto
+        threshold: 100%


### PR DESCRIPTION
## Summary

Adds Codecov coverage upload to the rhdh-plugins repository, following the same pattern established in `redhat-developer/rhdh` (PRs #4678 and #4692).

- **codecov.yml** (new): Codecov project configuration in informational mode (no blocking checks). Uses `default_rules` with carryforward so dynamic per-workspace flags are supported without manual enumeration.
- **ci.yml**: adds a Codecov upload step after the existing `test changed packages` step. Uses `flags: ${{ matrix.workspace }}` so each workspace (lightspeed, orchestrator, bulk-import, etc.) gets its own coverage flag in the Codecov dashboard. Pinned to `codecov-action@v5.5.4` (SHA). Never blocks the workflow (`fail_ci_if_error: false`).
- **coverage-baseline.yml** (new): runs the test suite for every workspace on push to `main` and uploads coverage per workspace. Establishes the project-level baselines for coverage delta calculations in PRs.

Coverage is already being generated — `yarn test:all` includes `--coverage` in all 23 workspaces. This PR adds the upload plumbing so Codecov receives the data.

### Prerequisites (admin actions, not part of this PR)
- [x] Install the [Codecov GitHub App](https://github.com/apps/codecov) on `redhat-developer/rhdh-plugins`
- [x] Provision `CODECOV_TOKEN` as a repository secret

### What this does NOT include
- Progressive coverage thresholds (will be activated after baselines mature)
- Playwright E2E coverage upload (separate concern)

## Jira
- Epic: [RHIDP-11862](https://issues.redhat.com/browse/RHIDP-11862) — Unit Test Coverage for RHDH Plugins Repository
- Feature: [RHDHPLAN-851](https://issues.redhat.com/browse/RHDHPLAN-851)

## Test plan
- [ ] PR CI passes (Codecov upload is informational, won't block)
- [ ] After Codecov App is installed + CODECOV_TOKEN provisioned, verify coverage report appears on a PR
- [ ] After merge, verify baseline upload runs on push to main and populates the dashboard per workspace

Generated with [Claude Code](https://claude.com/claude-code)