### PR TITLE
[RHIDP-13060] harden lightspeed proxy against arbitrary routes

### DIFF
--- a/workspaces/lightspeed/.changeset/brown-rivers-build.md
+++ b/workspaces/lightspeed/.changeset/brown-rivers-build.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
+---
+
+harden proxy passthrough by adding allowlist for routes

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/constant.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/constant.ts
@@ -88,6 +88,8 @@ export const HTTP_STATUS_INTERNAL_ERROR = 500; // Internal server error
 /**
  * Proxy path security - only these LCORE path prefixes may be proxied
  * Avoids authenticated users hitting arbitrary LCORE endpoints
+ * /v1/feedback is here to cover the /feedback/status case as
+ * the exact /v1/feedback has its own handler
  */
 export const ALLOWED_PROXY_PREFIXES = [
   '/v1/models',

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/constant.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/constant.ts
@@ -86,6 +86,26 @@ export const HTTP_STATUS_CONFLICT = 409; // Conflict
 export const HTTP_STATUS_INTERNAL_ERROR = 500; // Internal server error
 
 /**
+ * Proxy path security - only these LCORE path prefixes may be proxied
+ * Avoids authenticated users hitting arbitrary LCORE endpoints
+ */
+export const ALLOWED_PROXY_PREFIXES = [
+  '/v1/models',
+  '/v1/shields',
+  '/v2/conversations',
+  '/v1/feedback',
+];
+
+/**
+ * Paths that bypass the proxy middleware and are handled by dedicated route handlers
+ */
+export const PROXY_PASSTHROUGH_PATHS = [
+  '/v1/query',
+  '/v1/query/interrupt',
+  '/v1/feedback',
+];
+
+/**
  * SSRF Protection - Blocked hostnames for security
  * These hostnames are commonly used for Server-Side Request Forgery attacks
  */

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -744,6 +744,16 @@ describe('lightspeed router tests', () => {
         error: 'Requested path is not available',
       });
     });
+
+    it('should reject dot-segment path traversal attempts', async () => {
+      const backendServer = await startBackendServer();
+      // Express normalizes /v1/models/../admin to /v1/admin before
+      // the request reaches our middleware, so the allowlist rejects it.
+      const response = await request(backendServer).get(
+        '/api/lightspeed/v1/models/../admin',
+      );
+      expect(response.statusCode).toEqual(404);
+    });
   });
 
   describe('POST /v1/query/interrupt', () => {

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -711,6 +711,41 @@ describe('lightspeed router tests', () => {
     });
   });
 
+  describe('proxy path allowlist', () => {
+    it('should return 404 for non-allowlisted path /v1/admin', async () => {
+      const backendServer = await startBackendServer();
+      const response = await request(backendServer).get(
+        '/api/lightspeed/v1/admin',
+      );
+      expect(response.statusCode).toEqual(404);
+      expect(response.body).toEqual({
+        error: 'Requested path is not available',
+      });
+    });
+
+    it('should return 404 for non-allowlisted path /internal/config', async () => {
+      const backendServer = await startBackendServer();
+      const response = await request(backendServer).get(
+        '/api/lightspeed/internal/config',
+      );
+      expect(response.statusCode).toEqual(404);
+      expect(response.body).toEqual({
+        error: 'Requested path is not available',
+      });
+    });
+
+    it('should return 404 for POST to arbitrary path', async () => {
+      const backendServer = await startBackendServer();
+      const response = await request(backendServer)
+        .post('/api/lightspeed/some/arbitrary/path')
+        .send({});
+      expect(response.statusCode).toEqual(404);
+      expect(response.body).toEqual({
+        error: 'Requested path is not available',
+      });
+    });
+  });
+
   describe('POST /v1/query/interrupt', () => {
     it('returns success when interrupt succeeds', async () => {
       const backendServer = await startBackendServer();

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -32,7 +32,10 @@ import {
 
 import { Readable } from 'node:stream';
 
-import { DEFAULT_LIGHTSPEED_SERVICE_PORT } from './constant';
+import {
+  DEFAULT_LIGHTSPEED_SERVICE_PORT,
+  PROXY_PASSTHROUGH_PATHS,
+} from './constant';
 import { McpUserSettingsStore } from './mcp-server-store';
 import {
   McpServerResponse,
@@ -48,7 +51,7 @@ import {
   QueryRequestBody,
   RouterOptions,
 } from './types';
-import { validateCompletionsRequest } from './validation';
+import { isAllowedProxyPath, validateCompletionsRequest } from './validation';
 
 const SKIP_USER_ID_ENDPOINTS = new Set(['/v1/models', '/v1/shields']);
 
@@ -413,19 +416,19 @@ export async function createRouter(
   // ─── Proxy Middleware (existing) ────────────────────────────────────
 
   router.use('/', async (req, res, next) => {
-    const passthroughPaths = [
-      '/v1/query',
-      '/v1/query/interrupt',
-      '/v1/feedback',
-    ];
     // Skip middleware for notebooks routes and specific paths
     if (
       req.path.startsWith('/notebooks') ||
-      passthroughPaths.includes(req.path) ||
+      PROXY_PASSTHROUGH_PATHS.includes(req.path) ||
       req.method === 'PUT'
     ) {
       return next();
     }
+
+    if (!isAllowedProxyPath(req.path)) {
+      return res.status(404).json({ error: 'Requested path is not available' });
+    }
+
     // TODO: parse server_id from req.body and get URL and token when multi-server is supported
     const credentials = await httpAuth.credentials(req);
     const user = await userInfo.getUserInfo(credentials);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isAllowedProxyPath } from './validation';
+
+describe('isAllowedProxyPath', () => {
+  it.each(['/v1/models', '/v1/shields', '/v2/conversations', '/v1/feedback'])(
+    'should allow exact match for %s',
+    path => {
+      expect(isAllowedProxyPath(path)).toBe(true);
+    },
+  );
+
+  it.each([
+    ['/v2/conversations/conv-123', '/v2/conversations'],
+    ['/v1/feedback/status', '/v1/feedback'],
+  ])('should allow sub-path %s under prefix %s', path => {
+    expect(isAllowedProxyPath(path)).toBe(true);
+  });
+
+  it.each([
+    '/v1/admin',
+    '/internal/config',
+    '/metrics',
+    '/v3/something',
+    '/debug',
+    '',
+  ])('should reject arbitrary path %s', path => {
+    expect(isAllowedProxyPath(path)).toBe(false);
+  });
+
+  it.each([
+    '/v1/models-secret',
+    '/v1/shieldsadmin',
+    '/v2/conversationsextra',
+    '/v1/feedbackextra',
+  ])('should reject prefix false match %s', path => {
+    expect(isAllowedProxyPath(path)).toBe(false);
+  });
+});

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/validation.ts
@@ -16,7 +16,14 @@
 
 import type { NextFunction, Request, Response } from 'express';
 
+import { ALLOWED_PROXY_PREFIXES } from './constant';
 import { QueryRequestBody } from './types';
+
+export function isAllowedProxyPath(path: string): boolean {
+  return ALLOWED_PROXY_PREFIXES.some(
+    prefix => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}
 
 export const validateCompletionsRequest = (
   req: Request,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
- Adds an explicit allowlist for routes to restrict authenticated users from hitting arbitrary routes on the LCORE side 
- Moved the pre-existing passthrough routes array to constants

Issue: https://redhat.atlassian.net/browse/RHIDP-13060
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
