### PR TITLE
feat: add E2E coverage flags for overlay cross-repo uploads

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -135,3 +135,24 @@ flag_management:
     - name: x2a
       paths:
         - workspaces/x2a/
+    # E2E coverage flags — cross-repo uploads from rhdh-plugin-export-overlays
+    # Overlay E2E tests run instrumented plugins on a real RHDH/K8s deployment
+    # and upload Istanbul coverage attributed to this repo. See: RHIDP-13411
+    - name: e2e-adoption-insights
+      paths:
+        - workspaces/adoption-insights/
+    - name: e2e-global-header
+      paths:
+        - workspaces/global-header/
+    - name: e2e-homepage
+      paths:
+        - workspaces/homepage/
+    - name: e2e-quickstart
+      paths:
+        - workspaces/quickstart/
+    - name: e2e-scorecard
+      paths:
+        - workspaces/scorecard/
+    - name: e2e-theme
+      paths:
+        - workspaces/theme/

--- a/codecov.yml
+++ b/codecov.yml
@@ -90,6 +90,25 @@ flag_management:
     - name: dcm
       paths:
         - workspaces/dcm/
+    # E2E coverage flags — cross-repo uploads from overlay E2E pipeline (RHIDP-13411)
+    - name: e2e-adoption-insights
+      paths:
+        - workspaces/adoption-insights/
+    - name: e2e-global-header
+      paths:
+        - workspaces/global-header/
+    - name: e2e-homepage
+      paths:
+        - workspaces/homepage/
+    - name: e2e-quickstart
+      paths:
+        - workspaces/quickstart/
+    - name: e2e-scorecard
+      paths:
+        - workspaces/scorecard/
+    - name: e2e-theme
+      paths:
+        - workspaces/theme/
     - name: extensions
       paths:
         - workspaces/extensions/
@@ -135,24 +154,3 @@ flag_management:
     - name: x2a
       paths:
         - workspaces/x2a/
-    # E2E coverage flags — cross-repo uploads from rhdh-plugin-export-overlays
-    # Overlay E2E tests run instrumented plugins on a real RHDH/K8s deployment
-    # and upload Istanbul coverage attributed to this repo. See: RHIDP-13411
-    - name: e2e-adoption-insights
-      paths:
-        - workspaces/adoption-insights/
-    - name: e2e-global-header
-      paths:
-        - workspaces/global-header/
-    - name: e2e-homepage
-      paths:
-        - workspaces/homepage/
-    - name: e2e-quickstart
-      paths:
-        - workspaces/quickstart/
-    - name: e2e-scorecard
-      paths:
-        - workspaces/scorecard/
-    - name: e2e-theme
-      paths:
-        - workspaces/theme/


### PR DESCRIPTION
## Summary

- Adds 6 `e2e-*` flags to `codecov.yml` for workspaces that have E2E tests in [rhdh-plugin-export-overlays](https://github.com/redhat-developer/rhdh-plugin-export-overlays)
- These flags receive cross-repo Istanbul coverage uploads from instrumented dynamic plugin builds running on real RHDH/Kubernetes deployments
- Flags: `e2e-adoption-insights`, `e2e-global-header`, `e2e-homepage`, `e2e-quickstart`, `e2e-scorecard`, `e2e-theme`

## How it works

The overlay repo builds Istanbul-instrumented dynamic plugins (post-webpack `nyc instrument`), deploys them on a real RHDH instance, runs Playwright E2E tests, collects `window.__coverage__`, and uploads the resulting lcov to this repo's Codecov using:

```bash
codecov upload-process \
  --slug redhat-developer/rhdh-plugins \
  --sha <repo-ref from source.json> \
  --flag e2e-<workspace>
```

The coverage is attributed to the correct commit in this repo, and the `e2e-*` flags allow filtering E2E vs unit coverage on the Codecov dashboard.

Flags inherit `carryforward: true` and status rules from `default_rules`.

## Related

- Instrumentation pipeline: https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2383
- Jira: RHIDP-13411

## Test plan

- [ ] Verify `codecov.yml` syntax is valid (Codecov validates on next upload)
- [ ] Verify new flags appear on Codecov Flags page after first E2E upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)