### PR TITLE
fix(bulk-import): stop spinner on dismissed SCM login and show sign-in empty state

### DIFF
--- a/workspaces/bulk-import/.changeset/seven-cameras-eat.md
+++ b/workspaces/bulk-import/.changeset/seven-cameras-eat.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Fixed the add-repositories table staying in a loading state when the repository query was disabled after SCM token collection failed, and improved the experience when a user dismisses the SCM login prompt by showing a sign-in empty state instead of a configuration error.

--- a/workspaces/bulk-import/plugins/bulk-import/report-alpha.api.md
+++ b/workspaces/bulk-import/plugins/bulk-import/report-alpha.api.md
@@ -67,6 +67,7 @@ export const bulkImportTranslationRef: TranslationRef<
     readonly 'repositories.importedEntitiesCount': string;
     readonly 'repositories.noRecordsFound': string;
     readonly 'repositories.noProjectsFound': string;
+    readonly 'repositories.logInToViewProjects': string;
     readonly 'repositories.refresh': string;
     readonly 'repositories.import': string;
     readonly 'repositories.removing': string;

--- a/workspaces/bulk-import/plugins/bulk-import/report-alpha.api.md
+++ b/workspaces/bulk-import/plugins/bulk-import/report-alpha.api.md
@@ -68,6 +68,7 @@ export const bulkImportTranslationRef: TranslationRef<
     readonly 'repositories.noRecordsFound': string;
     readonly 'repositories.noProjectsFound': string;
     readonly 'repositories.logInToViewProjects': string;
+    readonly 'repositories.logInToViewRepositories': string;
     readonly 'repositories.refresh': string;
     readonly 'repositories.import': string;
     readonly 'repositories.removing': string;

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesPage.test.tsx
@@ -132,6 +132,7 @@ describe('AddRepositoriesPage', () => {
       loading: false,
       data: [],
       error: null,
+      loginRejected: false,
     });
     (useInstructionsConfig as jest.Mock).mockReturnValue({
       enabled: true,

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/AddRepositoriesTable.test.tsx
@@ -36,6 +36,7 @@ jest.mock('../../hooks', () => ({
     loading: false,
     data: null,
     error: undefined,
+    loginRejected: false,
   })),
   useNumberOfApprovalTools: jest.fn(() => ({
     numberOfApprovalTools: 1,
@@ -155,6 +156,7 @@ describe('AddRepositoriesTable', () => {
         totalOrganizations: 0,
       },
       error: undefined,
+      loginRejected: false,
     });
 
     // Mock formik context with selected repositories

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTable.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTable.tsx
@@ -92,7 +92,7 @@ export const RepositoriesTable = ({
   const [localPage, setLocalPage] = useState(0);
   const [drawerPage, setDrawerPage] = useState(0);
 
-  const { loading, data, error } = useRepositories({
+  const { loading, data, error, loginRejected } = useRepositories({
     showOrganizations,
     orgName: drawerOrganization,
     approvalTool: values.approvalTool,
@@ -345,6 +345,7 @@ export const RepositoriesTable = ({
             isDrawer={!!drawerOrganization}
             isApprovalToolGitlab={isApprovalToolGitlab}
             showOrganizations={showOrganizations}
+            loginRejected={loginRejected}
           />
         </Table>
         {!isOpen && tableData?.length > 0 && (

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { ApprovalTool } from '../../types';
+import type { AddRepositoryData } from '../../types';
+import { RepositoriesTableBody } from './RepositoriesTableBody';
+
+const mockT = jest.fn((key: string) => key);
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+jest.mock('./OrganizationTableRow', () => ({
+  OrganizationTableRow: ({ data }: { data: { id: string } }) => (
+    <tr data-testid={`org-row-${data.id}`} />
+  ),
+}));
+
+jest.mock('./RepositoryTableRow', () => ({
+  RepositoryTableRow: ({ data }: { data: { id: string } }) => (
+    <tr data-testid={`repo-row-${data.id}`} />
+  ),
+}));
+
+const noop = () => {};
+const noopClick = jest.fn();
+
+const baseRow: AddRepositoryData = {
+  id: 'repo-1',
+  repoName: 'demo',
+  approvalTool: ApprovalTool.Git,
+};
+
+const defaultProps = {
+  loading: false,
+  ariaLabel: 'repositories-table',
+  showOrganizations: false,
+  rows: [] as AddRepositoryData[],
+  onOrgRowSelected: noop,
+  onClick: noopClick,
+  selectedRepos: {},
+  isDrawer: false,
+};
+
+describe('RepositoriesTableBody', () => {
+  beforeEach(() => {
+    mockT.mockImplementation((key: string) => key);
+  });
+
+  it('shows log-in empty state when loginRejected is true', () => {
+    render(
+      <table>
+        <RepositoriesTableBody {...defaultProps} rows={[]} loginRejected />
+      </table>,
+    );
+
+    expect(screen.getByTestId('no-repositories-found')).toBeInTheDocument();
+    expect(mockT).toHaveBeenCalledWith('repositories.logInToViewProjects');
+  });
+
+  it('shows GitLab empty state when not loginRejected and GitLab tool', () => {
+    render(
+      <table>
+        <RepositoriesTableBody
+          {...defaultProps}
+          rows={[]}
+          isApprovalToolGitlab
+        />
+      </table>,
+    );
+
+    expect(screen.getByTestId('no-repositories-found')).toBeInTheDocument();
+    expect(mockT).toHaveBeenCalledWith('repositories.noProjectsFound');
+  });
+
+  it('shows GitHub empty state when not loginRejected and not GitLab', () => {
+    render(
+      <table>
+        <RepositoriesTableBody {...defaultProps} rows={[]} />
+      </table>,
+    );
+
+    expect(screen.getByTestId('no-repositories-found')).toBeInTheDocument();
+    expect(mockT).toHaveBeenCalledWith('repositories.noRecordsFound');
+  });
+
+  it('renders OrganizationTableRow when showOrganizations is true', () => {
+    render(
+      <table>
+        <RepositoriesTableBody
+          {...defaultProps}
+          rows={[baseRow]}
+          showOrganizations
+        />
+      </table>,
+    );
+
+    expect(screen.getByTestId('org-row-repo-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('repo-row-repo-1')).not.toBeInTheDocument();
+  });
+
+  it('renders RepositoryTableRow when showOrganizations is false', () => {
+    render(
+      <table>
+        <RepositoriesTableBody {...defaultProps} rows={[baseRow]} />
+      </table>,
+    );
+
+    expect(screen.getByTestId('repo-row-repo-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('org-row-repo-1')).not.toBeInTheDocument();
+  });
+});

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.test.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.test.tsx
@@ -63,10 +63,26 @@ describe('RepositoriesTableBody', () => {
     mockT.mockImplementation((key: string) => key);
   });
 
-  it('shows log-in empty state when loginRejected is true', () => {
+  it('shows log-in empty state for GitHub when loginRejected is true', () => {
     render(
       <table>
         <RepositoriesTableBody {...defaultProps} rows={[]} loginRejected />
+      </table>,
+    );
+
+    expect(screen.getByTestId('no-repositories-found')).toBeInTheDocument();
+    expect(mockT).toHaveBeenCalledWith('repositories.logInToViewRepositories');
+  });
+
+  it('shows log-in empty state for GitLab when loginRejected is true', () => {
+    render(
+      <table>
+        <RepositoriesTableBody
+          {...defaultProps}
+          rows={[]}
+          loginRejected
+          isApprovalToolGitlab
+        />
       </table>,
     );
 

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
@@ -104,10 +104,13 @@ export const RepositoriesTableBody = ({
 
   let emptyStateMessageKey:
     | 'repositories.logInToViewProjects'
+    | 'repositories.logInToViewRepositories'
     | 'repositories.noProjectsFound'
     | 'repositories.noRecordsFound';
   if (loginRejected) {
-    emptyStateMessageKey = 'repositories.logInToViewProjects';
+    emptyStateMessageKey = isApprovalToolGitlab
+      ? 'repositories.logInToViewProjects'
+      : 'repositories.logInToViewRepositories';
   } else if (isApprovalToolGitlab) {
     emptyStateMessageKey = 'repositories.noProjectsFound';
   } else {

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/RepositoriesTableBody.tsx
@@ -36,6 +36,7 @@ export const RepositoriesTableBody = ({
   selectedRepos,
   isDrawer,
   isApprovalToolGitlab = false,
+  loginRejected = false,
 }: {
   loading: boolean;
   ariaLabel: string;
@@ -46,6 +47,7 @@ export const RepositoriesTableBody = ({
   isDrawer?: boolean;
   showOrganizations?: boolean;
   isApprovalToolGitlab?: boolean;
+  loginRejected?: boolean;
 }) => {
   const { t } = useTranslation();
   const isSelected = (id: string) => {
@@ -99,6 +101,19 @@ export const RepositoriesTableBody = ({
       </TableBody>
     );
   }
+
+  let emptyStateMessageKey:
+    | 'repositories.logInToViewProjects'
+    | 'repositories.noProjectsFound'
+    | 'repositories.noRecordsFound';
+  if (loginRejected) {
+    emptyStateMessageKey = 'repositories.logInToViewProjects';
+  } else if (isApprovalToolGitlab) {
+    emptyStateMessageKey = 'repositories.noProjectsFound';
+  } else {
+    emptyStateMessageKey = 'repositories.noRecordsFound';
+  }
+
   return (
     <tbody>
       <tr>
@@ -113,11 +128,7 @@ export const RepositoriesTableBody = ({
               justifyContent: 'center',
             }}
           >
-            {t(
-              isApprovalToolGitlab
-                ? 'repositories.noProjectsFound'
-                : 'repositories.noRecordsFound',
-            )}
+            {t(emptyStateMessageKey)}
           </Box>
         </td>
       </tr>

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
@@ -239,6 +239,7 @@ describe('useRepositories', () => {
       expect(result.current.error?.errors).toEqual([
         'No user SCM credentials could be obtained. Please ensure your SCM OAuth integration is configured.',
       ]);
+      expect(result.current.loginRejected).toBe(false);
     });
 
     it('disables the query when tokenFetchError is set (no request fired without tokens)', async () => {
@@ -290,6 +291,60 @@ describe('useRepositories', () => {
       // is fired when user tokens are unavailable.
       const lastOptions = (useQuery as jest.Mock).mock.calls.at(-1)?.[2];
       expect(lastOptions?.enabled).toBe(false);
+      // Disabled TanStack Query v4 observers still report isLoading=true; the
+      // hook must not forward that as UI loading once token fetch failed.
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('treats OAuth login dismissal as loginRejected without surfacing SCM config error', async () => {
+      const rejected = new Error('Login failed, rejected by user');
+      rejected.name = 'RejectedError';
+      const mockGetCredentials = jest.fn().mockRejectedValue(rejected);
+      const mockScmAuth = { getCredentials: mockGetCredentials };
+
+      const mockGetSCMHosts = jest.fn().mockResolvedValue({
+        github: ['https://github.com'],
+        gitlab: ['https://gitlab.example.com'],
+      });
+      const mockBulkImportApi = {
+        getSCMHosts: mockGetSCMHosts,
+        dataFetcher: jest.fn(),
+      };
+
+      mockUseApiHolder.mockReturnValue({
+        get: jest.fn().mockReturnValue(mockScmAuth),
+      });
+
+      const mockUseApi = jest.requireMock('@backstage/core-plugin-api').useApi;
+      mockUseApi.mockImplementation((ref: { id: string }) => {
+        if (ref.id === 'plugin.bulk-import.service') return mockBulkImportApi;
+        return undefined;
+      });
+
+      (useQuery as jest.Mock).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useRepositories({
+          page: 1,
+          querySize: 10,
+          approvalTool: ApprovalTool.Gitlab,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBeFalsy();
+        expect(result.current.loginRejected).toBe(true);
+      });
+
+      expect(result.current.error?.errors).toBeUndefined();
+      const lastOptions = (useQuery as jest.Mock).mock.calls.at(-1)?.[2];
+      expect(lastOptions?.enabled).toBe(false);
+      expect(result.current.loading).toBe(false);
     });
 
     it('does not include raw token values in the React Query key', async () => {

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.test.ts
@@ -347,6 +347,51 @@ describe('useRepositories', () => {
       expect(result.current.loading).toBe(false);
     });
 
+    it('treats login dismissal by message when error name is not RejectedError', async () => {
+      const rejected = new Error('Login failed, rejected by user');
+      rejected.name = 'Error';
+      const mockGetCredentials = jest.fn().mockRejectedValue(rejected);
+      const mockScmAuth = { getCredentials: mockGetCredentials };
+
+      const mockGetSCMHosts = jest.fn().mockResolvedValue({
+        github: ['https://github.com'],
+        gitlab: [],
+      });
+      const mockBulkImportApi = {
+        getSCMHosts: mockGetSCMHosts,
+        dataFetcher: jest.fn(),
+      };
+
+      mockUseApiHolder.mockReturnValue({
+        get: jest.fn().mockReturnValue(mockScmAuth),
+      });
+
+      const mockUseApi = jest.requireMock('@backstage/core-plugin-api').useApi;
+      mockUseApi.mockImplementation((ref: { id: string }) => {
+        if (ref.id === 'plugin.bulk-import.service') return mockBulkImportApi;
+        return undefined;
+      });
+
+      (useQuery as jest.Mock).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useRepositories({
+          page: 1,
+          querySize: 10,
+          approvalTool: ApprovalTool.Git,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loginRejected).toBe(true);
+      });
+    });
+
     it('does not include raw token values in the React Query key', async () => {
       const secretToken = 'super-secret-oauth-token';
       const mockGetCredentials = jest

--- a/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/hooks/useRepositories.ts
@@ -41,6 +41,18 @@ import {
   prepareDataForRepositories,
 } from '../utils/repository-utils';
 
+function isLoginRejectedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'RejectedError' ||
+      error.message === 'Login failed, rejected by user')
+  );
+}
+
+type ScmTokenFetchResult =
+  | { kind: 'tokens'; tokens: Record<string, string> }
+  | { kind: 'userRejected' };
+
 export const useRepositories = (
   options: DataFetcherQueryParams,
   pollInterval?: number,
@@ -53,6 +65,7 @@ export const useRepositories = (
     totalOrganizations?: number;
   } | null;
   error: RepositoriesError | undefined;
+  loginRejected: boolean;
 } => {
   const identityApi = useApi(identityApiRef);
   const configApi = useApi(configApiRef);
@@ -71,10 +84,10 @@ export const useRepositories = (
   });
 
   const {
-    value: scmAuthTokens,
+    value: scmTokenFetchResult,
     loading: tokenLoading,
     error: tokenFetchError,
-  } = useAsync(async () => {
+  } = useAsync(async (): Promise<ScmTokenFetchResult | undefined> => {
     if (!scmAuth) return undefined;
     const hosts = await bulkImportApi.getSCMHosts();
     if (!hosts || hosts instanceof Response || !('github' in hosts))
@@ -87,6 +100,7 @@ export const useRepositories = (
     if (!urls?.length) return undefined;
 
     const tokenRecord: Record<string, string> = {};
+    let sawLoginRejection = false;
     for (const url of urls) {
       try {
         const { token } = await scmAuth.getCredentials({
@@ -94,17 +108,35 @@ export const useRepositories = (
           additionalScope: { repoWrite: false },
         });
         if (token) tokenRecord[url] = token;
-      } catch {
-        // No OAuth provider registered for this host — skip it.
+      } catch (e) {
+        if (isLoginRejectedError(e)) {
+          sawLoginRejection = true;
+        }
+        // Missing OAuth provider or other host-level failure — skip this host.
       }
     }
     if (Object.keys(tokenRecord).length === 0) {
+      if (sawLoginRejection) {
+        return { kind: 'userRejected' };
+      }
       throw new Error(
         'No user SCM credentials could be obtained. Please ensure your SCM OAuth integration is configured.',
       );
     }
-    return tokenRecord;
+    return { kind: 'tokens', tokens: tokenRecord };
   }, [scmAuth, bulkImportApi, options.approvalTool]);
+
+  const scmAuthTokens =
+    scmTokenFetchResult?.kind === 'tokens'
+      ? scmTokenFetchResult.tokens
+      : undefined;
+  const loginRejected = scmTokenFetchResult?.kind === 'userRejected';
+
+  const queryEnabled =
+    !tokenLoading &&
+    !tokenFetchError &&
+    !loginRejected &&
+    (scmAuthTokens === undefined || Object.keys(scmAuthTokens).length > 0);
 
   const fetchRepositories = async (queryOptions: DataFetcherQueryParams) => {
     const apiOptions: APITypes = {
@@ -141,7 +173,7 @@ export const useRepositories = (
     ],
     () => fetchRepositories(options),
     {
-      enabled: !tokenLoading && !tokenFetchError,
+      enabled: queryEnabled,
       refetchInterval: pollInterval || 60000,
       refetchOnWindowFocus: false,
     },
@@ -171,11 +203,12 @@ export const useRepositories = (
   }
 
   return {
-    loading: tokenLoading || isQueryLoading,
+    loading: tokenLoading || (queryEnabled && isQueryLoading),
     data: prepareData,
     error: {
       ...(error ?? {}),
       ...(errors.length > 0 ? { errors } : {}),
     } as RepositoriesError,
+    loginRejected,
   };
 };

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/de.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/de.ts
@@ -47,6 +47,8 @@ const bulkImportTranslationDe = createTranslationMessages({
     'repositories.noRecordsFound':
       'Keine Repositorys zum Importieren verfügbar.',
     'repositories.noProjectsFound': 'Keine Projekte zum Importieren verfügbar.',
+    'repositories.logInToViewProjects':
+      'Melden Sie sich an, um Projekte anzuzeigen.',
     'repositories.refresh': 'Aktualisieren',
     'repositories.import': 'Importieren',
     'repositories.removing': 'Wird entfernt...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/de.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/de.ts
@@ -49,6 +49,8 @@ const bulkImportTranslationDe = createTranslationMessages({
     'repositories.noProjectsFound': 'Keine Projekte zum Importieren verfügbar.',
     'repositories.logInToViewProjects':
       'Melden Sie sich an, um Projekte anzuzeigen.',
+    'repositories.logInToViewRepositories':
+      'Melden Sie sich an, um Repositorys anzuzeigen.',
     'repositories.refresh': 'Aktualisieren',
     'repositories.import': 'Importieren',
     'repositories.removing': 'Wird entfernt...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/es.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/es.ts
@@ -48,6 +48,8 @@ const bulkImportTranslationEs = createTranslationMessages({
     'repositories.noProjectsFound':
       'No hay proyectos disponibles para importar.',
     'repositories.logInToViewProjects': 'Inicie sesión para ver los proyectos.',
+    'repositories.logInToViewRepositories':
+      'Inicie sesión para ver los repositorios.',
     'repositories.refresh': 'Actualizar',
     'repositories.import': 'Importar',
     'repositories.removing': 'Eliminando...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/es.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/es.ts
@@ -47,6 +47,7 @@ const bulkImportTranslationEs = createTranslationMessages({
       'No hay repositorios disponibles para importar.',
     'repositories.noProjectsFound':
       'No hay proyectos disponibles para importar.',
+    'repositories.logInToViewProjects': 'Inicie sesión para ver los proyectos.',
     'repositories.refresh': 'Actualizar',
     'repositories.import': 'Importar',
     'repositories.removing': 'Eliminando...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
@@ -48,6 +48,8 @@ const bulkImportTranslationFr = createTranslationMessages({
       "Aucun projet disponible pour l'importation.",
     'repositories.logInToViewProjects':
       'Connectez-vous pour afficher les projets.',
+    'repositories.logInToViewRepositories':
+      'Connectez-vous pour afficher les dépôts.',
     'repositories.refresh': 'Rafraîchir',
     'repositories.import': 'Importer',
     'repositories.removing': 'Suppression...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
@@ -46,6 +46,8 @@ const bulkImportTranslationFr = createTranslationMessages({
     'repositories.noRecordsFound': 'Aucun enregistrement trouvé',
     'repositories.noProjectsFound':
       "Aucun projet disponible pour l'importation.",
+    'repositories.logInToViewProjects':
+      'Connectez-vous pour afficher les projets.',
     'repositories.refresh': 'Rafraîchir',
     'repositories.import': 'Importer',
     'repositories.removing': 'Suppression...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/it.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/it.ts
@@ -46,6 +46,7 @@ const bulkImportTranslationIt = createTranslationMessages({
     'repositories.noRecordsFound': 'Nessun record trovato',
     'repositories.noProjectsFound':
       "Nessun progetto disponibile per l'importazione.",
+    'repositories.logInToViewProjects': 'Accedi per visualizzare i progetti.',
     'repositories.refresh': 'Aggiorna',
     'repositories.import': 'Importa',
     'repositories.removing': 'Rimozione in corso...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/it.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/it.ts
@@ -47,6 +47,8 @@ const bulkImportTranslationIt = createTranslationMessages({
     'repositories.noProjectsFound':
       "Nessun progetto disponibile per l'importazione.",
     'repositories.logInToViewProjects': 'Accedi per visualizzare i progetti.',
+    'repositories.logInToViewRepositories':
+      'Accedi per visualizzare i repository.',
     'repositories.refresh': 'Aggiorna',
     'repositories.import': 'Importa',
     'repositories.removing': 'Rimozione in corso...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ja.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ja.ts
@@ -47,6 +47,8 @@ const bulkImportTranslationJa = createTranslationMessages({
     'repositories.noRecordsFound': 'レコードが見つかりません',
     'repositories.noProjectsFound':
       'インポート可能なプロジェクトがありません。',
+    'repositories.logInToViewProjects':
+      'ログインしてプロジェクトを表示します。',
     'repositories.refresh': '更新',
     'repositories.import': 'インポート',
     'repositories.removing': '削除中...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ja.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ja.ts
@@ -49,6 +49,8 @@ const bulkImportTranslationJa = createTranslationMessages({
       'インポート可能なプロジェクトがありません。',
     'repositories.logInToViewProjects':
       'ログインしてプロジェクトを表示します。',
+    'repositories.logInToViewRepositories':
+      'ログインしてリポジトリーを表示します。',
     'repositories.refresh': '更新',
     'repositories.import': 'インポート',
     'repositories.removing': '削除中...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
@@ -45,6 +45,7 @@ export const bulkImportMessages = {
     importedEntitiesCount: 'Imported entities ({{count}})',
     noRecordsFound: 'No repositories available to import.',
     noProjectsFound: 'No projects available to import.',
+    logInToViewProjects: 'Log in to view projects',
     refresh: 'Refresh',
     import: 'Import',
     removing: 'Removing...',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
@@ -46,6 +46,7 @@ export const bulkImportMessages = {
     noRecordsFound: 'No repositories available to import.',
     noProjectsFound: 'No projects available to import.',
     logInToViewProjects: 'Log in to view projects',
+    logInToViewRepositories: 'Log in to view repositories',
     refresh: 'Refresh',
     import: 'Import',
     removing: 'Removing...',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an issue where the loading spinner would continue to show after the user rejects the login modal. Now, we show an empty page with the text "Log in to view projects."

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

## Screenshots

GitHub:
<img width="1655" height="336" alt="Screenshot From 2026-05-11 10-33-33" src="https://github.com/user-attachments/assets/9b16a187-ca44-41eb-a6e8-b9c1917ca0f5" />
GitLab:
<img width="1655" height="336" alt="Screenshot From 2026-05-11 10-33-39" src="https://github.com/user-attachments/assets/665ff65a-1198-4b1f-9502-ac9c0367b5b4" />

