### PR TITLE
chore(deps): release-1.8: patch follow-redirects to 1.16.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9262,12 +9262,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
+  checksum: e90dce4607b1f6b8b9883287f912585573c19088209ad82341d550a795b4ba514522b73b1b340cf618279df27975cd46504d09149be60291ba6767384c1fd8f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
it patches follow-redirects to 1.16.0
CVE: https://www.cve.org/CVERecord?id=CVE-2026-40895
JIRA: https://redhat.atlassian.net/browse/RHIDP-13271