### PR TITLE
feat(translations): add pseudo-localization support

### DIFF
--- a/workspaces/translations/.changeset/sweet-ends-dance.md
+++ b/workspaces/translations/.changeset/sweet-ends-dance.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-translations': minor
+---
+
+Add pseudo-localization support using `i18next-pseudo` to help identify untranslated or hardcoded strings in the UI. Strings are transformed with diacritical marks and brackets (e.g., `"Settings"` → `"[Ṣḛḛţţḭḭṇḡṡ]"`). Activate via `?pseudolocalization=true` URL parameter or `i18n.pseudolocalization.enabled: true` in app-config. Includes a `PseudoLocalizationProvider` component for use as a dynamic plugin at the `application/provider` mount point.

--- a/workspaces/translations/app-config.yaml
+++ b/workspaces/translations/app-config.yaml
@@ -111,3 +111,8 @@ kubernetes:
 permission:
   # setting this to `false` will disable permissions
   enabled: true
+# Uncomment to enable pseudo-localization for identifying untranslated strings
+# i18n:
+#   pseudolocalization:
+#     enabled: true
+#     language: en

--- a/workspaces/translations/packages/app/src/App.tsx
+++ b/workspaces/translations/packages/app/src/App.tsx
@@ -55,7 +55,10 @@ import { SignalsDisplay } from '@backstage/plugin-signals';
 
 import { getThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
 
-import { TranslationsPage } from '@red-hat-developer-hub/backstage-plugin-translations';
+import {
+  TranslationsPage,
+  PseudoLocalizationProvider,
+} from '@red-hat-developer-hub/backstage-plugin-translations';
 import { TranslationsTestPage } from '@red-hat-developer-hub/backstage-plugin-translations-test';
 
 const app = createApp({
@@ -127,12 +130,12 @@ const routes = (
 );
 
 export default app.createRoot(
-  <>
+  <PseudoLocalizationProvider>
     <AlertDisplay />
     <OAuthRequestDialog />
     <SignalsDisplay />
     <AppRouter>
       <Root>{routes}</Root>
     </AppRouter>
-  </>,
+  </PseudoLocalizationProvider>,
 );

--- a/workspaces/translations/plugins/translations/config.d.ts
+++ b/workspaces/translations/plugins/translations/config.d.ts
@@ -13,6 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './apis';
-export * from './plugin';
-export { PseudoLocalizationProvider } from './components/PseudoLocalizationProvider';
+
+export interface Config {
+  i18n?: {
+    /**
+     * Pseudolocalization stretches translated strings to test layout (i18next-pseudo).
+     * @deepVisibility frontend
+     */
+    pseudolocalization?: {
+      /**
+       * When true, enables i18next-pseudo for strings that go through the translation API.
+       * @visibility frontend
+       */
+      enabled?: boolean;
+      /**
+       * Language code to pseudolocalize (e.g. en, de). Defaults to the active UI language when omitted.
+       * @visibility frontend
+       */
+      language?: string;
+    };
+  };
+}

--- a/workspaces/translations/plugins/translations/package.json
+++ b/workspaces/translations/plugins/translations/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/redhat-developer/rhdh-plugins",
     "directory": "workspaces/translations/plugins/translations"
   },
+  "configSchema": "config.d.ts",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "translations",
@@ -54,6 +55,7 @@
     "@mui/icons-material": "5.18.0",
     "@mui/material": "5.18.0",
     "i18next": "^22.4.15",
+    "i18next-pseudo": "^2.2.1",
     "zen-observable": "^0.10.0"
   },
   "peerDependencies": {
@@ -61,6 +63,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.36.0",
+    "@backstage/config": "^1.3.7",
     "@backstage/core-app-api": "^1.19.6",
     "@backstage/dev-utils": "^1.1.21",
     "@backstage/test-utils": "^1.7.16",

--- a/workspaces/translations/plugins/translations/report.api.md
+++ b/workspaces/translations/plugins/translations/report.api.md
@@ -5,9 +5,11 @@
 ```ts
 import { AppLanguageApi } from '@backstage/core-plugin-api/alpha';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import type { ConfigApi } from '@backstage/core-plugin-api';
 import { i18n } from 'i18next';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { Observable } from '@backstage/types';
+import { PropsWithChildren } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { TranslationApi } from '@backstage/core-plugin-api/alpha';
 import { TranslationMessages } from '@backstage/core-plugin-api/alpha';
@@ -15,6 +17,19 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 import { TranslationRef as TranslationRef_2 } from '@backstage/frontend-plugin-api';
 import { TranslationResource } from '@backstage/core-plugin-api/alpha';
 import { TranslationSnapshot } from '@backstage/core-plugin-api/alpha';
+
+// @public
+export function attachPseudolocalization(
+  translationApi: I18nextTranslationApi,
+  options?: PseudolocalizationOptions,
+): void;
+
+// @public
+export function attachPseudolocalizationIfEnabled(
+  translationApi: I18nextTranslationApi,
+  configApi: ConfigApi,
+  locationSearch?: string,
+): void;
 
 // @public
 export const ExportTranslationKeys: (input: {
@@ -52,6 +67,19 @@ export interface I18nextTranslationApiOptions {
   // (undocumented)
   resources?: Array<TranslationMessages | TranslationResource>;
 }
+
+// @public (undocumented)
+export interface PseudolocalizationOptions {
+  // (undocumented)
+  languageToPseudo?: string;
+  // (undocumented)
+  wrapped?: boolean;
+}
+
+// @public
+export const PseudoLocalizationProvider: (
+  input: PropsWithChildren<{}>,
+) => JSX_2.Element;
 
 // @public (undocumented)
 export const TranslationsPage: () => JSX_2.Element;

--- a/workspaces/translations/plugins/translations/src/apis/index.ts
+++ b/workspaces/translations/plugins/translations/src/apis/index.ts
@@ -15,3 +15,8 @@
  */
 export { I18nextTranslationApi } from './I18nextTranslationApi';
 export type { I18nextTranslationApiOptions } from './I18nextTranslationApi';
+export {
+  attachPseudolocalization,
+  attachPseudolocalizationIfEnabled,
+} from './pseudolocalization';
+export type { PseudolocalizationOptions } from './pseudolocalization';

--- a/workspaces/translations/plugins/translations/src/apis/pseudolocalization.test.ts
+++ b/workspaces/translations/plugins/translations/src/apis/pseudolocalization.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { createInstance as createI18n } from 'i18next';
+
+import {
+  attachPseudolocalization,
+  attachPseudolocalizationIfEnabled,
+} from './pseudolocalization';
+import type { I18nextTranslationApi } from './I18nextTranslationApi';
+
+function createMockTranslationApi(): I18nextTranslationApi {
+  const i18n = createI18n({
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+    resources: {
+      en: {
+        test: { greeting: 'Hello World' },
+      },
+    },
+    ns: ['test'],
+    defaultNS: 'test',
+    initImmediate: false,
+  });
+  i18n.init();
+
+  return { getI18nInstance: () => i18n } as unknown as I18nextTranslationApi;
+}
+
+describe('attachPseudolocalization', () => {
+  it('transforms strings with bracket wrapping', () => {
+    const api = createMockTranslationApi();
+    attachPseudolocalization(api);
+
+    const i18n = api.getI18nInstance();
+    const result = i18n.t('greeting');
+
+    expect(result).not.toBe('Hello World');
+    expect(result).toMatch(/^\[.*\]$/);
+  });
+
+  it('does not wrap when wrapped option is false', () => {
+    const api = createMockTranslationApi();
+    attachPseudolocalization(api, { wrapped: false });
+
+    const i18n = api.getI18nInstance();
+    const result = i18n.t('greeting');
+
+    expect(result).not.toBe('Hello World');
+    expect(result).not.toMatch(/^\[.*\]$/);
+  });
+
+  it('only transforms the specified language', () => {
+    const i18n = createI18n({
+      lng: 'de',
+      fallbackLng: 'en',
+      interpolation: { escapeValue: false },
+      resources: {
+        en: { test: { greeting: 'Hello World' } },
+        de: { test: { greeting: 'Hallo Welt' } },
+      },
+      ns: ['test'],
+      defaultNS: 'test',
+      initImmediate: false,
+    });
+    i18n.init();
+
+    const api = {
+      getI18nInstance: () => i18n,
+    } as unknown as I18nextTranslationApi;
+
+    attachPseudolocalization(api, { languageToPseudo: 'en' });
+
+    const result = i18n.t('greeting');
+    expect(result).toBe('Hallo Welt');
+  });
+});
+
+describe('attachPseudolocalizationIfEnabled', () => {
+  it('does nothing when not enabled', () => {
+    const api = createMockTranslationApi();
+    const configApi = new ConfigReader({});
+
+    attachPseudolocalizationIfEnabled(api, configApi, '');
+
+    const i18n = api.getI18nInstance();
+    expect(i18n.t('greeting')).toBe('Hello World');
+  });
+
+  it('activates via config', () => {
+    const api = createMockTranslationApi();
+    const configApi = new ConfigReader({
+      i18n: { pseudolocalization: { enabled: true } },
+    });
+
+    attachPseudolocalizationIfEnabled(api, configApi, '');
+
+    const i18n = api.getI18nInstance();
+    const result = i18n.t('greeting');
+    expect(result).not.toBe('Hello World');
+    expect(result).toMatch(/^\[.*\]$/);
+  });
+
+  it('activates via URL query parameter', () => {
+    const api = createMockTranslationApi();
+    const configApi = new ConfigReader({});
+
+    attachPseudolocalizationIfEnabled(
+      api,
+      configApi,
+      '?pseudolocalization=true',
+    );
+
+    const i18n = api.getI18nInstance();
+    const result = i18n.t('greeting');
+    expect(result).not.toBe('Hello World');
+    expect(result).toMatch(/^\[.*\]$/);
+  });
+
+  it('uses language from config', () => {
+    const api = createMockTranslationApi();
+    const configApi = new ConfigReader({
+      i18n: { pseudolocalization: { enabled: true, language: 'en' } },
+    });
+
+    attachPseudolocalizationIfEnabled(api, configApi, '');
+
+    const i18n = api.getI18nInstance();
+    const result = i18n.t('greeting');
+    expect(result).toMatch(/^\[.*\]$/);
+  });
+
+  it('uses lng from URL query parameter over config', () => {
+    const i18n = createI18n({
+      lng: 'en',
+      fallbackLng: 'en',
+      interpolation: { escapeValue: false },
+      resources: {
+        en: { test: { greeting: 'Hello World' } },
+      },
+      ns: ['test'],
+      defaultNS: 'test',
+      initImmediate: false,
+    });
+    i18n.init();
+
+    const api = {
+      getI18nInstance: () => i18n,
+    } as unknown as I18nextTranslationApi;
+
+    const configApi = new ConfigReader({
+      i18n: { pseudolocalization: { language: 'en' } },
+    });
+
+    attachPseudolocalizationIfEnabled(
+      api,
+      configApi,
+      '?pseudolocalization=true&lng=fr',
+    );
+
+    // Current language is 'en' but pseudo targets 'fr', so 'en' strings stay untransformed
+    expect(i18n.t('greeting')).toBe('Hello World');
+  });
+});

--- a/workspaces/translations/plugins/translations/src/apis/pseudolocalization.ts
+++ b/workspaces/translations/plugins/translations/src/apis/pseudolocalization.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ConfigApi } from '@backstage/core-plugin-api';
+import type { i18n as I18n } from 'i18next';
+import Pseudo from 'i18next-pseudo';
+
+import type { I18nextTranslationApi } from './I18nextTranslationApi';
+
+/** @public */
+export interface PseudolocalizationOptions {
+  wrapped?: boolean;
+  languageToPseudo?: string;
+}
+
+function mergePostProcess(i18n: I18n): void {
+  const cur = i18n.options.postProcess;
+  let list: string[];
+  if (!cur) {
+    list = [];
+  } else if (Array.isArray(cur)) {
+    list = [...cur];
+  } else {
+    list = [cur as string];
+  }
+  if (!list.includes('pseudo')) {
+    list.push('pseudo');
+  }
+  i18n.options.postProcess = list;
+}
+
+/**
+ * Attaches the i18next-pseudo post-processor to a translation API's i18n
+ * instance. Call once after {@link I18nextTranslationApi.create}.
+ *
+ * @public
+ */
+export function attachPseudolocalization(
+  translationApi: I18nextTranslationApi,
+  options?: PseudolocalizationOptions,
+): void {
+  const i18n = translationApi.getI18nInstance();
+  const wrapped = options?.wrapped ?? true;
+  const languageToPseudo =
+    options?.languageToPseudo ?? i18n.resolvedLanguage ?? i18n.language ?? 'en';
+
+  const pseudo = new Pseudo({
+    enabled: true,
+    wrapped,
+    languageToPseudo,
+  });
+
+  i18n.use(pseudo);
+  mergePostProcess(i18n);
+
+  const syncLanguageToPseudo = () => {
+    const next =
+      options?.languageToPseudo ??
+      i18n.resolvedLanguage ??
+      i18n.language ??
+      'en';
+    pseudo.configurePseudo({ languageToPseudo: next });
+  };
+
+  syncLanguageToPseudo();
+  i18n.on('languageChanged', syncLanguageToPseudo);
+}
+
+/**
+ * Convenience wrapper that enables pseudo-localization when activated via
+ * URL query parameter (`?pseudolocalization=true`) or app-config
+ * (`i18n.pseudolocalization.enabled: true`).
+ *
+ * @public
+ */
+export function attachPseudolocalizationIfEnabled(
+  translationApi: I18nextTranslationApi,
+  configApi: ConfigApi,
+  locationSearch?: string,
+): void {
+  const params = new URLSearchParams(locationSearch ?? window.location.search);
+  const fromQuery = params.get('pseudolocalization') === 'true';
+  const fromConfig =
+    configApi.getOptionalBoolean('i18n.pseudolocalization.enabled') ?? false;
+
+  if (!fromQuery && !fromConfig) {
+    return;
+  }
+
+  const languageToPseudo =
+    params.get('lng') ??
+    configApi.getOptionalString('i18n.pseudolocalization.language') ??
+    undefined;
+
+  attachPseudolocalization(translationApi, { languageToPseudo });
+}

--- a/workspaces/translations/plugins/translations/src/components/PseudoLocalizationProvider.tsx
+++ b/workspaces/translations/plugins/translations/src/components/PseudoLocalizationProvider.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type PropsWithChildren, useEffect, useRef } from 'react';
+
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { translationApiRef } from '@backstage/core-plugin-api/alpha';
+
+import { attachPseudolocalizationIfEnabled } from '../apis/pseudolocalization';
+import type { I18nextTranslationApi } from '../apis/I18nextTranslationApi';
+
+/**
+ * Provider component that enables pseudo-localization when activated via
+ * URL query parameter (`?pseudolocalization=true`) or app-config
+ * (`i18n.pseudolocalization.enabled: true`).
+ *
+ * Register as a dynamic plugin at the `application/provider` mount point.
+ *
+ * @public
+ */
+export const PseudoLocalizationProvider = ({
+  children,
+}: PropsWithChildren<{}>) => {
+  const configApi = useApi(configApiRef);
+  const translationApi = useApi(translationApiRef);
+  const attached = useRef(false);
+
+  useEffect(() => {
+    if (attached.current) {
+      return;
+    }
+    attached.current = true;
+    attachPseudolocalizationIfEnabled(
+      translationApi as unknown as I18nextTranslationApi,
+      configApi,
+    );
+  }, [translationApi, configApi]);
+
+  return <>{children}</>;
+};

--- a/workspaces/translations/yarn.lock
+++ b/workspaces/translations/yarn.lock
@@ -1663,10 +1663,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10c0/30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
   languageName: node
   linkType: hard
 
@@ -2387,14 +2387,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.3.6":
-  version: 1.3.6
-  resolution: "@backstage/config@npm:1.3.6"
+"@backstage/config@npm:^1.3.6, @backstage/config@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@backstage/config@npm:1.3.7"
   dependencies:
-    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/errors": "npm:^1.3.0"
     "@backstage/types": "npm:^1.2.2"
     ms: "npm:^2.1.3"
-  checksum: 10c0/e6f99f9077145bf103a98b2533c506ee3104af4345c4ace0b7e4714352f0374091f7c1d43b14715f9a3046464782d3bbe5e3821ae423c7a5e56dc921edc5bc59
+  checksum: 10c0/de4f88e0df17140dfe9d5041936a7dcb7c24aa5413af7b6cecb04b417d6370e43bee25d2deb91e07e4cf1442a9e7ef151f57c2bd60d8ec4f7f199e6bcfd9dedc
   languageName: node
   linkType: hard
 
@@ -2577,13 +2577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "@backstage/errors@npm:1.2.7"
+"@backstage/errors@npm:^1.2.7, @backstage/errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@backstage/errors@npm:1.3.0"
   dependencies:
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/types": "npm:^1.2.2"
     serialize-error: "npm:^8.0.1"
-  checksum: 10c0/ce04dccc96c49bf121f1de86a589bbe3a613a32f63546b100a9d074bf2cb79c8ba889e1e7ba39c44c717b1bc7dea7654de85b1229fb7e4106e31dd60327c10c1
+  checksum: 10c0/e47f4a42d989858ab148359a410a82e295b5090c3da8d3a761997fd95d41786183c4113d8db13525964d497c2963e2d532c32f93548bb35bd30c1b514c34af19
   languageName: node
   linkType: hard
 
@@ -4245,7 +4245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/types@npm:^1.2.1, @backstage/types@npm:^1.2.2":
+"@backstage/types@npm:^1.2.2":
   version: 1.2.2
   resolution: "@backstage/types@npm:1.2.2"
   checksum: 10c0/3c947cf83c058a56b0cfd90d91483e9a5c1c913f7978a0d5a3c0fd9b502d08e9bdf279afba626826eee84159e698ee4cdaa70040789ac47fc8a25df9f1925612
@@ -10549,6 +10549,7 @@ __metadata:
   resolution: "@red-hat-developer-hub/backstage-plugin-translations@workspace:plugins/translations"
   dependencies:
     "@backstage/cli": "npm:^0.36.0"
+    "@backstage/config": "npm:^1.3.7"
     "@backstage/core-app-api": "npm:^1.19.6"
     "@backstage/core-components": "npm:^0.18.8"
     "@backstage/core-plugin-api": "npm:^1.12.4"
@@ -10564,6 +10565,7 @@ __metadata:
     "@testing-library/user-event": "npm:^14.0.0"
     "@types/zen-observable": "npm:^0.8.7"
     i18next: "npm:^22.4.15"
+    i18next-pseudo: "npm:^2.2.1"
     msw: "npm:^1.0.0"
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     zen-observable: "npm:^0.10.0"
@@ -22126,6 +22128,24 @@ __metadata:
   version: 1.1.0
   resolution: "hyphenate-style-name@npm:1.1.0"
   checksum: 10c0/bfe88deac2414a41a0d08811e277c8c098f23993d6a1eb17f14a0f11b54c4d42865a63d3cfe1914668eefb9a188e2de58f38b55a179a238fd1fef606893e194f
+  languageName: node
+  linkType: hard
+
+"i18next-pseudo@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "i18next-pseudo@npm:2.2.1"
+  dependencies:
+    i18next: "npm:^19.1.0"
+  checksum: 10c0/9d00aeaa0d8410a5c8d0d00f2b72ee411860fc082114a613c144030356bc490bdedc727c3db1cd06ced4dd34224d681b7d805d5b0ada6334124674fef565f213
+  languageName: node
+  linkType: hard
+
+"i18next@npm:^19.1.0":
+  version: 19.9.2
+  resolution: "i18next@npm:19.9.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.0"
+  checksum: 10c0/ee4991039a9acfff3ff4d5872ba183fce6ddc7017b689095d3d3df98ca16c0563f7d1333b4a4d3d4de65af5a521661bed36d677a5dd712c62095683e33f33a66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 ## Summary

  **Resolves : [RHDHBUGS-3029](https://redhat.atlassian.net/browse/RHDHBUGS-3029)**
  
  Add pseudo-localization support to the translations plugin to help identify untranslated or hardcoded strings across the RHDH UI. Strings are transformed with diacritical marks and brackets (e.g., `"Settings"` →
   `"[Ṣḛḛţţḭḭṇḡṡ]"`), making untranslated text visually obvious.


  ### Usage in RHDH
  ```yaml
  dynamicPlugins:
    frontend:
      red-hat-developer-hub.backstage-plugin-translations:
        mountPoints:
          - mountPoint: application/provider
            importName: PseudoLocalizationProvider
```

  ## Activation

  **Option 1:** URL query parameter
  https://your-rhdh-instance.com/?pseudolocalization=true
  
  **Option 2:** App config
  ```yaml
  i18n:
    pseudolocalization:
      enabled: true
```

  ### demo
  
  

https://github.com/user-attachments/assets/e5702652-aac6-4288-a84d-22a6ef9828e8





  No static code changes required in RHDH.

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
