### PR TITLE
fix(global-header): localize header search “All results” and clear control

### DIFF
--- a/workspaces/global-header/.changeset/search-i18n-header.md
+++ b/workspaces/global-header/.changeset/search-i18n-header.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Add missing translations for the global header search experience: localize the autocomplete "All results" link and the clear control tooltip/accessible label (`search.allResults`, `search.clear`), with locale strings for German, Spanish, French, Italian, and Japanese.

--- a/workspaces/global-header/plugins/global-header/report-alpha.api.md
+++ b/workspaces/global-header/plugins/global-header/report-alpha.api.md
@@ -1024,6 +1024,8 @@ export const globalHeaderTranslationRef: TranslationRef<
     readonly 'search.placeholder': string;
     readonly 'search.noResults': string;
     readonly 'search.errorFetching': string;
+    readonly 'search.allResults': string;
+    readonly 'search.clear': string;
     readonly 'help.tooltip': string;
     readonly 'help.noSupportLinks': string;
     readonly 'help.noSupportLinksSubtitle': string;

--- a/workspaces/global-header/plugins/global-header/report.api.md
+++ b/workspaces/global-header/plugins/global-header/report.api.md
@@ -88,6 +88,8 @@ export const globalHeaderTranslationRef: TranslationRef<
     readonly 'search.placeholder': string;
     readonly 'search.noResults': string;
     readonly 'search.errorFetching': string;
+    readonly 'search.allResults': string;
+    readonly 'search.clear': string;
     readonly 'help.tooltip': string;
     readonly 'help.noSupportLinks': string;
     readonly 'help.noSupportLinksSubtitle': string;

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
@@ -90,6 +90,10 @@ export const SearchBar = (props: SearchBarProps) => {
                       : '0 2px 6px 2px rgba(0, 0, 0, 0.15), 0 1px 2px 0 rgba(0, 0, 0, 0.30)',
                 },
               },
+              clearIndicator: {
+                title: t('search.clear'),
+                'aria-label': t('search.clear'),
+              },
             }}
             sx={{
               width: '100%',

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchOption.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchOption.test.tsx
@@ -15,9 +15,22 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { SearchOption } from './SearchOption';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Result, SearchDocument } from '@backstage/plugin-search-common';
+
+import {
+  MockTrans,
+  mockUseTranslation,
+} from '../../test-utils/mockTranslations';
+import { SearchOption } from './SearchOption';
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+jest.mock('../../components/Trans', () => ({
+  Trans: MockTrans,
+}));
 
 jest.mock('./SearchResultItem', () => ({
   SearchResultItem: jest.fn(({ option }) => <div>{option}</div>),

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchOption.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchOption.tsx
@@ -23,6 +23,7 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { SearchResultItem } from './SearchResultItem';
 import { Result, SearchDocument } from '@backstage/plugin-search-common';
 import { SearchResultProps } from '@backstage/plugin-search-react';
+import { useTranslation } from '../../hooks/useTranslation';
 
 interface SearchOptionProps {
   option: string;
@@ -43,6 +44,8 @@ export const SearchOption = ({
   renderProps,
   searchLink,
 }: SearchOptionProps) => {
+  const { t } = useTranslation();
+
   if (option === query?.term && index === options.length - 1) {
     return (
       <Box key="all-results" id="all-results">
@@ -54,7 +57,9 @@ export const SearchOption = ({
             className="allResultsOption"
           >
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <Typography sx={{ flexGrow: 1 }}>All results</Typography>
+              <Typography sx={{ flexGrow: 1 }}>
+                {t('search.allResults')}
+              </Typography>
               <ArrowForwardIcon fontSize="small" />
             </Box>
           </ListItem>

--- a/workspaces/global-header/plugins/global-header/src/translations/de.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/de.ts
@@ -37,6 +37,8 @@ const globalHeaderTranslationDe = createTranslationMessages({
     'search.placeholder': 'Suchen...',
     'search.noResults': 'Keine Ergebnisse gefunden',
     'search.errorFetching': 'Fehler beim Abrufen der Ergebnisse',
+    'search.allResults': 'Alle Ergebnisse',
+    'search.clear': 'Löschen',
     'applicationLauncher.tooltip': 'Anwendungsstartprogramm',
     'applicationLauncher.noLinksTitle':
       'Keine Anwendungsverknüpfungen konfiguriert',

--- a/workspaces/global-header/plugins/global-header/src/translations/es.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/es.ts
@@ -37,6 +37,8 @@ const globalHeaderTranslationEs = createTranslationMessages({
     'search.placeholder': 'Buscar...',
     'search.noResults': 'No se encontraron resultados',
     'search.errorFetching': 'Error al extraer los resultados',
+    'search.allResults': 'Todos los resultados',
+    'search.clear': 'Limpiar',
     'applicationLauncher.tooltip': 'Iniciador de aplicaciones',
     'applicationLauncher.noLinksTitle':
       'No hay enlaces de aplicación configurados',

--- a/workspaces/global-header/plugins/global-header/src/translations/fr.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/fr.ts
@@ -37,6 +37,8 @@ const globalHeaderTranslationFr = createTranslationMessages({
     'search.placeholder': 'Recherche...',
     'search.noResults': 'Aucun résultat trouvé',
     'search.errorFetching': 'Erreur lors de la récupération des résultats',
+    'search.allResults': 'Tous les résultats',
+    'search.clear': 'Effacer',
     'applicationLauncher.tooltip': "Lanceur d'applications",
     'applicationLauncher.noLinksTitle': "Aucun lien d'application configuré",
     'applicationLauncher.noLinksSubtitle':

--- a/workspaces/global-header/plugins/global-header/src/translations/it.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/it.ts
@@ -37,6 +37,8 @@ const globalHeaderTranslationIt = createTranslationMessages({
     'search.placeholder': 'Cerca...',
     'search.noResults': 'Nessun risultato trovato',
     'search.errorFetching': 'Errore durante il recupero dei risultati',
+    'search.allResults': 'Tutti i risultati',
+    'search.clear': 'Cancella',
     'applicationLauncher.tooltip': 'Avvio applicazione',
     'applicationLauncher.noLinksTitle':
       "Nessun collegamento all'applicazione configurato",

--- a/workspaces/global-header/plugins/global-header/src/translations/ja.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/ja.ts
@@ -37,6 +37,8 @@ const globalHeaderTranslationJa = createTranslationMessages({
     'search.placeholder': '検索...',
     'search.noResults': '結果が見つかりません',
     'search.errorFetching': '結果の取得中にエラーが発生しました',
+    'search.allResults': 'すべての結果',
+    'search.clear': 'クリア',
     'applicationLauncher.tooltip': 'アプリケーションランチャー',
     'applicationLauncher.noLinksTitle':
       'アプリケーションリンクが設定されていません',

--- a/workspaces/global-header/plugins/global-header/src/translations/ref.ts
+++ b/workspaces/global-header/plugins/global-header/src/translations/ref.ts
@@ -35,6 +35,8 @@ export const globalHeaderMessages = {
     placeholder: 'Search...',
     noResults: 'No results found',
     errorFetching: 'Error fetching results',
+    allResults: 'All results',
+    clear: 'Clear',
   },
   applicationLauncher: {
     tooltip: 'Application launcher',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: 

https://redhat.atlassian.net/browse/RHDHBUGS-3074

Improves internationalization for the global-header search autocomplete: the footer link to the full search page and the clear control now use the plugin translation system instead of hardcoded English, with strings added for German, Spanish, French, Italian, and Japanese.

<img width="1132" height="451" alt="Screenshot 2026-05-06 at 12 03 35 PM" src="https://github.com/user-attachments/assets/2aac13e1-a787-48ae-aeac-1f56384e4c4a" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
