### PR TITLE
fix(orchestrator): replace values in ActiveMultiSelect when clearOnRetrigger is enabled

### DIFF
--- a/workspaces/orchestrator/.changeset/happy-geckos-rhyme.md
+++ b/workspaces/orchestrator/.changeset/happy-geckos-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Replace values in ActiveMultiSelect when clearOnRetrigger is enabled

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+import { ActiveMultiSelect } from './ActiveMultiSelect';
+import * as utils from '../utils';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    useTemplateUnitEvaluator: jest.fn(),
+    useRetriggerEvaluate: jest.fn(),
+    useFetch: jest.fn(),
+    useProcessingState: jest.fn(),
+  };
+});
+
+const mockedUseTemplateUnitEvaluator =
+  utils.useTemplateUnitEvaluator as jest.Mock;
+const mockedUseRetriggerEvaluate = utils.useRetriggerEvaluate as jest.Mock;
+const mockedUseFetch = utils.useFetch as jest.Mock;
+const mockedUseProcessingState = utils.useProcessingState as jest.Mock;
+
+type HarnessProps = {
+  initialValue?: string[];
+};
+
+const WidgetHarness = ({ initialValue = [] }: HarnessProps) => {
+  const [value, setValue] = useState<string[]>(initialValue);
+
+  return (
+    <ActiveMultiSelect
+      id="contacts"
+      name="contacts"
+      label="Contacts"
+      required={false}
+      readonly={false}
+      disabled={false}
+      autofocus={false}
+      schema={{ type: 'array', items: { type: 'string' } }}
+      uiSchema={{}}
+      options={{
+        props: {
+          'fetch:response:autocomplete': '$.contacts ? $.contacts : []',
+          'fetch:response:value': '$.contacts ? $.contacts : []',
+          'fetch:retrigger': ['current.step.xParams.selectedEnvironment'],
+          'fetch:clearOnRetrigger': true,
+        },
+      }}
+      value={value}
+      onChange={changed => setValue(changed as string[])}
+      onBlur={() => {}}
+      onFocus={() => {}}
+      formContext={
+        {
+          formData: {
+            current: {
+              step: {
+                xParams: {},
+              },
+            },
+          },
+          getIsChangedByUser: () => false,
+          setIsChangedByUser: () => {},
+        } as unknown as OrchestratorFormContextProps
+      }
+      rawErrors={[]}
+      registry={{} as any}
+    />
+  );
+};
+
+describe('ActiveMultiSelect', () => {
+  beforeEach(() => {
+    mockedUseTemplateUnitEvaluator.mockReturnValue(() => undefined);
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: false,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+  });
+
+  it('replaces values on retrigger when clearOnRetrigger is enabled', async () => {
+    let retrigger = ['sandbox'];
+    let responseData = { contacts: ['Alice', 'Bob', 'Charlie'] };
+
+    mockedUseRetriggerEvaluate.mockImplementation(() => retrigger);
+    mockedUseFetch.mockImplementation(() => ({
+      data: responseData,
+      error: undefined,
+      loading: false,
+    }));
+
+    const { rerender } = render(<WidgetHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contacts-chip-Alice')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Bob')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Charlie')).toBeInTheDocument();
+    });
+
+    retrigger = ['prod'];
+    responseData = { contacts: ['Alice', 'Bob', 'Charlie', 'Dave', 'Eve'] };
+    rerender(<WidgetHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contacts-chip-Dave')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Eve')).toBeInTheDocument();
+    });
+
+    retrigger = ['sandbox'];
+    responseData = { contacts: ['Alice', 'Bob', 'Charlie'] };
+    rerender(<WidgetHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contacts-chip-Alice')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Bob')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Charlie')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('contacts-chip-Dave'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('contacts-chip-Eve')).not.toBeInTheDocument();
+    });
+  });
+
+  it('replaces stale initial values when clearOnRetrigger is enabled', async () => {
+    const retrigger = ['sandbox'];
+    const responseData = { contacts: ['Alice', 'Bob', 'Charlie'] };
+
+    mockedUseRetriggerEvaluate.mockImplementation(() => retrigger);
+    mockedUseFetch.mockImplementation(() => ({
+      data: responseData,
+      error: undefined,
+      loading: false,
+    }));
+
+    render(
+      <WidgetHarness
+        initialValue={['Alice', 'Bob', 'Charlie', 'Dave', 'Eve']}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contacts-chip-Alice')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Bob')).toBeInTheDocument();
+      expect(screen.getByTestId('contacts-chip-Charlie')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('contacts-chip-Dave'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('contacts-chip-Eve')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveMultiSelect.tsx
@@ -19,6 +19,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import clsx from 'clsx';
@@ -98,6 +99,7 @@ export const ActiveMultiSelect: Widget<
       : `Missing fetch:response:autocomplete selector for ${id}`,
   );
   const [inProgressItem, setInProgressItem] = useState<string>('');
+  const clearedByRetriggerRef = useRef(false);
 
   const [autocompleteOptions, setAutocompleteOptions] = useState<string[]>();
   const [mandatoryValues, setMandatoryValues] = useState<string[]>();
@@ -149,6 +151,7 @@ export const ActiveMultiSelect: Widget<
   );
 
   const handleClear = useCallback(() => {
+    clearedByRetriggerRef.current = true;
     setInProgressItem('');
     onChange([]);
   }, [onChange]);
@@ -217,11 +220,21 @@ export const ActiveMultiSelect: Widget<
           }
         }
 
+        const shouldIgnoreCurrentValue =
+          clearOnRetrigger || clearedByRetriggerRef.current;
+        const valueForMerge = shouldIgnoreCurrentValue ? [] : value;
+
         if (
-          !mandatory.every(item => value.includes(item)) ||
-          !defaults.every(item => value.includes(item))
+          !mandatory.every(item => valueForMerge.includes(item)) ||
+          !defaults.every(item => valueForMerge.includes(item))
         ) {
-          onChange([...new Set([...mandatory, ...value, ...defaults])]);
+          const mergedValues = [
+            ...new Set([...mandatory, ...valueForMerge, ...defaults]),
+          ];
+          clearedByRetriggerRef.current = false;
+          onChange(mergedValues);
+        } else if (clearedByRetriggerRef.current) {
+          clearedByRetriggerRef.current = false;
         }
       });
     };
@@ -238,6 +251,7 @@ export const ActiveMultiSelect: Widget<
     data,
     props.id,
     value,
+    clearOnRetrigger,
     onChange,
     wrapProcessing,
   ]);


### PR DESCRIPTION
## Fixes

https://redhat.atlassian.net/browse/RHDHBUGS-3106

on retrigger, the field was cleared, but a subsequent render could still see the old values being merged with defaults. The widget did `mandatory + value + deafults` which retains the old value chips (Union behaviour) instead of replacing them.

**Solution**: When `fetch:clearOnRetrigger` is enabled, merge logic now ignores current value and applies server retruned values as the source of truth.


## Screenshots


https://github.com/user-attachments/assets/ea54153d-341a-4fab-8f91-230a4ae901b8



**Steps to reproduce:**


 Create and run the following test workflow:

```
# yaml-language-server: $schema=https://raw.githubusercontent.com/serverlessworkflow/specification/refs/heads/0.8.x/schema/workflow.yaml
id: active-multiselect-clear-on-retrigger
specVersion: "0.8"
version: "1.0.0"
name: ActiveMultiSelect clearOnRetrigger UI test
description: Reproduces and validates ActiveMultiSelect retrigger clearing behavior.
dataInputSchema: schemas/active-multiselect-clear-on-retrigger.input-schema.json
start: finish
functions:
  - name: logResult
    type: custom
    operation: sysout:INFO
states:
  - name: finish
    type: operation
    actions:
      - functionRef:
          refName: logResult
          arguments:
            message: ActiveMultiSelect clearOnRetrigger test workflow executed
            selectedEnvironment: '${ .selectedEnvironment }'
            contacts: '${ .contacts }'
    end: true

```

```
{
  "$id": "classpath:/schemas/active-multiselect-clear-on-retrigger.input-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "ActiveMultiSelect clearOnRetrigger UI test",
  "description": "Switch selectedEnvironment between sandbox and prod to verify contacts are replaced, not merged.",
  "type": "object",
  "required": ["step"],
  "properties": {
    "step": {
      "type": "object",
      "title": "Step",
      "properties": {
        "xParams": {
          "type": "object",
          "title": "Inputs",
          "required": ["selectedEnvironment"],
          "properties": {
            "selectedEnvironment": {
              "type": "string",
              "title": "Environment",
              "default": "sandbox",
              "enum": ["sandbox", "prod"]
            },
            "contacts": {
              "type": "array",
              "title": "Contacts",
              "items": {
                "type": "string"
              },
              "ui:widget": "ActiveMultiSelect",
              "ui:props": {
                "fetch:url": "$${{backend.baseUrl}}/api/proxy/postman-echo/post",
                "fetch:method": "POST",
                "fetch:body": {
                  "xParameters": {
                    "environmentName": "$${{current.step.xParams.selectedEnvironment}}"
                  }
                },
                "fetch:response:value": "$.json.xParameters.environmentName = 'sandbox' ? ['Alice','Bob','Charlie'] : ['Alice','Bob','Charlie','Dave','Eve']",
                "fetch:response:autocomplete": "$.json.xParameters.environmentName = 'sandbox' ? ['Alice','Bob','Charlie'] : ['Alice','Bob','Charlie','Dave','Eve']",
                "fetch:retrigger": ["current.step.xParams.selectedEnvironment"],
                "fetch:clearOnRetrigger": true
              }
            }
          }
        }
      }
    }
  }
}

```


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
