### PR TITLE
fix(lightspeed): disable automatic model refetch on window focus

### DIFF
--- a/workspaces/lightspeed/.changeset/quiet-models-sleep.md
+++ b/workspaces/lightspeed/.changeset/quiet-models-sleep.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Disable automatic model refetch on window focus to prevent unnecessary network requests

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useAllModels.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useAllModels.ts
@@ -31,5 +31,6 @@ export const useAllModels = (): UseQueryResult<LCSModel[], Error> => {
       return response;
     },
     staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: false,
   });
 };


### PR DESCRIPTION
## Summary

Keeps `refetchOnWindowFocus: false` for the models query to prevent automatic refetching when users switch browser tabs.

## Rationale

- Users already have a "Try Again" button to manually reload models when needed

## UI before changes

https://github.com/user-attachments/assets/152e75ae-ad5d-4695-acba-e925beb91769

## UI after changes

https://github.com/user-attachments/assets/e009b753-90ea-4a11-b745-9248c6cad00f



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
