### PR TITLE
fix(orchestrator-form-widgets): evaluate $${{…}} in fetch-response selectors

### DIFF
--- a/workspaces/orchestrator/.changeset/fetch-response-selector-templates.md
+++ b/workspaces/orchestrator/.changeset/fetch-response-selector-templates.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Evaluate `$${{…}}` placeholders in `fetch:response:value`, `fetch:response:autocomplete`, `fetch:response:label`, and `fetch:response:value` (dropdown) before applying JSONata to the fetch response, consistent with other fetch template fields. Align `ActiveDropdown` and `ActiveTextInput` autocomplete with `ActiveMultiSelect` by treating undefined selector results as empty string arrays when building options, so invalid paths while editing do not surface as hard errors.

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/evaluateTemplate.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/evaluateTemplate.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { JsonValue } from '@backstage/types';
-import { evaluateTemplate, evaluateTemplateProps } from './evaluateTemplate';
+import {
+  evaluateFetchResponseSelectorTemplate,
+  evaluateTemplate,
+  evaluateTemplateProps,
+} from './evaluateTemplate';
 import get from 'lodash/get';
 
 const unitEvaluator: evaluateTemplateProps['unitEvaluator'] = async (
@@ -28,6 +32,21 @@ const unitEvaluator: evaluateTemplateProps['unitEvaluator'] = async (
 
   // Just a copy for testing purposes
   return Promise.resolve(get(formData, unit));
+};
+
+/** Matches useTemplateUnitEvaluator: `current.*` uses the path after the first segment. */
+const unitEvaluatorAsInWidgets: evaluateTemplateProps['unitEvaluator'] = async (
+  unit,
+  formData,
+) => {
+  if (!unit) {
+    throw new Error('Template unit can not be empty');
+  }
+  const dot = unit.indexOf('.');
+  if (dot > 0 && unit.substring(0, dot) === 'current') {
+    return get(formData, unit.substring(dot + 1));
+  }
+  return get(formData, unit);
 };
 
 describe('evaluate template', () => {
@@ -239,5 +258,24 @@ describe('evaluate template', () => {
         ).resolves.toStrictEqual(c.expected),
       ),
     );
+  });
+
+  it('evaluateFetchResponseSelectorTemplate interpolates $${{current…}} into a JSONata string', async () => {
+    await expect(
+      evaluateFetchResponseSelectorTemplate({
+        unitEvaluator: unitEvaluatorAsInWidgets,
+        key: 'fetch:response:value',
+        formData: {
+          step: {
+            xParams: {
+              selectedEnvironment: 'a',
+              provisionedEnvironments: 'a,b',
+            },
+          },
+        },
+        template:
+          "$${{current.step.xParams.selectedEnvironment}} in $split($${{current.step.xParams.provisionedEnvironments}}, ',') ? 'update' : 'create'",
+      }),
+    ).resolves.toBe("a in $split(a,b, ',') ? 'update' : 'create'");
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/evaluateTemplate.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/evaluateTemplate.ts
@@ -126,6 +126,22 @@ export const evaluateTemplateString = async (
   return evaluated;
 };
 
+/**
+ * Substitutes `$${{…}}` in a fetch response selector (JSONata string) using the same rules as
+ * `fetch:body` / `fetch:url`, then returns a plain string for JSONata evaluation against the response.
+ */
+export const evaluateFetchResponseSelectorTemplate = async (
+  props: evaluateTemplateStringProps,
+): Promise<string> => {
+  const evaluated = await evaluateTemplateString(props);
+  if (typeof evaluated !== 'string') {
+    throw new Error(
+      `Template evaluation for "${props.key}" must produce a string (JSONata expression), got ${typeof evaluated}`,
+    );
+  }
+  return evaluated;
+};
+
 export const evaluateTemplate = async (
   props: evaluateTemplateProps,
 ): Promise<JsonValue> => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.tsx
@@ -35,6 +35,7 @@ import {
   resolveDropdownDefault,
   useProcessingState,
   useClearOnRetrigger,
+  evaluateFetchResponseSelectorTemplate,
 } from '../utils';
 import { UiProps } from '../uiPropTypes';
 import { ErrorText } from './ErrorText';
@@ -126,13 +127,36 @@ export const ActiveDropdown: Widget<
 
     const doItAsync = async () => {
       await wrapProcessing(async () => {
+        const fd = formData ?? {};
+        const resolvedLabelSelector =
+          await evaluateFetchResponseSelectorTemplate({
+            template: labelSelector,
+            key: 'fetch:response:label',
+            unitEvaluator: templateUnitEvaluator,
+            formData: fd,
+            responseData: data,
+            uiProps,
+          });
+        const resolvedValueSelector =
+          await evaluateFetchResponseSelectorTemplate({
+            template: valueSelector,
+            key: 'fetch:response:value',
+            unitEvaluator: templateUnitEvaluator,
+            formData: fd,
+            responseData: data,
+            uiProps,
+          });
         const selectedLabels = await applySelectorArray(
-          getSelectorContext(labelSelector),
-          labelSelector,
+          getSelectorContext(resolvedLabelSelector),
+          resolvedLabelSelector,
+          true,
+          true,
         );
         const selectedValues = await applySelectorArray(
-          getSelectorContext(valueSelector),
-          valueSelector,
+          getSelectorContext(resolvedValueSelector),
+          resolvedValueSelector,
+          true,
+          true,
         );
 
         if (selectedLabels.length !== selectedValues.length) {
@@ -148,7 +172,16 @@ export const ActiveDropdown: Widget<
     };
 
     doItAsync();
-  }, [labelSelector, valueSelector, data, formData, props.id, wrapProcessing]);
+  }, [
+    labelSelector,
+    valueSelector,
+    data,
+    formData,
+    uiProps,
+    templateUnitEvaluator,
+    props.id,
+    wrapProcessing,
+  ]);
 
   const handleChange = useCallback(
     (changed: string, isByUser: boolean) => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
@@ -43,6 +43,7 @@ import {
   useRetriggerEvaluate,
   useProcessingState,
   useClearOnRetrigger,
+  evaluateFetchResponseSelectorTemplate,
 } from '../utils';
 import { UiProps } from '../uiPropTypes';
 import { ErrorText } from './ErrorText';
@@ -168,10 +169,20 @@ export const ActiveMultiSelect: Widget<
 
     const doItAsync = async () => {
       await wrapProcessing(async () => {
+        const fd = formData ?? {};
         if (autocompleteSelector) {
+          const resolvedAutocomplete =
+            await evaluateFetchResponseSelectorTemplate({
+              template: autocompleteSelector,
+              key: 'fetch:response:autocomplete',
+              unitEvaluator: templateUnitEvaluator,
+              formData: fd,
+              responseData: data,
+              uiProps,
+            });
           const autocompleteValues = await applySelectorArray(
             data,
-            autocompleteSelector,
+            resolvedAutocomplete,
             true,
             true,
           );
@@ -192,9 +203,19 @@ export const ActiveMultiSelect: Widget<
         if (!skipInitialValue && !isChangedByUser) {
           // set this just once, when the user has not touched the field
           if (defaultValueSelector) {
+            const resolvedDefault = await evaluateFetchResponseSelectorTemplate(
+              {
+                template: defaultValueSelector,
+                key: 'fetch:response:value',
+                unitEvaluator: templateUnitEvaluator,
+                formData: fd,
+                responseData: data,
+                uiProps,
+              },
+            );
             defaults = await applySelectorArray(
               data,
-              defaultValueSelector,
+              resolvedDefault,
               true,
               true,
             );
@@ -204,7 +225,17 @@ export const ActiveMultiSelect: Widget<
 
         let mandatory: string[] = [];
         if (mandatorySelector) {
-          mandatory = await applySelectorArray(data, mandatorySelector, true);
+          const resolvedMandatory = await evaluateFetchResponseSelectorTemplate(
+            {
+              template: mandatorySelector,
+              key: 'fetch:response:mandatory',
+              unitEvaluator: templateUnitEvaluator,
+              formData: fd,
+              responseData: data,
+              uiProps,
+            },
+          );
+          mandatory = await applySelectorArray(data, resolvedMandatory, true);
 
           // Only update if arrays differ (by item or count).
           const arraysAreEqual =
@@ -236,6 +267,9 @@ export const ActiveMultiSelect: Widget<
     isChangedByUser,
     skipInitialValue,
     data,
+    formData,
+    uiProps,
+    templateUnitEvaluator,
     props.id,
     value,
     onChange,

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.tsx
@@ -38,6 +38,7 @@ import {
   applySelectorString,
   useProcessingState,
   useClearOnRetrigger,
+  evaluateFetchResponseSelectorTemplate,
 } from '../utils';
 import { ErrorText } from './ErrorText';
 import { UiProps } from '../uiPropTypes';
@@ -138,11 +139,20 @@ export const ActiveTextInput: Widget<
 
     const doItAsync = async () => {
       await wrapProcessing(async () => {
+        const fd = formData ?? {};
         // Only apply fetched value if user hasn't changed the field
         if (!skipInitialValue && !isChangedByUser && defaultValueSelector) {
+          const resolvedSelector = await evaluateFetchResponseSelectorTemplate({
+            template: defaultValueSelector,
+            key: 'fetch:response:value',
+            unitEvaluator: templateUnitEvaluator,
+            formData: fd,
+            responseData: data,
+            uiProps,
+          });
           const fetchedValue = await applySelectorString(
             data,
-            defaultValueSelector,
+            resolvedSelector,
           );
 
           if (
@@ -155,9 +165,20 @@ export const ActiveTextInput: Widget<
         }
 
         if (autocompleteSelector) {
+          const resolvedAutocomplete =
+            await evaluateFetchResponseSelectorTemplate({
+              template: autocompleteSelector,
+              key: 'fetch:response:autocomplete',
+              unitEvaluator: templateUnitEvaluator,
+              formData: fd,
+              responseData: data,
+              uiProps,
+            });
           const autocompleteValues = await applySelectorArray(
             data,
-            autocompleteSelector,
+            resolvedAutocomplete,
+            true,
+            true,
           );
           setAutocompleteOptions(autocompleteValues);
         }
@@ -169,6 +190,9 @@ export const ActiveTextInput: Widget<
     defaultValueSelector,
     autocompleteSelector,
     data,
+    formData,
+    uiProps,
+    templateUnitEvaluator,
     props.id,
     value,
     handleChange,

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/SchemaUpdater.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/SchemaUpdater.tsx
@@ -29,6 +29,7 @@ import {
   useFetch,
   applySelectorObject,
   useProcessingState,
+  evaluateFetchResponseSelectorTemplate,
 } from '../utils';
 import { ErrorText } from './ErrorText';
 import { UiProps } from '../uiPropTypes';
@@ -86,9 +87,17 @@ export const SchemaUpdater: Widget<
         let typedData: SchemaChunksResponse =
           data as unknown as SchemaChunksResponse;
         if (valueSelector) {
+          const resolvedSelector = await evaluateFetchResponseSelectorTemplate({
+            template: valueSelector,
+            key: 'fetch:response:value',
+            unitEvaluator: templateUnitEvaluator,
+            formData: formData ?? {},
+            responseData: data,
+            uiProps,
+          });
           typedData = (await applySelectorObject(
             data,
-            valueSelector,
+            resolvedSelector,
           )) as unknown as SchemaChunksResponse;
         }
 
@@ -115,7 +124,16 @@ export const SchemaUpdater: Widget<
       });
     };
     doItAsync();
-  }, [data, props.id, updateSchema, valueSelector, wrapProcessing]);
+  }, [
+    data,
+    formData,
+    props.id,
+    updateSchema,
+    valueSelector,
+    uiProps,
+    templateUnitEvaluator,
+    wrapProcessing,
+  ]);
 
   const shouldShowFetchError = uiProps['fetch:error:silent'] !== true;
   const displayError = localError ?? (shouldShowFetchError ? error : undefined);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3109

`fetch:url / fetch:body`-style props already interpolated $${{…}} via the shared template evaluator, but f`etch:response:value`, `fetch:response:autocomplete`, `fetch:response:label`, and dropdown `fetch:response:value` were passed straight to JSONata. This change runs those selector strings through the same template step first, then applies JSONata to the fetch response.


https://github.com/user-attachments/assets/e7825044-00a0-49ff-aad2-f184c87a9ed2

### How to test

Use below schema to test

```
{
  "$id": "classpath:/schemas/test-fetch-response-template__main-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Test fetch response selector templates",
  "type": "object",
  "properties": {
    "step1": {
      "type": "object",
      "title": "Step 1 - Dollar-brace templates in fetch response selectors",
      "description": "Change the templated selectors and confirm widgets refetch correctly.",
      "properties": {
        "intro": {
          "title": "About this workflow",
          "type": "string",
          "ui:widget": "ActiveText",
          "ui:props": {
            "ui:text": "**Purpose:** Validates that template units (syntax: two `$` chars then `${{expression}}`) are evaluated for **fetch:response:value**, **fetch:response:autocomplete**, **fetch:response:label**, and **fetch:response:value** (dropdown). ActiveText resolves `$ ${{…}}`-style placeholders in help copy if written with a space so it is not parsed as an expression. Uses form paths like `current.*`, `backend.baseUrl`, plus the widget fetch response; Sonata `/q/health` exposes `status`. Postman Echo (via backstage proxy `/postman-echo/get`) repeats `tag` query params under `args.tag`."
          }
        },
        "healthFieldKey": {
          "type": "string",
          "title": "Top-level key on Sonata `/q/health`",
          "default": "status"
        },
        "sonataHealthPreview": {
          "type": "string",
          "title": "ActiveTextInput — templated fetch:response:value",
          "description": "Reads the field named in Top-level key (default `status`).",
          "ui:widget": "ActiveTextInput",
          "ui:props": {
            "fetch:url": "http://localhost:8899/q/health",
            "fetch:response:value": "$${{current.step1.healthFieldKey}}",
            "fetch:retrigger": ["current.step1.healthFieldKey"]
          }
        },
        "tagsSelector": {
          "type": "string",
          "title": "JSONata selector for Echo tag list",
          "default": "args.tag",
          "description": "Echo returns repeated `tag` query params here (typically an array)."
        },
        "fruitsAutocomplete": {
          "type": "array",
          "title": "ActiveMultiSelect — templated fetch:response:autocomplete",
          "items": {
            "type": "string"
          },
          "ui:widget": "ActiveMultiSelect",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/postman-echo/get?tag=apple&tag=banana&tag=cherry",
            "fetch:response:autocomplete": "$${{current.step1.tagsSelector}}",
            "fetch:retrigger": ["current.step1.tagsSelector"]
          }
        },
        "dropdownSelector": {
          "type": "string",
          "title": "JSONata selector for dropdown label & value arrays",
          "default": "args.tag",
          "description": "Same Echo response as multiselect; label and value both use this path."
        },
        "echoTagChoice": {
          "type": "string",
          "title": "ActiveDropdown — templated fetch:response:label & value",
          "description": "Options come from Echo `tag` params via the templated selectors.",
          "ui:widget": "ActiveDropdown",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/postman-echo/get?tag=apple&tag=banana&tag=cherry",
            "fetch:response:label": "$${{current.step1.dropdownSelector}}",
            "fetch:response:value": "$${{current.step1.dropdownSelector}}",
            "fetch:retrigger": ["current.step1.dropdownSelector"]
          }
        }
      }
    }
  }
}
```

```
id: test-fetch-response-template
version: '1.0'
specVersion: '0.8'
name: Test fetch response selector templates
description:
  Demonstrates dollar-brace template units inside fetch response selectors
  (ActiveTextInput, ActiveMultiSelect, ActiveDropdown).
dataInputSchema: schemas/test-fetch-response-template__main-schema.json
start: StartState
functions:
  - name: runActionFunction
    type: custom
    operation: sysout
states:
  - name: StartState
    type: operation
    actions:
      - name: runAction
        functionRef:
          refName: runActionFunction
          arguments:
            message: Workflow input is ${.}
    end: true
```

In app-config.yaml, you can add below in proxy.endpoints

```
   "/postman-echo":
      target: "https://postman-echo.com"
      changeOrigin: true
      secure: true
      allowedMethods: [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE" ]
      headers:
        X-Requested-With: XMLHttpRequest
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
