### PR TITLE
fix(deps): add `react-router`-dom in devDependencies

### DIFF
--- a/workspaces/global-floating-action-button/.changeset/popular-chefs-play.md
+++ b/workspaces/global-floating-action-button/.changeset/popular-chefs-play.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-floating-action-button': patch
+---
+
+Add react-router-dom in devDependencies

--- a/workspaces/global-floating-action-button/plugins/global-floating-action-button/package.json
+++ b/workspaces/global-floating-action-button/plugins/global-floating-action-button/package.json
@@ -53,7 +53,9 @@
     "@openshift/dynamic-plugin-sdk": "5.0.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": "16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-router-dom": "^6.0.0"
   },
   "files": [
     "dist",

--- a/workspaces/global-floating-action-button/yarn.lock
+++ b/workspaces/global-floating-action-button/yarn.lock
@@ -10563,6 +10563,8 @@ __metadata:
     "@testing-library/react": "npm:^14.0.0"
     classnames: "npm:^2.5.1"
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    react-dom: "npm:16.13.1 || ^17.0.0 || ^18.0.0"
+    react-router-dom: "npm:^6.0.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
     react: 16.13.1 || ^17.0.0 || ^18.0.0
@@ -28876,7 +28878,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.0.2":
+"react-dom@npm:16.13.1 || ^17.0.0 || ^18.0.0, react-dom@npm:^18.0.2":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -29177,7 +29179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.30.2":
+"react-router-dom@npm:^6.0.0, react-router-dom@npm:^6.30.2":
   version: 6.30.3
   resolution: "react-router-dom@npm:6.30.3"
   dependencies:

--- a/workspaces/quickstart/.changeset/eleven-baboons-ask.md
+++ b/workspaces/quickstart/.changeset/eleven-baboons-ask.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-quickstart': patch
+---
+
+add react-router-dom in devDependencies

--- a/workspaces/quickstart/plugins/quickstart/package.json
+++ b/workspaces/quickstart/plugins/quickstart/package.json
@@ -50,7 +50,9 @@
     "react-use": "^17.6.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": "16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-router-dom": "^6.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.36.0",
@@ -62,7 +64,9 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
     "msw": "^1.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": "16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-router-dom": "^6.0.0"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/workspaces/quickstart/yarn.lock
+++ b/workspaces/quickstart/yarn.lock
@@ -11526,9 +11526,13 @@ __metadata:
     "@testing-library/user-event": "npm:^14.0.0"
     msw: "npm:^1.0.0"
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    react-dom: "npm:16.13.1 || ^17.0.0 || ^18.0.0"
+    react-router-dom: "npm:^6.0.0"
     react-use: "npm:^17.6.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: 16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -30619,7 +30623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.0.2":
+"react-dom@npm:16.13.1 || ^17.0.0 || ^18.0.0, react-dom@npm:^18.0.2":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -30927,7 +30931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.3.0, react-router-dom@npm:^6.30.2":
+"react-router-dom@npm:^6.0.0, react-router-dom@npm:^6.3.0, react-router-dom@npm:^6.30.2":
   version: 6.30.3
   resolution: "react-router-dom@npm:6.30.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To avoid build errors when building the plugin in isolation, Addin the missing dependency `react-router-dom` in the plugin's package.json.

Plugins covered:

1. Global-floating-action-button
2. Quickstart




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
