### PR TITLE
fix(lightspeed): preserve indentation for lists in chatbot

### DIFF
--- a/workspaces/lightspeed/.changeset/plenty-dolphins-sniff.md
+++ b/workspaces/lightspeed/.changeset/plenty-dolphins-sniff.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+preserve indentation for lists in chat window

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -138,7 +138,7 @@ const ConditionalWrapper = ({
 const useStyles = makeStyles(theme => ({
   body: {
     // remove default margin and padding from common elements
-    '& h1, & h2, & h3, & h4, & h5, & h6, & p, & ul, & ol, & li': {
+    '& h1, & h2, & h3, & h4, & h5, & h6, & p, & li': {
       margin: 0,
       padding: 0,
     },

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -138,6 +138,7 @@ const ConditionalWrapper = ({
 const useStyles = makeStyles(theme => ({
   body: {
     // remove default margin and padding from common elements
+    // lists excluded for proper formatting
     '& h1, & h2, & h3, & h4, & h5, & h6, & p, & li': {
       margin: 0,
       padding: 0,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
- Preserves the indentation for lists in the chatbot window

**Before**
<img width="836" height="706" alt="Screenshot 2026-05-08 at 2 10 50 PM" src="https://github.com/user-attachments/assets/50b13409-d5a6-47e8-b49e-3bfb696b245b" />

**After**
<img width="1088" height="663" alt="Screenshot 2026-05-08 at 2 19 30 PM" src="https://github.com/user-attachments/assets/7ab77ca6-571b-4882-976c-79c5469f0104" />


<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
