### PR TITLE
fix(coverage): use directory instead of files glob for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
-          files: workspaces/${{ matrix.workspace }}/plugins/**/coverage/lcov.info
-          disable_search: true
+          directory: ./workspaces/${{ matrix.workspace }}/plugins
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -84,7 +84,6 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
-          files: workspaces/${{ matrix.workspace }}/plugins/**/coverage/lcov.info
-          disable_search: true
+          directory: ./workspaces/${{ matrix.workspace }}/plugins
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- The `files` parameter with `**` glob + `disable_search: true` does not work — the codecov CLI treats the glob as a literal path, resulting in 0 coverage files found on every workspace
- Switch to `directory: ./workspaces/${{ matrix.workspace }}/plugins` which lets the action search recursively within the plugins directory only (excluding example apps)

**Evidence from baseline run [#25124281753](https://github.com/redhat-developer/rhdh-plugins/actions/runs/25124281753):**
```
warning -- Some files were not found --- {"not_found_files": ["workspaces/lightspeed/plugins/**/coverage/lcov.info"]}
info -- Found 0 coverage files to report
Error: No coverage reports found.
```

## Test plan
- [ ] Merge and verify `Coverage Baseline` workflow uploads successfully
- [ ] Check Codecov dashboard populates at https://app.codecov.io/gh/redhat-developer/rhdh-plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)