### PR TITLE
fix(bulk-import/lightspeed): opaque blue background on all rows in bulk-import

### DIFF
--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoryTableRow.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoryTableRow.tsx
@@ -22,9 +22,9 @@ import { useApi } from '@backstage/core-plugin-api';
 
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Checkbox from '@mui/material/Checkbox';
+import type { SxProps, Theme } from '@mui/material/styles';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-import { makeStyles } from '@mui/styles';
 import { useQuery } from '@tanstack/react-query';
 
 import { bulkImportApiRef } from '../../api/BulkImportBackendClient';
@@ -38,13 +38,11 @@ import {
 import { urlHelper } from '../../utils/repository-utils';
 import { CatalogInfoStatus } from './CatalogInfoStatus';
 
-const useStyles = makeStyles(() => ({
-  tableCellStyle: {
-    lineHeight: '1.5rem',
-    fontSize: '0.875rem',
-    padding: '15px 16px 15px 6px',
-  },
-}));
+const tableCellSx: SxProps<Theme> = {
+  lineHeight: '1.5rem',
+  fontSize: '0.875rem',
+  padding: '15px 16px 15px 6px',
+};
 
 export const RepositoryTableRow = ({
   handleClick,
@@ -57,7 +55,6 @@ export const RepositoryTableRow = ({
   data: AddRepositoryData;
   isDrawer?: boolean;
 }) => {
-  const classes = useStyles();
   const bulkImportApi = useApi(bulkImportApiRef);
   const startTimeRef = useRef(Date.now());
 
@@ -121,12 +118,7 @@ export const RepositoryTableRow = ({
       key={data.id}
       selected={isItemSelected}
     >
-      <TableCell
-        component="th"
-        scope="row"
-        padding="none"
-        className={classes.tableCellStyle}
-      >
+      <TableCell component="th" scope="row" padding="none" sx={tableCellSx}>
         <Checkbox
           disableRipple
           color="primary"
@@ -158,7 +150,7 @@ export const RepositoryTableRow = ({
         />
         {data.repoName}
       </TableCell>
-      <TableCell align="left" className={classes.tableCellStyle}>
+      <TableCell align="left" sx={tableCellSx}>
         {data.repoUrl ? (
           <Link to={data.repoUrl}>
             {urlHelper(data.repoUrl)}
@@ -171,7 +163,7 @@ export const RepositoryTableRow = ({
         )}
       </TableCell>
       {!isDrawer && (
-        <TableCell align="left" className={classes.tableCellStyle}>
+        <TableCell align="left" sx={tableCellSx}>
           {data?.organizationUrl ? (
             <Link to={data.organizationUrl}>
               {data.orgName}
@@ -185,7 +177,7 @@ export const RepositoryTableRow = ({
         </TableCell>
       )}
 
-      <TableCell align="left" className={classes.tableCellStyle}>
+      <TableCell align="left" sx={tableCellSx}>
         <CatalogInfoStatus
           data={data}
           importStatus={value?.status as string}

--- a/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
@@ -15,40 +15,14 @@
  */
 
 import Close from '@mui/icons-material/Close';
+import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { LightspeedFABIcon } from '../components/LightspeedIcon';
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
-
-const useStyles = makeStyles(theme => ({
-  fab: {
-    opacity: '1 !important',
-    backgroundColor: `${theme?.palette?.primary?.main ?? '#1976d2'} !important`,
-    color: `${theme?.palette?.primary?.contrastText ?? '#fff'} !important`,
-    boxShadow: `${
-      theme?.shadows?.[6] ??
-      '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)'
-    } !important`,
-  },
-  'fab-button': {
-    bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    alignItems: 'end',
-    zIndex: 200,
-    display: 'flex',
-    position: 'fixed',
-
-    // When ApplicationDrawer is docked, match main content inset
-    'body.docked-drawer-open &': {
-      transition: 'margin-right 0.3s ease',
-      marginRight: DOCKED_CONTENT_OFFSET,
-    },
-  },
-}));
 
 /**
  * @alpha
@@ -58,17 +32,27 @@ const useStyles = makeStyles(theme => ({
 export const LightspeedFAB = () => {
   const { isChatbotActive, toggleChatbot, displayMode } =
     useLightspeedDrawerContext();
-  const fabButton = useStyles();
 
   if (displayMode === ChatbotDisplayMode.embedded) {
     return null;
   }
 
   return (
-    <div
-      className={fabButton['fab-button']}
+    <Box
       id="lightspeed-fab"
       data-testid="lightspeed-fab"
+      sx={theme => ({
+        bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
+        right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
+        alignItems: 'end',
+        zIndex: 200,
+        display: 'flex',
+        position: 'fixed',
+        'body.docked-drawer-open &': {
+          transition: 'margin-right 0.3s ease',
+          marginRight: DOCKED_CONTENT_OFFSET,
+        },
+      })}
     >
       <Tooltip
         title={isChatbotActive ? 'Close Lightspeed' : 'Open Lightspeed'}
@@ -80,12 +64,22 @@ export const LightspeedFAB = () => {
           size="small"
           onClick={toggleChatbot}
           aria-label={isChatbotActive ? 'lightspeed-close' : 'lightspeed-open'}
-          className={fabButton.fab}
-          sx={{ borderRadius: '100% !important' }}
+          sx={theme => ({
+            opacity: 1,
+            backgroundColor: theme?.palette?.primary?.main ?? '#1976d2',
+            color: theme?.palette?.primary?.contrastText ?? '#fff',
+            boxShadow:
+              theme?.shadows?.[6] ??
+              '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)',
+            borderRadius: '100%',
+            '&:hover': {
+              backgroundColor: theme?.palette?.primary?.dark ?? '#1565c0',
+            },
+          })}
         >
           {isChatbotActive ? <Close fontSize="small" /> : <LightspeedFABIcon />}
         </Fab>
       </Tooltip>
-    </div>
+    </Box>
   );
 };

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -16,7 +16,7 @@
 
 import { PropsWithChildren } from 'react';
 
-import { makeStyles } from '@mui/styles';
+import { styled } from '@mui/material/styles';
 import { ChatbotModal } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
@@ -24,18 +24,18 @@ import { useLightspeedProviderState } from '../hooks/useLightspeedProviderState'
 import { LightspeedChatContainer } from './LightspeedChatContainer';
 import { LightspeedDrawerContext } from './LightspeedDrawerContext';
 
-const useStyles = makeStyles(theme => ({
-  chatbotModal: {
+const StyledChatbotModal = styled(ChatbotModal)(({ theme }) => ({
+  '&&': {
     boxShadow:
-      '0 14px 20px -7px rgba(0, 0, 0, 0.22), 0 32px 50px 6px rgba(0, 0, 0, 0.16), 0 12px 60px 12px rgba(0, 0, 0, 0.14) !important',
-    bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 5em)`,
-    right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    maxWidth: 'min(30rem, calc(100vw - 32px)) !important',
-    overflowX: 'hidden' as const,
-    transition: 'margin-right 0.3s ease',
-    'body.docked-drawer-open &': {
-      marginRight: DOCKED_CONTENT_OFFSET,
-    },
+      '0 14px 20px -7px rgba(0, 0, 0, 0.22), 0 32px 50px 6px rgba(0, 0, 0, 0.16), 0 12px 60px 12px rgba(0, 0, 0, 0.14)',
+    maxWidth: 'min(30rem, calc(100vw - 32px))',
+  },
+  bottom: `calc(${theme.spacing(2)} + 5em)`,
+  right: `calc(${theme.spacing(2)} + 1.5em)`,
+  overflowX: 'hidden',
+  transition: 'margin-right 0.3s ease',
+  'body.docked-drawer-open &': {
+    marginRight: DOCKED_CONTENT_OFFSET,
   },
 }));
 
@@ -43,7 +43,6 @@ const useStyles = makeStyles(theme => ({
  * @public
  */
 export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => {
-  const classes = useStyles();
   const { contextValue, shouldRenderOverlayModal, closeChatbot } =
     useLightspeedProviderState();
 
@@ -51,17 +50,16 @@ export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => {
     <LightspeedDrawerContext.Provider value={contextValue}>
       {children}
       {shouldRenderOverlayModal && (
-        <ChatbotModal
+        <StyledChatbotModal
           isOpen
           displayMode={contextValue.displayMode}
           disableFocusTrap
           onEscapePress={() => closeChatbot()}
           ouiaId="LightspeedChatbotModal"
           aria-labelledby="lightspeed-chatpopup-modal"
-          className={classes.chatbotModal}
         >
           <LightspeedChatContainer />
-        </ChatbotModal>
+        </StyledChatbotModal>
       )}
     </LightspeedDrawerContext.Provider>
   );

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
@@ -15,40 +15,14 @@
  */
 
 import Close from '@mui/icons-material/Close';
+import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { LightspeedFABIcon } from './LightspeedIcon';
-
-const useStyles = makeStyles(theme => ({
-  fab: {
-    opacity: '1 !important',
-    backgroundColor: `${theme?.palette?.primary?.main ?? '#1976d2'} !important`,
-    color: `${theme?.palette?.primary?.contrastText ?? '#fff'} !important`,
-    boxShadow: `${
-      theme?.shadows?.[6] ??
-      '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)'
-    } !important`,
-  },
-  'fab-button': {
-    bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    alignItems: 'end',
-    zIndex: 200,
-    display: 'flex',
-    position: 'fixed',
-
-    // When ApplicationDrawer is docked, match main content inset
-    'body.docked-drawer-open &': {
-      transition: 'margin-right 0.3s ease',
-      marginRight: DOCKED_CONTENT_OFFSET,
-    },
-  },
-}));
 
 /**
  * @public
@@ -58,17 +32,27 @@ const useStyles = makeStyles(theme => ({
 export const LightspeedFAB = () => {
   const { isChatbotActive, toggleChatbot, displayMode } =
     useLightspeedDrawerContext();
-  const fabButton = useStyles();
 
   if (displayMode === ChatbotDisplayMode.embedded) {
     return null;
   }
 
   return (
-    <div
-      className={fabButton['fab-button']}
+    <Box
       id="lightspeed-fab"
       data-testid="lightspeed-fab"
+      sx={theme => ({
+        bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
+        right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
+        alignItems: 'end',
+        zIndex: 200,
+        display: 'flex',
+        position: 'fixed',
+        'body.docked-drawer-open &': {
+          transition: 'margin-right 0.3s ease',
+          marginRight: DOCKED_CONTENT_OFFSET,
+        },
+      })}
     >
       <Tooltip
         title={isChatbotActive ? 'Close Lightspeed' : 'Open Lightspeed'}
@@ -80,12 +64,22 @@ export const LightspeedFAB = () => {
           size="small"
           onClick={toggleChatbot}
           aria-label={isChatbotActive ? 'lightspeed-close' : 'lightspeed-open'}
-          className={fabButton.fab}
-          sx={{ borderRadius: '100% !important' }}
+          sx={theme => ({
+            opacity: 1,
+            backgroundColor: theme?.palette?.primary?.main ?? '#1976d2',
+            color: theme?.palette?.primary?.contrastText ?? '#fff',
+            boxShadow:
+              theme?.shadows?.[6] ??
+              '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)',
+            borderRadius: '100%',
+            '&:hover': {
+              backgroundColor: theme?.palette?.primary?.dark ?? '#1565c0',
+            },
+          })}
         >
           {isChatbotActive ? <Close fontSize="small" /> : <LightspeedFABIcon />}
         </Fab>
       </Tooltip>
-    </div>
+    </Box>
   );
 };


### PR DESCRIPTION
## Fix: CSS class name collision between lightspeed and bulk-import plugins

- Both plugins were using `makeStyles` from `@mui/styles` (JSS) for styling.
- JSS generates sequential class names such as `jss1`, `jss2`, etc.
- As a result, unrelated components across plugins generated identical class names.
- This caused CSS collisions between the lightspeed and bulk-import plugins.
- Specifically, Lightspeed FAB styles containing `!important` properties (`background`, `color`, `position`, `zIndex`) leaked into bulk-import table rows.

### Resolution

Migrated the following components from `makeStyles` to Emotion-based styling (`sx` / `styled()`):

- Lightspeed FAB
- DrawerProvider
- bulk-import `RepositoryTableRow`
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
