### PR TITLE
fix(lightspeed): preserve temp chat mid-stream and scope Stop to active thread

### DIFF
--- a/workspaces/lightspeed/.changeset/selfish-adults-obey.md
+++ b/workspaces/lightspeed/.changeset/selfish-adults-obey.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Fix new chat streams when switching threads and scope Stop to the streaming conversation (RHDHBUGS-3040).

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -835,18 +835,27 @@ export const LightspeedChat = ({
     setNewChatCreated(false);
   };
 
-  const { conversationMessages, handleInputPrompt, scrollToBottomRef } =
-    useConversationMessages(
-      viewConversationId,
-      userName,
-      selectedModel,
-      selectedProvider,
-      avatar,
-      onComplete,
-      onStart,
-      undefined,
-      onRequestIdReady,
-    );
+  const {
+    conversationMessages,
+    handleInputPrompt,
+    scrollToBottomRef,
+    streamingConversationId,
+  } = useConversationMessages(
+    viewConversationId,
+    userName,
+    selectedModel,
+    selectedProvider,
+    avatar,
+    onComplete,
+    onStart,
+    undefined,
+    onRequestIdReady,
+  );
+
+  const streamingUiMatchesView =
+    isSendButtonDisabled &&
+    streamingConversationId !== null &&
+    viewConversationId === streamingConversationId;
 
   const [messages, setMessages] =
     useState<MessageProps[]>(conversationMessages);
@@ -1463,7 +1472,7 @@ export const LightspeedChat = ({
             ref={scrollToBottomRef}
             welcomePrompts={welcomePrompts}
             conversationId={conversationId}
-            isStreaming={isSendButtonDisabled}
+            isStreaming={streamingUiMatchesView}
             topicRestrictionEnabled={topicRestrictionEnabled}
             displayMode={displayMode}
           />
@@ -1487,8 +1496,10 @@ export const LightspeedChat = ({
           hasMicrophoneButton
           value={draftMessage}
           onChange={handleDraftMessage}
-          hasStopButton={isSendButtonDisabled}
-          handleStopButton={isSendButtonDisabled ? handleStopButton : undefined}
+          hasStopButton={streamingUiMatchesView}
+          handleStopButton={
+            streamingUiMatchesView ? handleStopButton : undefined
+          }
           buttonProps={{
             attach: {
               inputTestId: 'attachment-input',

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useConversationMessages.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/__tests__/useConversationMessages.test.tsx
@@ -840,4 +840,91 @@ data: {"event": "token", "data": {"id": 2, "token": ""}}\n
       ).toBeUndefined();
     });
   });
+
+  it('preserves temp thread when switching conversations mid-stream and returning (RHDHBUGS-3040)', async () => {
+    mockLightspeedApi.getConversationMessages.mockResolvedValue([]);
+    const onComplete = jest.fn();
+
+    let resolveSecondRead!: (value: IteratorResult<Uint8Array | null>) => void;
+    const secondReadPromise = new Promise<IteratorResult<Uint8Array | null>>(
+      resolve => {
+        resolveSecondRead = resolve;
+      },
+    );
+
+    const firstChunk = createSSEStream([
+      { event: 'start', data: { conversation_id: 'persisted-after-stream' } },
+      { event: 'token', data: { id: 0, token: 'Hello ', role: 'inference' } },
+    ]);
+    const secondChunk = createSSEStream([
+      { event: 'token', data: { id: 1, token: 'world!', role: 'inference' } },
+    ]);
+
+    const read = jest
+      .fn()
+      .mockResolvedValueOnce({
+        done: false,
+        value: new TextEncoder().encode(firstChunk),
+      })
+      .mockImplementationOnce(() => secondReadPromise)
+      .mockResolvedValueOnce({ done: true, value: null });
+
+    const lightSpeedApi = {
+      ...mockLightspeedApi,
+      createMessage: jest.fn().mockResolvedValue({ read }),
+    };
+    (useApi as jest.Mock).mockReturnValue(lightSpeedApi);
+
+    const { result, rerender } = renderHook(
+      ({ conversationId }) =>
+        useConversationMessages(
+          conversationId,
+          'test-user',
+          'gpt-3',
+          'openai',
+          'user.png',
+          onComplete,
+        ),
+      {
+        initialProps: { conversationId: TEMP_CONVERSATION_ID },
+        wrapper,
+      },
+    );
+
+    await act(async () => {
+      void result.current.handleInputPrompt('Hi');
+    });
+
+    await waitFor(() => {
+      const msgs = result.current.conversations[TEMP_CONVERSATION_ID];
+      expect(msgs?.[1]?.content).toContain('Hello ');
+    });
+
+    expect(result.current.streamingConversationId).toBe(TEMP_CONVERSATION_ID);
+
+    rerender({ conversationId: 'other-conv-id' });
+
+    expect(result.current.streamingConversationId).toBe(TEMP_CONVERSATION_ID);
+
+    rerender({ conversationId: TEMP_CONVERSATION_ID });
+
+    await waitFor(() => {
+      const msgs = result.current.conversations[TEMP_CONVERSATION_ID] ?? [];
+      expect(msgs.length).toBeGreaterThanOrEqual(2);
+      expect(String(msgs[1]?.content ?? '')).toContain('Hello ');
+    });
+
+    await act(async () => {
+      resolveSecondRead({
+        done: false,
+        value: new TextEncoder().encode(secondChunk),
+      });
+    });
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    expect(result.current.streamingConversationId).toBeNull();
+  });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useConversationMessages.ts
@@ -137,6 +137,7 @@ export type UseConversationMessagesReturn = {
   ) => Promise<void>;
   conversations: Conversations;
   scrollToBottomRef: RefObject<ScrollContainerHandle | null>;
+  streamingConversationId: string | null;
   data?: BaseMessage[] | undefined;
   error: Error | null;
   isPending: boolean;
@@ -182,6 +183,13 @@ export const useConversationMessages = (
     [currentConversation]: [],
   });
 
+  /** True while a send on the provisional thread is still running (even if UI switched to another conv). */
+  const isTempStreamInProgressRef = useRef(false);
+
+  const [streamingConversationId, setStreamingConversationId] = useState<
+    string | null
+  >(null);
+
   // Track pending tool calls during streaming
   const pendingToolCalls = useRef<Record<string, ToolCall>>({});
 
@@ -189,8 +197,15 @@ export const useConversationMessages = (
     if (currentConversation !== conversationId) {
       setCurrentConversation(conversationId);
       setConversations(prev => {
-        // Always clear TEMP when switching to it so "New chat" again gets empty messages and correct scroll.
+        // New chat from the nav resets TEMP to []. When returning to a still-streaming temp thread,
+        // keep existing messages so the user sees the full inflight exchange (RHDHBUGS-3040).
         if (conversationId === TEMP_CONVERSATION_ID) {
+          if (
+            isTempStreamInProgressRef.current &&
+            (prev[TEMP_CONVERSATION_ID]?.length ?? 0) > 0
+          ) {
+            return prev;
+          }
           return { ...prev, [TEMP_CONVERSATION_ID]: [] };
         }
         if (prev[conversationId]) return prev;
@@ -261,7 +276,10 @@ export const useConversationMessages = (
         );
       }
 
-      setConversations(_conversations);
+      setConversations(prev => ({
+        ...prev,
+        ..._conversations,
+      }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -275,273 +293,368 @@ export const useConversationMessages = (
 
   const handleInputPrompt = useCallback(
     async (prompt: string, attachments: Attachment[] = []) => {
-      let newConversationId = '';
-      let requestId = '';
-      const toolCallsCacheKeyPrefix =
-        currentConversation === TEMP_CONVERSATION_ID
-          ? createTempToolCallsCacheSessionPrefix()
-          : currentConversation;
-
-      const conversationTuple = [
-        createUserMessage({
-          avatar,
-          name: userName,
-          content: prompt,
-          timestamp: getTimestamp(Date.now()) ?? '',
-        }),
-        createBotMessage({
-          avatar: botAvatar,
-          isLoading: true,
-          name: selectedModel,
-          content: '',
-          timestamp: '',
-        }),
-      ];
-
-      streamingConversations.current = {
-        ...streamingConversations.current,
-        [currentConversation]: conversationTuple,
-      };
-
-      setConversations((prevConv: Conversations) => {
-        return {
-          ...prevConv,
-          [currentConversation]: [
-            ...(prevConv?.[currentConversation] ?? []),
-            ...conversationTuple,
-          ],
-        };
-      });
-
-      setTimeout(() => {
-        scrollToBottomRef.current?.scrollToBottom();
-      }, 0);
-      const finalMessages: string[] = [];
-      let buffer = '';
+      const streamStartedOnTemp = currentConversation === TEMP_CONVERSATION_ID;
+      if (streamStartedOnTemp) {
+        isTempStreamInProgressRef.current = true;
+      }
 
       try {
-        const reader = await createMessage({
-          prompt,
-          selectedModel,
-          selectedProvider,
-          currentConversation,
-          attachments,
+        let newConversationId = '';
+        let requestId = '';
+        setStreamingConversationId(currentConversation);
+
+        const toolCallsCacheKeyPrefix =
+          currentConversation === TEMP_CONVERSATION_ID
+            ? createTempToolCallsCacheSessionPrefix()
+            : currentConversation;
+
+        const conversationTuple = [
+          createUserMessage({
+            avatar,
+            name: userName,
+            content: prompt,
+            timestamp: getTimestamp(Date.now()) ?? '',
+          }),
+          createBotMessage({
+            avatar: botAvatar,
+            isLoading: true,
+            name: selectedModel,
+            content: '',
+            timestamp: '',
+          }),
+        ];
+
+        streamingConversations.current = {
+          ...streamingConversations.current,
+          [currentConversation]: conversationTuple,
+        };
+
+        setConversations((prevConv: Conversations) => {
+          return {
+            ...prevConv,
+            [currentConversation]: [
+              ...(prevConv?.[currentConversation] ?? []),
+              ...conversationTuple,
+            ],
+          };
         });
 
-        const decoder = new TextDecoder('utf-8');
-        let streamEnded = false;
+        setTimeout(() => {
+          scrollToBottomRef.current?.scrollToBottom();
+        }, 0);
+        const finalMessages: string[] = [];
+        let buffer = '';
 
-        while (!streamEnded) {
-          const { value, done } = await reader.read();
-          if (done) {
-            streamEnded = true;
-            break;
-          }
+        try {
+          const reader = await createMessage({
+            prompt,
+            selectedModel,
+            selectedProvider,
+            currentConversation,
+            attachments,
+          });
 
-          buffer += decoder.decode(value, { stream: true });
+          const decoder = new TextDecoder('utf-8');
+          let streamEnded = false;
 
-          // Process all complete messages separated by double newlines
-          const parts = buffer.split('\n\n');
-          buffer = parts.pop()!;
+          while (!streamEnded) {
+            const { value, done } = await reader.read();
+            if (done) {
+              streamEnded = true;
+              break;
+            }
 
-          for (const part of parts) {
-            const lines = part
-              .split('\n')
-              .filter(line => line.startsWith('data:'));
+            buffer += decoder.decode(value, { stream: true });
 
-            const jsonString = lines
-              .map(line => line.trim().slice(5).trim())
-              .join('');
-            try {
-              const { event, data } = JSON.parse(jsonString);
-              if (event === 'start') {
-                requestId = data?.request_id;
-                onRequestIdReady?.(requestId);
+            // Process all complete messages separated by double newlines
+            const parts = buffer.split('\n\n');
+            buffer = parts.pop()!;
 
-                if (currentConversation === TEMP_CONVERSATION_ID) {
-                  // If the conversation is temp, we need to set the new conversation id
-                  newConversationId = data?.conversation_id;
-                }
-              }
+            for (const part of parts) {
+              const lines = part
+                .split('\n')
+                .filter(line => line.startsWith('data:'));
 
-              // Handle tool_call event
-              if (event === 'tool_call') {
-                const toolCallData = data?.token;
-                const legacyObjectCall =
-                  typeof toolCallData === 'object' &&
-                  toolCallData !== null &&
-                  !Array.isArray(toolCallData) &&
-                  (toolCallData as { tool_name?: string }).tool_name;
+              const jsonString = lines
+                .map(line => line.trim().slice(5).trim())
+                .join('');
+              try {
+                const { event, data } = JSON.parse(jsonString);
+                if (event === 'start') {
+                  requestId = data?.request_id;
+                  onRequestIdReady?.(requestId);
 
-                const mcpStyle = isMcpStyleToolCallPayload(data);
-                const rawArgs = data?.args ?? data?.arguments;
-                const mcpArgs: Record<string, any> =
-                  rawArgs &&
-                  typeof rawArgs === 'object' &&
-                  !Array.isArray(rawArgs)
-                    ? rawArgs
-                    : {};
-
-                let toolCall: ToolCall | undefined;
-                // Prefer legacy token object when present (backward compatible)
-                if (legacyObjectCall && data.id !== null) {
-                  toolCall = {
-                    id: data.id,
-                    toolName: (toolCallData as { tool_name: string }).tool_name,
-                    arguments:
-                      (toolCallData as { arguments?: Record<string, any> })
-                        .arguments || {},
-                    startTime: Date.now(),
-                    isLoading: true,
-                  };
-                } else if (mcpStyle) {
-                  toolCall = {
-                    id: data.id,
-                    toolName: data.name.trim(),
-                    description:
-                      typeof data.type === 'string' && data.type !== data.name
-                        ? data.type
-                        : undefined,
-                    arguments: mcpArgs,
-                    startTime: Date.now(),
-                    isLoading: true,
-                  };
-                }
-
-                if (toolCall && data.id !== null) {
-                  const newToolCall: ToolCall = toolCall;
-                  pendingToolCalls.current[toolCallIdKey(data.id)] =
-                    newToolCall;
-
-                  // Update the bot message with the pending tool call
-                  setConversations(prevConversations => {
-                    const conversation =
-                      prevConversations[currentConversation] ?? [];
-                    const lastMessageIndex = conversation.length - 1;
-
-                    if (lastMessageIndex < 0) return prevConversations;
-
-                    const lastMessage = { ...conversation[lastMessageIndex] };
-                    const existingToolCalls = normalizeToolCalls(
-                      lastMessage.toolCalls,
-                    );
-                    const nextToolCalls: ToolCall[] = [
-                      ...existingToolCalls,
-                      newToolCall,
-                    ];
-                    lastMessage.toolCalls = nextToolCalls;
-
-                    // Cache tool calls for this message (message pair index)
-                    const messageIndex = Math.floor(lastMessageIndex / 2);
-                    const cacheKey = `${toolCallsCacheKeyPrefix}-${messageIndex}`;
-                    setSharedToolCallsCache(cacheKey, nextToolCalls);
-
-                    const updatedConversation = [
-                      ...conversation.slice(0, lastMessageIndex),
-                      lastMessage,
-                    ];
-
-                    return {
-                      ...prevConversations,
-                      [currentConversation]: updatedConversation,
-                    };
-                  });
-
-                  // Also update streaming ref
-                  const [humanMessage, aiMessage] =
-                    streamingConversations.current[currentConversation] || [];
-                  if (aiMessage) {
-                    const existingStreamingToolCalls = normalizeToolCalls(
-                      aiMessage.toolCalls,
-                    );
-                    streamingConversations.current[currentConversation] = [
-                      humanMessage,
-                      {
-                        ...aiMessage,
-                        toolCalls: [...existingStreamingToolCalls, newToolCall],
-                      },
-                    ];
+                  if (currentConversation === TEMP_CONVERSATION_ID) {
+                    // If the conversation is temp, we need to set the new conversation id
+                    newConversationId = data?.conversation_id;
                   }
                 }
-              }
 
-              // Handle tool_result event
-              if (event === 'tool_result') {
-                const tokenResult = data?.token;
-                const legacyResult = isLegacyToolResultToken(tokenResult);
+                // Handle tool_call event
+                if (event === 'tool_call') {
+                  const toolCallData = data?.token;
+                  const legacyObjectCall =
+                    typeof toolCallData === 'object' &&
+                    toolCallData !== null &&
+                    !Array.isArray(toolCallData) &&
+                    (toolCallData as { tool_name?: string }).tool_name;
 
-                const mcpHasContent =
-                  data?.id !== null &&
-                  data.content !== undefined &&
-                  !legacyResult;
+                  const mcpStyle = isMcpStyleToolCallPayload(data);
+                  const rawArgs = data?.args ?? data?.arguments;
+                  const mcpArgs: Record<string, any> =
+                    rawArgs &&
+                    typeof rawArgs === 'object' &&
+                    !Array.isArray(rawArgs)
+                      ? rawArgs
+                      : {};
 
-                let responsePayload: string | undefined;
-                let matchToolName: string | undefined;
-                let toolIdKey: string | undefined;
+                  let toolCall: ToolCall | undefined;
+                  // Prefer legacy token object when present (backward compatible)
+                  if (legacyObjectCall && data.id !== null) {
+                    toolCall = {
+                      id: data.id,
+                      toolName: (toolCallData as { tool_name: string })
+                        .tool_name,
+                      arguments:
+                        (toolCallData as { arguments?: Record<string, any> })
+                          .arguments || {},
+                      startTime: Date.now(),
+                      isLoading: true,
+                    };
+                  } else if (mcpStyle) {
+                    toolCall = {
+                      id: data.id,
+                      toolName: data.name.trim(),
+                      description:
+                        typeof data.type === 'string' && data.type !== data.name
+                          ? data.type
+                          : undefined,
+                      arguments: mcpArgs,
+                      startTime: Date.now(),
+                      isLoading: true,
+                    };
+                  }
 
-                if (legacyResult) {
-                  responsePayload = legacyToolResultToString(
-                    tokenResult.response,
-                  );
-                  matchToolName = tokenResult.tool_name;
-                  toolIdKey =
-                    data?.id !== null ? toolCallIdKey(data.id) : undefined;
-                } else if (mcpHasContent) {
-                  toolIdKey = toolCallIdKey(data.id);
-                  responsePayload =
-                    typeof data.content === 'string'
-                      ? data.content
-                      : JSON.stringify(data.content);
+                  if (toolCall && data.id !== null) {
+                    const newToolCall: ToolCall = toolCall;
+                    pendingToolCalls.current[toolCallIdKey(data.id)] =
+                      newToolCall;
+
+                    // Update the bot message with the pending tool call
+                    setConversations(prevConversations => {
+                      const conversation =
+                        prevConversations[currentConversation] ?? [];
+                      const lastMessageIndex = conversation.length - 1;
+
+                      if (lastMessageIndex < 0) return prevConversations;
+
+                      const lastMessage = { ...conversation[lastMessageIndex] };
+                      const existingToolCalls = normalizeToolCalls(
+                        lastMessage.toolCalls,
+                      );
+                      const nextToolCalls: ToolCall[] = [
+                        ...existingToolCalls,
+                        newToolCall,
+                      ];
+                      lastMessage.toolCalls = nextToolCalls;
+
+                      // Cache tool calls for this message (message pair index)
+                      const messageIndex = Math.floor(lastMessageIndex / 2);
+                      const cacheKey = `${toolCallsCacheKeyPrefix}-${messageIndex}`;
+                      setSharedToolCallsCache(cacheKey, nextToolCalls);
+
+                      const updatedConversation = [
+                        ...conversation.slice(0, lastMessageIndex),
+                        lastMessage,
+                      ];
+
+                      return {
+                        ...prevConversations,
+                        [currentConversation]: updatedConversation,
+                      };
+                    });
+
+                    // Also update streaming ref
+                    const [humanMessage, aiMessage] =
+                      streamingConversations.current[currentConversation] || [];
+                    if (aiMessage) {
+                      const existingStreamingToolCalls = normalizeToolCalls(
+                        aiMessage.toolCalls,
+                      );
+                      streamingConversations.current[currentConversation] = [
+                        humanMessage,
+                        {
+                          ...aiMessage,
+                          toolCalls: [
+                            ...existingStreamingToolCalls,
+                            newToolCall,
+                          ],
+                        },
+                      ];
+                    }
+                  }
+                }
+
+                // Handle tool_result event
+                if (event === 'tool_result') {
+                  const tokenResult = data?.token;
+                  const legacyResult = isLegacyToolResultToken(tokenResult);
+
+                  const mcpHasContent =
+                    data?.id !== null &&
+                    data.content !== undefined &&
+                    !legacyResult;
+
+                  let responsePayload: string | undefined;
+                  let matchToolName: string | undefined;
+                  let toolIdKey: string | undefined;
+
+                  if (legacyResult) {
+                    responsePayload = legacyToolResultToString(
+                      tokenResult.response,
+                    );
+                    matchToolName = tokenResult.tool_name;
+                    toolIdKey =
+                      data?.id !== null ? toolCallIdKey(data.id) : undefined;
+                  } else if (mcpHasContent) {
+                    toolIdKey = toolCallIdKey(data.id);
+                    responsePayload =
+                      typeof data.content === 'string'
+                        ? data.content
+                        : JSON.stringify(data.content);
+                    if (
+                      typeof data.status === 'string' &&
+                      data.status !== 'success'
+                    ) {
+                      responsePayload = `[${data.status}] ${responsePayload}`;
+                    }
+                  }
+
                   if (
-                    typeof data.status === 'string' &&
-                    data.status !== 'success'
+                    responsePayload !== undefined &&
+                    toolIdKey !== undefined
                   ) {
-                    responsePayload = `[${data.status}] ${responsePayload}`;
+                    const pendingCall = pendingToolCalls.current[toolIdKey];
+                    const endTime = Date.now();
+                    const executionTime = pendingCall
+                      ? (endTime - pendingCall.startTime) / 1000
+                      : 0;
+
+                    // Update the tool call with result
+                    setConversations(prevConversations => {
+                      const conversation =
+                        prevConversations[currentConversation] ?? [];
+                      const lastMessageIndex = conversation.length - 1;
+
+                      if (lastMessageIndex < 0) return prevConversations;
+
+                      const lastMessage = { ...conversation[lastMessageIndex] };
+                      const toolCalls = lastMessage.toolCalls || [];
+
+                      // Find and update the matching tool call
+                      const updatedToolCalls = toolCalls.map(tc => {
+                        const idMatches =
+                          toolCallIdKey(tc.id) === toolIdKey ||
+                          (matchToolName !== undefined &&
+                            tc.toolName === matchToolName);
+                        if (idMatches) {
+                          return {
+                            ...tc,
+                            response: responsePayload,
+                            endTime,
+                            executionTime,
+                            isLoading: false,
+                          };
+                        }
+                        return tc;
+                      });
+
+                      lastMessage.toolCalls = updatedToolCalls;
+
+                      // Update cache with completed tool call
+                      const messageIndex = Math.floor(lastMessageIndex / 2);
+                      const cacheKey = `${toolCallsCacheKeyPrefix}-${messageIndex}`;
+                      setSharedToolCallsCache(cacheKey, updatedToolCalls);
+
+                      const updatedConversation = [
+                        ...conversation.slice(0, lastMessageIndex),
+                        lastMessage,
+                      ];
+
+                      return {
+                        ...prevConversations,
+                        [currentConversation]: updatedConversation,
+                      };
+                    });
+
+                    // Also update streaming ref
+                    const [humanMessage, aiMessage] =
+                      streamingConversations.current[currentConversation] || [];
+                    if (aiMessage) {
+                      const toolCalls = aiMessage.toolCalls || [];
+                      const updatedToolCalls = toolCalls.map(tc => {
+                        const idMatches =
+                          toolCallIdKey(tc.id) === toolIdKey ||
+                          (matchToolName !== undefined &&
+                            tc.toolName === matchToolName);
+                        if (idMatches) {
+                          return {
+                            ...tc,
+                            response: responsePayload,
+                            endTime,
+                            executionTime,
+                            isLoading: false,
+                          };
+                        }
+                        return tc;
+                      });
+                      streamingConversations.current[currentConversation] = [
+                        humanMessage,
+                        { ...aiMessage, toolCalls: updatedToolCalls },
+                      ];
+                    }
+
+                    // Clean up pending tool call
+                    delete pendingToolCalls.current[toolIdKey];
                   }
                 }
 
-                if (responsePayload !== undefined && toolIdKey !== undefined) {
-                  const pendingCall = pendingToolCalls.current[toolIdKey];
-                  const endTime = Date.now();
-                  const executionTime = pendingCall
-                    ? (endTime - pendingCall.startTime) / 1000
-                    : 0;
+                if (event === 'token') {
+                  const content = data?.token || '';
 
-                  // Update the tool call with result
+                  finalMessages.push(content);
+
+                  // Store streaming message
+                  const [humanMessage, aiMessage] =
+                    streamingConversations.current[currentConversation];
+                  streamingConversations.current[currentConversation] = [
+                    humanMessage,
+                    { ...aiMessage, content: aiMessage.content + content },
+                  ];
+
                   setConversations(prevConversations => {
                     const conversation =
                       prevConversations[currentConversation] ?? [];
+
                     const lastMessageIndex = conversation.length - 1;
+                    const lastMessage =
+                      conversation.length === 0
+                        ? createBotMessage({
+                            content: '',
+                            timestamp: getTimestamp(Date.now()),
+                          })
+                        : { ...conversation[lastMessageIndex] };
 
-                    if (lastMessageIndex < 0) return prevConversations;
-
-                    const lastMessage = { ...conversation[lastMessageIndex] };
-                    const toolCalls = lastMessage.toolCalls || [];
-
-                    // Find and update the matching tool call
-                    const updatedToolCalls = toolCalls.map(tc => {
-                      const idMatches =
-                        toolCallIdKey(tc.id) === toolIdKey ||
-                        (matchToolName !== undefined &&
-                          tc.toolName === matchToolName);
-                      if (idMatches) {
-                        return {
-                          ...tc,
-                          response: responsePayload,
-                          endTime,
-                          executionTime,
-                          isLoading: false,
-                        };
-                      }
-                      return tc;
-                    });
-
-                    lastMessage.toolCalls = updatedToolCalls;
-
-                    // Update cache with completed tool call
-                    const messageIndex = Math.floor(lastMessageIndex / 2);
-                    const cacheKey = `${toolCallsCacheKeyPrefix}-${messageIndex}`;
-                    setSharedToolCallsCache(cacheKey, updatedToolCalls);
+                    if ((lastMessage?.content ?? '').trim().length > 0) {
+                      lastMessage.isLoading = false;
+                    }
+                    lastMessage.content += content;
+                    lastMessage.name =
+                      data?.response_metadata?.model || selectedModel;
+                    lastMessage.timestamp = getTimestamp(
+                      // TODO: To be fixed in the query response
+                      data?.response_metadata?.created_at || Date.now(),
+                    );
 
                     const updatedConversation = [
                       ...conversation.slice(0, lastMessageIndex),
@@ -553,234 +666,166 @@ export const useConversationMessages = (
                       [currentConversation]: updatedConversation,
                     };
                   });
+                }
 
-                  // Also update streaming ref
-                  const [humanMessage, aiMessage] =
-                    streamingConversations.current[currentConversation] || [];
-                  if (aiMessage) {
-                    const toolCalls = aiMessage.toolCalls || [];
-                    const updatedToolCalls = toolCalls.map(tc => {
-                      const idMatches =
-                        toolCallIdKey(tc.id) === toolIdKey ||
-                        (matchToolName !== undefined &&
-                          tc.toolName === matchToolName);
-                      if (idMatches) {
-                        return {
-                          ...tc,
-                          response: responsePayload,
-                          endTime,
-                          executionTime,
-                          isLoading: false,
-                        };
-                      }
-                      return tc;
-                    });
-                    streamingConversations.current[currentConversation] = [
-                      humanMessage,
-                      { ...aiMessage, toolCalls: updatedToolCalls },
+                if (event === 'interrupted') {
+                  if (
+                    currentConversation === TEMP_CONVERSATION_ID &&
+                    data?.conversation_id
+                  ) {
+                    newConversationId = data.conversation_id;
+                  }
+                  setConversations(prevConversations => {
+                    const conversation =
+                      prevConversations[currentConversation] ?? [];
+                    const lastMessageIndex = conversation.length - 1;
+                    const lastMessage =
+                      conversation.length === 0
+                        ? createBotMessage({
+                            content: '',
+                            isLoading: false,
+                            timestamp: getTimestamp(Date.now()),
+                          })
+                        : {
+                            ...conversation[lastMessageIndex],
+                            isLoading: false,
+                          };
+                    const updatedConversation = [
+                      ...conversation.slice(0, lastMessageIndex),
+                      lastMessage,
                     ];
-                  }
-
-                  // Clean up pending tool call
-                  delete pendingToolCalls.current[toolIdKey];
-                }
-              }
-
-              if (event === 'token') {
-                const content = data?.token || '';
-
-                finalMessages.push(content);
-
-                // Store streaming message
-                const [humanMessage, aiMessage] =
-                  streamingConversations.current[currentConversation];
-                streamingConversations.current[currentConversation] = [
-                  humanMessage,
-                  { ...aiMessage, content: aiMessage.content + content },
-                ];
-
-                setConversations(prevConversations => {
-                  const conversation =
-                    prevConversations[currentConversation] ?? [];
-
-                  const lastMessageIndex = conversation.length - 1;
-                  const lastMessage =
-                    conversation.length === 0
-                      ? createBotMessage({
-                          content: '',
-                          timestamp: getTimestamp(Date.now()),
-                        })
-                      : { ...conversation[lastMessageIndex] };
-
-                  if ((lastMessage?.content ?? '').trim().length > 0) {
-                    lastMessage.isLoading = false;
-                  }
-                  lastMessage.content += content;
-                  lastMessage.name =
-                    data?.response_metadata?.model || selectedModel;
-                  lastMessage.timestamp = getTimestamp(
-                    // TODO: To be fixed in the query response
-                    data?.response_metadata?.created_at || Date.now(),
-                  );
-
-                  const updatedConversation = [
-                    ...conversation.slice(0, lastMessageIndex),
-                    lastMessage,
-                  ];
-
-                  return {
-                    ...prevConversations,
-                    [currentConversation]: updatedConversation,
-                  };
-                });
-              }
-
-              if (event === 'interrupted') {
-                if (
-                  currentConversation === TEMP_CONVERSATION_ID &&
-                  data?.conversation_id
-                ) {
-                  newConversationId = data.conversation_id;
-                }
-                setConversations(prevConversations => {
-                  const conversation =
-                    prevConversations[currentConversation] ?? [];
-                  const lastMessageIndex = conversation.length - 1;
-                  const lastMessage =
-                    conversation.length === 0
-                      ? createBotMessage({
-                          content: '',
-                          isLoading: false,
-                          timestamp: getTimestamp(Date.now()),
-                        })
-                      : { ...conversation[lastMessageIndex], isLoading: false };
-                  const updatedConversation = [
-                    ...conversation.slice(0, lastMessageIndex),
-                    lastMessage,
-                  ];
-                  return {
-                    ...prevConversations,
-                    [currentConversation]: updatedConversation,
-                  };
-                });
-                streamEnded = true;
-                break;
-              }
-
-              if (event === 'end') {
-                const documents = data?.referenced_documents || [];
-
-                setConversations(prevConversations => {
-                  const conversation =
-                    prevConversations[currentConversation] ?? [];
-
-                  const lastMessageIndex = conversation.length - 1;
-                  const lastMessage =
-                    conversation.length === 0
-                      ? createBotMessage({
-                          content: '',
-                          isLoading: false,
-                          timestamp: getTimestamp(Date.now()),
-                        })
-                      : { ...conversation[lastMessageIndex], isLoading: false };
-
-                  if (documents.length) {
-                    lastMessage.sources = {
-                      sources: documents.map((doc: ReferencedDocument) => ({
-                        title: doc.doc_title,
-                        link: doc.doc_url,
-                        body: doc.doc_description,
-                      })),
+                    return {
+                      ...prevConversations,
+                      [currentConversation]: updatedConversation,
                     };
-                  }
+                  });
+                  streamEnded = true;
+                  break;
+                }
 
-                  const updatedConversation = [
-                    ...conversation.slice(0, lastMessageIndex),
-                    lastMessage,
-                  ];
+                if (event === 'end') {
+                  const documents = data?.referenced_documents || [];
 
-                  return {
-                    ...prevConversations,
-                    [currentConversation]: updatedConversation,
-                  };
-                });
-              }
-            } catch (error) {
-              // eslint-disable-next-line no-console
-              console.warn('Error parsing JSON:', error);
-              if (typeof onComplete === 'function') {
-                onComplete('Invalid JSON received');
+                  setConversations(prevConversations => {
+                    const conversation =
+                      prevConversations[currentConversation] ?? [];
+
+                    const lastMessageIndex = conversation.length - 1;
+                    const lastMessage =
+                      conversation.length === 0
+                        ? createBotMessage({
+                            content: '',
+                            isLoading: false,
+                            timestamp: getTimestamp(Date.now()),
+                          })
+                        : {
+                            ...conversation[lastMessageIndex],
+                            isLoading: false,
+                          };
+
+                    if (documents.length) {
+                      lastMessage.sources = {
+                        sources: documents.map((doc: ReferencedDocument) => ({
+                          title: doc.doc_title,
+                          link: doc.doc_url,
+                          body: doc.doc_description,
+                        })),
+                      };
+                    }
+
+                    const updatedConversation = [
+                      ...conversation.slice(0, lastMessageIndex),
+                      lastMessage,
+                    ];
+
+                    return {
+                      ...prevConversations,
+                      [currentConversation]: updatedConversation,
+                    };
+                  });
+                }
+              } catch (error) {
+                // eslint-disable-next-line no-console
+                console.warn('Error parsing JSON:', error);
+                if (typeof onComplete === 'function') {
+                  onComplete('Invalid JSON received');
+                }
               }
             }
+            if (streamEnded) break;
           }
-          if (streamEnded) break;
-        }
-      } catch (e) {
-        setConversations(prevConversations => {
-          const conversation = prevConversations[currentConversation] ?? [];
+        } catch (e) {
+          setConversations(prevConversations => {
+            const conversation = prevConversations[currentConversation] ?? [];
 
-          const lastMessageIndex = conversation.length - 1;
-          const lastMessage =
-            conversation.length === 0
-              ? createBotMessage({
-                  content: '',
-                  timestamp: getTimestamp(Date.now()),
-                })
-              : { ...conversation[lastMessageIndex] };
+            const lastMessageIndex = conversation.length - 1;
+            const lastMessage =
+              conversation.length === 0
+                ? createBotMessage({
+                    content: '',
+                    timestamp: getTimestamp(Date.now()),
+                  })
+                : { ...conversation[lastMessageIndex] };
 
-          lastMessage.isLoading = false;
-          lastMessage.content += e;
-          lastMessage.error = {
-            title: e.message,
-          };
-          lastMessage.timestamp = getTimestamp(Date.now());
+            lastMessage.isLoading = false;
+            lastMessage.content += e;
+            lastMessage.error = {
+              title: e.message,
+            };
+            lastMessage.timestamp = getTimestamp(Date.now());
 
-          const updatedConversation = [
-            ...conversation.slice(0, lastMessageIndex),
-            lastMessage,
-          ];
+            const updatedConversation = [
+              ...conversation.slice(0, lastMessageIndex),
+              lastMessage,
+            ];
 
-          finalMessages.push(`${e}`);
+            finalMessages.push(`${e}`);
 
-          return {
-            ...prevConversations,
-            [newConversationId.length > 0
-              ? newConversationId
-              : currentConversation]: updatedConversation,
-          };
-        });
-      }
-      // reset current streaming
-      streamingConversations.current[currentConversation] = [];
-      if (typeof onComplete === 'function') {
-        onComplete(finalMessages.join(''));
-      }
-      // Swap temp conversation messages with new conversation
-
-      if (currentConversation === TEMP_CONVERSATION_ID && newConversationId) {
-        migrateSharedToolCallsCacheSessionPrefixToConversation(
-          toolCallsCacheKeyPrefix,
-          newConversationId,
-        );
-
-        setConversations(prevConversations => {
-          return {
-            ...prevConversations,
-            [newConversationId]: prevConversations[TEMP_CONVERSATION_ID],
-          };
-        });
-
-        onStart?.(newConversationId);
-
-        // Defer removal so it runs after the sync useEffect updates currentConversation.
-        setTimeout(() => {
-          setConversations(prev => {
-            const { [TEMP_CONVERSATION_ID]: _, ...rest } = prev;
-            return rest;
+            return {
+              ...prevConversations,
+              [newConversationId.length > 0
+                ? newConversationId
+                : currentConversation]: updatedConversation,
+            };
           });
-        }, 0);
-      } else if (currentConversation === TEMP_CONVERSATION_ID) {
-        clearSharedToolCallsCacheSessionPrefix(toolCallsCacheKeyPrefix);
+        }
+        // reset current streaming
+        streamingConversations.current[currentConversation] = [];
+        if (typeof onComplete === 'function') {
+          onComplete(finalMessages.join(''));
+        }
+        // Swap temp conversation messages with new conversation
+
+        if (currentConversation === TEMP_CONVERSATION_ID && newConversationId) {
+          migrateSharedToolCallsCacheSessionPrefixToConversation(
+            toolCallsCacheKeyPrefix,
+            newConversationId,
+          );
+
+          setConversations(prevConversations => {
+            return {
+              ...prevConversations,
+              [newConversationId]: prevConversations[TEMP_CONVERSATION_ID],
+            };
+          });
+
+          onStart?.(newConversationId);
+
+          // Defer removal so it runs after the sync useEffect updates currentConversation.
+          setTimeout(() => {
+            setConversations(prev => {
+              const { [TEMP_CONVERSATION_ID]: _, ...rest } = prev;
+              return rest;
+            });
+          }, 0);
+        } else if (currentConversation === TEMP_CONVERSATION_ID) {
+          clearSharedToolCallsCacheSessionPrefix(toolCallsCacheKeyPrefix);
+        }
+      } finally {
+        if (streamStartedOnTemp) {
+          isTempStreamInProgressRef.current = false;
+        }
+        setStreamingConversationId(null);
       }
     },
 
@@ -802,6 +847,7 @@ export const useConversationMessages = (
     handleInputPrompt,
     conversations,
     scrollToBottomRef,
+    streamingConversationId,
     ...queryProps,
   };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!


https://redhat.atlassian.net/browse/RHDHBUGS-3040


Fixes chat behavior when a **new chat thread** is still streaming: switching to another conversation and returning via **New chat** no longer loses the in-flight exchange or shows a broken partial message. Also limits the **Stop** control and streaming UI to the conversation that actually owns the active stream.


## Screenshots:

**Before:**
<img width="1916" height="932" alt="incomplete_streaming" src="https://github.com/user-attachments/assets/5800c5d9-4437-4ce8-a322-4393e5b62de9" />

**After:**


https://github.com/user-attachments/assets/3636db7c-1b53-48a3-94d4-0eaf09739277



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

