### PR TITLE
fix(scorecard): use resolveMetricTranslation in drilldown header

### DIFF
--- a/workspaces/scorecard/.changeset/tall-dragons-cry.md
+++ b/workspaces/scorecard/.changeset/tall-dragons-cry.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': patch
+---
+
+Fix drilldown page header showing raw provider title instead of the translated scorecard title

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardPage/ScorecardPage.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardPage/ScorecardPage.tsx
@@ -26,6 +26,7 @@ import { ScorecardQueryProvider } from '../../api';
 import { ScorecardHomepageCard } from '../ScorecardHomepageSection/ScorecardHomepageCard';
 import NotFoundState from '../Common/NotFoundState';
 import { useTranslation } from '../../hooks/useTranslation';
+import { resolveMetricTranslation } from '../../utils/translationUtils';
 
 import { ScorecardPageHeader } from './ScorecardPageHeader';
 import { EntitiesTable } from './EntitiesTable/EntitiesTable';
@@ -44,9 +45,9 @@ export const ScorecardPage = () => {
 
   const { t } = useTranslation();
 
-  const titleKey = `metric.${resolvedMetricId}.title`;
-  const title = t(titleKey as any, {});
-  const finalTitle = title === titleKey ? metricTitle : title;
+  const finalTitle =
+    resolveMetricTranslation(t, resolvedMetricId, 'title', metricTitle) ||
+    metricTitle;
 
   if (metricNotFound) {
     return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

[RHDHBUGS-3119](https://redhat.atlassian.net/browse/RHDHBUGS-3119)

The drilldown page header was looking up `metric.filecheck.codeowners.title` directly, which doesn't exist. It fell back to the raw provider title ("File: CODEOWNERS"), which differed from the homepage card title ("File check: codeowners"). 
<img width="1497" height="752" alt="Screenshot 2026-05-11 at 13 43 19" src="https://github.com/user-attachments/assets/028ed42b-8763-43b9-a9df-384185dbb109" />

The homepage card already used `resolveMetricTranslation`, which has a template fallback (metric.filecheck.title + name) that produces the correct label. Applying the same function to the drilldown page makes the two titles consistent. 
<img width="1497" height="752" alt="Screenshot 2026-05-11 at 13 43 35" src="https://github.com/user-attachments/assets/5031a513-dc5f-4af0-ad46-0fe386e55a67" />

I discovered this during the process of writing new e2e tests for scorecard, so checking the correct title will be covered in these tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
