### PR TITLE
RHDHBUGS-3045 Scorecard: Display correct legend for average aggregation

### DIFF
--- a/workspaces/scorecard/.changeset/sharp-mangos-build.md
+++ b/workspaces/scorecard/.changeset/sharp-mangos-build.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': patch
+---
+
+Fix average score card donut tooltip behavior and align pie chart tooltips

--- a/workspaces/scorecard/packages/app-legacy/e2e-tests/pages/HomePage.ts
+++ b/workspaces/scorecard/packages/app-legacy/e2e-tests/pages/HomePage.ts
@@ -131,7 +131,8 @@ export class HomePage {
   }
 
   /**
-   * Clicks the homepage KPI drill-down link (healthy/total subheader). Mock data uses 10/10.
+   * Clicks the homepage KPI drill-down link (healthy/total subheader).
+   * Defaults to 10/10 (plain “10 entities” link). Pass overrides when mock `result.total` differs.
    */
   async clickDrillDownLink(options?: { healthy?: string; total?: string }) {
     const healthy = options?.healthy ?? '10';

--- a/workspaces/scorecard/packages/app-legacy/e2e-tests/scorecard.test.ts
+++ b/workspaces/scorecard/packages/app-legacy/e2e-tests/scorecard.test.ts
@@ -1111,12 +1111,12 @@ test.describe('Scorecard Plugin Tests', () => {
         const card = homePage.getCard(
           AGGREGATED_CARDS_METRIC_IDS.withOpenPrsWeightedKpi,
         );
-        await expectAverageCardCenterPercent(card, '50%');
+        await expectAverageCardCenterPercent(card, '51.5%');
         await verifyAverageDonutCenterTooltip(
           page,
           card,
           translations,
-          500,
+          515,
           1000,
         );
         await verifyAverageCenterTooltipBreakdownRows(
@@ -1187,7 +1187,13 @@ test.describe('Scorecard Plugin Tests', () => {
         );
         await homePage.saveChanges();
 
-        await homePage.clickDrillDownLink();
+        const weightedEntityTotal = String(
+          openPrsWeightedAggregatedResponse.result.total,
+        );
+        await homePage.clickDrillDownLink({
+          healthy: weightedEntityTotal,
+          total: weightedEntityTotal,
+        });
         await scorecardDrillDownPage.expectOnPage('github.open_prs', {
           aggregationId: AGGREGATED_CARDS_METRIC_IDS.withOpenPrsWeightedKpi,
         });
@@ -1202,7 +1208,7 @@ test.describe('Scorecard Plugin Tests', () => {
             aggregationId: AGGREGATED_CARDS_METRIC_IDS.withOpenPrsWeightedKpi,
           },
         );
-        await expectAverageCardCenterPercent(drillCard, '50%');
+        await expectAverageCardCenterPercent(drillCard, '51.5%');
         await scorecardDrillDownPage.expectTableHeadersVisible();
         await scorecardDrillDownPage.expectEntityNamesVisible([
           'all-scorecards-service',

--- a/workspaces/scorecard/packages/app-legacy/e2e-tests/scorecard.test.ts
+++ b/workspaces/scorecard/packages/app-legacy/e2e-tests/scorecard.test.ts
@@ -68,7 +68,7 @@ import {
 import {
   expectAverageCardCenterPercent,
   verifyAverageDonutCenterTooltip,
-  verifyAverageLegendTooltipForStatus,
+  verifyAverageCenterTooltipBreakdownRows,
 } from './utils/averageCardAssertions';
 import { runAccessibilityTests } from './utils/accessibility';
 import { ScorecardRoutes } from './constants/routes';
@@ -1119,12 +1119,11 @@ test.describe('Scorecard Plugin Tests', () => {
           500,
           1000,
         );
-        await verifyAverageLegendTooltipForStatus(
+        await verifyAverageCenterTooltipBreakdownRows(
           page,
           card,
           translations,
           currentLocale,
-          'success',
         );
       });
 

--- a/workspaces/scorecard/packages/app-legacy/e2e-tests/utils/averageCardAssertions.ts
+++ b/workspaces/scorecard/packages/app-legacy/e2e-tests/utils/averageCardAssertions.ts
@@ -62,7 +62,10 @@ function expectedAverageCenterTooltipBreakdownLine(
   const n = Number.parseInt(count, 10);
   const templateKey = averageCenterTooltipBreakdownTemplateKey(locale, n);
   const template = metricCopy(translations, templateKey);
-  const status = statusKey.charAt(0).toUpperCase() + statusKey.slice(1);
+  const status =
+    statusKey in translations.thresholds
+      ? translations.thresholds[statusKey]
+      : statusKey.charAt(0).toUpperCase() + statusKey.slice(1);
   return interpolate(template, { status, count, score });
 }
 
@@ -103,13 +106,14 @@ export async function verifyAverageDonutCenterTooltip(
 
 /** Matches `openPrsWeightedAggregatedResponse.result.values` in scorecardResponseUtils.ts */
 const OPEN_PRS_WEIGHTED_MOCK_BREAKDOWN: Array<{
-  statusKey: 'success' | 'warning' | 'error';
+  statusKey: 'success' | 'warning' | 'error' | 'critical';
   count: string;
   score: string;
 }> = [
   { statusKey: 'success', count: '3', score: '100' },
   { statusKey: 'warning', count: '5', score: '40' },
-  { statusKey: 'error', count: '2', score: '0' },
+  { statusKey: 'error', count: '1', score: '15' },
+  { statusKey: 'critical', count: '1', score: '0' },
 ];
 
 /**

--- a/workspaces/scorecard/packages/app-legacy/e2e-tests/utils/averageCardAssertions.ts
+++ b/workspaces/scorecard/packages/app-legacy/e2e-tests/utils/averageCardAssertions.ts
@@ -33,24 +33,37 @@ function interpolate(template: string, vars: Record<string, string>): string {
   );
 }
 
-function averageLegendTooltipEntitiesEachTemplateKey(
+function averageCenterTooltipBreakdownTemplateKey(
   locale: string,
-  countStr: string,
+  count: number,
 ):
-  | 'averageLegendTooltipEntitiesEach_one'
-  | 'averageLegendTooltipEntitiesEach_other' {
-  const n = Number.parseInt(countStr, 10);
-  if (Number.isNaN(n)) {
-    return 'averageLegendTooltipEntitiesEach_other';
+  | 'averageCenterTooltipBreakdownRow_one'
+  | 'averageCenterTooltipBreakdownRow_other' {
+  if (Number.isNaN(count)) {
+    return 'averageCenterTooltipBreakdownRow_other';
   }
-  // Align with `getEntityCount` / i18next-style pluralization used in the app.
-  if (locale.startsWith('fr') && n === 0) {
-    return 'averageLegendTooltipEntitiesEach_one';
+  // Align with i18next-style pluralization for `metric.averageCenterTooltipBreakdownRow`.
+  if (locale.startsWith('fr') && count === 0) {
+    return 'averageCenterTooltipBreakdownRow_one';
   }
-  if (n === 1) {
-    return 'averageLegendTooltipEntitiesEach_one';
+  if (count === 1) {
+    return 'averageCenterTooltipBreakdownRow_one';
   }
-  return 'averageLegendTooltipEntitiesEach_other';
+  return 'averageCenterTooltipBreakdownRow_other';
+}
+
+function expectedAverageCenterTooltipBreakdownLine(
+  translations: ScorecardMessages,
+  locale: string,
+  statusKey: string,
+  count: string,
+  score: string,
+): string {
+  const n = Number.parseInt(count, 10);
+  const templateKey = averageCenterTooltipBreakdownTemplateKey(locale, n);
+  const template = metricCopy(translations, templateKey);
+  const status = statusKey.charAt(0).toUpperCase() + statusKey.slice(1);
+  return interpolate(template, { status, count, score });
 }
 
 export async function expectAverageCardCenterPercent(
@@ -88,31 +101,35 @@ export async function verifyAverageDonutCenterTooltip(
   ).toBeVisible();
 }
 
-const AVERAGE_LEGEND_EXPECTED: Record<
-  'success' | 'warning' | 'error',
-  { count: string; score: string }
-> = {
-  success: { count: '3', score: '100' },
-  warning: { count: '5', score: '40' },
-  error: { count: '2', score: '0' },
-};
+/** Matches `openPrsWeightedAggregatedResponse.result.values` in scorecardResponseUtils.ts */
+const OPEN_PRS_WEIGHTED_MOCK_BREAKDOWN: Array<{
+  statusKey: 'success' | 'warning' | 'error';
+  count: string;
+  score: string;
+}> = [
+  { statusKey: 'success', count: '3', score: '100' },
+  { statusKey: 'warning', count: '5', score: '40' },
+  { statusKey: 'error', count: '2', score: '0' },
+];
 
-export async function verifyAverageLegendTooltipForStatus(
+/**
+ * Per-status lines under total/max in the center donut tooltip (replaces old side-legend tooltips).
+ */
+export async function verifyAverageCenterTooltipBreakdownRows(
   page: Page,
   card: Locator,
   translations: ScorecardMessages,
   locale: string,
-  statusKey: 'success' | 'warning' | 'error',
 ): Promise<void> {
-  await card.getByTestId(`legend-colorbox-${statusKey}`).hover();
-  const { count, score } = AVERAGE_LEGEND_EXPECTED[statusKey];
-  const templateKey = averageLegendTooltipEntitiesEachTemplateKey(
-    locale,
-    count,
-  );
-  const entitiesLabel = interpolate(metricCopy(translations, templateKey), {
-    count,
-    score,
-  });
-  await expect(page.getByText(entitiesLabel)).toBeVisible();
+  await card.getByTestId('average-card-center-percent-hit-area').hover();
+  for (const row of OPEN_PRS_WEIGHTED_MOCK_BREAKDOWN) {
+    const line = expectedAverageCenterTooltipBreakdownLine(
+      translations,
+      locale,
+      row.statusKey,
+      row.count,
+      row.score,
+    );
+    await expect(page.getByText(line)).toBeVisible();
+  }
 }

--- a/workspaces/scorecard/packages/app-legacy/e2e-tests/utils/scorecardResponseUtils.ts
+++ b/workspaces/scorecard/packages/app-legacy/e2e-tests/utils/scorecardResponseUtils.ts
@@ -214,7 +214,8 @@ export const openPrsWeightedKpiMetadataResponse = {
 };
 
 /**
- * Average KPI: 3×100 + 5×40 + 2×0 = 500 weighted sum; max 100×10 entities → 50% score.
+ * Average KPI: 3×100 + 5×40 + 1×15 + 1×0 = 515 weighted sum; max 100×10 entities → 51.5% score.
+ * Includes `critical` as a non-threshold status name (no `thresholds.critical` copy).
  * Colors align with aggregation KPI `options.thresholds` warning band (30–79%) in app-config.
  */
 export const openPrsWeightedAggregatedResponse = {
@@ -227,13 +228,14 @@ export const openPrsWeightedAggregatedResponse = {
     values: [
       { count: 3, name: 'success', score: 100 },
       { count: 5, name: 'warning', score: 40 },
-      { count: 2, name: 'error', score: 0 },
+      { count: 1, name: 'error', score: 15 },
+      { count: 1, name: 'critical', score: 0 },
     ],
     total: 10,
     timestamp: '2026-01-24T14:10:32.858Z',
     thresholds: DEFAULT_NUMBER_THRESHOLDS,
-    averageScore: 50,
-    averageWeightedSum: 500,
+    averageScore: 51.5,
+    averageWeightedSum: 515,
     averageMaxPossible: 1000,
     aggregationChartDisplayColor: 'rgb(224, 189, 108)',
   },

--- a/workspaces/scorecard/plugins/scorecard/README.md
+++ b/workspaces/scorecard/plugins/scorecard/README.md
@@ -345,6 +345,8 @@ Define KPI ids and optional labels under **`scorecard.aggregationKPIs`** so each
 
 **`type: average`** KPIs require **`options.statusScores`** (weights per threshold rule key). Optionally set **`options.thresholds`** so the API returns **`aggregationChartDisplayColor`** for the headline percentage. Behavior, validation, and drill-down notes are described in [aggregation.md](../scorecard-backend/docs/aggregation.md).
 
+For **`type: average`**, the homepage card shows a **centered donut** with the headline percentage. Hovering the **center** opens a tooltip with **total score**, **max possible score**, and a **per-status breakdown** (from aggregation **`result.values`**). There is **no side status legend**; **`statusGrouped`** cards use a multi-slice pie with a legend instead.
+
 #### Card props
 
 The supported model is **a single `aggregationId` string** whose value is either:

--- a/workspaces/scorecard/plugins/scorecard/report-alpha.api.md
+++ b/workspaces/scorecard/plugins/scorecard/report-alpha.api.md
@@ -200,6 +200,8 @@ export const scorecardTranslationRef: TranslationRef<
     readonly 'metric.someEntitiesNotReportingValues': string;
     readonly 'metric.averageCenterTooltipTotalLabel': string;
     readonly 'metric.averageCenterTooltipMaxLabel': string;
+    readonly 'metric.averageCenterTooltipBreakdownRow_one': string;
+    readonly 'metric.averageCenterTooltipBreakdownRow_other': string;
     readonly 'metric.averageLegendTooltipEntitiesEach_one': string;
     readonly 'metric.averageLegendTooltipEntitiesEach_other': string;
     readonly 'metric.averageLegendTooltipRowTotal': string;

--- a/workspaces/scorecard/plugins/scorecard/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard/report.api.md
@@ -100,6 +100,8 @@ export const scorecardTranslationRef: TranslationRef<
     readonly 'metric.someEntitiesNotReportingValues': string;
     readonly 'metric.averageCenterTooltipTotalLabel': string;
     readonly 'metric.averageCenterTooltipMaxLabel': string;
+    readonly 'metric.averageCenterTooltipBreakdownRow_one': string;
+    readonly 'metric.averageCenterTooltipBreakdownRow_other': string;
     readonly 'metric.averageLegendTooltipEntitiesEach_one': string;
     readonly 'metric.averageLegendTooltipEntitiesEach_other': string;
     readonly 'metric.averageLegendTooltipRowTotal': string;

--- a/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/AverageCardComponent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/AverageCardComponent.tsx
@@ -21,20 +21,14 @@ import { useTheme } from '@mui/material/styles';
 
 import { CardWrapper } from '../../Common/CardWrapper';
 import type { PieData } from '../../types';
-import {
-  getThresholdRuleColor,
-  resolveStatusColor,
-  SCORECARD_ERROR_STATE_COLOR,
-} from '../../../utils';
+import { resolveStatusColor } from '../../../utils';
 import { ResponsivePieChart } from '../../ScorecardHomepageSection/ResponsivePieChart';
 import { CardInfoButton } from '../components/CardInfoButton';
 import { CardSubheader } from '../components/CardSubheader';
 import { CardChartContainer } from '../components/CardChartContainer';
 import { CardTooltip } from '../components/CardTooltip';
-import { LegendTooltipContent } from './LegendTooltipContent';
 import { DonutChartTooltipContent } from './DonutChartTooltipContent';
 import type { AverageCardComponentProps, TooltipPosition } from './types';
-import { CardLegendContent } from '../components/CardLegendContent';
 import { AverageCardPieCenterLabel } from './AverageCardPieCenterLabel';
 import { formatPercentage } from '../../../utils/formatPercentage';
 
@@ -60,9 +54,6 @@ export const AverageCardComponent = ({
 }: AverageCardComponentProps) => {
   const theme = useTheme();
 
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-  const [tooltipPosition, setTooltipPosition] =
-    useState<TooltipPosition | null>(null);
   const [centerTooltipPosition, setCenterTooltipPosition] =
     useState<TooltipPosition | null>(null);
 
@@ -99,18 +90,6 @@ export const AverageCardComponent = ({
     },
   ];
 
-  const statusPieData: PieData[] =
-    scorecard.result.values?.map(value => ({
-      name: value.name,
-      value: value.count,
-      score: value.score,
-      color: resolveStatusColor(
-        theme,
-        getThresholdRuleColor(scorecard.result.thresholds.rules, value.name) ??
-          SCORECARD_ERROR_STATE_COLOR,
-      ),
-    })) ?? [];
-
   const subheader = showSubheader ? (
     <CardSubheader
       aggregationId={aggregationId}
@@ -141,19 +120,8 @@ export const AverageCardComponent = ({
               {...props}
               centerPercentLabel={centerPercentLabel}
               arcResolvedColor={arcResolvedColor}
-              setActiveIndex={setActiveIndex}
-              setTooltipPosition={setTooltipPosition}
               updateCenterTooltipPosition={updateCenterTooltipPosition}
               setCenterTooltipPosition={setCenterTooltipPosition}
-            />
-          )}
-          legendContent={props => (
-            <CardLegendContent
-              {...props}
-              activeIndex={activeIndex}
-              setActiveIndex={setActiveIndex}
-              setTooltipPosition={setTooltipPosition}
-              pieData={statusPieData}
             />
           )}
         />
@@ -173,32 +141,11 @@ export const AverageCardComponent = ({
               <DonutChartTooltipContent
                 weightedSum={scorecard.result.averageWeightedSum}
                 maxPossible={scorecard.result.averageMaxPossible}
+                statusValues={scorecard.result.values}
               />
             }
           />
         )}
-
-        {activeIndex !== null &&
-          tooltipPosition &&
-          statusPieData[activeIndex] && (
-            <CardTooltip
-              tooltipPosition={tooltipPosition}
-              pieData={statusPieData}
-              payload={[
-                {
-                  name: statusPieData[activeIndex].name,
-                  value: statusPieData[activeIndex].value || 1,
-                  payload: statusPieData[activeIndex],
-                },
-              ]}
-              customContent={
-                <LegendTooltipContent
-                  row={statusPieData[activeIndex]}
-                  maxPossible={scorecard.result.averageMaxPossible}
-                />
-              }
-            />
-          )}
       </CardChartContainer>
     </CardWrapper>
   );

--- a/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/AverageCardPieCenterLabel.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/AverageCardPieCenterLabel.tsx
@@ -15,13 +15,12 @@
  */
 
 import { PieLabelRenderProps } from 'recharts';
+
 import { TooltipPosition } from './types';
 
 type AverageCardPieCenterLabelProps = PieLabelRenderProps & {
   centerPercentLabel: string;
   arcResolvedColor: string;
-  setActiveIndex: (index: number | null) => void;
-  setTooltipPosition: (position: TooltipPosition | null) => void;
   updateCenterTooltipPosition: (e: React.MouseEvent<SVGCircleElement>) => void;
   setCenterTooltipPosition: (position: TooltipPosition | null) => void;
 };
@@ -32,8 +31,6 @@ export function AverageCardPieCenterLabel({
   index,
   centerPercentLabel,
   arcResolvedColor,
-  setActiveIndex,
-  setTooltipPosition,
   updateCenterTooltipPosition,
   setCenterTooltipPosition,
 }: AverageCardPieCenterLabelProps) {
@@ -60,8 +57,6 @@ export function AverageCardPieCenterLabel({
         pointerEvents="all"
         data-testid="average-card-center-percent-hit-area"
         onMouseEnter={e => {
-          setActiveIndex(null);
-          setTooltipPosition(null);
           updateCenterTooltipPosition(e);
         }}
         onMouseMove={updateCenterTooltipPosition}

--- a/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/DonutChartTooltipContent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/DonutChartTooltipContent.tsx
@@ -14,29 +14,62 @@
  * limitations under the License.
  */
 
+import type { AggregatedMetricValue } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
-import { TooltipContent } from './TooltipContent';
+import Typography from '@mui/material/Typography';
+
+import { TooltipContent, formatAggregationScoreDetail } from './TooltipContent';
 import { useTranslation } from '../../../hooks/useTranslation';
 
 export const DonutChartTooltipContent = ({
   weightedSum,
   maxPossible,
+  statusValues = [],
 }: {
   weightedSum: number | undefined;
   maxPossible: number | undefined;
+  statusValues?: AggregatedMetricValue[];
 }) => {
   const { t } = useTranslation();
 
   return (
-    <Stack direction="row" spacing={3}>
-      <TooltipContent
-        label={t('metric.averageCenterTooltipTotalLabel')}
-        value={weightedSum}
-      />
-      <TooltipContent
-        label={t('metric.averageCenterTooltipMaxLabel')}
-        value={maxPossible}
-      />
+    <Stack spacing={0.5} sx={{ minWidth: 220 }}>
+      <Stack direction="row" spacing={3}>
+        <TooltipContent
+          label={t('metric.averageCenterTooltipTotalLabel')}
+          value={weightedSum}
+        />
+        <TooltipContent
+          label={t('metric.averageCenterTooltipMaxLabel')}
+          value={maxPossible}
+        />
+      </Stack>
+      {statusValues.length > 0 ? (
+        <Box
+          sx={{
+            borderTop: 1,
+            borderColor: 'divider',
+            pt: 1.5,
+          }}
+        >
+          <Stack spacing={0.75}>
+            {statusValues.map(row => (
+              <Typography
+                key={row.name}
+                variant="body2"
+                sx={{ color: 'text.primary', fontWeight: 500 }}
+              >
+                {t('metric.averageCenterTooltipBreakdownRow', {
+                  count: row.count,
+                  status: row.name.charAt(0).toUpperCase() + row.name.slice(1),
+                  score: formatAggregationScoreDetail(row.score ?? 0),
+                } as any)}
+              </Typography>
+            ))}
+          </Stack>
+        </Box>
+      ) : null}
     </Stack>
   );
 };

--- a/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/DonutChartTooltipContent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/DonutChartTooltipContent.tsx
@@ -33,6 +33,16 @@ export const DonutChartTooltipContent = ({
 }) => {
   const { t } = useTranslation();
 
+  const getStatus = (status: string) => {
+    const translatedStatus = t(`thresholds.${status}` as any, {});
+
+    if (translatedStatus === `thresholds.${status}` && status) {
+      return status.charAt(0).toUpperCase() + status.slice(1);
+    }
+
+    return translatedStatus;
+  };
+
   return (
     <Stack spacing={0.5} sx={{ minWidth: 220 }}>
       <Stack direction="row" spacing={3}>
@@ -62,7 +72,7 @@ export const DonutChartTooltipContent = ({
               >
                 {t('metric.averageCenterTooltipBreakdownRow', {
                   count: row.count,
-                  status: row.name.charAt(0).toUpperCase() + row.name.slice(1),
+                  status: getStatus(row.name),
                   score: formatAggregationScoreDetail(row.score ?? 0),
                 } as any)}
               </Typography>

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ResponsivePieChart.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/ResponsivePieChart.tsx
@@ -53,7 +53,7 @@ interface PieTooltipContentProps {
 interface ResponsivePieChartProps {
   pieData: PieData[];
   LabelContent?: (props: PieLabelRenderProps) => React.ReactNode;
-  legendContent: (props: PieLegendContentProps) => React.ReactNode;
+  legendContent?: (props: PieLegendContentProps) => React.ReactNode;
   tooltipContent?: (props: PieTooltipContentProps) => React.ReactNode;
   isErrorState?: boolean;
   setIsInsidePieCircle?: (isInside: boolean) => void;
@@ -68,6 +68,7 @@ export const ResponsivePieChart = ({
   setIsInsidePieCircle,
 }: ResponsivePieChartProps) => {
   const isTooltipEnabled = Boolean(tooltipContent);
+  const pieCx = legendContent ? '30%' : '50%';
 
   return (
     <ResponsiveContainer style={{ outline: 'none' }}>
@@ -76,7 +77,7 @@ export const ResponsivePieChart = ({
         {isErrorState && (
           <g>
             <circle
-              cx="30%"
+              cx={pieCx}
               cy="50%"
               r={90}
               fill="transparent"
@@ -97,7 +98,7 @@ export const ResponsivePieChart = ({
           data={pieData}
           dataKey="value"
           nameKey="name"
-          cx="30%"
+          cx={pieCx}
           cy="50%"
           innerRadius="78%"
           outerRadius="90%"
@@ -121,15 +122,17 @@ export const ResponsivePieChart = ({
           ))}
         </Pie>
 
-        <Legend
-          layout="vertical"
-          verticalAlign="middle"
-          wrapperStyle={{
-            position: 'absolute',
-            left: '60%',
-          }}
-          content={legendContent}
-        />
+        {legendContent ? (
+          <Legend
+            layout="vertical"
+            verticalAlign="middle"
+            wrapperStyle={{
+              position: 'absolute',
+              left: '60%',
+            }}
+            content={legendContent}
+          />
+        ) : null}
 
         <Tooltip content={isTooltipEnabled ? tooltipContent : () => null} />
       </PieChart>

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageCard.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/ScorecardHomepageCard.test.tsx
@@ -66,8 +66,8 @@ jest.mock('../ResponsivePieChart', () => ({
     pieData,
     LabelContent,
   }: {
-    legendContent: (props: unknown) => React.ReactNode;
-    tooltipContent: (props: {
+    legendContent?: (props: unknown) => React.ReactNode;
+    tooltipContent?: (props: {
       active?: boolean;
       payload?: unknown[];
     }) => React.ReactNode;
@@ -92,7 +92,9 @@ jest.mock('../ResponsivePieChart', () => ({
           ) : null}
         </svg>
       </div>
-      <div data-testid="legend">{legendContent({})}</div>
+      {legendContent ? (
+        <div data-testid="legend">{legendContent({})}</div>
+      ) : null}
       <div data-testid="tooltip">
         {typeof tooltipContent === 'function'
           ? tooltipContent({ active: true, payload: [] })

--- a/workspaces/scorecard/plugins/scorecard/src/translations/de.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/de.ts
@@ -132,6 +132,10 @@ const scorecardTranslationDe = createTranslationMessages({
       'Einige Elemente melden keine Werte, die mit dieser Metrik in Verbindung stehen.',
     'metric.averageCenterTooltipTotalLabel': 'Gesamtpunktzahl',
     'metric.averageCenterTooltipMaxLabel': 'Maximal mögliche Punktzahl',
+    'metric.averageCenterTooltipBreakdownRow_one':
+      '{{status}}: {{count}} Element, Punktzahl: {{score}}',
+    'metric.averageCenterTooltipBreakdownRow_other':
+      '{{status}}: {{count}} Elemente, Punktzahl: {{score}}',
     'metric.averageLegendTooltipEntitiesEach_one':
       '{{count}} Element, je {{score}}',
     'metric.averageLegendTooltipEntitiesEach_other':

--- a/workspaces/scorecard/plugins/scorecard/src/translations/es.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/es.ts
@@ -136,6 +136,10 @@ const scorecardTranslationEs = createTranslationMessages({
       'Algunas entidades no están reportando valores relacionados con esta métrica.',
     'metric.averageCenterTooltipTotalLabel': 'Puntuación total',
     'metric.averageCenterTooltipMaxLabel': 'Puntuación máxima posible',
+    'metric.averageCenterTooltipBreakdownRow_one':
+      '{{status}}: {{count}} entidad, puntuación: {{score}}',
+    'metric.averageCenterTooltipBreakdownRow_other':
+      '{{status}}: {{count}} entidades, puntuación: {{score}}',
     'metric.averageLegendTooltipEntitiesEach_one':
       '{{count}} entidad, cada una {{score}}',
     'metric.averageLegendTooltipEntitiesEach_other':

--- a/workspaces/scorecard/plugins/scorecard/src/translations/fr.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/fr.ts
@@ -134,6 +134,10 @@ const scorecardTranslationFr = createTranslationMessages({
       'Certaines entités ne communiquent pas de valeurs liées à cette métrique.',
     'metric.averageCenterTooltipTotalLabel': 'Score total',
     'metric.averageCenterTooltipMaxLabel': 'Score maximum possible',
+    'metric.averageCenterTooltipBreakdownRow_one':
+      '{{status}} : {{count}} entité, score : {{score}}',
+    'metric.averageCenterTooltipBreakdownRow_other':
+      '{{status}} : {{count}} entités, score : {{score}}',
     'metric.averageLegendTooltipEntitiesEach_one':
       '{{count}} entité, chacune {{score}}',
     'metric.averageLegendTooltipEntitiesEach_other':

--- a/workspaces/scorecard/plugins/scorecard/src/translations/it.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/it.ts
@@ -136,6 +136,10 @@ const scorecardTranslationIt = createTranslationMessages({
       'Alcune entità non stanno riportando valori relativi a questa metrica.',
     'metric.averageCenterTooltipTotalLabel': 'Punteggio totale',
     'metric.averageCenterTooltipMaxLabel': 'Punteggio massimo possibile',
+    'metric.averageCenterTooltipBreakdownRow_one':
+      '{{status}}: {{count}} entità, punteggio: {{score}}',
+    'metric.averageCenterTooltipBreakdownRow_other':
+      '{{status}}: {{count}} entità, punteggio: {{score}}',
     'metric.averageLegendTooltipEntitiesEach_one':
       '{{count}} entità, ciascuna {{score}}',
     'metric.averageLegendTooltipEntitiesEach_other':

--- a/workspaces/scorecard/plugins/scorecard/src/translations/ja.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/ja.ts
@@ -134,6 +134,10 @@ const scorecardTranslationJa = createTranslationMessages({
       'エンティティーがこの指標に関連する値を報告していません。',
     'metric.averageCenterTooltipTotalLabel': '合計スコア',
     'metric.averageCenterTooltipMaxLabel': '最大可能スコア',
+    'metric.averageCenterTooltipBreakdownRow_one':
+      '{{status}}: {{count}} 件、スコア {{score}}',
+    'metric.averageCenterTooltipBreakdownRow_other':
+      '{{status}}: {{count}} 件、スコア {{score}}',
     'metric.averageLegendTooltipEntitiesEach_one':
       '{{count}} 件のエンティティー、各 {{score}}',
     'metric.averageLegendTooltipEntitiesEach_other':

--- a/workspaces/scorecard/plugins/scorecard/src/translations/ref.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/translations/ref.ts
@@ -150,6 +150,10 @@ export const scorecardMessages = {
       'Some entities are not reporting values related to this metric.',
     averageCenterTooltipTotalLabel: 'Total score',
     averageCenterTooltipMaxLabel: 'Max possible score',
+    averageCenterTooltipBreakdownRow_one:
+      '{{status}}: {{count}} entity, score: {{score}}',
+    averageCenterTooltipBreakdownRow_other:
+      '{{status}}: {{count}} entities, score: {{score}}',
     averageLegendTooltipEntitiesEach_one: '{{count}} entity, each {{score}}',
     averageLegendTooltipEntitiesEach_other:
       '{{count}} entities, each {{score}}',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This issue originated from the homepage widget for the Average aggregation type card. The card features a chart with its own threshold color configuration, while the metric provider colors are also displayed in the legend. This can confuse users, as these colors may differ. The card was changed to the following:

<img width="663" height="438" alt="Screenshot 2026-05-14 at 20 30 37" src="https://github.com/user-attachments/assets/e9991d35-d405-4fa2-986d-f6f77008cb15" />


#### Fix for the:
* [RHDHBUGS-3045](https://redhat.atlassian.net/browse/RHDHBUGS-3045)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
