### PR TITLE
release-1.9: fix types errors in orchestrator for widgets plugin

### DIFF
--- a/workspaces/orchestrator/.changeset/warm-coins-speak.md
+++ b/workspaces/orchestrator/.changeset/warm-coins-speak.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Fix type errors in orchestrator form widgets

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/safeSet.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/safeSet.test.ts
@@ -17,7 +17,7 @@
 import { ERRORS_KEY } from '@rjsf/utils';
 
 import { safeSet } from './safeSet';
-import { JsonObject } from '@backstage/types/index';
+import { JsonObject } from '@backstage/types';
 
 describe('safeSet', () => {
   it('splits only on the first dot so deep paths (e.g. step.x.y) are not truncated', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Fixes:

https://redhat.atlassian.net/browse/RHDHBUGS-3061

Replace`import … from '@backstage/types/index'` with `import … from '@backstage/types'`. The /index subpath isn’t exposed in the package exports, so strict CI resolution failed while local checks could still pass.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
