### PR TITLE
fix(orchestrator): disable duplicate page header in NFS app

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-orchestrator-no-header.md
+++ b/workspaces/orchestrator/.changeset/fix-orchestrator-no-header.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fixed duplicate header and double scrollbars in the NFS app by adding `noHeader: true` to the PageBlueprint so Backstage does not render a second page shell on top of the plugin's own header.

--- a/workspaces/orchestrator/plugins/orchestrator/src/alpha.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/alpha.tsx
@@ -50,6 +50,7 @@ const orchestratorPage = PageBlueprint.make({
   params: {
     path: '/orchestrator',
     routeRef: orchestratorRootRouteRef,
+    noHeader: true,
     loader: () => import('./components/Router').then(m => <m.Router />),
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-2942

- Add `noHeader: true` to the orchestrator `PageBlueprint` in `alpha.tsx` so Backstage does not render a second page shell on top of `BaseOrchestratorPage`.

---------------------------------

<img width="1728" height="962" alt="Screenshot 2026-05-15 at 1 32 24 PM" src="https://github.com/user-attachments/assets/26740a7a-952d-44a4-b500-1f232d00919f" />
<img width="1728" height="1044" alt="Screenshot 2026-05-15 at 1 38 55 PM" src="https://github.com/user-attachments/assets/57b93393-4e7e-4246-a43c-0566cc908223" />

---------------------------------

--------------RHDH-------------

<img width="1728" height="1045" alt="image" src="https://github.com/user-attachments/assets/f944eaac-48ab-4d3f-be72-4f1f069e6699" />

<img width="1727" height="1045" alt="image" src="https://github.com/user-attachments/assets/9cbb9948-0f6e-4ca4-b248-60ee8767a0de" />


---------------------------------

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
