### PR TITLE
fix(coverage): scope Codecov flags to workspace paths and harden jest-junit install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,9 @@ jobs:
         run: yarn backstage-cli repo fix --check --publish
 
       - name: Install jest-junit reporter
-        run: npm install jest-junit@17.0.0 --prefix ${{ runner.temp }}/jest-junit
+        run: |
+          npm install jest-junit@17.0.0 --ignore-scripts --prefix ${{ runner.temp }}/jest-junit
+          mkdir -p ${{ runner.temp }}/test-results/${{ matrix.workspace }}
 
       - name: Test changed packages
         id: tests

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -76,7 +76,9 @@ jobs:
         run: yarn install --immutable
 
       - name: Install jest-junit reporter
-        run: npm install jest-junit@17.0.0 --prefix ${{ runner.temp }}/jest-junit
+        run: |
+          npm install jest-junit@17.0.0 --ignore-scripts --prefix ${{ runner.temp }}/jest-junit
+          mkdir -p ${{ runner.temp }}/test-results/${{ matrix.workspace }}
 
       - name: Run tests with coverage
         id: tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,8 @@
 # Epic: RHIDP-11862 — Unit Test Coverage for RHDH Plugins Repository
 #
 # Each workspace uploads coverage with its own flag (e.g., lightspeed,
-# orchestrator). Flags are created dynamically by the upload step in CI;
-# default_rules apply to all of them automatically.
+# orchestrator). individual_flags scope each flag to its workspace path
+# so the Flags page shows per-workspace coverage correctly.
 
 codecov:
   require_ci_to_pass: false
@@ -68,3 +68,70 @@ flag_management:
       - type: patch
         target: auto
         threshold: 100%
+  individual_flags:
+    - name: adoption-insights
+      paths:
+        - workspaces/adoption-insights/
+    - name: ai-integrations
+      paths:
+        - workspaces/ai-integrations/
+    - name: app-defaults
+      paths:
+        - workspaces/app-defaults/
+    - name: augment
+      paths:
+        - workspaces/augment/
+    - name: bulk-import
+      paths:
+        - workspaces/bulk-import/
+    - name: cost-management
+      paths:
+        - workspaces/cost-management/
+    - name: dcm
+      paths:
+        - workspaces/dcm/
+    - name: extensions
+      paths:
+        - workspaces/extensions/
+    - name: global-floating-action-button
+      paths:
+        - workspaces/global-floating-action-button/
+    - name: global-header
+      paths:
+        - workspaces/global-header/
+    - name: homepage
+      paths:
+        - workspaces/homepage/
+    - name: konflux
+      paths:
+        - workspaces/konflux/
+    - name: lightspeed
+      paths:
+        - workspaces/lightspeed/
+    - name: mcp-integrations
+      paths:
+        - workspaces/mcp-integrations/
+    - name: orchestrator
+      paths:
+        - workspaces/orchestrator/
+    - name: quickstart
+      paths:
+        - workspaces/quickstart/
+    - name: repo-tools
+      paths:
+        - workspaces/repo-tools/
+    - name: sandbox
+      paths:
+        - workspaces/sandbox/
+    - name: scorecard
+      paths:
+        - workspaces/scorecard/
+    - name: theme
+      paths:
+        - workspaces/theme/
+    - name: translations
+      paths:
+        - workspaces/translations/
+    - name: x2a
+      paths:
+        - workspaces/x2a/


### PR DESCRIPTION
## Summary
- Adds `individual_flags` with `paths` to `codecov.yml` so each workspace flag only covers its own files
- Adds `--ignore-scripts` to `jest-junit` install for supply-chain hardening
- Pre-creates test output directories with `mkdir -p`

## Problem
Without `paths` in `flag_management`, `carryforward: true` caused every flag to contain coverage data from **all** workspaces (2005 files instead of ~100-150 per workspace). The Codecov Flags page showed "No report uploaded" for all flags because it couldn't compute meaningful per-flag coverage.

## How it works
Each flag now has an explicit `paths` entry scoping it to `workspaces/<name>/`. When Codecov processes a flag-tagged upload, it only considers files under that workspace directory, giving accurate per-workspace coverage on the Flags page.

## Jira
- Feature: RHDHPLAN-851
- Epic: RHIDP-11862

## Test plan
- [ ] CI passes with the updated jest-junit install
- [ ] After merge and baseline run, Codecov Flags page shows per-workspace coverage instead of "No report uploaded"
- [ ] Coverage percentages on the Flags page match expected per-workspace values

🤖 Generated with [Claude Code](https://claude.com/claude-code)