### PR TITLE
fix: fixed broken docs links

### DIFF
--- a/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/PermissionRequiredState.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/components/Common/PermissionRequiredState.tsx
@@ -47,7 +47,7 @@ const PermissionRequiredState = () => {
             variant="outlined"
             color="primary"
             target="_blank"
-            href="https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/adoption_insights_in_red_hat_developer_hub/assembly-adoption-insights#proc-customize-adoption-insights_title-adoption-insights"
+            href="https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/adoption_insights_in_red_hat_developer_hub/customize-the-adoption-insights-plugin-in-rhdh_adoption-insights-in-rhdh"
           >
             {t('common.readMore')} &nbsp; <OpenInNewIcon />
           </Button>

--- a/workspaces/extensions/plugins/extensions/src/components/SharedAlerts.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/SharedAlerts.tsx
@@ -28,10 +28,10 @@ import {
 import { useTranslation } from '../hooks/useTranslation';
 
 const PRODUCTION_DOCS_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh#con-extensions-managing-plugins_rhdh-extensions-plugins';
+  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/extensions-in-rhdh_plugins-in-rhdh#manage-plugins-by-using-extensions_extensions-in-rhdh';
 
 const EXTENSIONS_ENABLE_DOCS_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh#proc-extensions-enabling-plugins-installation_rhdh-extensions-plugins';
+  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/extensions-in-rhdh_plugins-in-rhdh#configure-rhdh-to-install-plugins-by-using-extensions_extensions-in-rhdh';
 
 export const ProductionEnvironmentAlert = () => {
   const { t } = useTranslation();

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
@@ -29,7 +29,7 @@ import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import { useTranslation } from '../hooks/useTranslation';
 
 const LLAMA_STACK_CONFIGURE_DOCS_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/developer-lightspeed#proc-installing-and-configuring-lightspeed_developer-lightspeed';
+  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/';
 const LIGHTSPEED_BACKEND_README_URL =
   'https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
@@ -29,7 +29,7 @@ import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import { useTranslation } from '../hooks/useTranslation';
 
 const LLAMA_STACK_CONFIGURE_DOCS_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/';
+  'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/install-and-configure_interacting-with-developer-lightspeed-for-rhdh/';
 const LIGHTSPEED_BACKEND_README_URL =
   'https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md';
 

--- a/workspaces/quickstart/app-config.yaml
+++ b/workspaces/quickstart/app-config.yaml
@@ -40,7 +40,7 @@ app:
       cta:
         text: Learn more
         textKey: steps.configureGit.ctaTitle
-        link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/
+        link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_your_git_provider/index
     - title: Manage plugins
       titleKey: steps.managePlugins.title
       icon: Plugins

--- a/workspaces/scorecard/plugins/scorecard/src/components/Common/PermissionRequiredState.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Common/PermissionRequiredState.tsx
@@ -75,7 +75,7 @@ const PermissionRequiredState = () => {
           <Button
             variant="outlined"
             target="_blank"
-            href="https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html-single/understand_and_visualize_red_hat_developer_hub_project_health_using_scorecards/index#proc-authenticating-and-managing-scorecard-plugins_assembly-setting-up-scorecards-to-monitor-your-rhdh-health"
+            href="https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html-single/evaluate_project_health_using_scorecards/index#set-up-scorecards-to-monitor-your-project-health_evaluate-project-health-using-scorecards"
             sx={theme => ({
               color: theme.palette.primary.main,
             })}

--- a/workspaces/x2a/docs/csv-bulk-import.md
+++ b/workspaces/x2a/docs/csv-bulk-import.md
@@ -129,4 +129,4 @@ import { RepoAuthenticationExtension } from '@red-hat-developer-hub/backstage-pl
 </ScaffolderFieldExtensions>
 ```
 
-For Red Hat Developer Hub (RHDH) with dynamic plugins, the extension is registered via configuration instead. See [Providing custom Scaffolder field extensions](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-front-end-plugin-wiring.adoc_rhdh-extensions-plugins#con-providing-custom-scaffolder-field-extensions.adoc_assembly-front-end-plugin-wiring) in the RHDH documentation.
+For Red Hat Developer Hub (RHDH) with dynamic plugins, the extension is registered via configuration instead. See [Providing custom Scaffolder field extensions](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/front-end-plugin-wiring_plugins-in-rhdh#providing-custom-scaffolder-field-extensions_front-end-plugin-wiring) in the RHDH documentation.

--- a/workspaces/x2a/packages/app/src/App.tsx
+++ b/workspaces/x2a/packages/app/src/App.tsx
@@ -157,7 +157,7 @@ const routes = (
     <Route path="/oauth2/*" element={<DcrConsentPage />} />
 
     {/* At RHDH runtime, this is replaced by dynamicPlugin configuration:
-      https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-front-end-plugin-wiring.adoc_rhdh-extensions-plugins#con-providing-custom-scaffolder-field-extensions.adoc_assembly-front-end-plugin-wiring
+      https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/front-end-plugin-wiring_plugins-in-rhdh#providing-custom-scaffolder-field-extensions_front-end-plugin-wiring
     */}
     <Route path="/create" element={<ScaffolderPage />}>
       <ScaffolderFieldExtensions>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

after 1.9 docs release, some links to docs.redhat.com stopped working. this PR replaces them with updated links.

https://redhat.atlassian.net/browse/RHDHBUGS-3060

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
