### PR TITLE
fix(bulk-import): correct dataFetcher return type and replace unsafe Response casts

### DIFF
--- a/workspaces/bulk-import/.changeset/plain-candles-bake.md
+++ b/workspaces/bulk-import/.changeset/plain-candles-bake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Corrected `dataFetcher` return type to include `Response` and replaced unsafe type casts with `instanceof` narrowing.

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.test.ts
@@ -348,7 +348,7 @@ describe('BulkImportBackendClient with open-pull-requests', () => {
 
       await expect(
         bulkImportApi.dataFetcher(1, 2, '', ApprovalTool.Git),
-      ).resolves.toEqual(expect.objectContaining([]));
+      ).resolves.toBeInstanceOf(Response);
     });
   });
 
@@ -427,7 +427,7 @@ describe('BulkImportBackendClient with open-pull-requests', () => {
         bulkImportApi.dataFetcher(1, 2, '', ApprovalTool.Git, {
           fetchOrganizations: true,
         }),
-      ).resolves.toEqual(expect.objectContaining([]));
+      ).resolves.toBeInstanceOf(Response);
     });
   });
 
@@ -459,6 +459,12 @@ describe('BulkImportBackendClient with open-pull-requests', () => {
     });
 
     it('getImportJobs should handle non-200/204 responses correctly', async () => {
+      server.use(
+        rest.get(`${LOCAL_ADDR}/api/bulk-import/imports`, (_req, res, ctx) => {
+          return res(ctx.status(404));
+        }),
+      );
+
       await expect(
         bulkImportApi.getImportJobs(
           1,
@@ -467,7 +473,7 @@ describe('BulkImportBackendClient with open-pull-requests', () => {
           AddedRepositoryColumnNameEnum.repoName,
           SortingOrderEnum.Asc,
         ),
-      ).resolves.toEqual(expect.objectContaining([]));
+      ).resolves.toBeInstanceOf(Response);
     });
   });
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
@@ -47,7 +47,7 @@ export type BulkImportAPI = {
     searchString: string,
     approvalTool: ApprovalTool,
     options?: APITypes,
-  ) => Promise<OrgAndRepoResponse>;
+  ) => Promise<OrgAndRepoResponse | Response>;
   getImportJobs: (
     page: number,
     size: number,

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebar.tsx
@@ -95,14 +95,14 @@ export const PreviewFileSidebar = ({
       branch || 'main',
       approvalTool,
     );
-    if ((result as Response)?.statusText) {
+    if (result instanceof Response) {
       setStatus({
         ...status,
         errors: {
           ...(status?.errors || {}),
           [id]: {
             error: {
-              title: (result as Response)?.statusText,
+              title: result.statusText,
               message: [t('previewFile.failedToFetchPR')],
             },
           },

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Repositories/CatalogInfoAction.tsx
@@ -103,11 +103,11 @@ const CatalogInfoAction = ({ data }: { data: AddRepositoryData }) => {
         value?.status === RepositoryStatus.WAIT_PR_APPROVAL &&
         values.repositories[(value as ImportJobStatus)?.repository?.id];
 
-      if ((value as Response)?.statusText) {
+      if (value instanceof Response) {
         setOpenDrawer(false);
         setStatus({
-          title: (value as Response)?.statusText,
-          url: (value as Response)?.url,
+          title: value.statusText,
+          url: value.url,
         });
         removeQueryParams();
       } else if (shouldOpenPanel) {

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useAddedRepositories.ts
@@ -120,10 +120,10 @@ export const useAddedRepositories = (
     loading: isLoadingTable,
     error: {
       ...(error ?? {}),
-      ...((value as Response)?.statusText
+      ...(value instanceof Response
         ? {
             name: 'Error',
-            message: (value as Response)?.statusText,
+            message: value.statusText,
           }
         : {}),
     },

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
@@ -158,16 +158,24 @@ export const useRepositories = (
     );
   }, [options?.showOrganizations, value, user, baseUrl]);
 
+  const errors: string[] = [];
+
+  if (tokenFetchError) {
+    errors.push(tokenFetchError.message);
+  }
+
+  if (value instanceof Response) {
+    errors.push(value.statusText);
+  } else if (value?.errors && value.errors.length > 0) {
+    errors.push(...value.errors);
+  }
+
   return {
     loading: tokenLoading || isQueryLoading,
     data: prepareData,
     error: {
-      ...(tokenFetchError ? { errors: [tokenFetchError.message] } : {}),
       ...(error ?? {}),
-      ...((value?.errors && value.errors.length > 0) ||
-      (value as any as Response)?.statusText
-        ? { errors: value?.errors || (value as any as Response)?.statusText }
-        : {}),
+      ...(errors.length > 0 ? { errors } : {}),
     } as RepositoriesError,
   };
 };


### PR DESCRIPTION
The `dataFetcher` method returns a raw `Response` on error but the type declared only `OrgAndRepoResponse`. Fixed the return type union and replaced all unsafe `as Response` casts with `instanceof` narrowing. Also fixed three no-op test assertions that never validated anything.