### PR TITLE
fix: bg-color of myGroup sidebar

### DIFF
--- a/workspaces/theme/.changeset/clever-peas-float.md
+++ b/workspaces/theme/.changeset/clever-peas-float.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Fixed the background color of myGroup sidebar submenu in light theme

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -35,7 +35,7 @@ export const lightThemeOverrides: Partial<ThemeConfigPalette> = {
       hoverBackground: '#ffffff',
     },
     submenu: {
-      background: '#222427',
+      background: '#FFF',
     },
   },
   text: {


### PR DESCRIPTION
## Description

**Fixes: ** https://redhat.atlassian.net/browse/RHDHBUGS-2089
The sidebar submenu (used by MyGroupsSidebarItem) was using a dark background color (#222427) in the light theme, making it visually inconsistent and hard to read. This patch updates the submenu background to **#FFF** so it matches the rest of the light theme sidebar.

**Note:** 
 background Color of the sub-sidebar === selected item bg in sidebar 
 since the sub-sidebar uses the same items as sidebar, so no hover and selected effect won't be shown in the subsidebar

### UI before changes
<img width="495" height="835" alt="image-2025-09-29-16-07-22-209 (2)" src="https://github.com/user-attachments/assets/25e797d1-0a91-445c-af65-13ae75629911" />

 
### UI after changes
 

https://github.com/user-attachments/assets/c953476c-00ae-4e0f-a465-0f2b2208fdd0



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
