### PR TITLE
fix(scorecard): Fix custom threshold status translation

### DIFF
--- a/workspaces/scorecard/.changeset/brown-fans-pay.md
+++ b/workspaces/scorecard/.changeset/brown-fans-pay.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': patch
+---
+
+Fixes severity threshold category translation for custom thresholds

--- a/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/DonutChartTooltipContent.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/AggregatedMetricCards/AverageCard/DonutChartTooltipContent.tsx
@@ -21,6 +21,7 @@ import Typography from '@mui/material/Typography';
 
 import { TooltipContent, formatAggregationScoreDetail } from './TooltipContent';
 import { useTranslation } from '../../../hooks/useTranslation';
+import { getTranslatedStatus } from '../../../utils';
 
 export const DonutChartTooltipContent = ({
   weightedSum,
@@ -32,16 +33,6 @@ export const DonutChartTooltipContent = ({
   statusValues?: AggregatedMetricValue[];
 }) => {
   const { t } = useTranslation();
-
-  const getStatus = (status: string) => {
-    const translatedStatus = t(`thresholds.${status}` as any, {});
-
-    if (translatedStatus === `thresholds.${status}` && status) {
-      return status.charAt(0).toUpperCase() + status.slice(1);
-    }
-
-    return translatedStatus;
-  };
 
   return (
     <Stack spacing={0.5} sx={{ minWidth: 220 }}>
@@ -72,7 +63,7 @@ export const DonutChartTooltipContent = ({
               >
                 {t('metric.averageCenterTooltipBreakdownRow', {
                   count: row.count,
-                  status: getStatus(row.name),
+                  status: getTranslatedStatus(row.name, t),
                   score: formatAggregationScoreDetail(row.score ?? 0),
                 } as any)}
               </Typography>

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/CustomLegend.tsx
@@ -25,6 +25,7 @@ import { styled, useTheme } from '@mui/material/styles';
 
 import { useTranslation } from '../../hooks/useTranslation';
 import {
+  getTranslatedStatus,
   getThresholdRuleColor,
   resolveStatusColor,
   SCORECARD_ERROR_STATE_COLOR,
@@ -93,13 +94,7 @@ const CustomLegend = (props: CustomLegendProps) => {
                 variant="body2"
                 sx={{ fontSize: '0.875rem', fontWeight: 400 }}
               >
-                {(() => {
-                  const translated = t(`thresholds.${ruleKey}` as any, {});
-                  // If translation returns the ruleKey itself, fallback to capitalized ruleKey
-                  return translated === `thresholds.${ruleKey}`
-                    ? ruleKey.charAt(0).toUpperCase() + ruleKey.slice(1)
-                    : translated;
-                })()}
+                {getTranslatedStatus(ruleKey, t)}
                 {ruleExpression &&
                   !/^==(?:true|false)$/.test(ruleExpression) &&
                   ` ${ruleExpression}`}

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomLegend.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomLegend.tsx
@@ -20,6 +20,7 @@ import { styled } from '@mui/material/styles';
 
 import type { PieData as PieDataProps } from '../types';
 import { useTranslation } from '../../hooks/useTranslation';
+import { getTranslatedStatus } from '../../utils';
 
 const StyledLegend = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -106,15 +107,7 @@ const CustomLegend = (props: CustomLegendProps) => {
               variant="body2"
               sx={{ fontSize: '0.875rem', fontWeight: 400 }}
             >
-              {(() => {
-                const translated = t(`thresholds.${category.name}` as any, {});
-                const label =
-                  typeof translated === 'string' &&
-                  translated.startsWith('thresholds.')
-                    ? category.name
-                    : translated;
-                return label.charAt(0).toUpperCase() + label.slice(1);
-              })()}
+              {getTranslatedStatus(category.name, t)}
             </Typography>
           </StyledLegendItem>
         );

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomTooltip.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/CustomTooltip.tsx
@@ -23,6 +23,7 @@ import Typography from '@mui/material/Typography';
 
 import type { PieData } from '../types';
 import { useTranslation } from '../../hooks/useTranslation';
+import { getTranslatedStatus } from '../../utils';
 
 export type CustomTooltipPayload = {
   name?: string;
@@ -77,10 +78,10 @@ export const CustomTooltip = ({
       contentElement = <Box sx={{ m: 0 }}>{customContent as ReactNode}</Box>;
     }
   } else if (payload?.[0]?.value === 0 || payload?.[0]?.value === undefined) {
-    const translatedState = t(`thresholds.${payload?.[0]?.name}` as any, {});
+    const translatedStatus = getTranslatedStatus(payload?.[0]?.name, t);
     contentElement = (
       <Typography sx={{ fontSize: '0.875rem', margin: 0, fontWeight: '500' }}>
-        {t('thresholds.noEntities', { category: translatedState } as any)}
+        {t('thresholds.noEntities', { category: translatedStatus } as any)}
       </Typography>
     );
   } else {

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/CustomTooltip.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardHomepageSection/__tests__/CustomTooltip.test.tsx
@@ -61,6 +61,19 @@ describe('CustomTooltip Component', () => {
     expect(screen.getByText('No entities in Test state')).toBeInTheDocument();
   });
 
+  it('should render no-entities message with title capitalized status for custom status', () => {
+    render(
+      <CustomTooltip
+        payload={[{ name: 'critical', value: 0 }]}
+        pieData={[{ name: 'critical', value: 0, color: 'red' }]}
+      />,
+    );
+
+    expect(
+      screen.getByText('No entities in Critical state'),
+    ).toBeInTheDocument();
+  });
+
   it('should render custom content when provided', () => {
     render(
       <CustomTooltip

--- a/workspaces/scorecard/plugins/scorecard/src/components/ScorecardPage/EntitiesTable/cells/MetricStatusCell.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/ScorecardPage/EntitiesTable/cells/MetricStatusCell.tsx
@@ -17,7 +17,7 @@
 import { memo } from 'react';
 
 import Box from '@mui/material/Box';
-import { resolveStatusColor } from '../../../../utils';
+import { getTranslatedStatus, resolveStatusColor } from '../../../../utils';
 import { useTranslation } from '../../../../hooks/useTranslation';
 
 export const MetricStatusCell = memo(
@@ -31,11 +31,7 @@ export const MetricStatusCell = memo(
     statusColor: string;
   }) => {
     const { t } = useTranslation();
-
-    let translatedStatus = t(`thresholds.${status}` as any, {});
-    if (translatedStatus === `thresholds.${status}` && status) {
-      translatedStatus = status?.charAt(0).toUpperCase() + status?.slice(1);
-    }
+    const translatedStatus = getTranslatedStatus(status, t);
 
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/statusUtils.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/statusUtils.test.tsx
@@ -15,13 +15,16 @@
  */
 
 import type { Theme } from '@mui/material/styles';
+import type { TranslationFunction } from '@backstage/core-plugin-api/alpha';
 
 import {
   DEFAULT_NUMBER_THRESHOLDS,
   ScorecardThresholdRuleColors,
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
+import { scorecardTranslationRef } from '../../translations';
 import {
   getStatusConfig,
+  getTranslatedStatus,
   resolveStatusColor,
   SCORECARD_ERROR_STATE_COLOR,
 } from '..';
@@ -327,6 +330,37 @@ describe('statusUtils', () => {
         'nonexistent.path',
       );
       expect(color).toBe('#d32f2f');
+    });
+  });
+
+  describe('getTranslatedStatus', () => {
+    type ScorecardT = TranslationFunction<typeof scorecardTranslationRef.T>;
+
+    it('should return translated status when translation exists', () => {
+      const t = ((key: string) =>
+        key === 'thresholds.success'
+          ? 'Success'
+          : key) as any as TranslationFunction<
+        typeof scorecardTranslationRef.T
+      >;
+
+      expect(getTranslatedStatus('success', t)).toBe('Success');
+    });
+
+    it('should fallback to title capitalized status when translation is missing', () => {
+      const t = ((key: string) => key) as any as ScorecardT;
+
+      expect(getTranslatedStatus('critical', t)).toBe('Critical');
+    });
+
+    it('should return empty string for undefined status', () => {
+      const t = ((key: string) => key) as any as ScorecardT;
+      expect(getTranslatedStatus(undefined, t)).toBe('');
+    });
+
+    it('should return empty string for empty status', () => {
+      const t = ((key: string) => key) as any as ScorecardT;
+      expect(getTranslatedStatus('', t)).toBe('');
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/utils/index.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/index.ts
@@ -23,6 +23,10 @@ export {
   SCORECARD_ERROR_STATE_COLOR,
 } from './constants';
 export { getLastUpdatedLabel } from './entityTableUtils';
-export { getStatusConfig, resolveStatusColor } from './statusUtils';
+export {
+  getStatusConfig,
+  getTranslatedStatus,
+  resolveStatusColor,
+} from './statusUtils';
 export { getThresholdRuleColor, getThresholdRuleIcon } from './thresholdUtils';
 export { resolveMetricTranslation } from './translationUtils';

--- a/workspaces/scorecard/plugins/scorecard/src/utils/statusUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/statusUtils.ts
@@ -15,15 +15,34 @@
  */
 
 import type { Theme } from '@mui/material/styles';
+import type { TranslationFunction } from '@backstage/core-plugin-api/alpha';
 import type { ThresholdRule } from '@red-hat-developer-hub/backstage-plugin-scorecard-common';
 import type { ThemeConfig } from '@red-hat-developer-hub/backstage-plugin-theme';
 
+import { scorecardTranslationRef } from '../translations';
 import { SCORECARD_ERROR_STATE_COLOR } from './constants';
 import { getThresholdRuleColor, getThresholdRuleIcon } from './thresholdUtils';
 
 export type StatusConfig = {
   color: string;
   icon?: string;
+};
+
+export const getTranslatedStatus = (
+  status: string | undefined,
+  t: TranslationFunction<typeof scorecardTranslationRef.T>,
+): string => {
+  if (!status) {
+    return '';
+  }
+
+  const translationKey = `thresholds.${status}`;
+  const translatedStatus = t(translationKey as any, {});
+  if (translatedStatus === translationKey) {
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+
+  return translatedStatus;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fix and unify threshold status translation.

In some places, custom thresholds were rendered incorrectly:
<img width="765" height="443" alt="Screenshot 2026-05-19 at 9 29 12" src="https://github.com/user-attachments/assets/e598da99-4043-4c76-9b2f-1655a660fc90" />

Now:
<img width="765" height="443" alt="Screenshot 2026-05-19 at 10 01 17" src="https://github.com/user-attachments/assets/b22b952c-a15f-4699-b493-e5e310539836" />
<img width="765" height="443" alt="Screenshot 2026-05-19 at 10 01 28" src="https://github.com/user-attachments/assets/3ae8a5d4-9173-4c87-b5a7-1de33e0749c6" />

#### Fixes

https://redhat.atlassian.net/browse/RHDHBUGS-3165

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
