### PR TITLE
fix(lightspeed): fix notebook prompts and add Developer preview badge

### DIFF
--- a/workspaces/lightspeed/.changeset/simplify-notebook-prompts.md
+++ b/workspaces/lightspeed/.changeset/simplify-notebook-prompts.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Fix notebook prompts and add Developer preview badge for Notebooks tab

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -197,11 +197,16 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'prompts.openshift.message': string;
     readonly 'prompts.rhdh.title': string;
     readonly 'prompts.rhdh.message': string;
+    readonly 'notebooks.prompts.coreConcepts.title': string;
+    readonly 'notebooks.prompts.vulnerabilities.title': string;
+    readonly 'notebooks.prompts.accessIssue.title': string;
+    readonly 'notebooks.prompts.somethingElse.title': string;
     readonly 'page.title': string;
     readonly 'page.subtitle': string;
     readonly 'tabs.ariaLabel': string;
     readonly 'tabs.chat': string;
     readonly 'tabs.notebooks': string;
+    readonly 'tabs.notebooks.devPreview': string;
     readonly 'tabs.notebooks.empty': string;
     readonly 'notebooks.title': string;
     readonly 'notebooks.empty.title': string;

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -200,7 +200,6 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'notebooks.prompts.coreConcepts.title': string;
     readonly 'notebooks.prompts.vulnerabilities.title': string;
     readonly 'notebooks.prompts.accessIssue.title': string;
-    readonly 'notebooks.prompts.somethingElse.title': string;
     readonly 'page.title': string;
     readonly 'page.subtitle': string;
     readonly 'tabs.ariaLabel': string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
@@ -88,7 +88,7 @@ export const DeleteModal = ({
               position: 'absolute',
               right: 1,
               top: 1,
-              color: 'grey.700',
+              color: 'text.primary',
             }}
           >
             <CloseIcon />

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -1969,7 +1969,14 @@ export const LightspeedChat = ({
                   }}
                 >
                   {t('tabs.notebooks')}
-                  <Label color="purple" isCompact>
+                  <Label
+                    color="purple"
+                    isCompact
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                    }}
+                  >
                     {t('tabs.notebooks.devPreview')}
                   </Label>
                 </span>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -60,6 +60,7 @@ import {
   AlertGroup,
   AlertVariant,
   DropdownItem,
+  Label,
   MenuToggle,
   MenuToggleElement,
   Select,
@@ -1959,7 +1960,20 @@ export const LightspeedChat = ({
             />
             <Tab
               disableRipple
-              label={t('tabs.notebooks')}
+              label={
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 8,
+                  }}
+                >
+                  {t('tabs.notebooks')}
+                  <Label color="purple" isCompact>
+                    {t('tabs.notebooks.devPreview')}
+                  </Label>
+                </span>
+              }
               aria-label={t('tabs.notebooks')}
             />
           </Tabs>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -1971,10 +1971,10 @@ export const LightspeedChat = ({
                   {t('tabs.notebooks')}
                   <Label
                     color="purple"
-                    isCompact
                     style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
+                      alignSelf: 'center',
+                      margin: 0,
+                      lineHeight: 1,
                     }}
                   >
                     {t('tabs.notebooks.devPreview')}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/McpServersSettings.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/McpServersSettings.tsx
@@ -110,7 +110,7 @@ const useStyles = makeStyles(theme => ({
   closeButton: {
     marginTop: -theme.spacing(1),
     marginRight: -theme.spacing(1),
-    color: theme.palette.text.secondary,
+    color: theme.palette.text.primary,
   },
   nameHeaderButton: {
     paddingLeft: 0,
@@ -189,7 +189,7 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     top: theme.spacing(2),
     right: theme.spacing(-0.5),
-    color: '#1F1F1F',
+    color: theme.palette.text.primary,
   },
   modalHeading: {
     display: 'flex',
@@ -214,7 +214,7 @@ const useStyles = makeStyles(theme => ({
     top: '50%',
     transform: 'translateY(-50%)',
     zIndex: 1,
-    color: theme.palette.text.secondary,
+    color: theme.palette.action.active,
   },
   tokenHelper: {
     color: theme.palette.text.secondary,
@@ -700,7 +700,6 @@ export const McpServersSettings = ({
     >
       <CancelOutlinedIcon
         style={{
-          color: '#6A6E73',
           fontSize: 24,
           width: 24,
           height: 24,

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/RenameConversationModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/RenameConversationModal.tsx
@@ -114,7 +114,7 @@ export const RenameConversationModal = ({
               position: 'absolute',
               right: 1,
               top: 1,
-              color: 'grey.700',
+              color: 'text.primary',
             }}
           >
             <CloseIcon />

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/AddDocumentModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/AddDocumentModal.tsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles(theme => ({
     letterSpacing: '-0.25px',
   },
   closeButton: {
-    color: theme.palette.grey[700],
+    color: theme.palette.text.primary,
   },
   dialogContent: {
     padding: '0 24px 24px',

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteNotebookModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteNotebookModal.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     right: theme.spacing(1),
     top: theme.spacing(1),
-    color: theme.palette.grey[700],
+    color: theme.palette.text.primary,
   },
   errorBox: {
     maxWidth: 650,

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/FileListItem.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/FileListItem.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles(theme => ({
   },
   removeButton: {
     padding: 4,
-    color: theme.palette.grey[600],
+    color: theme.palette.action.active,
     '&:hover': {
       color: theme.palette.error.main,
     },

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
@@ -23,7 +23,6 @@ import {
   ChatbotContent,
   ChatbotFooter,
   ChatbotFootnote,
-  ChatbotWelcomePrompt,
   MessageBar,
   MessageProps,
 } from '@patternfly/chatbot';
@@ -56,8 +55,8 @@ import {
 } from '../../hooks/notebooks/useDocumentStatusPolling';
 import { useConversationMessages } from '../../hooks/useConversationMessages';
 import { CreateMessageVariables } from '../../hooks/useCreateCoversationMessage';
+import { useNotebookWelcomePrompts } from '../../hooks/useNotebookWelcomePrompts';
 import { useTranslation } from '../../hooks/useTranslation';
-import { useWelcomePrompts } from '../../hooks/useWelcomePrompts';
 import { NotebookSessionMetadata, SessionDocument } from '../../types';
 import { LightspeedChatBox } from '../LightspeedChatBox';
 import { AddDocumentModal } from './AddDocumentModal';
@@ -218,9 +217,29 @@ const useStyles = makeStyles(theme => ({
     paddingTop: theme.spacing(0.5),
   },
   promptSuggestions: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: theme.spacing(1),
     width: '95%',
     maxWidth: 'unset',
-    margin: '0 auto',
+    margin: `${theme.spacing(3)}px auto ${theme.spacing(3)}px auto`,
+    justifyContent: 'flex-start',
+  },
+  promptPill: {
+    appearance: 'none' as const,
+    background: 'transparent',
+    border: `1px solid var(--pf-t--global--border--color--default)`,
+    borderRadius: '999px',
+    padding: `${theme.spacing(1)}px ${theme.spacing(2.5)}px`,
+    fontSize: '0.875rem',
+    color: 'var(--pf-t--global--text--color--regular)',
+    cursor: 'pointer',
+    transition: 'background-color 0.15s, border-color 0.15s',
+    '&:hover': {
+      backgroundColor:
+        'var(--pf-t--global--background--color--secondary--default)',
+      borderColor: 'var(--pf-t--global--border--color--hover)',
+    },
   },
   footer: {
     backgroundColor:
@@ -369,16 +388,11 @@ export const NotebookView = ({
     [handleInputPrompt, t],
   );
 
-  const samplePrompts = useWelcomePrompts();
-  const welcomePrompts =
-    samplePrompts?.map(prompt => {
-      const p = prompt as { title: string; message: string };
-      return {
-        title: p.title,
-        message: p.message,
-        onClick: () => sendMessage(p.message),
-      };
-    }) ?? [];
+  const notebookPrompts = useNotebookWelcomePrompts();
+  const welcomePrompts = notebookPrompts.map(title => ({
+    title,
+    onClick: () => sendMessage(title),
+  }));
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
@@ -580,6 +594,7 @@ export const NotebookView = ({
     }
     return (
       <div className={classes.welcomeContainer}>
+        <div style={{ flex: 1 }} />
         {renderNotebookDisclaimerAlert()}
         <div className={classes.notebookContentArea}>
           <Typography className={classes.notebookHeading}>
@@ -593,11 +608,16 @@ export const NotebookView = ({
         </div>
         {welcomePrompts.length > 0 && (
           <div className={classes.promptSuggestions}>
-            <ChatbotWelcomePrompt
-              title=""
-              description=""
-              prompts={welcomePrompts}
-            />
+            {welcomePrompts.map(prompt => (
+              <button
+                key={prompt.title}
+                type="button"
+                className={classes.promptPill}
+                onClick={prompt.onClick}
+              >
+                {prompt.title}
+              </button>
+            ))}
           </div>
         )}
       </div>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/OverwriteConfirmModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/OverwriteConfirmModal.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles(theme => ({
     letterSpacing: '-0.25px',
   },
   closeButton: {
-    color: theme.palette.grey[700],
+    color: theme.palette.text.primary,
   },
   dialogContent: {
     padding: '0 24px 24px',

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/RenameNotebookModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/RenameNotebookModal.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     right: theme.spacing(1),
     top: theme.spacing(1),
-    color: theme.palette.grey[700],
+    color: theme.palette.text.primary,
   },
   dialogContent: {
     paddingTop: 0,

--- a/workspaces/lightspeed/plugins/lightspeed/src/const.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/const.ts
@@ -90,6 +90,13 @@ export const RHDH_SAMPLE_PROMPTS: SamplePrompts = [
   createPrompt('prompts.rhdh.title', 'prompts.rhdh.message'),
 ];
 
+export const NOTEBOOK_PROMPT_KEYS: string[] = [
+  'notebooks.prompts.coreConcepts.title',
+  'notebooks.prompts.vulnerabilities.title',
+  'notebooks.prompts.accessIssue.title',
+  'notebooks.prompts.somethingElse.title',
+];
+
 // Topic restriction valid provider IDs
 export const VALID_TOPIC_RESTRICTION_PROVIDER_IDS = [
   'lightspeed_question_validity-shield',

--- a/workspaces/lightspeed/plugins/lightspeed/src/const.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/const.ts
@@ -94,7 +94,6 @@ export const NOTEBOOK_PROMPT_KEYS: string[] = [
   'notebooks.prompts.coreConcepts.title',
   'notebooks.prompts.vulnerabilities.title',
   'notebooks.prompts.accessIssue.title',
-  'notebooks.prompts.somethingElse.title',
 ];
 
 // Topic restriction valid provider IDs

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useNotebookWelcomePrompts.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useNotebookWelcomePrompts.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+
+import { NOTEBOOK_PROMPT_KEYS } from '../const';
+import { useTranslation } from './useTranslation';
+
+export const useNotebookWelcomePrompts = (): string[] => {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () => NOTEBOOK_PROMPT_KEYS.map(key => t(key as any, { defaultValue: key })),
+    [t],
+  );
+};

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -30,6 +30,7 @@ const lightspeedTranslationDe = createTranslationMessages({
     'tabs.ariaLabel': 'Lightspeed-Ansichten',
     'tabs.chat': 'Chat',
     'tabs.notebooks': 'Notizbücher',
+    'tabs.notebooks.devPreview': 'Entwicklervorschau',
     'tabs.notebooks.empty': 'Inhalte der Notizbücher kommen hierhin.',
     'notebooks.title': 'Meine Notizbücher',
     'notebooks.empty.title': 'Keine erstellten Notizbücher',
@@ -55,6 +56,13 @@ const lightspeedTranslationDe = createTranslationMessages({
     'notebooks.updated.days': 'Vor {{days}} Tagen aktualisiert',
     'notebooks.updated.on': 'Aktualisiert am',
     'notebooks.card.openAria': 'Notizbuch {{name}} öffnen',
+
+    // Notebook sample prompts
+    'notebooks.prompts.coreConcepts.title': 'Was sind die Kernkonzepte?',
+    'notebooks.prompts.vulnerabilities.title':
+      'Zeige meine kritischen Schwachstellen',
+    'notebooks.prompts.accessIssue.title': 'Hilf mir bei einem Zugriffsproblem',
+    'notebooks.prompts.somethingElse.title': 'Etwas anderes',
 
     // Notebook view
     'notebook.view.title': 'Unbenanntes Notizbuch',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -62,7 +62,6 @@ const lightspeedTranslationDe = createTranslationMessages({
     'notebooks.prompts.vulnerabilities.title':
       'Zeige meine kritischen Schwachstellen',
     'notebooks.prompts.accessIssue.title': 'Hilf mir bei einem Zugriffsproblem',
-    'notebooks.prompts.somethingElse.title': 'Etwas anderes',
 
     // Notebook view
     'notebook.view.title': 'Unbenanntes Notizbuch',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -62,7 +62,6 @@ const lightspeedTranslationEs = createTranslationMessages({
     'notebooks.prompts.vulnerabilities.title':
       'Mostrar mis vulnerabilidades críticas',
     'notebooks.prompts.accessIssue.title': 'Ayúdame con un problema de acceso',
-    'notebooks.prompts.somethingElse.title': 'Algo más',
 
     // Notebook view
     'notebook.view.title': 'Cuaderno sin título',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -30,6 +30,7 @@ const lightspeedTranslationEs = createTranslationMessages({
     'tabs.ariaLabel': 'Vistas de Lightspeed',
     'tabs.chat': 'Chat',
     'tabs.notebooks': 'Cuadernos',
+    'tabs.notebooks.devPreview': 'Vista previa para desarrolladores',
     'tabs.notebooks.empty': 'El contenido de los cuadernos va aquí.',
     'notebooks.title': 'Mis cuadernos',
     'notebooks.empty.title': 'No hay cuadernos creados',
@@ -55,6 +56,13 @@ const lightspeedTranslationEs = createTranslationMessages({
     'notebooks.updated.days': 'Actualizado hace {{days}} días',
     'notebooks.updated.on': 'Actualizado el',
     'notebooks.card.openAria': 'Abrir el cuaderno {{name}}',
+
+    // Notebook sample prompts
+    'notebooks.prompts.coreConcepts.title': '¿Cuáles son los conceptos clave?',
+    'notebooks.prompts.vulnerabilities.title':
+      'Mostrar mis vulnerabilidades críticas',
+    'notebooks.prompts.accessIssue.title': 'Ayúdame con un problema de acceso',
+    'notebooks.prompts.somethingElse.title': 'Algo más',
 
     // Notebook view
     'notebook.view.title': 'Cuaderno sin título',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -63,7 +63,6 @@ const lightspeedTranslationFr = createTranslationMessages({
     'notebooks.prompts.vulnerabilities.title':
       'Afficher mes vulnérabilités critiques',
     'notebooks.prompts.accessIssue.title': "Aidez-moi avec un problème d'accès",
-    'notebooks.prompts.somethingElse.title': 'Autre chose',
 
     // Notebook view
     'notebook.view.title': 'Carnet sans titre',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -30,6 +30,7 @@ const lightspeedTranslationFr = createTranslationMessages({
     'tabs.ariaLabel': 'Vues Lightspeed',
     'tabs.chat': 'Chat',
     'tabs.notebooks': 'Carnets',
+    'tabs.notebooks.devPreview': 'Aperçu développeur',
     'tabs.notebooks.empty': 'Le contenu des carnets s’affichera ici.',
     'notebooks.title': 'Mes carnets',
     'notebooks.empty.title': 'Aucun carnet créé',
@@ -55,6 +56,14 @@ const lightspeedTranslationFr = createTranslationMessages({
     'notebooks.updated.days': 'Mis à jour il y a {{days}} jours',
     'notebooks.updated.on': 'Mis à jour le',
     'notebooks.card.openAria': 'Ouvrir le carnet {{name}}',
+
+    // Notebook sample prompts
+    'notebooks.prompts.coreConcepts.title':
+      'Quels sont les concepts fondamentaux ?',
+    'notebooks.prompts.vulnerabilities.title':
+      'Afficher mes vulnérabilités critiques',
+    'notebooks.prompts.accessIssue.title': "Aidez-moi avec un problème d'accès",
+    'notebooks.prompts.somethingElse.title': 'Autre chose',
 
     // Notebook view
     'notebook.view.title': 'Carnet sans titre',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -31,6 +31,7 @@ const lightspeedTranslationIt = createTranslationMessages({
     'tabs.ariaLabel': 'Viste di Lightspeed',
     'tabs.chat': 'Chat',
     'tabs.notebooks': 'Quaderni',
+    'tabs.notebooks.devPreview': 'Anteprima per sviluppatori',
     'tabs.notebooks.empty': 'Il contenuto dei quaderni va qui.',
     'notebooks.title': 'I miei quaderni',
     'notebooks.empty.title': 'Nessun quaderno creato',
@@ -56,6 +57,13 @@ const lightspeedTranslationIt = createTranslationMessages({
     'notebooks.updated.days': 'Aggiornato {{days}} giorni fa',
     'notebooks.updated.on': 'Aggiornato il',
     'notebooks.card.openAria': 'Apri il taccuino {{name}}',
+
+    // Notebook sample prompts
+    'notebooks.prompts.coreConcepts.title': 'Quali sono i concetti chiave?',
+    'notebooks.prompts.vulnerabilities.title':
+      'Mostra le mie vulnerabilità critiche',
+    'notebooks.prompts.accessIssue.title': 'Aiutami con un problema di accesso',
+    'notebooks.prompts.somethingElse.title': 'Altro',
 
     // Notebook view
     'notebook.view.title': 'Quaderno senza titolo',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -63,7 +63,6 @@ const lightspeedTranslationIt = createTranslationMessages({
     'notebooks.prompts.vulnerabilities.title':
       'Mostra le mie vulnerabilità critiche',
     'notebooks.prompts.accessIssue.title': 'Aiutami con un problema di accesso',
-    'notebooks.prompts.somethingElse.title': 'Altro',
 
     // Notebook view
     'notebook.view.title': 'Quaderno senza titolo',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -30,6 +30,7 @@ const lightspeedTranslationJa = createTranslationMessages({
     'tabs.ariaLabel': 'Lightspeed のビュー',
     'tabs.chat': 'チャット',
     'tabs.notebooks': 'ノートブック',
+    'tabs.notebooks.devPreview': '開発者プレビュー',
     'tabs.notebooks.empty': 'ノートブックの内容はここに表示されます。',
     'notebooks.title': 'マイノートブック',
     'notebooks.empty.title': '作成されたノートブックはありません',
@@ -55,6 +56,12 @@ const lightspeedTranslationJa = createTranslationMessages({
     'notebooks.updated.days': '{{days}}日前に更新',
     'notebooks.updated.on': '更新日',
     'notebooks.card.openAria': 'ノートブック {{name}} を開く',
+
+    // Notebook sample prompts
+    'notebooks.prompts.coreConcepts.title': 'コアコンセプトは何ですか？',
+    'notebooks.prompts.vulnerabilities.title': '重大な脆弱性を表示してください',
+    'notebooks.prompts.accessIssue.title': 'アクセスの問題を解決してください',
+    'notebooks.prompts.somethingElse.title': 'その他',
 
     // Notebook view
     'notebook.view.title': '無題のノートブック',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -61,7 +61,6 @@ const lightspeedTranslationJa = createTranslationMessages({
     'notebooks.prompts.coreConcepts.title': 'コアコンセプトは何ですか？',
     'notebooks.prompts.vulnerabilities.title': '重大な脆弱性を表示してください',
     'notebooks.prompts.accessIssue.title': 'アクセスの問題を解決してください',
-    'notebooks.prompts.somethingElse.title': 'その他',
 
     // Notebook view
     'notebook.view.title': '無題のノートブック',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -28,6 +28,7 @@ export const lightspeedMessages = {
   'tabs.ariaLabel': 'Lightspeed views',
   'tabs.chat': 'Chat',
   'tabs.notebooks': 'Notebooks',
+  'tabs.notebooks.devPreview': 'Developer preview',
   'tabs.notebooks.empty': 'Notebooks content goes here.',
   'notebooks.title': 'My Notebooks',
   'notebooks.empty.title': 'No created notebooks',
@@ -53,6 +54,12 @@ export const lightspeedMessages = {
   'notebooks.updated.days': 'Updated {{days}} days ago',
   'notebooks.updated.on': 'Updated on',
   'notebooks.card.openAria': 'Open notebook {{name}}',
+
+  // Notebook sample prompts
+  'notebooks.prompts.coreConcepts.title': 'What are the core concepts?',
+  'notebooks.prompts.vulnerabilities.title': 'Show my critical vulnerabilities',
+  'notebooks.prompts.accessIssue.title': 'Help me with an access issue',
+  'notebooks.prompts.somethingElse.title': 'Something else',
 
   // Notebook view
   'notebook.view.title': 'Untitled notebook',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -59,7 +59,6 @@ export const lightspeedMessages = {
   'notebooks.prompts.coreConcepts.title': 'What are the core concepts?',
   'notebooks.prompts.vulnerabilities.title': 'Show my critical vulnerabilities',
   'notebooks.prompts.accessIssue.title': 'Help me with an access issue',
-  'notebooks.prompts.somethingElse.title': 'Something else',
 
   // Notebook view
   'notebook.view.title': 'Untitled notebook',


### PR DESCRIPTION
## Summary
- Added a purple "Developer preview" badge in the Notebooks tab
- Updated the prompts of notebook tab and improved padding
- Fixed close button icons appearing gray instead of black in light theme across all modals and dialogs.


## Fixed
- https://redhat.atlassian.net/browse/RHDHBUGS-3107
- https://redhat.atlassian.net/browse/RHDHBUGS-3108

## UI after changes


https://github.com/user-attachments/assets/6bd58bb0-4898-4f0e-bb01-59b4f9d08dd8

Modal Close icon color
- Light Theme

https://github.com/user-attachments/assets/a95f2a3a-27e2-47ab-8c79-b05e731b288b


- Dark theme

https://github.com/user-attachments/assets/a079b0d8-364e-42d5-ae54-a0de41835e6a



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
