### PR TITLE
fix(global-header): close help dropdown when selecting Quick Start menu item

### DIFF
--- a/workspaces/global-header/.changeset/tasty-teachers-attend.md
+++ b/workspaces/global-header/.changeset/tasty-teachers-attend.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Fix help dropdown not closing when selecting Quick Start menu item.

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HelpDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HelpDropdown.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useMemo, useRef } from 'react';
 import type { ComponentType, CSSProperties } from 'react';
+import type { MenuItemProps } from '@mui/material/MenuItem';
 import { HeaderDropdownComponent } from './HeaderDropdownComponent';
 import { useDropdownManager } from '../../hooks';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
@@ -25,6 +26,7 @@ import { DropdownEmptyState } from './DropdownEmptyState';
 import SupportAgentIcon from '@mui/icons-material/SupportAgent';
 import { useValidComponentTracker } from '../../hooks/useValidComponentTracker';
 import { useTranslation } from '../../hooks/useTranslation';
+import type { MenuItemLinkProps } from '../MenuItemLink/MenuItemLink';
 
 /**
  * @public
@@ -102,14 +104,17 @@ export const HelpDropdown = ({ layout }: HelpDropdownProps) => {
 
         return {
           componentId,
-          Component: () => (
-            <ValidityTracker
-              Component={mp.Component}
-              props={mp.config?.props || {}}
-              componentId={componentId}
-              onValidityChange={updateComponentValidity}
-            />
-          ),
+          Component: (props: MenuItemLinkProps | MenuItemProps | {}) => {
+            const onClick = 'onClick' in props ? props.onClick : undefined;
+            return (
+              <ValidityTracker
+                Component={mp.Component}
+                props={{ ...(mp.config?.props || {}), onClick }}
+                componentId={componentId}
+                onValidityChange={updateComponentValidity}
+              />
+            );
+          },
           icon: mp.config?.props?.icon,
           label: mp.config?.props?.title,
           link: mp.config?.props?.link,


### PR DESCRIPTION
## Summary
- Fix help dropdown not closing when selecting Quick Start menu item or other mounted components


## Fixed
- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-2891


## Root Cause
The `HelpDropdown` component wraps menu items in a `ValidityTracker` but wasn't forwarding the `onClick` callback passed by `MenuSection`. When `MenuSection` renders menu items, it passes `onClick={handleClose}` to close the dropdown, but this prop was being ignored.


## UI before changes


https://github.com/user-attachments/assets/039a2049-6b3f-445c-b87c-80572fa383ad

## UI after changes

https://github.com/user-attachments/assets/48e1cbaf-4600-47f1-adc1-18b885d47d70


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
