### PR TITLE
fix(cost-management): use dots instead of slashes in menuItems keys

### DIFF
--- a/workspaces/cost-management/.changeset/fix-menu-items-separator.md
+++ b/workspaces/cost-management/.changeset/fix-menu-items-separator.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/plugin-cost-management': patch
+---
+
+Fix `menuItems` keys in `app-config.dynamic.yaml` to use dots instead of slashes as path separators, so that "Optimizations" and "OpenShift" are properly nested under the "Cost management" parent menu in the RHDH sidebar.

--- a/workspaces/cost-management/plugins/cost-management/app-config.dynamic.yaml
+++ b/workspaces/cost-management/plugins/cost-management/app-config.dynamic.yaml
@@ -16,10 +16,10 @@ dynamicPlugins:
             icon: costManagementIconOutlined
             text: OpenShift
       menuItems:
-        cost-management/optimizations:
+        cost-management.optimizations:
           parent: cost-management
           priority: 10
-        cost-management/openshift:
+        cost-management.openshift:
           parent: cost-management
           priority: 20
         cost-management:


### PR DESCRIPTION
## Summary

- Fix `menuItems` keys in `app-config.dynamic.yaml` to use dots (`.`) instead of slashes (`/`) as path separators
- Without this fix, "Optimizations" and "OpenShift" appear as flat top-level sidebar entries instead of being nested under the "Cost management" parent menu

The [RHDH front-end plugin wiring documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-front-end-plugin-wiring.adoc_rhdh-extensions-plugins) specifies that for a path like `/cost-management/optimizations`, the corresponding `menu_item_name` should be `cost-management.optimizations` (with a dot), not `cost-management/optimizations` (with a slash).

## Test plan

- [ ] Deploy RHDH with the cost-management dynamic plugin using the updated `app-config.dynamic.yaml`
- [ ] Verify the sidebar shows "Cost management" as a parent menu with "Optimizations" and "OpenShift" nested underneath

Made with [Cursor](https://cursor.com)