### PR TITLE
refactor: MigrationPhase as class with helper methods

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/src/router/collectArtifacts.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/collectArtifacts.ts
@@ -26,6 +26,7 @@ import {
   Artifact,
   JobStatusEnum,
   Telemetry,
+  Phase,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import type { RouterDeps } from './types';
@@ -165,11 +166,11 @@ class RequestValidator {
     phase: MigrationPhase,
     moduleId: string | undefined,
   ): void {
-    if (phase === 'init' && moduleId) {
+    if (Phase.from(phase).isProjectPhase() && moduleId) {
       throw new InputError('moduleId must not be provided for init phase');
     }
 
-    if (phase !== 'init' && !moduleId) {
+    if (Phase.from(phase).isModulePhase() && !moduleId) {
       throw new InputError(`moduleId is required for ${phase} phase`);
     }
   }
@@ -211,7 +212,7 @@ class RequestValidator {
       );
     }
 
-    if (phase !== 'init' && job.moduleId !== moduleId) {
+    if (Phase.from(phase).isModulePhase() && job.moduleId !== moduleId) {
       throw new InputError(
         `Job moduleId mismatch: expected ${moduleId}, got ${job.moduleId}`,
       );

--- a/workspaces/x2a/plugins/x2a-backend/src/router/jobs.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/jobs.ts
@@ -20,6 +20,7 @@ import { InputError, NotFoundError } from '@backstage/errors';
 import {
   ModulePhase,
   Job,
+  Phase,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import type { RouterDeps } from './types';
@@ -151,7 +152,7 @@ export function registerJobRoutes(
     const phase = req.query.phase as ModulePhase;
 
     // Validate phase parameter (required)
-    if (!phase || !['analyze', 'migrate', 'publish'].includes(phase)) {
+    if (!phase || !Phase.modulePhaseValues().includes(phase)) {
       throw new InputError(
         'phase query parameter is required and must be one of: analyze, migrate, publish',
       );

--- a/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/router/modules.ts
@@ -18,6 +18,11 @@ import { z } from 'zod';
 import express from 'express';
 import { InputError, NotFoundError } from '@backstage/errors';
 
+import {
+  type ModulePhase,
+  Phase,
+} from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+
 import type { RouterDeps } from './types';
 import {
   generateCallbackToken,
@@ -179,7 +184,9 @@ export function registerModuleRoutes(
 
       // Validate request body
       const runModuleRequestSchema = z.object({
-        phase: z.enum(['analyze', 'migrate', 'publish']),
+        phase: z.enum(
+          Phase.modulePhaseValues() as [ModulePhase, ...ModulePhase[]],
+        ),
         sourceRepoAuth: z
           .object({
             token: z.string(),
@@ -364,7 +371,9 @@ export function registerModuleRoutes(
       );
 
       const cancelModuleRequestSchema = z.object({
-        phase: z.enum(['analyze', 'migrate', 'publish']),
+        phase: z.enum(
+          Phase.modulePhaseValues() as [ModulePhase, ...ModulePhase[]],
+        ),
       });
 
       const parsedBody = cancelModuleRequestSchema

--- a/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/jobOperations.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/jobOperations.ts
@@ -23,6 +23,7 @@ import {
   MigrationPhase,
   Artifact,
   Telemetry,
+  Phase,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import { mapRowToJob, mapRowToArtifact } from './mappers';
@@ -253,7 +254,7 @@ export class JobOperations {
         if (moduleId) {
           queryBuilder.where('module_id', moduleId);
         }
-        if (phase === 'init') {
+        if (phase && Phase.from(phase).isProjectPhase()) {
           queryBuilder.whereNull('module_id');
         }
       })

--- a/workspaces/x2a/plugins/x2a-common/report.api.md
+++ b/workspaces/x2a/plugins/x2a-common/report.api.md
@@ -196,6 +196,40 @@ export function normalizeSourceTechnology(raw: string | undefined): SourceTechno
 // @public
 export function parseCsvContent(dataUrl: string): CsvProjectRow[];
 
+// @public (undocumented)
+export class Phase {
+    // (undocumented)
+    static all(): readonly Phase[];
+    // (undocumented)
+    static readonly ANALYZE: Phase;
+    // (undocumented)
+    equals(other: Phase): boolean;
+    // (undocumented)
+    static from(raw: string): Phase;
+    // (undocumented)
+    static readonly INIT: Phase;
+    // (undocumented)
+    isModulePhase(): boolean;
+    // (undocumented)
+    isProjectPhase(): boolean;
+    // (undocumented)
+    static readonly MIGRATE: Phase;
+    // (undocumented)
+    static modulePhases(): readonly Phase[];
+    // (undocumented)
+    static modulePhaseValues(): readonly ModulePhase[];
+    // (undocumented)
+    readonly ordinal: number;
+    // (undocumented)
+    static readonly PUBLISH: Phase;
+    // (undocumented)
+    toString(): string;
+    // (undocumented)
+    readonly value: MigrationPhase;
+    // (undocumented)
+    static values(): readonly MigrationPhase[];
+}
+
 // @public
 export const POLLING_INTERVAL_MS: number;
 

--- a/workspaces/x2a/plugins/x2a-common/src/domain/Phase.test.ts
+++ b/workspaces/x2a/plugins/x2a-common/src/domain/Phase.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Phase } from './Phase';
+
+describe('Phase', () => {
+  describe('from', () => {
+    it('returns Phase.INIT for "init"', () => {
+      expect(Phase.from('init')).toBe(Phase.INIT);
+    });
+
+    it('returns Phase.ANALYZE for "analyze"', () => {
+      expect(Phase.from('analyze')).toBe(Phase.ANALYZE);
+    });
+
+    it('returns Phase.MIGRATE for "migrate"', () => {
+      expect(Phase.from('migrate')).toBe(Phase.MIGRATE);
+    });
+
+    it('returns Phase.PUBLISH for "publish"', () => {
+      expect(Phase.from('publish')).toBe(Phase.PUBLISH);
+    });
+
+    it('throws for an invalid phase', () => {
+      expect(() => Phase.from('invalid')).toThrow(
+        'Invalid migration phase: "invalid". Valid: init, analyze, migrate, publish',
+      );
+    });
+  });
+
+  describe('all', () => {
+    it('returns 4 phases in ordinal order', () => {
+      const all = Phase.all();
+      expect(all).toHaveLength(4);
+      expect(all).toEqual([
+        Phase.INIT,
+        Phase.ANALYZE,
+        Phase.MIGRATE,
+        Phase.PUBLISH,
+      ]);
+    });
+  });
+
+  describe('modulePhases', () => {
+    it('returns 3 phases excluding init', () => {
+      const modulePhases = Phase.modulePhases();
+      expect(modulePhases).toHaveLength(3);
+      expect(modulePhases).toEqual([
+        Phase.ANALYZE,
+        Phase.MIGRATE,
+        Phase.PUBLISH,
+      ]);
+    });
+  });
+
+  describe('values', () => {
+    it('returns raw string values for all phases', () => {
+      expect(Phase.values()).toEqual(['init', 'analyze', 'migrate', 'publish']);
+    });
+  });
+
+  describe('modulePhaseValues', () => {
+    it('returns raw string values for module phases', () => {
+      expect(Phase.modulePhaseValues()).toEqual([
+        'analyze',
+        'migrate',
+        'publish',
+      ]);
+    });
+  });
+
+  describe('isProjectPhase / isModulePhase', () => {
+    it('INIT is a project phase', () => {
+      expect(Phase.INIT.isProjectPhase()).toBe(true);
+      expect(Phase.INIT.isModulePhase()).toBe(false);
+    });
+
+    it('ANALYZE is a module phase', () => {
+      expect(Phase.ANALYZE.isModulePhase()).toBe(true);
+      expect(Phase.ANALYZE.isProjectPhase()).toBe(false);
+    });
+
+    it('MIGRATE is a module phase', () => {
+      expect(Phase.MIGRATE.isModulePhase()).toBe(true);
+      expect(Phase.MIGRATE.isProjectPhase()).toBe(false);
+    });
+
+    it('PUBLISH is a module phase', () => {
+      expect(Phase.PUBLISH.isModulePhase()).toBe(true);
+      expect(Phase.PUBLISH.isProjectPhase()).toBe(false);
+    });
+  });
+
+  describe('ordinal', () => {
+    it('assigns ordinals in order', () => {
+      expect(Phase.INIT.ordinal).toBe(0);
+      expect(Phase.ANALYZE.ordinal).toBe(1);
+      expect(Phase.MIGRATE.ordinal).toBe(2);
+      expect(Phase.PUBLISH.ordinal).toBe(3);
+    });
+  });
+
+  describe('toString', () => {
+    it('returns the raw string value', () => {
+      expect(Phase.INIT.toString()).toBe('init');
+      expect(Phase.ANALYZE.toString()).toBe('analyze');
+      expect(Phase.MIGRATE.toString()).toBe('migrate');
+      expect(Phase.PUBLISH.toString()).toBe('publish');
+    });
+  });
+
+  describe('equals', () => {
+    it('returns true for same instance', () => {
+      expect(Phase.INIT.equals(Phase.INIT)).toBe(true);
+    });
+
+    it('returns true for Phase.from result', () => {
+      expect(Phase.INIT.equals(Phase.from('init'))).toBe(true);
+    });
+
+    it('returns false for different phases', () => {
+      expect(Phase.INIT.equals(Phase.ANALYZE)).toBe(false);
+    });
+  });
+});

--- a/workspaces/x2a/plugins/x2a-common/src/domain/Phase.ts
+++ b/workspaces/x2a/plugins/x2a-common/src/domain/Phase.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  MigrationPhase,
+  ModulePhase,
+} from '../../client/src/schema/openapi';
+
+/** @public */
+export class Phase {
+  static readonly INIT = new Phase('init', 0);
+  static readonly ANALYZE = new Phase('analyze', 1);
+  static readonly MIGRATE = new Phase('migrate', 2);
+  static readonly PUBLISH = new Phase('publish', 3);
+
+  private static readonly BY_VALUE = new Map<string, Phase>(
+    [Phase.INIT, Phase.ANALYZE, Phase.MIGRATE, Phase.PUBLISH].map(p => [
+      p.value,
+      p,
+    ]),
+  );
+
+  private constructor(
+    readonly value: MigrationPhase,
+    readonly ordinal: number,
+  ) {}
+
+  static from(raw: string): Phase {
+    const phase = Phase.BY_VALUE.get(raw);
+    if (!phase) {
+      throw new Error(
+        `Invalid migration phase: "${raw}". Valid: ${Phase.values().join(', ')}`,
+      );
+    }
+    return phase;
+  }
+
+  static all(): readonly Phase[] {
+    return [Phase.INIT, Phase.ANALYZE, Phase.MIGRATE, Phase.PUBLISH];
+  }
+
+  static modulePhases(): readonly Phase[] {
+    return [Phase.ANALYZE, Phase.MIGRATE, Phase.PUBLISH];
+  }
+
+  static values(): readonly MigrationPhase[] {
+    return Phase.all().map(p => p.value);
+  }
+
+  static modulePhaseValues(): readonly ModulePhase[] {
+    return Phase.modulePhases().map(p => p.value as ModulePhase);
+  }
+
+  isModulePhase(): boolean {
+    return this !== Phase.INIT;
+  }
+
+  isProjectPhase(): boolean {
+    return this === Phase.INIT;
+  }
+
+  equals(other: Phase): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/workspaces/x2a/plugins/x2a-common/src/domain/index.ts
+++ b/workspaces/x2a/plugins/x2a-common/src/domain/index.ts
@@ -14,17 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * Common functionalities for the x2a plugin.
- *
- * @packageDocumentation
- */
-export * from '../client/src/schema/openapi';
-export * from './permissions';
-export * from './x2aJobStatusLiterals';
-export * from './x2aArtifactTypeLiterals';
-export * from './constants';
-export * from './utils';
-export * from './scm';
-export * from './csv';
-export * from './domain';
+export { Phase } from './Phase';

--- a/workspaces/x2a/plugins/x2a-node/report.api.md
+++ b/workspaces/x2a/plugins/x2a-node/report.api.md
@@ -12,7 +12,7 @@ import type { Job } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 import type { JobStatusEnum } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 import type { LoggerService } from '@backstage/backend-plugin-api';
 import type { MigrationPhase } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
-import type { Module } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+import { Module } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 import type { ModuleStatus } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 import type { PermissionsService } from '@backstage/backend-plugin-api';
 import type { Project } from '@red-hat-developer-hub/backstage-plugin-x2a-common';

--- a/workspaces/x2a/plugins/x2a-node/src/modulesReconcile.ts
+++ b/workspaces/x2a/plugins/x2a-node/src/modulesReconcile.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { Module } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+import {
+  type Module,
+  Phase,
+} from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import { calculateModuleStatus } from './moduleStatus';
 import type { ReconcileJobDeps } from './services';
@@ -29,7 +32,7 @@ export async function reconcileModuleJobs(
   module: Module,
   deps: ReconcileJobDeps,
 ): Promise<Module> {
-  const phases = ['analyze', 'migrate', 'publish'] as const;
+  const phases = Phase.modulePhaseValues();
   for (const phase of phases) {
     const job = module[phase];
     if (job && ['pending', 'running'].includes(job.status)) {


### PR DESCRIPTION
It helps with having all in the same place, and using always the same class instead of multiple strings in a lot of places.
