### PR TITLE
fix: migrate bulk-import makeStyles to sx preventing JSS collisions

### DIFF
--- a/workspaces/bulk-import/.changeset/old-eggs-pick.md
+++ b/workspaces/bulk-import/.changeset/old-eggs-pick.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Scope JSS class names with a unique seed to prevent style collisions with

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/Router.tsx
@@ -16,6 +16,7 @@
 
 import { Navigate, Route, Routes } from 'react-router-dom';
 
+import { createGenerateClassName, StylesProvider } from '@mui/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { importHistoryRouteRef } from '../routes';
@@ -24,20 +25,26 @@ import { ImportHistoryPage } from './Repositories/ImportHistoryPage';
 
 const queryClient = new QueryClient();
 
+const generateClassName = createGenerateClassName({
+  seed: 'bulk-import',
+});
+
 /**
  *
  * @public
  */
 export const Router = () => (
-  <QueryClientProvider client={queryClient}>
-    <Routes>
-      <Route path="/" element={<AddRepositoriesPage />} />
-      <Route
-        path={importHistoryRouteRef.path}
-        element={<ImportHistoryPage />}
-      />
-      {/* Redirect any undefined paths to the root */}
-      <Route path="*" element={<Navigate to="/bulk-import" replace />} />
-    </Routes>
-  </QueryClientProvider>
+  <StylesProvider generateClassName={generateClassName}>
+    <QueryClientProvider client={queryClient}>
+      <Routes>
+        <Route path="/" element={<AddRepositoriesPage />} />
+        <Route
+          path={importHistoryRouteRef.path}
+          element={<ImportHistoryPage />}
+        />
+        {/* Redirect any undefined paths to the root */}
+        <Route path="*" element={<Navigate to="/bulk-import" replace />} />
+      </Routes>
+    </QueryClientProvider>
+  </StylesProvider>
 );


### PR DESCRIPTION
## Fix: CSS class name collision between  bulk-import plugins and lightspeed 

### Issue

fixes: https://redhat.atlassian.net/browse/RHDHBUGS-2822
Fixes this as well: https://redhat.atlassian.net/browse/RHDHBUGS-2958

#### possible reason for the bug

- Both plugins used `makeStyles` from `@mui/styles` (JSS), which generates global class names such as `jss1`, `jss2`, etc.
- In RHDH, dynamically loaded plugins create independent JSS instances with counters starting from `1`, causing identical class names across plugins.
- Since styles are injected into the same document `<head>`, Lightspeed FAB's `!important` styles (`position: fixed`, `backgroundColor`, `maxWidth`) leaked into bulk-import table rows.
- This resulted in table misalignment and unintended style overrides.

### Fix

Wrapped the bulk-import Router with a seeded StylesProvider (createGenerateClassName({ seed: 'bulk-import'
   })) to prefix all JSS class names with 'bulk-import-', preventing collisions with other plugins.

## UI before changes

https://github.com/user-attachments/assets/5cf73bb6-8e4a-4c1b-af9c-e125314ba4fc


## UI after changes

https://github.com/user-attachments/assets/e1573771-8f3c-471a-bbe9-729b7642e0b7

### changed class
<img width="457" height="57" alt="Screenshot 2026-05-11 at 2 57 57 PM" src="https://github.com/user-attachments/assets/e7156ca5-6d2f-4750-8d1b-0e3bb6665630" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
