### PR TITLE
fix(lightspeed): notification toaster z-index fix

### DIFF
--- a/workspaces/lightspeed/.changeset/fix-toast-hidden-behind-global-header.md
+++ b/workspaces/lightspeed/.changeset/fix-toast-hidden-behind-global-header.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+fix(lightspeed): fix toast notifications being obscured by Global Header

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -413,6 +413,7 @@ const useStyles = makeStyles(theme => ({
     '--pf-v6-c-alert-group--m-toast--InsetInlineEnd': `${theme.spacing(2.5)}px`,
     '--pf-v6-c-alert-group--m-toast--InsetBlockStart': `${theme.spacing(2.5)}px`,
     '--pf-v6-c-alert-group--m-toast--MaxWidth': '350px',
+    '--pf-v6-c-alert-group--m-toast--ZIndex': '9999',
   },
   toastAlert: {
     maxWidth: '350px',

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
@@ -175,6 +175,7 @@ const useStyles = makeStyles(theme => ({
     '--pf-v6-c-alert-group--m-toast--InsetInlineEnd': `${theme.spacing(2.5)}px`,
     '--pf-v6-c-alert-group--m-toast--InsetBlockStart': `${theme.spacing(2.5)}px`,
     '--pf-v6-c-alert-group--m-toast--MaxWidth': '350px',
+    '--pf-v6-c-alert-group--m-toast--ZIndex': '9999',
   },
   toastAlert: {
     maxWidth: '350px',


### PR DESCRIPTION
## Description
 fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3041
  - Fixed toast notifications being rendered behind the Global Header in the lightspeed
  plugin

### UI before changes
<img width="1710" height="1107" alt="Screenshot 2026-04-30 at 12 59 29 PM" src="https://github.com/user-attachments/assets/25517ed4-78c6-4846-b99f-68d3824b2bee" />


 ### UI after changes

https://github.com/user-attachments/assets/68925e39-029a-4097-b83d-504e2a71160f


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
