### PR TITLE
fix(theme): use &.Mui-selected syntax for MuiBottomNavigationAction

### DIFF
--- a/workspaces/theme/.changeset/fix-mui-bottom-nav-selected.md
+++ b/workspaces/theme/.changeset/fix-mui-bottom-nav-selected.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+fix(RHDHBUGS-2291): use `&.Mui-selected` syntax for MuiBottomNavigationAction to resolve CSS specificity console warning

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -701,10 +701,10 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           '&:hover, &:focus-visible': {
             backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,
           },
-        },
-        selected: {
-          backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,
-          color: `${navigationSelectedColor} !important`,
+          '&.Mui-selected': {
+            backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,
+            color: `${navigationSelectedColor} !important`,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary
Fixes [RHDHBUGS-2291](https://redhat.atlassian.net/browse/RHDHBUGS-2291)

- The `MuiBottomNavigationAction` theme override in the RHDH theme plugin used `selected` as a top-level key in `styleOverrides`, which MUI does not support for internal state overrides.
- Moved the selected styles into `root` using the `&.Mui-selected` CSS selector, as recommended by MUI.
- This eliminates the CSS specificity console warning that appeared on every page load.


## Test Plan
- [ ] Run `yarn start:legacy` in `workspaces/theme` and verify no MUI console warning about `MuiBottomNavigationAction`
- [ ] Verify bottom navigation selected state still renders correctly (background color + text color)
- [ ] Type checking passes (`tsc --noEmit --skipLibCheck`)
- [ ] Changeset included

---
Assisted-by: Cursor

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
