### PR TITLE
feat(orchestrator): show workflow version and duplicate-ID info alert

### DIFF
--- a/workspaces/orchestrator/.changeset/orchestrator-version-duplicate-id-ui.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-version-duplicate-id-ui.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+- Add **Version** column to the workflows table (after Description) and a **Version** field on the workflow details card when the overview API provides `version`.
+- Show an **info** alert when the workflow list contains duplicate `workflowId` values, with a **Learn more** link to Red Hat documentation on unique workflow ID requirements.

--- a/workspaces/orchestrator/.changeset/orchestrator-version-duplicate-id-ui.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-version-duplicate-id-ui.md
@@ -2,5 +2,6 @@
 '@red-hat-developer-hub/backstage-plugin-orchestrator': patch
 ---
 
-- Add **Version** column to the workflows table (after Description) and a **Version** field on the workflow details card when the overview API provides `version`.
-- Show an **info** alert when the workflow list contains duplicate `workflowId` values, with a **Learn more** link to Red Hat documentation on unique workflow ID requirements.
+- Add **Version** column to the workflows table and a **Version** field on the workflow details card when the overview API provides `version`.
+- Show **Version** on the workflow run (**execution**) details card (same overview data as the workflow definition page).
+- Show a **warning** alert when the workflow list contains duplicate `workflowId` values, with a **Learn more** link to Red Hat documentation on unique workflow ID requirements.

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -248,6 +248,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'table.title.allWorkflowRuns': string;
     readonly 'table.headers.name': string;
     readonly 'table.headers.description': string;
+    readonly 'table.headers.version': string;
     readonly 'table.headers.duration': string;
     readonly 'table.headers.status': string;
     readonly 'table.headers.runStatus': string;
@@ -341,6 +342,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.status.available': string;
     readonly 'workflow.status.unavailable': string;
     readonly 'workflow.fields.description': string;
+    readonly 'workflow.fields.version': string;
     readonly 'workflow.fields.workflowId': string;
     readonly 'workflow.fields.duration': string;
     readonly 'workflow.fields.runStatus': string;
@@ -381,6 +383,8 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'permissions.contactAdmin': string;
     readonly 'permissions.missingOwnership': string;
     readonly 'permissions.notYourRun': string;
+    readonly 'alerts.duplicateWorkflowIds.message': string;
+    readonly 'alerts.duplicateWorkflowIds.learnMore': string;
     readonly 'stepperObjectField.error': string;
     readonly 'formDecorator.error': string;
     readonly 'aria.close': string;

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -42,6 +42,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'table.title.allWorkflowRuns': string;
     readonly 'table.headers.name': string;
     readonly 'table.headers.description': string;
+    readonly 'table.headers.version': string;
     readonly 'table.headers.duration': string;
     readonly 'table.headers.status': string;
     readonly 'table.headers.runStatus': string;
@@ -135,6 +136,7 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.status.available': string;
     readonly 'workflow.status.unavailable': string;
     readonly 'workflow.fields.description': string;
+    readonly 'workflow.fields.version': string;
     readonly 'workflow.fields.workflowId': string;
     readonly 'workflow.fields.duration': string;
     readonly 'workflow.fields.runStatus': string;
@@ -175,6 +177,8 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'permissions.contactAdmin': string;
     readonly 'permissions.missingOwnership': string;
     readonly 'permissions.notYourRun': string;
+    readonly 'alerts.duplicateWorkflowIds.message': string;
+    readonly 'alerts.duplicateWorkflowIds.learnMore': string;
     readonly 'stepperObjectField.error': string;
     readonly 'formDecorator.error': string;
     readonly 'aria.close': string;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
@@ -381,7 +381,7 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
       )}
       <Box sx={{ mb: showDuplicateWorkflowIdAlert ? 2 : 0 }}>
         {showDuplicateWorkflowIdAlert ? (
-          <Alert severity="info">
+          <Alert severity="warning">
             {t('alerts.duplicateWorkflowIds.message')}{' '}
             <MuiLink
               href={ENFORCING_UNIQUE_WORKFLOW_IDS_DOC_URL}

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
@@ -25,7 +25,11 @@ import { usePermission } from '@backstage/plugin-permission-react';
 import { SvgIcon } from '@material-ui/core';
 import DeveloperModeOutlinedMui from '@mui/icons-material/DeveloperModeOutlined';
 import FormatListBulletedMui from '@mui/icons-material/FormatListBulleted';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowMui from '@mui/icons-material/PlayArrow';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import MuiLink from '@mui/material/Link';
 
 import {
   orchestratorWorkflowPermission,
@@ -36,6 +40,7 @@ import {
   WorkflowOverviewDTO,
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 
+import { ENFORCING_UNIQUE_WORKFLOW_IDS_DOC_URL } from '../../constants';
 import WorkflowOverviewFormatter, {
   FormattedWorkflowOverview,
 } from '../../dataFormatters/WorkflowOverviewFormatter';
@@ -296,6 +301,11 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
     ],
   );
 
+  const showDuplicateWorkflowIdAlert = useMemo(() => {
+    const ids = items.map(i => i.workflowId);
+    return new Set(ids).size < ids.length;
+  }, [items]);
+
   const columns = useMemo<TableColumn<FormattedWorkflowOverview>[]>(
     () => [
       {
@@ -341,6 +351,10 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
         field: 'description',
         minWidth: '25vw',
       },
+      {
+        title: t('table.headers.version'),
+        field: 'version',
+      },
     ],
     [t, canViewWorkflow, entityLink, items, instanceLink],
   );
@@ -365,13 +379,35 @@ export const WorkflowsTable = ({ items }: WorkflowsTableProps) => {
           toggleInputSchemaDialog={toggleInputSchemaDialog}
         />
       )}
-      <OverrideBackstageTable<FormattedWorkflowOverview>
-        title={t('table.title.workflows')}
-        options={options}
-        columns={columns}
-        data={data}
-        actions={actions}
-      />
+      <Box sx={{ mb: showDuplicateWorkflowIdAlert ? 2 : 0 }}>
+        {showDuplicateWorkflowIdAlert ? (
+          <Alert severity="info">
+            {t('alerts.duplicateWorkflowIds.message')}{' '}
+            <MuiLink
+              href={ENFORCING_UNIQUE_WORKFLOW_IDS_DOC_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              color="primary"
+              underline="always"
+              variant="body2"
+              sx={{ fontWeight: 600 }}
+            >
+              {t('alerts.duplicateWorkflowIds.learnMore')}
+              <OpenInNewIcon
+                sx={{ ml: 0.5, fontSize: '1em', verticalAlign: 'text-bottom' }}
+                aria-hidden
+              />
+            </MuiLink>
+          </Alert>
+        ) : null}
+        <OverrideBackstageTable<FormattedWorkflowOverview>
+          title={t('table.title.workflows')}
+          options={options}
+          columns={columns}
+          data={data}
+          actions={actions}
+        />
+      </Box>
     </>
   );
 };

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowRunDetails.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowRunDetails.tsx
@@ -149,6 +149,17 @@ export const WorkflowRunDetails: FC<WorkflowDetailsCardProps> = ({
           </Typography>
         </AboutField>
       </Grid>
+      <Grid item md={12} key="Version">
+        <AboutField label={t('workflow.fields.version')}>
+          <Typography variant="subtitle2" component="div">
+            <b>
+              {!error && !loading
+                ? (value?.version ?? VALUE_UNAVAILABLE)
+                : VALUE_UNAVAILABLE}
+            </b>
+          </Typography>
+        </AboutField>
+      </Grid>
     </Grid>
   );
 };

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/WorkflowDetailsCard.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/WorkflowDetailsCard.tsx
@@ -57,7 +57,7 @@ const WorkflowDefinitionDetailsCard = ({
 
   return (
     <InfoCard title={t('workflow.details')} className={classes.details}>
-      <Grid container spacing={7} alignContent="flex-start" wrap="nowrap">
+      <Grid container spacing={7} alignContent="flex-start" wrap="wrap">
         <Grid item key="workflow status">
           {/* AboutField requires the value to be defined as a prop as well */}
           <AboutField
@@ -84,6 +84,18 @@ const WorkflowDefinitionDetailsCard = ({
               <Skeleton variant="text" />
             ) : (
               formattedWorkflowOverview?.description
+            )}
+          </AboutField>
+        </Grid>
+        <Grid item key="version">
+          <AboutField
+            label={t('workflow.fields.version')}
+            value={formattedWorkflowOverview?.version}
+          >
+            {loading ? (
+              <Skeleton variant="text" />
+            ) : (
+              formattedWorkflowOverview?.version
             )}
           </AboutField>
         </Grid>

--- a/workspaces/orchestrator/plugins/orchestrator/src/constants.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/constants.ts
@@ -26,3 +26,10 @@ export const WORKFLOW_STATUS_KEYS = {
 export const SHORT_REFRESH_INTERVAL = 5000;
 export const LONG_REFRESH_INTERVAL = 15000;
 export const DEFAULT_TABLE_PAGE_SIZE = 20;
+
+/**
+ * RHDH product docs — Orchestrator · “Learn more” on duplicate workflow ID alert.
+ * Build and deploy Serverless Workflows — unique workflow ID requirements.
+ */
+export const ENFORCING_UNIQUE_WORKFLOW_IDS_DOC_URL =
+  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html-single/orchestrator_in_red_hat_developer_hub/index#unique-workflow-id-requirements-to-prevent-duplicates_build-and-deploy-serverless-workflows';

--- a/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
@@ -40,12 +40,23 @@ describe('WorkflowOverviewAdapter', () => {
 
     expect(adaptedData.id).toBe(mockWorkflowOverview.workflowId);
     expect(adaptedData.name).toBe(mockWorkflowOverview.name);
+    expect(adaptedData.version).toBe('---');
     expect(adaptedData.lastTriggered).toBe(
       new Date(mockWorkflowOverview.lastTriggeredMs!).toLocaleString(),
     );
     expect(adaptedData.lastRunStatus).toBe(mockWorkflowOverview.lastRunStatus);
     expect(adaptedData.description).toBe(mockWorkflowOverview.description);
     expect(adaptedData.format).toBe('yaml'); // Adjust based on your expected value
+  });
+
+  it('should include version when provided', () => {
+    const mockWorkflowOverview: WorkflowOverviewDTO = {
+      workflowId: 'wf-1',
+      format: 'yaml',
+      version: '1.0.0',
+    };
+    const adaptedData = WorkflowOverviewFormatter.format(mockWorkflowOverview);
+    expect(adaptedData.version).toBe('1.0.0');
   });
 
   it('should have --- for undefined data', () => {
@@ -62,6 +73,7 @@ describe('WorkflowOverviewAdapter', () => {
     expect(adaptedData.lastTriggered).toBe('---');
     expect(adaptedData.lastRunStatus).toBe('---');
     expect(adaptedData.description).toBe('---');
+    expect(adaptedData.version).toBe('---');
     expect(adaptedData.format).toBe('yaml');
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
@@ -27,6 +27,7 @@ import DataFormatter from './DataFormatter';
 export interface FormattedWorkflowOverview {
   readonly id: string;
   readonly name: string;
+  readonly version: string;
   readonly lastTriggered: string;
   readonly lastRunStatus: string;
   readonly lastRunId: string;
@@ -56,6 +57,7 @@ const WorkflowOverviewFormatter: DataFormatter<
     return {
       id: data.workflowId,
       name: data.name ?? VALUE_UNAVAILABLE,
+      version: data.version ?? VALUE_UNAVAILABLE,
       lastTriggered: data.lastTriggeredMs
         ? DateTime.fromMillis(data.lastTriggeredMs).toLocaleString(
             DateTime.DATETIME_SHORT_WITH_SECONDS,

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -62,6 +62,8 @@ const orchestratorTranslationDe = createTranslationMessages({
     'workflow.fields.workflowId': 'Ausführungs-ID',
     'workflow.fields.workflowIdCopied':
       'Ausführungs-ID wurde in die Zwischenablage kopiert',
+    'workflow.fields.version': 'Version',
+    'table.headers.version': 'Version',
     'workflow.errors.retriggerFailed':
       'Erneuter Auslöser fehlgeschlagen: {{reason}}',
     'workflow.errors.abortFailedWithReason':
@@ -153,6 +155,9 @@ const orchestratorTranslationDe = createTranslationMessages({
     'duration.months': '{{count}} Monate',
     'duration.aYear': 'Ein Jahr',
     'duration.years': '{{count}} Jahre',
+    'alerts.duplicateWorkflowIds.message':
+      'Es wurden mehrere Workflows mit derselben ID erkannt. Verwenden Sie eindeutige IDs über verschiedene Versionen hinweg.',
+    'alerts.duplicateWorkflowIds.learnMore': 'Weitere Informationen',
     'stepperObjectField.error':
       'Das Stepper-Objektfeld wird für Schemata, die keine Eigenschaften enthalten, nicht unterstützt.',
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -62,6 +62,8 @@ const orchestratorTranslationEs = createTranslationMessages({
     'workflow.fields.workflowId': 'ID de ejecución',
     'workflow.fields.workflowIdCopied':
       'ID de ejecución copiado en el portapapeles',
+    'workflow.fields.version': 'Versión',
+    'table.headers.version': 'Versión',
     'workflow.errors.retriggerFailed': 'Error al reactivar: {{reason}}',
     'workflow.errors.abortFailedWithReason': 'Error al cancelar: {{reason}}',
     'workflow.buttons.runAsEvent': 'Ejecutar como evento',
@@ -151,6 +153,9 @@ const orchestratorTranslationEs = createTranslationMessages({
     'duration.months': '{{count}} meses',
     'duration.aYear': 'un año',
     'duration.years': '{{count}} años',
+    'alerts.duplicateWorkflowIds.message':
+      'Se detectaron varios flujos de trabajo con el mismo ID. Use identificadores únicos entre versiones.',
+    'alerts.duplicateWorkflowIds.learnMore': 'Más información',
     'stepperObjectField.error':
       'El campo de objeto paso a paso no es compatible con esquemas que no contienen propiedades',
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -43,6 +43,7 @@ const orchestratorTranslationFr = createTranslationMessages({
     'table.headers.lastRun': 'Dernière course',
     'table.headers.lastRunStatus': 'Statut de la dernière exécution',
     'table.headers.workflowName': 'Nom du flux de travail',
+    'table.headers.version': 'Version',
     'table.actions.run': 'Exécution',
     'table.actions.runAsEvent': "Exécuter en tant qu'événement",
     'table.actions.viewRuns': 'Voir les exécutions',
@@ -73,6 +74,7 @@ const orchestratorTranslationFr = createTranslationMessages({
     'workflow.fields.workflowId': "ID d'exécution",
     'workflow.fields.workflowIdCopied':
       "ID d'exécution copié dans le presse-papiers",
+    'workflow.fields.version': 'Version',
     'workflow.errors.retriggerFailed': 'Échec du re-déclenchement : {{reason}}',
     'workflow.errors.abortFailed':
       "Échec de l'abandon : l'exécution a déjà été terminée.",
@@ -193,6 +195,9 @@ const orchestratorTranslationFr = createTranslationMessages({
     'duration.months': '{{count}} mois',
     'duration.aYear': 'un an',
     'duration.years': '{{count}} ans',
+    'alerts.duplicateWorkflowIds.message':
+      'Plusieurs workflows avec le même ID ont été détectés. Utilisez des ID uniques entre les versions.',
+    'alerts.duplicateWorkflowIds.learnMore': 'En savoir plus',
     'stepperObjectField.error':
       "Le champ d'objet Stepper n'est pas pris en charge pour les schémas qui ne contiennent pas de propriétés",
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -44,6 +44,7 @@ const orchestratorTranslationIt = createTranslationMessages({
     'table.headers.lastRun': 'Ultima esecuzione',
     'table.headers.lastRunStatus': "Stato dell'ultima esecuzione",
     'table.headers.workflowName': 'Nome flusso di lavoro',
+    'table.headers.version': 'Versione',
     'table.actions.run': 'Esecuzione',
     'table.actions.runAsEvent': 'Esegui come evento',
     'table.actions.viewRuns': 'Visualizza esecuzioni',
@@ -73,6 +74,7 @@ const orchestratorTranslationIt = createTranslationMessages({
     'workflow.fields.started': 'Iniziata',
     'workflow.fields.workflowId': 'ID esecuzione',
     'workflow.fields.workflowIdCopied': 'ID esecuzione copiato negli appunti',
+    'workflow.fields.version': 'Versione',
     'workflow.errors.retriggerFailed': 'Riattivazione non riuscita: {{reason}}',
     'workflow.errors.abortFailed':
       "Interruzione non riuscita: l'esecuzione è già stata completata.",
@@ -194,6 +196,9 @@ const orchestratorTranslationIt = createTranslationMessages({
     'duration.months': '{{count}} mesi',
     'duration.aYear': 'un anno',
     'duration.years': '{{count}} anni',
+    'alerts.duplicateWorkflowIds.message':
+      'Sono stati rilevati più flussi di lavoro con lo stesso ID. Assicurati di utilizzare ID univoci tra le versioni.',
+    'alerts.duplicateWorkflowIds.learnMore': 'Ulteriori informazioni',
     'stepperObjectField.error':
       "Il campo dell'oggetto Stepper non è supportato per lo schema che non contiene proprietà",
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
@@ -43,6 +43,7 @@ const orchestratorTranslationJa = createTranslationMessages({
     'table.headers.lastRun': '最終実行',
     'table.headers.lastRunStatus': '最終実行のステータス',
     'table.headers.workflowName': 'ワークフロー名',
+    'table.headers.version': 'バージョン',
     'table.actions.run': '実行',
     'table.actions.runAsEvent': 'イベントとして実行',
     'table.actions.viewRuns': '実行の表示',
@@ -73,6 +74,7 @@ const orchestratorTranslationJa = createTranslationMessages({
     'workflow.fields.workflowId': '実行 ID',
     'workflow.fields.workflowIdCopied':
       '実行 ID がクリップボードにコピーされました',
+    'workflow.fields.version': 'バージョン',
     'workflow.errors.retriggerFailed': '再トリガーに失敗しました: {{reason}}',
     'workflow.errors.abortFailed':
       '中止に失敗しました: すでに実行が完了しています。',
@@ -164,6 +166,9 @@ const orchestratorTranslationJa = createTranslationMessages({
     'common.next': '次へ',
     'common.review': '確認',
     'common.unavailable': '---',
+    'alerts.duplicateWorkflowIds.message':
+      '同じ ID のワークフローが複数検出されました。バージョン間で一意の ID を使用してください。',
+    'alerts.duplicateWorkflowIds.learnMore': '詳細情報',
     'stepperObjectField.error':
       'ステッパーオブジェクトフィールドは、プロパティーを含まないスキーマではサポートされていません',
     'formDecorator.error':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -44,6 +44,7 @@ export const orchestratorMessages = {
       lastRun: 'Last run',
       lastRunStatus: 'Last run status',
       workflowName: 'Workflow name',
+      version: 'Version',
     },
     actions: {
       run: 'Run',
@@ -87,6 +88,7 @@ export const orchestratorMessages = {
       started: 'Started',
       workflowId: 'Run ID',
       workflowIdCopied: 'Run ID copied to clipboard',
+      version: 'Version',
     },
     errors: {
       retriggerFailed: 'Retrigger failed: {{reason}}',
@@ -224,6 +226,13 @@ export const orchestratorMessages = {
     months: '{{count}} months',
     aYear: 'a year',
     years: '{{count}} years',
+  },
+  alerts: {
+    duplicateWorkflowIds: {
+      message:
+        'Multiple workflows with the same ID detected. Please ensure unique IDs are used across different versions.',
+      learnMore: 'Learn more',
+    },
   },
   stepperObjectField: {
     error:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3012

#### Description

Surfaces workflow definition version from the overview API (after [backend adds version](https://github.com/redhat-developer/rhdh-plugins/pull/2925) on WorkflowOverviewDTO), adds UI for duplicate workflowId detection, and points users to Red Hat docs on unique IDs.

#### Changes

- Workflows table: Version column after Description .
- Workflow details: Version field in the details/metadata card after Description.
- Duplicate IDs: When two or more overview rows share the same workflowId, show an info alert with copy from product requirements and a Learn more link.

<img width="1481" height="784" alt="Screenshot 2026-05-05 at 12 53 24 PM" src="https://github.com/user-attachments/assets/07b78240-bffe-48dd-9caf-0f59af42dc46" />

<img width="1484" height="870" alt="Screenshot 2026-05-05 at 5 48 38 PM" src="https://github.com/user-attachments/assets/1ceb7b1e-df23-4237-971d-8329db4919b8" />

<img width="777" height="577" alt="Screenshot 2026-05-05 at 5 47 07 PM" src="https://github.com/user-attachments/assets/e9a25b31-c224-479a-ad71-927d3607e4ec" />

#### Testing

- Version column & details

- Duplicate-ID alert (optional local hack)
In WorkflowsTabContent, temporarily after fetch:

```
const overviews = overviewsResp.data.overviews ?? [];
    if (overviews.length > 0) {
      return [...overviews, { ...overviews[0] }];
    }
    return overviews;
```

- Reload Workflows: info alert appears; Learn more opens docs in a new tab.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
