### PR TITLE
 fix(lightspeed): replace JSS makeStyles with emotion-based implement…

### DIFF
--- a/workspaces/lightspeed/.changeset/dull-swans-do.md
+++ b/workspaces/lightspeed/.changeset/dull-swans-do.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Replace JSS-based makeStyles with emotion-based implementation to fix CSS class name collisions when lightspeed plugin is loaded alongside other plugins. Added MUI ClassNameGenerator with `ls-` prefix for

--- a/workspaces/lightspeed/.changeset/dull-swans-do.md
+++ b/workspaces/lightspeed/.changeset/dull-swans-do.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-lightspeed': patch
 ---
 
-Replace JSS-based makeStyles with emotion-based implementation to fix CSS class name collisions when lightspeed plugin is loaded alongside other plugins. Added MUI ClassNameGenerator with `ls-` prefix for
+Replace JSS-based `makeStyles` with an Emotion-based implementation to avoid CSS class name collisions when the Lightspeed plugin loads alongside other plugins. Configure MUI `ClassNameGenerator` with an `ls-` prefix for Lightspeed-owned component class names.

--- a/workspaces/lightspeed/.changeset/dull-swans-do.md
+++ b/workspaces/lightspeed/.changeset/dull-swans-do.md
@@ -3,3 +3,5 @@
 ---
 
 Replace JSS-based `makeStyles` with an Emotion-based implementation to avoid CSS class name collisions when the Lightspeed plugin loads alongside other plugins. Configure MUI `ClassNameGenerator` with an `ls-` prefix for Lightspeed-owned component class names.
+
+Fix MCP settings UI: render the configure-server modal in a top-level portal so it stacks above the chatbot drawer, and align the MCP servers table background with the page background in dark theme.

--- a/workspaces/lightspeed/.prettierignore
+++ b/workspaces/lightspeed/.prettierignore
@@ -1,5 +1,7 @@
 dist
 dist-types
+dist-dynamic
+dist-scalprum
 coverage
 .vscode
 .eslintrc.js

--- a/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
@@ -17,13 +17,13 @@
 import Close from '@mui/icons-material/Close';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { LightspeedFABIcon } from '../components/LightspeedIcon';
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import { makeStyles } from '../utils/makeStyles';
 
 const useStyles = makeStyles(theme => ({
   fab: {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/Attachment.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/Attachment.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core';
 import {
   AttachmentEdit,
   ChatbotDisplayMode,
@@ -22,6 +21,7 @@ import {
 } from '@patternfly/chatbot';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { makeStyles } from '../utils/makeStyles';
 import { useFileAttachmentContext } from './AttachmentContext';
 
 const useStyles = makeStyles(() => ({

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/CollapsedHistoryStrip.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/CollapsedHistoryStrip.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core';
 import { Button, Tooltip } from '@patternfly/react-core';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { makeStyles } from '../utils/makeStyles';
 import { SidebarExpandIcon } from './notebooks/SidebarCollapseIcon';
 
 type IconProps = {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -155,9 +155,7 @@ const useStyles = makeStyles(theme => ({
     },
   },
   header: {
-    padding: `${theme.spacing(3)}px ${theme.spacing(3)}px 0 ${theme.spacing(
-      3,
-    )}px !important`,
+    padding: `${theme.spacing(3, 3, 0, 3)} !important`,
     backgroundColor:
       'var(--pf-t--global--background--color--floating--default) !important',
   },
@@ -406,8 +404,8 @@ const useStyles = makeStyles(theme => ({
       'var(--pf-t--global--background--color--floating--default)',
   },
   toastAlertGroup: {
-    '--pf-v6-c-alert-group--m-toast--InsetInlineEnd': `${theme.spacing(2.5)}px`,
-    '--pf-v6-c-alert-group--m-toast--InsetBlockStart': `${theme.spacing(2.5)}px`,
+    '--pf-v6-c-alert-group--m-toast--InsetInlineEnd': theme.spacing(2.5),
+    '--pf-v6-c-alert-group--m-toast--InsetBlockStart': theme.spacing(2.5),
     '--pf-v6-c-alert-group--m-toast--MaxWidth': '350px',
   },
   toastAlert: {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -34,7 +34,7 @@ import { useLocation, useMatch, useNavigate } from 'react-router-dom';
 
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
-import { Button, makeStyles } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import {
@@ -112,6 +112,7 @@ import {
   getFootnoteProps,
   SortOption,
 } from '../utils/lightspeed-chatbox-utils';
+import { makeStyles } from '../utils/makeStyles';
 import Attachment from './Attachment';
 import { useFileAttachmentContext } from './AttachmentContext';
 import { CollapsedHistoryStrip, EditSquareIcon } from './CollapsedHistoryStrip';
@@ -346,7 +347,7 @@ const useStyles = makeStyles(theme => ({
     },
     '& .pf-chatbot__message-bar': {
       backgroundColor:
-        theme.palette.type === 'light'
+        theme.palette.mode === 'light'
           ? theme.palette.grey[100]
           : 'var(--pf-t--global--background--color--secondary--default)',
     },

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -423,8 +423,7 @@ const useStyles = makeStyles(theme => ({
     height: '100%',
     width: '100%',
     '&.pf-chatbot__settings-form-container': {
-      background:
-        'var(--pf-v6-c-table--BackgroundColor, var(--pf-t--global--background--color--primary--default))',
+      background: 'var(--pf-t--global--background--color--floating--default)',
       padding: 0,
       margin: 0,
       minHeight: '100%',
@@ -436,8 +435,7 @@ const useStyles = makeStyles(theme => ({
     '& .pf-chatbot__settings-form': {
       margin: 0,
       padding: 0,
-      background:
-        'var(--pf-v6-c-table--BackgroundColor, var(--pf-t--global--background--color--primary--default))',
+      background: 'var(--pf-t--global--background--color--floating--default)',
       minHeight: '100%',
       display: 'flex',
       flexDirection: 'column',
@@ -445,8 +443,7 @@ const useStyles = makeStyles(theme => ({
       maxWidth: 'none',
     },
     '& .pf-chatbot__settings-form-row': {
-      background:
-        'var(--pf-v6-c-table--BackgroundColor, var(--pf-t--global--background--color--primary--default))',
+      background: 'var(--pf-t--global--background--color--floating--default)',
       border: 0,
       margin: 0,
       padding: 0,
@@ -485,7 +482,7 @@ const useStyles = makeStyles(theme => ({
     minWidth: 0,
     borderLeft: `1px solid ${theme.palette.divider}`,
     backgroundColor:
-      'var(--pf-v6-c-table--BackgroundColor, var(--pf-t--global--background--color--primary--default))',
+      'var(--pf-t--global--background--color--floating--default)',
     display: 'flex',
     flexDirection: 'column',
     minHeight: 0,
@@ -569,6 +566,16 @@ const useStyles = makeStyles(theme => ({
     minHeight: 0,
     minWidth: 0,
     overflow: 'hidden',
+  },
+  /** Renders MCP configure modals above chatbot drawer / split MCP pane (z-index 1300). */
+  mcpConfigureModalPortal: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 1500,
+    pointerEvents: 'none',
+    '& .pf-v6-c-backdrop, & .pf-v5-c-backdrop': {
+      pointerEvents: 'auto',
+    },
   },
 }));
 
@@ -703,6 +710,11 @@ export const LightspeedChat = ({
   const [chatHeaderBgColor, setChatHeaderBgColor] = useState<string>();
   const contentScrollRef = useRef<HTMLDivElement>(null);
   const bottomSentinelRef = useRef<HTMLDivElement>(null);
+  const mcpConfigureModalPortalRef = useRef<HTMLDivElement>(null);
+  const getMcpConfigureModalAppendTo = useCallback(
+    () => mcpConfigureModalPortalRef.current ?? document.body,
+    [],
+  );
   const [messageBarKey, setMessageBarKey] = useState(0);
   const [hasChatContentOverflow, setHasChatContentOverflow] = useState(false);
   const wasStoppedByUserRef = useRef(false);
@@ -1755,6 +1767,7 @@ export const LightspeedChat = ({
     <McpServersSettings
       onClose={() => setIsMcpSettingsOpen(false)}
       backgroundColor={chatHeaderBgColor}
+      getModalAppendTo={getMcpConfigureModalAppendTo}
     />
   );
 
@@ -1859,6 +1872,11 @@ export const LightspeedChat = ({
           }
         />
       )}
+      <div
+        ref={mcpConfigureModalPortalRef}
+        className={classes.mcpConfigureModalPortal}
+        data-testid="lightspeed-mcp-configure-modal-portal"
+      />
       <Chatbot
         displayMode={ChatbotDisplayMode.embedded}
         className={`${classes.body} ${

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBox.tsx
@@ -22,7 +22,6 @@ import {
   useRef,
 } from 'react';
 
-import { makeStyles } from '@material-ui/core';
 import {
   ChatbotDisplayMode,
   ChatbotWelcomePrompt,
@@ -42,6 +41,7 @@ import { useBufferedMessages } from '../hooks/useBufferedMessages';
 import { useFeedbackActions } from '../hooks/useFeedbackActions';
 import { useTranslation } from '../hooks/useTranslation';
 import { ToolCall } from '../types';
+import { makeStyles } from '../utils/makeStyles';
 import { parseReasoning } from '../utils/reasoningParser';
 import { mapToPatternFlyToolCall } from '../utils/toolCallMapper';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatBoxHeader.tsx
@@ -16,7 +16,6 @@
 
 import { Ref, useState } from 'react';
 
-import { createStyles, makeStyles } from '@material-ui/core';
 import ToggleOffOutlinedIcon from '@mui/icons-material/ToggleOffOutlined';
 import ToggleOnOutlinedIcon from '@mui/icons-material/ToggleOnOutlined';
 import Divider from '@mui/material/Divider';
@@ -40,6 +39,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { createStyles, makeStyles } from '../utils/makeStyles';
 import { McpSettingsIcon } from './McpSettingsIcon';
 
 type LightspeedChatBoxHeaderProps = {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatModelsState.tsx
@@ -21,12 +21,12 @@ import {
   Link,
   Typography,
 } from '@material-ui/core';
-import { createStyles, makeStyles } from '@material-ui/core/styles';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { createStyles, makeStyles } from '../utils/makeStyles';
 
 const LLAMA_STACK_CONFIGURE_DOCS_URL =
   'https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/developer-lightspeed#proc-installing-and-configuring-lightspeed_developer-lightspeed';

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -16,11 +16,11 @@
 
 import { PropsWithChildren } from 'react';
 
-import { makeStyles } from '@mui/styles';
 import { ChatbotModal } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedProviderState } from '../hooks/useLightspeedProviderState';
+import { makeStyles } from '../utils/makeStyles';
 import { LightspeedChatContainer } from './LightspeedChatContainer';
 import { LightspeedDrawerContext } from './LightspeedDrawerContext';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
@@ -17,12 +17,12 @@
 import Close from '@mui/icons-material/Close';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import { makeStyles } from '../utils/makeStyles';
 import { LightspeedFABIcon } from './LightspeedIcon';
 
 const useStyles = makeStyles(theme => ({

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedPage.tsx
@@ -16,9 +16,8 @@
 
 import { Content, Header, Page } from '@backstage/core-components';
 
-import { createStyles, makeStyles } from '@material-ui/core/styles';
-
 import { useTranslation } from '../hooks/useTranslation';
+import { createStyles, makeStyles } from '../utils/makeStyles';
 import { LightspeedChatContainer } from './LightspeedChatContainer';
 
 const useStyles = makeStyles(() =>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/McpServersSettings.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/McpServersSettings.tsx
@@ -19,7 +19,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import { usePermission } from '@backstage/plugin-permission-react';
 
-import { makeStyles } from '@material-ui/core';
 import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import ModeEditOutlineOutlinedIcon from '@mui/icons-material/ModeEditOutlineOutlined';
@@ -50,6 +49,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { lightspeedMcpManagePermission } from '@red-hat-developer-hub/backstage-plugin-lightspeed-common';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { makeStyles } from '../utils/makeStyles';
 
 type ServerStatus = 'tokenRequired' | 'disabled' | 'ok' | 'failed' | 'unknown';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/McpServersSettings.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/McpServersSettings.tsx
@@ -68,6 +68,8 @@ type McpServer = {
 type McpServersSettingsProps = {
   onClose: () => void;
   backgroundColor?: string;
+  /** Portal target for the configure modal; use a root outside the chatbot tree to avoid z-index clashes. */
+  getModalAppendTo?: () => HTMLElement;
 };
 
 type TokenValidationState = 'idle' | 'validating' | 'success' | 'error';
@@ -75,20 +77,14 @@ type TokenValidationState = 'idle' | 'validating' | 'success' | 'error';
 const SAVED_TOKEN_MASK = '********************';
 
 const useStyles = makeStyles(theme => ({
-  '@global': {
-    '.pf-v6-c-backdrop': {
-      zIndex: '1400 !important',
-    },
-    '.pf-v5-c-backdrop': {
-      zIndex: '1400 !important',
-    },
-  },
   root: {
     padding: 0,
     height: '100%',
     minHeight: '100%',
     width: '100%',
     overflow: 'auto',
+    backgroundColor:
+      'var(--pf-t--global--background--color--floating--default)',
   },
   headerRow: {
     display: 'flex',
@@ -288,13 +284,15 @@ const useStyles = makeStyles(theme => ({
       backgroundColor: 'rgba(201, 25, 11, 0.08)',
     },
   },
+  configureModalBackdrop: {
+    zIndex: 1,
+  },
   configureModal: {
-    '& .pf-v6-c-modal-box': {
-      width: '608px',
-      maxWidth: '608px',
-      height: '326px',
-      minHeight: '326px',
-    },
+    width: '608px',
+    maxWidth: '608px',
+    height: '326px',
+    minHeight: '326px',
+    zIndex: 2,
     '& .pf-v6-c-modal-box__title, & .pf-v6-c-modal-box__title-text, & .pf-v5-c-modal-box__title, & .pf-v5-c-modal-box__title-text':
       {
         fontSize: '1.25rem !important',
@@ -316,6 +314,12 @@ const useStyles = makeStyles(theme => ({
   },
   table: {
     width: '100%',
+    // Match panel background (PF table defaults to primary in dark mode).
+    '--pf-v6-c-table--BackgroundColor': 'transparent',
+    '--pf-v6-c-table__tr--m-ghost-row--BackgroundColor': 'transparent',
+    '--pf-v6-c-table__expandable-row-content--BackgroundColor': 'transparent',
+    '--pf-v6-c-table__control-row--BackgroundColor': 'transparent',
+    backgroundColor: 'transparent',
     '& th': {
       borderBottom: 0,
       fontSize: '0.75rem',
@@ -407,6 +411,7 @@ const toUiServer = (
 export const McpServersSettings = ({
   onClose,
   backgroundColor,
+  getModalAppendTo,
 }: McpServersSettingsProps) => {
   const classes = useStyles();
   const { t } = useTranslation();
@@ -1016,6 +1021,8 @@ export const McpServersSettings = ({
         })}
         isOpen={Boolean(editingServer)}
         onClose={closeConfigureModal}
+        appendTo={getModalAppendTo ?? (() => document.body)}
+        backdropClassName={classes.configureModalBackdrop}
         className={classes.configureModal}
       >
         <div className={classes.modalContent}>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/MessageBarModelSelector.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/MessageBarModelSelector.tsx
@@ -16,7 +16,6 @@
 
 import { Ref, useState } from 'react';
 
-import { makeStyles } from '@material-ui/core';
 import {
   Dropdown,
   DropdownItem,
@@ -27,6 +26,7 @@ import {
 import { AngleDownIcon } from '@patternfly/react-icons';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { makeStyles } from '../utils/makeStyles';
 
 type MessageBarModelSelectorProps = {
   selectedModel: string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/PermissionRequiredState.tsx
@@ -19,9 +19,9 @@ import { Fragment } from 'react';
 import { EmptyState } from '@backstage/core-components';
 
 import { Typography } from '@material-ui/core';
-import { createStyles, makeStyles } from '@material-ui/core/styles';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { createStyles, makeStyles } from '../utils/makeStyles';
 import { PermissionRequiredIcon } from './PermissionRequiredIcon';
 import { Trans } from './Trans';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/ToolCallContent.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/ToolCallContent.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core';
 import { Message } from '@patternfly/chatbot';
 import {
   Content,
@@ -32,6 +31,7 @@ import { WrenchIcon } from '@patternfly/react-icons';
 import { useTranslation } from '../hooks/useTranslation';
 import { ToolCall } from '../types';
 import { formatToolResponseForMarkdown } from '../utils/formatToolResponseForMarkdown';
+import { makeStyles } from '../utils/makeStyles';
 
 interface ToolCallContentProps {
   toolCall: ToolCall;

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/AddDocumentModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/AddDocumentModal.tsx
@@ -17,7 +17,6 @@
 import { useEffect, useState } from 'react';
 import { FileRejection } from 'react-dropzone';
 
-import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -37,6 +36,7 @@ import { UploadIcon } from '@patternfly/react-icons';
 import { NOTEBOOK_MAX_FILES } from '../../const';
 import { useUploadDocument } from '../../hooks/notebooks/useUploadDocument';
 import { useTranslation } from '../../hooks/useTranslation';
+import { makeStyles } from '../../utils/makeStyles';
 import {
   getNotebookAcceptedFileTypes,
   validateFiles,

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteNotebookModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteNotebookModal.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -28,6 +27,7 @@ import Typography from '@mui/material/Typography';
 
 import { useDeleteNotebook } from '../../hooks/notebooks/useDeleteNotebook';
 import { useTranslation } from '../../hooks/useTranslation';
+import { makeStyles } from '../../utils/makeStyles';
 
 const useStyles = makeStyles(theme => ({
   dialogPaper: {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DocumentSidebar.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DocumentSidebar.tsx
@@ -90,7 +90,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1),
-    padding: `${theme.spacing(1)}px ${theme.spacing(0.5)}px`,
+    padding: theme.spacing(1, 1),
     borderRadius: 4,
   },
   fileIcon: {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DocumentSidebar.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DocumentSidebar.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from 'react';
 
-import { makeStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import {
   Button,
   Dropdown,
@@ -31,6 +31,7 @@ import { EllipsisVIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { NOTEBOOK_MAX_FILES } from '../../const';
 import { useTranslation } from '../../hooks/useTranslation';
 import { SessionDocument } from '../../types';
+import { makeStyles } from '../../utils/makeStyles';
 import { FileTypeIcon } from './FileTypeIcon';
 import { SidebarCollapseIcon } from './SidebarCollapseIcon';
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/FileListItem.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/FileListItem.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 
+import { makeStyles } from '../../utils/makeStyles';
 import { FileTypeIcon } from './FileTypeIcon';
 
 const useStyles = makeStyles(theme => ({
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     padding: '8px 12px',
     borderRadius: 8,
-    backgroundColor: theme.palette.type === 'dark' ? '#2a2a2a' : '#f5f5f5',
+    backgroundColor: theme.palette.mode === 'dark' ? '#2a2a2a' : '#f5f5f5',
     marginBottom: 8,
     '&:last-child': {
       marginBottom: 0,

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/FileTypeIcon.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/FileTypeIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '../../utils/makeStyles';
 
 const FILE_TYPE_COLORS: Record<string, string> = {
   pdf: '#C9190B',

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
-import { makeStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import {
   ChatbotContent,
   ChatbotFooter,
@@ -58,6 +58,7 @@ import { CreateMessageVariables } from '../../hooks/useCreateCoversationMessage'
 import { useNotebookWelcomePrompts } from '../../hooks/useNotebookWelcomePrompts';
 import { useTranslation } from '../../hooks/useTranslation';
 import { NotebookSessionMetadata, SessionDocument } from '../../types';
+import { makeStyles } from '../../utils/makeStyles';
 import { LightspeedChatBox } from '../LightspeedChatBox';
 import { AddDocumentModal } from './AddDocumentModal';
 import { DocumentSidebar } from './DocumentSidebar';
@@ -250,7 +251,7 @@ const useStyles = makeStyles(theme => ({
     },
     '& .pf-chatbot__message-bar': {
       backgroundColor:
-        theme.palette.type === 'light'
+        theme.palette.mode === 'light'
           ? theme.palette.grey[100]
           : 'var(--pf-t--global--background--color--secondary--default)',
     },

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
@@ -119,7 +119,7 @@ const useStyles = makeStyles(theme => ({
   topBar: {
     display: 'flex',
     justifyContent: 'flex-end',
-    padding: `${theme.spacing(1.5)}px ${theme.spacing(2)}px`,
+    padding: theme.spacing(1.5, 2),
     backgroundColor:
       'var(--pf-t--global--background--color--floating--default)',
   },
@@ -148,7 +148,7 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     maxWidth: 'unset',
     margin: 0,
-    padding: `0 0 ${theme.spacing(1)}px`,
+    padding: theme.spacing(0, 0, 2, 0),
     boxSizing: 'border-box',
     backgroundColor:
       'var(--pf-t--global--background--color--floating--default)',
@@ -172,8 +172,8 @@ const useStyles = makeStyles(theme => ({
     margin: '0 auto',
   },
   toastAlertGroup: {
-    '--pf-v6-c-alert-group--m-toast--InsetInlineEnd': `${theme.spacing(2.5)}px`,
-    '--pf-v6-c-alert-group--m-toast--InsetBlockStart': `${theme.spacing(2.5)}px`,
+    '--pf-v6-c-alert-group--m-toast--InsetInlineEnd': theme.spacing(2.5),
+    '--pf-v6-c-alert-group--m-toast--InsetBlockStart': theme.spacing(2.5),
     '--pf-v6-c-alert-group--m-toast--MaxWidth': '350px',
   },
   toastAlert: {
@@ -191,6 +191,15 @@ const useStyles = makeStyles(theme => ({
     backgroundColor:
       'var(--pf-t--global--background--color--floating--default)',
   },
+  welcomeBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    flexShrink: 0,
+    width: '100%',
+    gap: theme.spacing(3),
+    marginTop: theme.spacing(4),
+    paddingBottom: theme.spacing(2),
+  },
   notebookEmptyUpload: {
     flex: 1,
     display: 'flex',
@@ -202,20 +211,22 @@ const useStyles = makeStyles(theme => ({
   notebookContentArea: {
     width: '95%',
     maxWidth: 'unset',
-    margin: `${theme.spacing(3)}px auto 0 auto`,
+    margin: '0 auto',
     padding: 0,
   },
   notebookHeading: {
     fontSize: '2rem',
     fontWeight: 500,
     lineHeight: 1.25,
-    padding: `${theme.spacing(1)}px 0`,
+    margin: 0,
+    padding: theme.spacing(2, 0, 1, 0),
   },
   notebookSummary: {
     fontSize: '1rem',
     lineHeight: 2,
     color: 'var(--pf-t--global--text--color--regular)',
-    paddingTop: theme.spacing(0.5),
+    margin: 0,
+    paddingTop: theme.spacing(1),
   },
   promptSuggestions: {
     display: 'flex',
@@ -223,7 +234,7 @@ const useStyles = makeStyles(theme => ({
     gap: theme.spacing(1),
     width: '95%',
     maxWidth: 'unset',
-    margin: `${theme.spacing(3)}px auto ${theme.spacing(3)}px auto`,
+    margin: `0 auto ${theme.spacing(3)} auto`,
     justifyContent: 'flex-start',
   },
   promptPill: {
@@ -231,7 +242,7 @@ const useStyles = makeStyles(theme => ({
     background: 'transparent',
     border: `1px solid var(--pf-t--global--border--color--default)`,
     borderRadius: '999px',
-    padding: `${theme.spacing(1)}px ${theme.spacing(2.5)}px`,
+    padding: theme.spacing(1, 2.5),
     fontSize: '0.875rem',
     color: 'var(--pf-t--global--text--color--regular)',
     cursor: 'pointer',
@@ -597,30 +608,32 @@ export const NotebookView = ({
       <div className={classes.welcomeContainer}>
         <div style={{ flex: 1 }} />
         {renderNotebookDisclaimerAlert()}
-        <div className={classes.notebookContentArea}>
-          <Typography className={classes.notebookHeading}>
-            {notebookName}
-          </Typography>
-          {topicSummary && (
-            <Typography className={classes.notebookSummary}>
-              {topicSummary}
+        <div className={classes.welcomeBody}>
+          <div className={classes.notebookContentArea}>
+            <Typography className={classes.notebookHeading}>
+              {notebookName}
             </Typography>
+            {topicSummary && (
+              <Typography className={classes.notebookSummary}>
+                {topicSummary}
+              </Typography>
+            )}
+          </div>
+          {welcomePrompts.length > 0 && (
+            <div className={classes.promptSuggestions}>
+              {welcomePrompts.map(prompt => (
+                <button
+                  key={prompt.title}
+                  type="button"
+                  className={classes.promptPill}
+                  onClick={prompt.onClick}
+                >
+                  {prompt.title}
+                </button>
+              ))}
+            </div>
           )}
         </div>
-        {welcomePrompts.length > 0 && (
-          <div className={classes.promptSuggestions}>
-            {welcomePrompts.map(prompt => (
-              <button
-                key={prompt.title}
-                type="button"
-                className={classes.promptPill}
-                onClick={prompt.onClick}
-              >
-                {prompt.title}
-              </button>
-            ))}
-          </div>
-        )}
       </div>
     );
   };

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/OverwriteConfirmModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/OverwriteConfirmModal.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
@@ -26,6 +25,7 @@ import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 
 import { useTranslation } from '../../hooks/useTranslation';
+import { makeStyles } from '../../utils/makeStyles';
 import { FileTypeIcon } from './FileTypeIcon';
 
 const useStyles = makeStyles(theme => ({

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/OverwriteConfirmModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/OverwriteConfirmModal.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1),
-    padding: `${theme.spacing(2)}px 0`,
+    padding: theme.spacing(2, 0),
     borderBottom:
       '1px solid var(--pf-t--global--border--color--default, #c7c7c7)',
     cursor: 'pointer',

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/RenameNotebookModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/RenameNotebookModal.tsx
@@ -17,7 +17,6 @@
 import { useEffect, useState } from 'react';
 
 import { TextField } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -31,6 +30,7 @@ import Typography from '@mui/material/Typography';
 
 import { useRenameNotebook } from '../../hooks/notebooks/useRenameNotebook';
 import { useTranslation } from '../../hooks/useTranslation';
+import { makeStyles } from '../../utils/makeStyles';
 
 const useStyles = makeStyles(theme => ({
   dialogPaper: {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/UploadResourceScreen.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/UploadResourceScreen.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { makeStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import { Button } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons';
 import { CatalogIcon } from '@patternfly/react-icons/dist/esm/icons';
 
 import { useTranslation } from '../../hooks/useTranslation';
+import { makeStyles } from '../../utils/makeStyles';
 
 const useStyles = makeStyles(theme => ({
   container: {

--- a/workspaces/lightspeed/plugins/lightspeed/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/index.ts
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('ls-')
+    ? componentName
+    : `ls-${componentName}`;
+});
+
 export {
   lightspeedPlugin,
   LightspeedPage,

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/makeStyles.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/makeStyles.ts
@@ -23,6 +23,12 @@ import { insertStyles, registerStyles } from '@emotion/utils';
 import type { Theme } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
 
+/**
+ * Emotion-backed makeStyles uses `useTheme` from `@mui/material` (MUI v5).
+ * Unlike MUI v4, `theme.spacing(n)` returns strings with units (e.g. `"8px"`).
+ * Do not append `px` after `theme.spacing(...)` in style objects — that produces
+ * invalid values like `16pxpx` and drops the whole declaration in the browser.
+ */
 const emotionCache = createCache({ key: 'ls' });
 
 type StylesObj<K extends string> = Record<K, CSSInterpolation>;

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/makeStyles.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/makeStyles.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+
+import createCache from '@emotion/cache';
+import { serializeStyles } from '@emotion/serialize';
+import type { CSSInterpolation } from '@emotion/serialize';
+import { insertStyles, registerStyles } from '@emotion/utils';
+import type { Theme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
+
+const emotionCache = createCache({ key: 'ls' });
+
+type StylesObj<K extends string> = Record<K, CSSInterpolation>;
+
+function cssClass(style: CSSInterpolation): string {
+  const serialized = serializeStyles([style as any], emotionCache.registered);
+  registerStyles(emotionCache, serialized, false);
+  insertStyles(emotionCache, serialized, false);
+  return `${emotionCache.key}-${serialized.name}`;
+}
+
+export function makeStyles<K extends string>(
+  stylesOrFactory: StylesObj<K> | ((theme: Theme) => StylesObj<K>),
+): () => Record<K, string> {
+  return function useStyles() {
+    const theme = useTheme();
+    return useMemo(() => {
+      const stylesObj =
+        typeof stylesOrFactory === 'function'
+          ? stylesOrFactory(theme)
+          : stylesOrFactory;
+
+      const classes = {} as Record<K, string>;
+      for (const key of Object.keys(stylesObj) as K[]) {
+        classes[key] = cssClass(stylesObj[key]);
+      }
+      return classes;
+    }, [theme]);
+  };
+}
+
+export function createStyles<T extends Record<string, CSSInterpolation>>(
+  styles: T,
+): T {
+  return styles;
+}


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                              
 **Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3133**  
The lightspeed plugin uses JSS `makeStyles` which generates class names based on a global counter (e.g., `jss-1`). When multiple plugins load on the same page, their counters collide, causing styles to bleed across plugins.

  ### What changed                                                                                                                                                                            

  - **New `utils/makeStyles.ts`** — a custom `makeStyles` implementation built on top of emotion's `sx` engine (already bundled via MUI). It mimics the same API as MUI's `makeStyles` — identical call signature, returns `classes` with real CSS class names — so existing component code stays untouched. Class names are content-hashed (`ls-abc123`), so collisions are impossible regardless of plugin load order.
  - **Migrated all 23 component files** — only import lines changed. Zero changes to style definitions or `className` usage.
  - **Fixed `theme.palette.type` → `theme.palette.mode`** in `FileListItem.tsx` (MUI v4 → v5 API).

  ### Why not the seed approach?

  1. Lightspeed has multiple independent mount points (`LightspeedPage`, `LightspeedFAB`, `LightspeedDrawerProvider`) — each would need to be wrapped in its own `StylesProvider`, and their counters would still collide with each other.
  2. `makeStyles` from `@material-ui/core` and `@mui/styles` is already deprecated by MUI. Building on top of emotion aligns with MUI's recommended direction.

  Emotion avoids all of this — no provider, no counter, no wrapping needed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
