### PR TITLE
test(lightspeed): add Playwright e2e for notebooks

### DIFF
--- a/workspaces/lightspeed/app-config.yaml
+++ b/workspaces/lightspeed/app-config.yaml
@@ -16,13 +16,12 @@ app:
 organization:
   name: Red Hat
 
-# Disable AI Notebooks feature by default
 lightspeed:
   notebooks:
-    enabled: false
+    enabled: true
     queryDefaults:
-      model: ${NOTEBOOKS_QUERY_MODEL}
-      provider_id: ${NOTEBOOKS_QUERY_PROVIDER_ID}
+      model: llama3.2:3b
+      provider_id: vllm
 
 backend:
   # Used for enabling authentication, secret is shared by all backend plugins

--- a/workspaces/lightspeed/e2e-tests/fixtures/responses.ts
+++ b/workspaces/lightspeed/e2e-tests/fixtures/responses.ts
@@ -15,6 +15,7 @@
  */
 
 export const modelBaseUrl = '*/**/api/lightspeed';
+
 export const createdAt = Date.now();
 
 export const models = [
@@ -147,6 +148,84 @@ export const demoChatContent = [
 ];
 
 export const botResponse = `This is a placeholder message`;
+
+/** Stable conversation id aligned with seeded `chat_history` for notebook-tab e2e. */
+export const NOTEBOOK_E2E_RAG_CONVERSATION_ID =
+  '98f24095a40b95ce4d929bbee4aeb26759275bc7b0a5791e';
+
+/** Assistant message body built from {@link notebookRagConversationChatHistoryForUploadTitle} (assertions + clipboard). */
+export function notebookRagConversationAssistantPlainTextForUploadTitle(
+  uploadDocumentTitle: string,
+): string {
+  return `E2E summary: ${uploadDocumentTitle} describes an uploaded fixture. [${uploadDocumentTitle}]`;
+}
+
+/** User bubble text in {@link notebookRagConversationChatHistoryForUploadTitle} (assert in notebook conversation e2e). */
+export function notebookRagConversationUserPromptForUploadTitle(
+  uploadDocumentTitle: string,
+): string {
+  return `Tell me about ${uploadDocumentTitle} in one line.`;
+}
+
+/**
+ * One `chat_history` entry as returned by `GET /v2/conversations/:id` (notebook RAG + referenced_documents).
+ * `uploadDocumentTitle` must match an attached notebook document basename (e.g. {@link localeNotebookUpload1Path}).
+ */
+export function notebookRagConversationChatHistoryForUploadTitle(
+  uploadDocumentTitle: string,
+): Record<string, unknown>[] {
+  const userPrompt =
+    notebookRagConversationUserPromptForUploadTitle(uploadDocumentTitle);
+  const assistantText =
+    notebookRagConversationAssistantPlainTextForUploadTitle(
+      uploadDocumentTitle,
+    );
+  return [
+    {
+      provider: 'vllm',
+      model: 'llama3.2:3b',
+      messages: [
+        {
+          content: userPrompt,
+          type: 'user',
+          referenced_documents: null,
+        },
+        {
+          content: assistantText,
+          type: 'assistant',
+          referenced_documents: [
+            {
+              doc_url: null,
+              doc_title: uploadDocumentTitle,
+              source: 'vs_e2e_notebook_rag',
+            },
+          ],
+        },
+      ],
+      tool_calls: [
+        {
+          id: 'fc_e2e_notebook_file_search',
+          name: 'file_search',
+          args: {
+            queries: [uploadDocumentTitle.replace(/\.[^.]+$/, '')],
+          },
+          type: 'file_search_call',
+        },
+      ],
+      tool_results: [
+        {
+          id: 'fc_e2e_notebook_file_search',
+          status: 'completed',
+          content: JSON.stringify({ results: [] }),
+          type: 'file_search_call',
+          round: 1,
+        },
+      ],
+      started_at: '2026-05-04T12:08:13Z',
+      completed_at: '2026-05-04T12:08:26Z',
+    },
+  ];
+}
 
 /** SSE `start.request_id` in {@link generateQueryResponse}. */
 const mockStreamRequestId = '0e3c4cd7-2817-4c34-91a2-6944550364df';

--- a/workspaces/lightspeed/e2e-tests/lightspeed.conversation.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.conversation.test.ts
@@ -129,8 +129,7 @@ test.describe('Lightspeed conversation', () => {
       await assertClipboardContains(sharedPage, botResponse);
     });
 
-    // Remove skip once the NewChat button's functionality is fixed
-    test.skip('Conversation is created and shown in side panel', async () => {
+    test('Conversation is created and shown in side panel', async () => {
       await sendMessage('test', sharedPage, translations);
       await verifySidePanelConversation(sharedPage, translations);
     });

--- a/workspaces/lightspeed/e2e-tests/lightspeed.notebooks.conversation.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.notebooks.conversation.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  NOTEBOOK_E2E_RAG_CONVERSATION_ID,
+  notebookRagConversationAssistantPlainTextForUploadTitle,
+  notebookRagConversationChatHistoryForUploadTitle,
+  notebookRagConversationUserPromptForUploadTitle,
+} from './fixtures/responses';
+import {
+  NotebookSurfacePage,
+  NOTEBOOK_UNTITLED_GRID_NAME,
+} from './pages/NotebookSurfacePage';
+import { withNotebookTabSeededConversation } from './utils/devMode';
+import { bootstrapLightspeedE2ePage } from './utils/lightspeedE2eSetup';
+import {
+  localeNotebookUpload1Path,
+  NOTEBOOK_EDITOR_URL_RE,
+} from './utils/notebooks';
+import type { LightspeedMessages } from './utils/translations';
+import {
+  assertClipboardContains,
+  submitFeedback,
+  verifyFeedbackButtons,
+} from './utils/testHelper';
+
+test.describe('Lightspeed notebooks conversation', () => {
+  let sharedPage: Page;
+  let translations: LightspeedMessages;
+  let notebooks: NotebookSurfacePage;
+
+  test.beforeAll(async ({ browser }) => {
+    const boot = await bootstrapLightspeedE2ePage(browser);
+    sharedPage = boot.page;
+    translations = boot.translations;
+    notebooks = new NotebookSurfacePage(sharedPage, translations);
+  });
+
+  test('notebook tab: seeded conversation, feedback, clipboard, and delete notebook', async ({}, testInfo) => {
+    const { fileName } = localeNotebookUpload1Path(testInfo.project.name);
+    const assistantPlain =
+      notebookRagConversationAssistantPlainTextForUploadTitle(fileName);
+    const chatHistory =
+      notebookRagConversationChatHistoryForUploadTitle(fileName);
+
+    const endMocks = await withNotebookTabSeededConversation(sharedPage, {
+      conversationId: NOTEBOOK_E2E_RAG_CONVERSATION_ID,
+      chatHistory,
+    });
+
+    try {
+      await notebooks.gotoFullscreenNotebooksTab();
+      await notebooks.clickPrimaryNotebookCreate();
+      await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+
+      const region = notebooks.chatbotRegion();
+      const userMessage = region.locator('.pf-chatbot__message--user');
+      const botMessage = region.locator('.pf-chatbot__message--bot');
+      const copyButton = sharedPage.getByRole('button', { name: 'Copy' });
+
+      await expect(userMessage).toContainText(
+        notebookRagConversationUserPromptForUploadTitle(fileName),
+        { timeout: 5_000 },
+      );
+      await expect(botMessage).toContainText(assistantPlain, {
+        timeout: 5_000,
+      });
+
+      await verifyFeedbackButtons(sharedPage);
+      await submitFeedback(sharedPage, 'Good response', translations);
+      await submitFeedback(sharedPage, 'Bad response', translations);
+
+      await copyButton.click();
+      await assertClipboardContains(sharedPage, assistantPlain);
+
+      await notebooks.clickCloseNotebookEditor();
+      const untitledCountBeforeDelete = await notebooks
+        .untitledNotebookCards()
+        .count();
+
+      const cardCreatedThisTest = notebooks.newestUntitledNotebookCard();
+      await notebooks
+        .notebookCardOverflowMenuButton(cardCreatedThisTest)
+        .click();
+      await notebooks.deleteNotebookOverflowMenuItem().click();
+
+      const confirmDelete = notebooks.notebookDeleteConfirmationDialog(
+        NOTEBOOK_UNTITLED_GRID_NAME,
+      );
+      await confirmDelete.expectDialogVisible();
+      await confirmDelete.expectPermanentDeletionWarningText();
+      await confirmDelete.confirmDeletion();
+
+      await notebooks.expectUntitledNotebookCardCount(
+        untitledCountBeforeDelete - 1,
+      );
+    } finally {
+      await endMocks();
+    }
+  });
+});

--- a/workspaces/lightspeed/e2e-tests/lightspeed.notebooks.conversation.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.notebooks.conversation.test.ts
@@ -43,12 +43,17 @@ test.describe('Lightspeed notebooks conversation', () => {
   let sharedPage: Page;
   let translations: LightspeedMessages;
   let notebooks: NotebookSurfacePage;
+  let endMocks: (() => Promise<void>) | undefined;
 
   test.beforeAll(async ({ browser }) => {
     const boot = await bootstrapLightspeedE2ePage(browser);
     sharedPage = boot.page;
     translations = boot.translations;
     notebooks = new NotebookSurfacePage(sharedPage, translations);
+  });
+
+  test.afterAll(async () => {
+    await endMocks?.();
   });
 
   test('notebook tab: seeded conversation, feedback, clipboard, and delete notebook', async ({}, testInfo) => {
@@ -58,59 +63,53 @@ test.describe('Lightspeed notebooks conversation', () => {
     const chatHistory =
       notebookRagConversationChatHistoryForUploadTitle(fileName);
 
-    const endMocks = await withNotebookTabSeededConversation(sharedPage, {
+    endMocks = await withNotebookTabSeededConversation(sharedPage, {
       conversationId: NOTEBOOK_E2E_RAG_CONVERSATION_ID,
       chatHistory,
     });
 
-    try {
-      await notebooks.gotoFullscreenNotebooksTab();
-      await notebooks.clickPrimaryNotebookCreate();
-      await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+    await notebooks.gotoFullscreenNotebooksTab();
+    await notebooks.clickPrimaryNotebookCreate();
+    await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
 
-      const region = notebooks.chatbotRegion();
-      const userMessage = region.locator('.pf-chatbot__message--user');
-      const botMessage = region.locator('.pf-chatbot__message--bot');
-      const copyButton = sharedPage.getByRole('button', { name: 'Copy' });
+    const region = notebooks.chatbotRegion();
+    const userMessage = region.locator('.pf-chatbot__message--user');
+    const botMessage = region.locator('.pf-chatbot__message--bot');
+    const copyButton = sharedPage.getByRole('button', { name: 'Copy' });
 
-      await expect(userMessage).toContainText(
-        notebookRagConversationUserPromptForUploadTitle(fileName),
-        { timeout: 5_000 },
-      );
-      await expect(botMessage).toContainText(assistantPlain, {
-        timeout: 5_000,
-      });
+    await expect(userMessage).toContainText(
+      notebookRagConversationUserPromptForUploadTitle(fileName),
+      { timeout: 5_000 },
+    );
+    await expect(botMessage).toContainText(assistantPlain, {
+      timeout: 5_000,
+    });
 
-      await verifyFeedbackButtons(sharedPage);
-      await submitFeedback(sharedPage, 'Good response', translations);
-      await submitFeedback(sharedPage, 'Bad response', translations);
+    await verifyFeedbackButtons(sharedPage);
+    await submitFeedback(sharedPage, 'Good response', translations);
+    await submitFeedback(sharedPage, 'Bad response', translations);
 
-      await copyButton.click();
-      await assertClipboardContains(sharedPage, assistantPlain);
+    await copyButton.click();
+    await assertClipboardContains(sharedPage, assistantPlain);
 
-      await notebooks.clickCloseNotebookEditor();
-      const untitledCountBeforeDelete = await notebooks
-        .untitledNotebookCards()
-        .count();
+    await notebooks.clickCloseNotebookEditor();
+    const untitledCountBeforeDelete = await notebooks
+      .untitledNotebookCards()
+      .count();
 
-      const cardCreatedThisTest = notebooks.newestUntitledNotebookCard();
-      await notebooks
-        .notebookCardOverflowMenuButton(cardCreatedThisTest)
-        .click();
-      await notebooks.deleteNotebookOverflowMenuItem().click();
+    const cardCreatedThisTest = notebooks.newestUntitledNotebookCard();
+    await notebooks.notebookCardOverflowMenuButton(cardCreatedThisTest).click();
+    await notebooks.deleteNotebookOverflowMenuItem().click();
 
-      const confirmDelete = notebooks.notebookDeleteConfirmationDialog(
-        NOTEBOOK_UNTITLED_GRID_NAME,
-      );
-      await confirmDelete.expectDialogVisible();
-      await confirmDelete.expectPermanentDeletionWarningText();
-      await confirmDelete.confirmDeletion();
+    const confirmDelete = notebooks.notebookDeleteConfirmationDialog(
+      NOTEBOOK_UNTITLED_GRID_NAME,
+    );
+    await confirmDelete.expectDialogVisible();
+    await confirmDelete.expectPermanentDeletionWarningText();
+    await confirmDelete.confirmDeletion();
 
-      await notebooks.expectUntitledNotebookCardCount(
-        untitledCountBeforeDelete - 1,
-      );
-    } finally {
-      await endMocks();
-    }
+    await notebooks.expectUntitledNotebookCardCount(
+      untitledCountBeforeDelete - 1,
+    );
   });
 });

--- a/workspaces/lightspeed/e2e-tests/lightspeed.notebooks.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.notebooks.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+import {
+  NotebookSurfacePage,
+  NOTEBOOK_UNTITLED_GRID_NAME,
+} from './pages/NotebookSurfacePage';
+import type { LightspeedMessages } from './utils/translations';
+import { bootstrapLightspeedE2ePage } from './utils/lightspeedE2eSetup';
+import {
+  localeNotebookUpload1Path,
+  NOTEBOOK_EDITOR_URL_RE,
+  NOTEBOOK_SESSION_MAX_DOCUMENTS,
+  notebookElevenFileStagingPaths,
+  notebookUnsupportedTypeFixturePath,
+} from './utils/notebooks';
+import { substituteNotebookTemplate } from './utils/notebookTranslation';
+
+const RENAMED_NOTEBOOK_TITLE = 'E2E Notebook Renamed';
+
+test.describe('Lightspeed notebooks', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let sharedPage: Page;
+  let translations: LightspeedMessages;
+  let notebooks: NotebookSurfacePage;
+
+  test.beforeAll(async ({ browser }) => {
+    const boot = await bootstrapLightspeedE2ePage(browser);
+    sharedPage = boot.page;
+    translations = boot.translations;
+    notebooks = new NotebookSurfacePage(sharedPage, translations);
+  });
+
+  test('fullscreen list: header and empty state', async () => {
+    await notebooks.gotoFullscreenNotebooksTab();
+    await notebooks.expectNotebookListHeaderControlsVisible();
+    await notebooks.expectEmptyNotebookListMatchesAriaSnapshot();
+  });
+
+  test('new notebook: editor onboarding', async () => {
+    await notebooks.gotoFullscreenNotebooksTab();
+    await notebooks.clickCreateNotebookFromEmptyList();
+    await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+    await notebooks.expectNewNotebookEditorEmptyStateOnboarding();
+  });
+
+  test('upload modal: drop zone and disabled add', async () => {
+    await notebooks.clickOpenUploadDocumentModal();
+    const uploadModal = notebooks.uploadDocumentModal();
+
+    await uploadModal.expectUploadAreaFullyDescribed();
+    await uploadModal.expectModalTitleBarMatchesAriaSnapshot();
+    await uploadModal.expectAddFilesButtonDisabled(0);
+    await uploadModal.clickCancel();
+  });
+
+  test('document sidebar: collapse and expand', async () => {
+    await notebooks.collapseThenExpandDocumentSidebar();
+  });
+
+  test('sidebar: add file then remove', async ({}, testInfo) => {
+    const { absolutePath, fileName } = localeNotebookUpload1Path(
+      testInfo.project.name,
+    );
+
+    await notebooks.clickOpenUploadDocumentModal();
+    const uploadModal = notebooks.uploadDocumentModal();
+    await uploadModal.selectFilesViaBrowsePicker([absolutePath]);
+
+    await uploadModal.expectStagedFileCountCaptionVisible(
+      1,
+      NOTEBOOK_SESSION_MAX_DOCUMENTS,
+    );
+    await uploadModal.clickAddFilesForStagedCount(1);
+
+    await notebooks.expectDocumentFileListedInSidebar(fileName);
+    await notebooks.deleteFirstListedDocumentFromSidebarOverflowMenu();
+    await notebooks.expectNotebookEditorUploadResourceButtonVisible();
+  });
+
+  test('upload modal: eleven files rejected at cap', async () => {
+    await notebooks.clickOpenUploadDocumentModal();
+    const uploadModal = notebooks.uploadDocumentModal();
+    await uploadModal.selectFilesViaBrowsePicker(
+      notebookElevenFileStagingPaths(),
+    );
+    await expect(uploadModal.dialog().getByRole('alert')).toContainText(
+      substituteNotebookTemplate(
+        translations['notebook.upload.error.tooManyFiles'],
+        { max: NOTEBOOK_SESSION_MAX_DOCUMENTS },
+      ),
+    );
+    await uploadModal.clickCancel();
+  });
+
+  test('upload modal: unsupported extension rejected', async () => {
+    await notebooks.clickOpenUploadDocumentModal();
+    const uploadModal = notebooks.uploadDocumentModal();
+    await uploadModal.selectFilesViaBrowsePicker([
+      notebookUnsupportedTypeFixturePath(),
+    ]);
+    await expect(uploadModal.dialog().getByRole('alert')).toContainText(
+      translations['notebook.upload.error.unsupportedType'],
+    );
+    await uploadModal.clickCancel();
+  });
+
+  test('upload modal: duplicate file confirms overwrite then upload', async ({}, testInfo) => {
+    const { absolutePath, fileName } = localeNotebookUpload1Path(
+      testInfo.project.name,
+    );
+
+    await notebooks.clickOpenUploadDocumentModal();
+    let uploadModal = notebooks.uploadDocumentModal();
+    await uploadModal.selectFilesViaBrowsePicker([absolutePath]);
+    await uploadModal.clickAddFilesForStagedCount(1);
+    await notebooks.expectDocumentFileListedInSidebar(fileName);
+    await sharedPage.waitForTimeout(1000);
+
+    await notebooks.clickOpenUploadDocumentModal();
+    uploadModal = notebooks.uploadDocumentModal();
+    await uploadModal.selectFilesViaBrowsePicker([absolutePath]);
+
+    const overwriteModal = notebooks.notebookOverwriteConfirmModal();
+    await overwriteModal.expectDialogVisible();
+    await overwriteModal.expectListedOverwriteFile(fileName);
+    await overwriteModal.clickCancel();
+    await sharedPage.waitForTimeout(200);
+    await uploadModal.clickCancel();
+
+    await notebooks.deleteFirstListedDocumentFromSidebarOverflowMenu();
+    await notebooks.expectNotebookEditorUploadResourceButtonVisible();
+  });
+
+  test('grid: close editor, rename, delete', async () => {
+    const untitledBefore = await notebooks.untitledNotebookCards().count();
+
+    await notebooks.clickCloseNotebookEditor();
+
+    await notebooks.expectUntitledNotebookCardCount(untitledBefore + 1);
+    await expect(notebooks.newestUntitledNotebookCard()).toBeVisible();
+
+    await notebooks.expectNotebookListShowsDocumentCountSummaryAndUpdatedToday(
+      0,
+    );
+
+    await notebooks
+      .notebookCardOverflowMenuButton(notebooks.newestUntitledNotebookCard())
+      .click();
+    await notebooks.renameNotebookOverflowMenuItem().click();
+
+    const renameModal = notebooks.renameNotebookDialog(
+      NOTEBOOK_UNTITLED_GRID_NAME,
+    );
+    await renameModal.enterNewDisplayedNameAndSubmit(RENAMED_NOTEBOOK_TITLE);
+
+    await expect(sharedPage.getByText(RENAMED_NOTEBOOK_TITLE)).toBeVisible();
+
+    await notebooks
+      .notebookCardOverflowMenuButton(
+        notebooks.notebookCardByDisplayedName(RENAMED_NOTEBOOK_TITLE),
+      )
+      .click();
+    await notebooks.deleteNotebookOverflowMenuItem().click();
+
+    const confirmDelete = notebooks.notebookDeleteConfirmationDialog(
+      RENAMED_NOTEBOOK_TITLE,
+    );
+    await confirmDelete.expectDialogVisible();
+    await confirmDelete.expectPermanentDeletionWarningText();
+    await confirmDelete.confirmDeletion();
+
+    await notebooks.expectNotebookCardAbsent(RENAMED_NOTEBOOK_TITLE);
+    await notebooks.expectUntitledNotebookCardCount(untitledBefore);
+
+    await expect(sharedPage.getByText(RENAMED_NOTEBOOK_TITLE)).toBeHidden();
+  });
+});

--- a/workspaces/lightspeed/e2e-tests/pages/NotebookAddDocumentModalPage.ts
+++ b/workspaces/lightspeed/e2e-tests/pages/NotebookAddDocumentModalPage.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { LightspeedMessages } from '../utils/translations';
+import { substituteNotebookTemplate } from '../utils/notebookTranslation';
+
+/**
+ * “Add a document to Notebook” modal: staged files, browse picker, localized Add(n).
+ */
+export class NotebookAddDocumentModalPage {
+  constructor(
+    private readonly page: Page,
+    private readonly t: LightspeedMessages,
+  ) {}
+
+  dialog(): Locator {
+    return this.page.getByRole('dialog', {
+      name: this.t['notebook.upload.modal.title'],
+    });
+  }
+
+  modalTitleAccessibilityRegion(): Locator {
+    return this.page.locator('#add-document-modal-title');
+  }
+
+  dragAndDropInstructions(): Locator {
+    return this.dialog().getByText(
+      this.t['notebook.upload.modal.dragDropTitle'],
+    );
+  }
+
+  separatorBetweenDragZoneAndBrowse(): Locator {
+    return this.dialog().getByText(this.t['notebook.upload.modal.separator'], {
+      exact: true,
+    });
+  }
+
+  browseFilesButton(): Locator {
+    return this.dialog().getByRole('button', {
+      name: this.t['notebook.upload.modal.browseButton'],
+      exact: true,
+    });
+  }
+
+  acceptedFileTypesParagraph(): Locator {
+    return this.dialog().getByText(this.t['notebook.upload.modal.infoText'], {
+      exact: true,
+    });
+  }
+
+  addFilesButton(stagedCount: number): Locator {
+    const label = substituteNotebookTemplate(
+      this.t['notebook.upload.modal.addButton'],
+      {
+        count: stagedCount,
+      },
+    );
+    return this.dialog().getByRole('button', { name: label });
+  }
+
+  cancelButton(): Locator {
+    return this.dialog().getByRole('button', {
+      name: this.t['modal.cancel'],
+    });
+  }
+
+  /** Drop-zone copy, “or”, browse button, accepted file types paragraph. */
+  async expectUploadAreaFullyDescribed(): Promise<void> {
+    await expect(this.dragAndDropInstructions()).toBeVisible();
+    await expect(this.separatorBetweenDragZoneAndBrowse()).toBeVisible();
+    await expect(this.browseFilesButton()).toBeVisible();
+    await expect(this.acceptedFileTypesParagraph()).toBeVisible();
+  }
+
+  async expectModalTitleBarMatchesAriaSnapshot(): Promise<void> {
+    await expect(this.modalTitleAccessibilityRegion()).toMatchAriaSnapshot(`
+      - heading :
+        - heading "${this.t['notebook.upload.modal.title']}"
+        - button "${this.t['modal.close']}"
+      `);
+  }
+
+  async expectAddFilesButtonDisabled(stagedCount: number): Promise<void> {
+    await expect(this.addFilesButton(stagedCount)).toBeDisabled();
+  }
+
+  async selectFilesViaBrowsePicker(filePaths: string[]): Promise<void> {
+    const [fileChooser] = await Promise.all([
+      this.page.waitForEvent('filechooser'),
+      this.browseFilesButton().click(),
+    ]);
+    await fileChooser.setFiles(filePaths);
+  }
+
+  async expectStagedFileCountCaptionVisible(
+    stagedCount: number,
+    maxSelectable: number,
+  ): Promise<void> {
+    const caption = substituteNotebookTemplate(
+      this.t['notebook.upload.modal.selectedFiles'],
+      {
+        count: stagedCount,
+        max: maxSelectable,
+      },
+    );
+    await expect(
+      this.dialog().getByText(caption, { exact: true }),
+    ).toBeVisible();
+  }
+
+  async clickAddFilesForStagedCount(stagedCount: number): Promise<void> {
+    await this.addFilesButton(stagedCount).click();
+  }
+
+  async clickCancel(): Promise<void> {
+    await this.cancelButton().click();
+  }
+
+  errorAlert(): Locator {
+    return this.dialog().getByRole('alert');
+  }
+
+  async expectValidationAlertsInclude(text: string): Promise<void> {
+    await expect(this.errorAlert()).toContainText(text);
+  }
+
+  /** `notebook.upload.error.tooManyFiles` with `{{max}}` interpolated (matches `AddDocumentModal.tsx`). */
+  formatTooManyFilesMessage(maxFiles: number): string {
+    return substituteNotebookTemplate(
+      this.t['notebook.upload.error.tooManyFiles'],
+      { max: maxFiles },
+    );
+  }
+
+  async expectTooManyFilesValidation(maxFiles: number): Promise<void> {
+    await this.expectValidationAlertsInclude(
+      this.formatTooManyFilesMessage(maxFiles),
+    );
+  }
+
+  async expectUnsupportedTypeValidation(): Promise<void> {
+    await this.expectValidationAlertsInclude(
+      this.t['notebook.upload.error.unsupportedType'],
+    );
+  }
+}

--- a/workspaces/lightspeed/e2e-tests/pages/NotebookDeleteDialogPage.ts
+++ b/workspaces/lightspeed/e2e-tests/pages/NotebookDeleteDialogPage.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { LightspeedMessages } from '../utils/translations';
+
+/** Page object for the delete-notebook confirmation modal on the grid. */
+export class NotebookDeleteDialogPage {
+  constructor(
+    private readonly page: Page,
+    private readonly t: LightspeedMessages,
+    private readonly notebookDisplayName: string,
+  ) {}
+
+  /** Dialog anchored by visible notebook title (matches MUI `DeleteNotebookModal` content). */
+  dialog(): Locator {
+    return this.page
+      .getByRole('dialog')
+      .filter({ hasText: this.notebookDisplayName });
+  }
+
+  deleteNotebookConfirmButton(): Locator {
+    return this.dialog().getByRole('button', {
+      name: this.t['notebooks.delete.action'],
+      exact: true,
+    });
+  }
+
+  async expectDialogVisible(): Promise<void> {
+    await expect(this.dialog()).toBeVisible();
+  }
+
+  async expectPermanentDeletionWarningText(): Promise<void> {
+    await expect(this.dialog()).toContainText(
+      this.t['notebooks.delete.message'],
+    );
+  }
+
+  async confirmDeletion(): Promise<void> {
+    await this.deleteNotebookConfirmButton().click();
+  }
+}

--- a/workspaces/lightspeed/e2e-tests/pages/NotebookOverwriteConfirmModalPage.ts
+++ b/workspaces/lightspeed/e2e-tests/pages/NotebookOverwriteConfirmModalPage.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { LightspeedMessages } from '../utils/translations';
+
+/**
+ * “Overwrite Files?” confirmation when staging a file whose name already exists in the notebook (`OverwriteConfirmModal.tsx`).
+ */
+export class NotebookOverwriteConfirmModalPage {
+  constructor(
+    private readonly page: Page,
+    private readonly t: LightspeedMessages,
+  ) {}
+
+  dialog(): Locator {
+    /** MUI dialogs may not use the plain title as the whole accessible name across engines. */
+    return this.page.getByRole('dialog').filter({
+      has: this.page.getByRole('heading', {
+        name: this.t['notebook.overwrite.modal.title'],
+        level: 2,
+      }),
+    });
+  }
+
+  async expectDialogVisible(timeout = 15_000): Promise<void> {
+    await expect(this.dialog()).toBeVisible({ timeout });
+    await expect(
+      this.dialog().getByText(this.t['notebook.overwrite.modal.description'], {
+        exact: true,
+      }),
+    ).toBeVisible();
+  }
+
+  async clickCancel(): Promise<void> {
+    await this.dialog()
+      .getByRole('button', { name: this.t['common.cancel'], exact: true })
+      .click();
+  }
+
+  async expectListedOverwriteFile(fileName: string): Promise<void> {
+    await expect(
+      this.dialog().getByText(fileName, { exact: true }),
+    ).toBeVisible();
+  }
+
+  async clickOverwrite(): Promise<void> {
+    await this.dialog()
+      .getByRole('button', {
+        name: this.t['notebook.overwrite.modal.action'],
+        exact: true,
+      })
+      .click();
+  }
+}

--- a/workspaces/lightspeed/e2e-tests/pages/NotebookSurfacePage.ts
+++ b/workspaces/lightspeed/e2e-tests/pages/NotebookSurfacePage.ts
@@ -1,0 +1,387 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { LightspeedMessages } from '../utils/translations';
+import { substituteNotebookTemplate } from '../utils/notebookTranslation';
+import { openLightspeed } from '../utils/testHelper';
+
+import { NotebookAddDocumentModalPage } from './NotebookAddDocumentModalPage';
+import { NotebookDeleteDialogPage } from './NotebookDeleteDialogPage';
+import { NotebookOverwriteConfirmModalPage } from './NotebookOverwriteConfirmModalPage';
+import { RenameNotebookModalPage } from './RenameNotebookModalPage';
+
+/**
+ * Display name for an untitled session on the grid (matches `UNTITLED_NOTEBOOK_NAME` from the plugin).
+ */
+export const NOTEBOOK_UNTITLED_GRID_NAME = 'Untitled Notebook';
+
+/**
+ * Developer Lightspeed **Notebooks** surface: fullscreen tab, notebook list/editor, sidebar, cards, modals.
+ * Same role as {@link ./LightspeedPage.ts}: shared locators/assertions keep specs short.
+ */
+export class NotebookSurfacePage {
+  constructor(
+    private readonly page: Page,
+    private readonly t: LightspeedMessages,
+  ) {}
+
+  /**
+   * Scoped to the fullscreen chatbot region that contains notebooks (list + notebook editor).
+   * Matches the landmark labeled “Chatbot” in the accessibility tree.
+   */
+  chatbotRegion(): Locator {
+    return this.page.getByLabel('Chatbot', { exact: true });
+  }
+
+  async gotoFullscreenNotebooksTab(): Promise<void> {
+    await openLightspeed(this.page);
+    await this.page
+      .getByRole('button', { name: this.t['aria.settings.label'] })
+      .click();
+    await this.page
+      .getByRole('menuitem', {
+        name: this.t['settings.displayMode.fullscreen'],
+      })
+      .click();
+    await this.page
+      .getByRole('tab', { name: this.t['tabs.notebooks'] })
+      .click();
+  }
+
+  notebooksTab(): Locator {
+    return this.page.getByRole('tab', { name: this.t['tabs.notebooks'] });
+  }
+
+  myNotebooksHeading(): Locator {
+    return this.page.getByRole('heading', { name: this.t['notebooks.title'] });
+  }
+
+  createNotebookFromEmptyStateButton(): Locator {
+    return this.page
+      .getByRole('button', { name: this.t['notebooks.empty.action'] })
+      .first();
+  }
+
+  /** Notebooks tab, “My Notebooks” heading, and primary create action are visible (empty listing). */
+  async expectNotebookListHeaderControlsVisible(): Promise<void> {
+    await expect(this.notebooksTab()).toBeVisible();
+    await expect(this.myNotebooksHeading()).toBeVisible();
+    await expect(this.createNotebookFromEmptyStateButton()).toBeVisible();
+  }
+
+  async expectEmptyNotebookListMatchesAriaSnapshot(): Promise<void> {
+    await expect(this.chatbotRegion()).toMatchAriaSnapshot(`
+    - heading "${this.t['notebooks.empty.title']}"
+    - paragraph: ${this.t['notebooks.empty.description']}
+    - button "${this.t['notebooks.empty.action']}"
+    `);
+  }
+
+  async clickCreateNotebookFromEmptyList(): Promise<void> {
+    await this.createNotebookFromEmptyStateButton().click();
+  }
+
+  /** Same label as empty-state create; first match is header when the grid is non-empty. */
+  async clickPrimaryNotebookCreate(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: this.t['notebooks.empty.action'] })
+      .first()
+      .click();
+  }
+
+  closeNotebookButton(): Locator {
+    return this.page.getByRole('button', {
+      name: this.t['notebook.view.close'],
+    });
+  }
+
+  uploadResourceHeading(): Locator {
+    return this.page.getByText(this.t['notebook.view.upload.heading'], {
+      exact: true,
+    });
+  }
+
+  uploadResourceActionButton(): Locator {
+    return this.page.getByRole('button', {
+      name: this.t['notebook.view.upload.action'],
+    });
+  }
+
+  /** Composer stub while no documents are attached. */
+  disabledComposerPlaceholder(): Locator {
+    return this.chatbotRegion().getByRole('textbox', {
+      name: this.t['notebook.view.input.placeholder'],
+    });
+  }
+
+  sidebarCollapseButton(): Locator {
+    return this.page.getByRole('button', {
+      name: this.t['notebook.view.sidebar.collapse'],
+    });
+  }
+
+  sidebarExpandButton(): Locator {
+    return this.page.getByRole('button', {
+      name: this.t['notebook.view.sidebar.expand'],
+    });
+  }
+
+  sidebarAddDocumentButton(): Locator {
+    return this.chatbotRegion()
+      .getByRole('button', { name: this.t['notebook.view.documents.add'] })
+      .first();
+  }
+
+  async clickOpenUploadDocumentModal(): Promise<void> {
+    await this.sidebarAddDocumentButton().click();
+  }
+
+  /** Opens the upload flow for attaching documents to the current notebook. */
+  uploadDocumentModal(): NotebookAddDocumentModalPage {
+    return new NotebookAddDocumentModalPage(this.page, this.t);
+  }
+
+  notebookOverwriteConfirmModal(): NotebookOverwriteConfirmModalPage {
+    return new NotebookOverwriteConfirmModalPage(this.page, this.t);
+  }
+
+  /**
+   * Deleting from the notebooks list/card menu opens this confirmation (before session is removed).
+   */
+  notebookDeleteConfirmationDialog(
+    notebookDisplayName: string,
+  ): NotebookDeleteDialogPage {
+    return new NotebookDeleteDialogPage(this.page, this.t, notebookDisplayName);
+  }
+
+  /** Shown after choosing Rename on a notebook card. `currentDisplayedName` is the title shown on that card. */
+  renameNotebookDialog(
+    currentDisplayedNotebookName: string,
+  ): RenameNotebookModalPage {
+    return new RenameNotebookModalPage(
+      this.page,
+      this.t,
+      currentDisplayedNotebookName,
+    );
+  }
+
+  /**
+   * New notebook with no documents: upload prompts, disclaimer, disabled composer (+ tooltip when hovered), sidebar Add.
+   */
+  async expectNewNotebookEditorEmptyStateOnboarding(): Promise<void> {
+    await expect(this.closeNotebookButton()).toBeVisible();
+    await expect(this.uploadResourceHeading()).toBeVisible();
+    await expect(this.uploadResourceActionButton()).toBeVisible();
+    await expect(
+      this.page.getByText(this.t['disclaimer.withValidation'], { exact: true }),
+    ).toBeVisible();
+
+    const disabledPrompt = this.disabledComposerPlaceholder();
+    await expect(disabledPrompt).toBeDisabled();
+    await disabledPrompt.locator('..').hover({ force: true });
+    await expect(
+      this.page.getByRole('tooltip', {
+        name: this.t['notebook.view.input.disabledTooltip'],
+      }),
+    ).toBeVisible();
+
+    await expect(this.sidebarCollapseButton()).toBeVisible();
+    await expect(this.sidebarAddDocumentButton()).toBeVisible();
+  }
+
+  /** Document sidebar collapsed: expand visible, collapse hidden, Add still reachable. */
+  async expectDocumentSidebarCollapsedState(): Promise<void> {
+    await expect(this.sidebarExpandButton()).toBeVisible();
+    await expect(this.sidebarCollapseButton()).toBeHidden();
+    await expect(this.sidebarAddDocumentButton()).toBeVisible();
+  }
+
+  /** Collapse document sidebar, verify Add stays available, expand again to restore. */
+  async collapseThenExpandDocumentSidebar(): Promise<void> {
+    await expect(this.sidebarCollapseButton()).toBeVisible();
+    await this.sidebarCollapseButton().click();
+    await this.expectDocumentSidebarCollapsedState();
+    await this.sidebarExpandButton().click();
+    await expect(this.sidebarCollapseButton()).toBeVisible();
+  }
+
+  /** Kebab on the first document row in the sidebar list. */
+  firstListedDocumentOverflowMenuToggle(): Locator {
+    return this.chatbotRegion()
+      .getByRole('button', {
+        name: this.t['notebook.document.delete'],
+        exact: true,
+      })
+      .first();
+  }
+
+  documentRowDeleteMenuItem(): Locator {
+    return this.page.getByRole('menuitem', {
+      name: this.t['notebook.document.delete'],
+      exact: true,
+    });
+  }
+
+  /** Opens the overflow menu on the first sidebar document and chooses Delete document. */
+  async deleteFirstListedDocumentFromSidebarOverflowMenu(): Promise<void> {
+    await this.firstListedDocumentOverflowMenuToggle().click();
+    await this.documentRowDeleteMenuItem().click();
+  }
+
+  async expectDocumentFileListedInSidebar(fileName: string): Promise<void> {
+    await expect(
+      this.chatbotRegion().getByText(fileName, { exact: true }).first(),
+    ).toBeVisible({ timeout: 60_000 });
+  }
+
+  /**
+   * Success toast title uses `notebook.upload.success` (`NotebookView` PF `Alert`), auto-dismiss ~2s after show.
+   */
+  async expectNotebookUploadSuccessToastVisible(
+    fileName: string,
+  ): Promise<void> {
+    const title = substituteNotebookTemplate(
+      this.t['notebook.upload.success'],
+      {
+        fileName,
+      },
+    );
+    await expect(
+      this.page.getByText(title, { exact: true }).first(),
+    ).toBeVisible({
+      timeout: 120_000,
+    });
+  }
+
+  /**
+   * Once the notebook reaches the attachment cap, sidebar Add is disabled (`DocumentSidebar.tsx`).
+   */
+  async expectSidebarDocumentsAddDisabled(): Promise<void> {
+    await expect(this.sidebarAddDocumentButton()).toBeDisabled({
+      timeout: 15_000,
+    });
+  }
+
+  /** Waits until every uploaded title is visible (parallel uploads). */
+  async expectDocumentTitlesListedInSidebar(
+    fileNames: string[],
+    options?: { timeout?: number },
+  ): Promise<void> {
+    const timeout = options?.timeout ?? 120_000;
+    await Promise.all(
+      fileNames.map(name =>
+        expect(
+          this.chatbotRegion().getByText(name, { exact: true }).first(),
+        ).toBeVisible({ timeout }),
+      ),
+    );
+  }
+
+  /** Open the most recently listed Untitled Notebook card (`NotebookCard`). */
+  async openUntitledNotebookFromGrid(): Promise<void> {
+    const card = this.chatbotRegion()
+      .locator('.pf-v6-c-card')
+      .filter({ hasText: NOTEBOOK_UNTITLED_GRID_NAME })
+      .last();
+    await card.getByText(NOTEBOOK_UNTITLED_GRID_NAME, { exact: true }).click();
+  }
+
+  /** Shown again when no documents remain in the sidebar list. */
+  async expectNotebookEditorUploadResourceButtonVisible(
+    timeout = 5_000,
+  ): Promise<void> {
+    await expect(this.uploadResourceActionButton()).toBeVisible({ timeout });
+  }
+
+  /** Cards on “My notebooks” when session display name matches the backend default. */
+  untitledNotebookCards(): Locator {
+    return this.chatbotRegion()
+      .locator('.pf-v6-c-card')
+      .filter({ hasText: NOTEBOOK_UNTITLED_GRID_NAME });
+  }
+
+  newestUntitledNotebookCard(): Locator {
+    return this.untitledNotebookCards().last();
+  }
+
+  /** Per-card overflow (…) that opens Rename / Delete on a notebook card. */
+  notebookCardOverflowMenuButton(card: Locator): Locator {
+    return card.getByRole('button', {
+      name: this.t['aria.options.label'],
+      exact: true,
+    });
+  }
+
+  notebookCardByDisplayedName(notebookDisplayedName: string): Locator {
+    return this.chatbotRegion()
+      .locator('.pf-v6-c-card')
+      .filter({ hasText: notebookDisplayedName })
+      .first();
+  }
+
+  renameNotebookOverflowMenuItem(): Locator {
+    return this.page.getByRole('menuitem', {
+      name: this.t['notebooks.actions.rename'],
+    });
+  }
+
+  deleteNotebookOverflowMenuItem(): Locator {
+    return this.page.getByRole('menuitem', {
+      name: this.t['notebooks.actions.delete'],
+    });
+  }
+
+  /**
+   * Shown on each card as count + plural label (same pattern as NotebookCard.tsx:
+   * `{ document_count } { t('notebooks.documents') }`, not `notebook.view.documents.count`).
+   */
+  formatNotebookCardDocumentsSummary(documentCount: number): string {
+    return `${documentCount} ${this.t['notebooks.documents']}`;
+  }
+
+  async expectUntitledNotebookCardCount(expected: number): Promise<void> {
+    await expect(this.untitledNotebookCards()).toHaveCount(expected, {
+      timeout: 5_000,
+    });
+  }
+
+  async expectNotebookCardAbsent(notebookDisplayedName: string): Promise<void> {
+    await expect(
+      this.chatbotRegion()
+        .locator('.pf-v6-c-card')
+        .filter({ hasText: notebookDisplayedName }),
+    ).toHaveCount(0, { timeout: 5_000 });
+  }
+
+  /** Closes the notebook editor and returns focus to “My notebooks” list view. */
+  async clickCloseNotebookEditor(): Promise<void> {
+    await this.closeNotebookButton().click();
+  }
+
+  /** After closing the editor, summary lines on cards include document count and “updated …” wording. */
+  async expectNotebookListShowsDocumentCountSummaryAndUpdatedToday(
+    documentCountOnCard = 0,
+  ): Promise<void> {
+    await expect(this.chatbotRegion()).toContainText(
+      this.formatNotebookCardDocumentsSummary(documentCountOnCard),
+    );
+    await expect(this.chatbotRegion()).toContainText(
+      this.t['notebooks.updated.today'],
+    );
+  }
+}

--- a/workspaces/lightspeed/e2e-tests/pages/RenameNotebookModalPage.ts
+++ b/workspaces/lightspeed/e2e-tests/pages/RenameNotebookModalPage.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { LightspeedMessages } from '../utils/translations';
+import { substituteNotebookTemplate } from '../utils/notebookTranslation';
+
+/** Page object for rename notebook dialog opened from the notebooks grid. */
+export class RenameNotebookModalPage {
+  constructor(
+    private readonly page: Page,
+    private readonly t: LightspeedMessages,
+    private readonly currentNotebookName: string,
+  ) {}
+
+  /** Resolved “Rename …?” title matching the notebook card heading. */
+  expectedRenameDialogHeading(): string {
+    return substituteNotebookTemplate(this.t['notebooks.rename.title'], {
+      name: this.currentNotebookName,
+    });
+  }
+
+  dialog(): Locator {
+    return this.page.getByRole('dialog').filter({
+      hasText: this.expectedRenameDialogHeading(),
+    });
+  }
+
+  newNameTextbox(): Locator {
+    return this.dialog().getByRole('textbox', {
+      name: this.t['notebooks.rename.label'],
+    });
+  }
+
+  submitRenameButton(): Locator {
+    return this.dialog().getByRole('button', {
+      name: this.t['notebooks.rename.action'],
+    });
+  }
+
+  async expectDialogVisible(): Promise<void> {
+    await expect(this.dialog()).toBeVisible();
+  }
+
+  async enterNewDisplayedNameAndSubmit(newName: string): Promise<void> {
+    await this.newNameTextbox().fill(newName);
+    await this.submitRenameButton().click();
+  }
+}

--- a/workspaces/lightspeed/e2e-tests/utils/devMode.ts
+++ b/workspaces/lightspeed/e2e-tests/utils/devMode.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Page } from '@playwright/test';
+
+import { randomUUID } from 'node:crypto';
+
+import { Page, Route } from '@playwright/test';
 import {
   contentsWithRedactedThinking,
   E2E_MCP_VALID_TOKEN,
@@ -79,6 +82,440 @@ export async function mockChatHistory(page: Page, contents?: any[]) {
  */
 export async function mockChatHistoryWithRedactedThinking(page: Page) {
   await mockChatHistory(page, contentsWithRedactedThinking);
+}
+
+const notebookLightspeedV1RouteMatches = (url: URL): boolean =>
+  url.pathname.includes('/api/lightspeed/notebooks/v1/');
+
+const notebookConversationSeedByPage = new WeakMap<Page, string>();
+
+/** Per-page seed for {@link mockNotebookLightspeedBackend} (`metadata.conversation_id` on sessions). */
+export function notebookE2eSetConversationSeed(
+  page: Page,
+  conversationId: string,
+) {
+  notebookConversationSeedByPage.set(page, conversationId);
+}
+
+export function notebookE2eClearConversationSeed(page: Page) {
+  notebookConversationSeedByPage.delete(page);
+}
+
+const E2E_NB_USER = 'user:development/guest';
+
+function stripTrailingSlashes(path: string): string {
+  let result = path;
+  while (result.endsWith('/')) {
+    result = result.slice(0, -1);
+  }
+  return result;
+}
+
+/** Session list path tail after `/v1/sessions`, or `null` if URL is not notebooks v1 sessions. */
+function notebookV1SessionsPathTail(pathname: string): string[] | null {
+  const normalized = stripTrailingSlashes(pathname);
+  const parts = normalized.split('/').filter(Boolean);
+  const i = parts.indexOf('sessions');
+  if (i < 1 || parts[i - 1] !== 'v1') return null;
+  return parts.slice(i + 1);
+}
+
+/** `name` from JSON body when present and a string (`POST` creates, `PUT` renames); otherwise `undefined`. */
+function notebookRouteJsonName(route: Route): string | undefined {
+  try {
+    const body: unknown = route.request().postDataJSON();
+    if (typeof body !== 'object' || body === null) return undefined;
+    const name = (body as { name?: unknown }).name;
+    return typeof name === 'string' ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Stateful handler for `/api/lightspeed/notebooks/v1/**` (sessions + documents).
+ * Same idea as {@link mockMcpServers}: closure holds maps; one `page.route` callback.
+ */
+function createNotebookLightspeedRouteHandler(page: Page) {
+  const sessionsOrder: string[] = [];
+  const sessions = new Map<string, Record<string, unknown>>();
+  const documents = new Map<string, Map<string, Record<string, unknown>>>();
+  let sessionIdSeq = 0;
+
+  const nextSessionId = () => {
+    sessionIdSeq += 1;
+    return `vs_e2e_${Date.now()}_${sessionIdSeq}`;
+  };
+
+  const docCount = (sessionId: string) => documents.get(sessionId)?.size ?? 0;
+
+  const docsFor = (sessionId: string): Map<string, Record<string, unknown>> => {
+    let m = documents.get(sessionId);
+    if (!m) {
+      m = new Map();
+      documents.set(sessionId, m);
+    }
+    return m;
+  };
+
+  /** Rough `source_type` for uploaded titles (fixture JSON etc.). */
+  const inferSourceType = (fileName: string): string => {
+    const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+    if (ext === 'yml') return 'yaml';
+    if (
+      ext === 'json' ||
+      ext === 'yaml' ||
+      ext === 'md' ||
+      ext === 'txt' ||
+      ext === 'log'
+    )
+      return ext;
+    return 'text';
+  };
+
+  const decorateSession = (
+    base: Record<string, unknown>,
+  ): Record<string, unknown> => {
+    const cid = notebookConversationSeedByPage.get(page);
+    if (!cid) return base;
+    const meta =
+      (base.metadata as Record<string, unknown> | undefined) ??
+      ({} as Record<string, unknown>);
+    return {
+      ...base,
+      metadata: { ...meta, conversation_id: cid },
+    };
+  };
+
+  const readSessionForApi = (sessionId: string): Record<string, unknown> => {
+    const s = sessions.get(sessionId);
+    if (!s) {
+      throw new Error(`mock notebook: missing session ${sessionId}`);
+    }
+    return decorateSession({
+      ...s,
+      document_count: docCount(sessionId),
+    });
+  };
+
+  const touchSessionAfterDocChange = (sid: string, updatedAt: string) => {
+    const prev = sessions.get(sid);
+    if (!prev) return;
+    sessions.set(sid, {
+      ...prev,
+      updated_at: updatedAt,
+      document_count: docCount(sid),
+    });
+  };
+
+  const fulfillSessionsCollection = async (
+    route: Route,
+    method: string,
+  ): Promise<boolean> => {
+    if (method === 'GET') {
+      const list = sessionsOrder.map(id => readSessionForApi(id));
+      await route.fulfill({
+        json: { status: 'success', sessions: list, count: list.length },
+      });
+      return true;
+    }
+    if (method !== 'POST') return false;
+
+    const name = notebookRouteJsonName(route) ?? 'Untitled Notebook';
+    const id = nextSessionId();
+    const now = new Date().toISOString();
+    const session: Record<string, unknown> = {
+      session_id: id,
+      user_id: E2E_NB_USER,
+      name,
+      description: '',
+      created_at: now,
+      updated_at: now,
+      document_count: 0,
+      metadata: {
+        embedding_model: 'sentence-transformers/e2e-mock',
+        provider_id: 'notebooks',
+        conversation_id: null,
+        embedding_dimension: '768',
+      },
+    };
+    sessions.set(id, session);
+    sessionsOrder.push(id);
+    await route.fulfill({
+      json: {
+        status: 'success',
+        session: readSessionForApi(id),
+      },
+    });
+    return true;
+  };
+
+  const fulfillSessionSingle = async (
+    route: Route,
+    method: string,
+    sid: string,
+  ): Promise<boolean> => {
+    const existing = sessions.get(sid);
+    if (!existing) {
+      await route.fulfill({
+        status: 404,
+        json: { status: 'error', error: 'Session not found' },
+      });
+      return true;
+    }
+    if (method === 'GET') {
+      await route.fulfill({
+        json: { status: 'success', session: readSessionForApi(sid) },
+      });
+      return true;
+    }
+    if (method === 'PUT') {
+      const newName = notebookRouteJsonName(route);
+      const next = { ...existing };
+      if (newName !== undefined) next.name = newName;
+      next.updated_at = new Date().toISOString();
+      sessions.set(sid, next);
+      await route.fulfill({ json: { status: 'success' } });
+      return true;
+    }
+    if (method !== 'DELETE') return false;
+
+    sessions.delete(sid);
+    const ix = sessionsOrder.indexOf(sid);
+    if (ix >= 0) sessionsOrder.splice(ix, 1);
+    documents.delete(sid);
+    await route.fulfill({ json: { status: 'success' } });
+    return true;
+  };
+
+  const fulfillDocumentsDocumentsRoot = async (
+    route: Route,
+    method: string,
+    sid: string,
+  ): Promise<boolean> => {
+    if (method === 'GET') {
+      const arr = Array.from(docsFor(sid).values());
+      await route.fulfill({
+        json: {
+          status: 'success',
+          session_id: sid,
+          documents: arr,
+          count: arr.length,
+        },
+      });
+      return true;
+    }
+    if (method !== 'PUT') return false;
+
+    let fileName = 'upload.json';
+    try {
+      const buf = await route.request().postDataBuffer();
+      if (buf) {
+        const m = /filename="([^"]+)"/.exec(buf.toString('latin1'));
+        if (m?.[1]) fileName = m[1];
+      }
+    } catch {
+      /* keep default */
+    }
+
+    const docId = `doc_e2e_${Date.now()}_${randomUUID()}`;
+    const now = new Date().toISOString();
+    const doc: Record<string, unknown> = {
+      document_id: docId,
+      title: fileName,
+      session_id: sid,
+      user_id: E2E_NB_USER,
+      source_type: inferSourceType(fileName),
+      created_at: now,
+    };
+    docsFor(sid).set(docId, doc);
+    touchSessionAfterDocChange(sid, now);
+
+    await route.fulfill({
+      status: 202,
+      json: {
+        status: 'processing',
+        document_id: docId,
+        session_id: sid,
+        message: 'mock upload accepted',
+      },
+    });
+    return true;
+  };
+
+  const fulfillDocumentDelete = async (
+    route: Route,
+    method: string,
+    sid: string,
+    encodedDocId: string,
+  ): Promise<boolean> => {
+    if (method !== 'DELETE') return false;
+
+    docsFor(sid).delete(decodeURIComponent(encodedDocId));
+    touchSessionAfterDocChange(sid, new Date().toISOString());
+    await route.fulfill({ json: { status: 'success' } });
+    return true;
+  };
+
+  const fulfillDocumentStatus = async (
+    route: Route,
+    method: string,
+    sid: string,
+    encodedDocId: string,
+  ): Promise<boolean> => {
+    if (method !== 'GET') return false;
+
+    const docId = decodeURIComponent(encodedDocId);
+    if (!docsFor(sid).has(docId)) {
+      await route.fulfill({
+        status: 404,
+        json: { status: 'error', error: 'Document not found' },
+      });
+      return true;
+    }
+    await route.fulfill({
+      json: {
+        status: 'completed',
+        document_id: docId,
+        session_id: sid,
+      },
+    });
+    return true;
+  };
+
+  const fulfillDocumentsRoutes = async (
+    route: Route,
+    method: string,
+    tail: string[],
+    sid: string,
+  ): Promise<boolean> => {
+    if (!sessions.has(sid)) {
+      await route.fulfill({
+        status: 404,
+        json: { status: 'error', error: 'Session not found' },
+      });
+      return true;
+    }
+    if (tail.length === 2 && tail[1] === 'documents') {
+      return fulfillDocumentsDocumentsRoot(route, method, sid);
+    }
+    if (
+      tail.length === 4 &&
+      tail[1] === 'documents' &&
+      tail[3] === 'status' &&
+      tail[2]
+    ) {
+      return fulfillDocumentStatus(route, method, sid, tail[2]);
+    }
+    if (tail.length === 3 && tail[1] === 'documents' && tail[2]) {
+      return fulfillDocumentDelete(route, method, sid, tail[2]);
+    }
+    return false;
+  };
+
+  return async (route: Route): Promise<void> => {
+    const req = route.request();
+    const urlObj = new URL(req.url());
+    if (!notebookLightspeedV1RouteMatches(urlObj)) {
+      await route.fallback();
+      return;
+    }
+    const tail = notebookV1SessionsPathTail(urlObj.pathname);
+    if (!tail) {
+      await route.fallback();
+      return;
+    }
+    const method = req.method();
+    try {
+      if (tail.length === 0 && (await fulfillSessionsCollection(route, method)))
+        return;
+      const sessionSegment = tail[0];
+      if (!sessionSegment) {
+        await route.fallback();
+        return;
+      }
+      const sid = decodeURIComponent(sessionSegment);
+      if (
+        tail.length === 1 &&
+        (await fulfillSessionSingle(route, method, sid))
+      ) {
+        return;
+      }
+      if (
+        tail.length >= 2 &&
+        tail[1] === 'documents' &&
+        (await fulfillDocumentsRoutes(route, method, tail, sid))
+      ) {
+        return;
+      }
+    } catch {
+      await route.fulfill({
+        status: 500,
+        json: { status: 'error', error: 'mock notebooks handler error' },
+      });
+      return;
+    }
+    await route.fallback();
+  };
+}
+
+/**
+ * In-memory notebooks API (`NotebooksApiClient`): sessions CRUD, document upload/list/delete/status.
+ * Mirrors how other Lightspeed mocks use `page.route` + in-memory state (see {@link mockMcpServers}).
+ */
+export async function mockNotebookLightspeedBackend(page: Page): Promise<void> {
+  await page.route(
+    notebookLightspeedV1RouteMatches,
+    createNotebookLightspeedRouteHandler(page),
+  );
+}
+
+/**
+ * Notebook tab only loads `/v2/conversations/:id` when `NotebookSession.metadata.conversation_id`
+ * is set. Sets the per-page conversation seed for {@link mockNotebookLightspeedBackend}, overrides
+ * GET `/v2/conversations/*` with seeded `chat_history`. Teardown clears the seed and restores
+ * {@link mockChatHistory}.
+ */
+export async function withNotebookTabSeededConversation(
+  page: Page,
+  options: { conversationId: string; chatHistory: Record<string, unknown>[] },
+): Promise<() => Promise<void>> {
+  const { conversationId, chatHistory } = options;
+
+  notebookE2eSetConversationSeed(page, conversationId);
+
+  const conversationGetHandler = async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    const url = route.request().url();
+    const match = url.match(/\/v2\/conversations\/([^/?]+)/);
+    const captured = match?.[1];
+    const id =
+      captured === undefined ? conversationId : decodeURIComponent(captured);
+    await route.fulfill({
+      json: {
+        conversation_id: id,
+        chat_history: chatHistory,
+      },
+    });
+  };
+
+  await page.unroute(`${modelBaseUrl}/v2/conversations/*`);
+  await page.route(
+    `${modelBaseUrl}/v2/conversations/*`,
+    conversationGetHandler,
+  );
+
+  return async () => {
+    notebookE2eClearConversationSeed(page);
+    await page.unroute(
+      `${modelBaseUrl}/v2/conversations/*`,
+      conversationGetHandler,
+    );
+    await mockChatHistory(page);
+  };
 }
 
 export async function mockQuery(
@@ -181,7 +618,12 @@ export async function mockMcpServers(
       segments.length === 2 &&
       segments[1] === 'validate'
     ) {
-      const name = decodeURIComponent(segments[0]!);
+      const nameSeg = segments[0];
+      if (!nameSeg) {
+        await route.fulfill({ status: 400, json: { error: 'Invalid path' } });
+        return;
+      }
+      const name = decodeURIComponent(nameSeg);
       if (mcpMockOptions.failServerValidateFor === name) {
         await route.fulfill({
           json: {
@@ -224,7 +666,12 @@ export async function mockMcpServers(
     }
 
     if (req.method() === 'PATCH' && segments.length === 1) {
-      const name = decodeURIComponent(segments[0]!);
+      const nameSeg = segments[0];
+      if (!nameSeg) {
+        await route.fulfill({ status: 400, json: { error: 'Invalid path' } });
+        return;
+      }
+      const name = decodeURIComponent(nameSeg);
       let body: { enabled?: boolean; token?: string | null };
       try {
         body = req.postDataJSON();

--- a/workspaces/lightspeed/e2e-tests/utils/lightspeedE2eSetup.ts
+++ b/workspaces/lightspeed/e2e-tests/utils/lightspeedE2eSetup.ts
@@ -23,6 +23,7 @@ import {
   mockFeedbackStatus,
   mockMcpServers,
   mockModels,
+  mockNotebookLightspeedBackend,
   mockQuery,
   mockShields,
 } from './devMode';
@@ -68,6 +69,7 @@ export async function bootstrapLightspeedE2ePage(
   await mockShields(page, mockedShields);
   await mockMcpServers(page);
   await mockFeedbackStatus(page);
+  await mockNotebookLightspeedBackend(page);
 
   await page.goto('/');
   await loginAsGuest(page);

--- a/workspaces/lightspeed/e2e-tests/utils/notebookTranslation.ts
+++ b/workspaces/lightspeed/e2e-tests/utils/notebookTranslation.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Replace `{{placeholders}}` like plugin i18n templates. */
+export function substituteNotebookTemplate(
+  template: string,
+  vars: Record<string, string | number>,
+): string {
+  return Object.entries(vars).reduce(
+    (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, String(v)),
+    template,
+  );
+}

--- a/workspaces/lightspeed/e2e-tests/utils/notebooks.ts
+++ b/workspaces/lightspeed/e2e-tests/utils/notebooks.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'node:path';
+
+/** Same cap as plugin `NOTEBOOK_MAX_FILES`: max attachments per notebook session. */
+export const NOTEBOOK_SESSION_MAX_DOCUMENTS = 10;
+
+/** Playwright URL match when a notebook editor session route is active. */
+export const NOTEBOOK_EDITOR_URL_RE = /\/lightspeed\/notebooks\/[^/]+$/;
+
+/** Chat upload JSON fixtures shared with conversational upload e2e (`fixtures/uploads`). */
+const UPLOAD_FIXTURE_DIR = path.join(__dirname, '..', 'fixtures', 'uploads');
+
+/**
+ * Eleven distinct `*.upload*.json` files under `fixtures/uploads` (`NOTEBOOK_SESSION_MAX_DOCUMENTS` + 1)
+ * so the staging UI rejects the batch with `notebook.upload.error.tooManyFiles`.
+ */
+const DISTINCT_UPLOAD_JSON_FOR_CAP_TEST = [
+  'de.upload1.json',
+  'de.upload2.json',
+  'en.upload1.json',
+  'en.upload2.json',
+  'es.upload1.json',
+  'es.upload2.json',
+  'fr.upload1.json',
+  'fr.upload2.json',
+  'it.upload1.json',
+  'it.upload2.json',
+  'ja.upload1.json',
+] as const;
+
+/** Eleven paths — one over `NOTEBOOK_SESSION_MAX_DOCUMENTS` — to assert `notebook.upload.error.tooManyFiles`. */
+export function notebookElevenFileStagingPaths(): string[] {
+  return DISTINCT_UPLOAD_JSON_FOR_CAP_TEST.map(f =>
+    path.join(UPLOAD_FIXTURE_DIR, f),
+  );
+}
+
+export function notebookUnsupportedTypeFixturePath(): string {
+  return path.join(__dirname, 'notebookTranslation.ts');
+}
+
+/** Same locale-keyed JSON fixtures as chat uploads (`fixtures/uploads/{locale}.upload1.json`). */
+export function localeNotebookUpload1Path(playwrightLocale: string): {
+  absolutePath: string;
+  fileName: string;
+} {
+  const locale = playwrightLocale.split('-')[0] ?? playwrightLocale;
+  const fileName = `${locale}.upload1.json`;
+  return {
+    absolutePath: path.join(UPLOAD_FIXTURE_DIR, fileName),
+    fileName,
+  };
+}


### PR DESCRIPTION
**Resolves:** [RHIDP-11796](https://redhat.atlassian.net/browse/RHIDP-11796)

### Summary

Adds Playwright coverage for the Lightspeed **Notebooks** surface (fullscreen UI, uploads, grid, and seeded notebook-thread behavior), plus dev **`app-config`** defaults to keep e2e stable. **Notebook REST behavior** is exercised via a stateful **`devMode`** mock for `/api/lightspeed/notebooks/v1/**` (sessions, documents, upload, inference), with small **Sonar-friendly** helpers (e.g. `randomUUID` for mock document ids, non–ReDoS path normalization).

### Notebooks UI (`lightspeed.notebooks.test.ts`, serial)

| Area | Coverage |
|------|----------|
| **List / empty state** | Fullscreen tab header and empty grid (a11y snapshot). |
| **New notebook** | Open editor; empty onboarding (upload CTA, disclaimer, disabled composer + tooltip, sidebar). |
| **Upload modal** | Drop zone (snapshots); Add disabled when no files staged. |
| **Document sidebar** | Collapse / expand; add locale JSON fixture, listed in sidebar; delete via row overflow. |
| **Validation** | Staging eleven files → **too many files** error; staging `.ts` → **unsupported type** error. |
| **Duplicate upload** | Re-stage same file → **overwrite** confirmation (file listed); **Cancel** on overwrite and upload modals (localized **page object** `clickCancel`); then remove doc from sidebar. |
| **Grid** | Close editor → new card; rename via overflow; delete with confirmation. |

### Notebook chat (`lightspeed.notebooks.conversation.test.ts`)

Mocks **`GET /api/lightspeed/v2/conversations/:id`** and injects **`metadata.conversation_id`** on notebook session payloads so the notebook tab loads seeded history. Asserts user + assistant turns (RAG-style copy), **feedback** (good/bad), **copy to clipboard**, then deletes the notebook. **`withNotebookTabSeededConversation`** returns a teardown function; mocks are restored in **`test.afterAll`** (`endMocks?.()`).

### Other e2e

**`lightspeed.conversation.test.ts`** — **“Conversation is created and shown in side panel”** is enabled again (skip removed).

