### PR TITLE
fix(lightspeed): convert FAB from makeStyles/StylesProvider to sx prop to prevent global style leak

### DIFF
--- a/workspaces/lightspeed/.changeset/fix-lightspeed-jss-style-leak.md
+++ b/workspaces/lightspeed/.changeset/fix-lightspeed-jss-style-leak.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+fix(lightspeed): prevent JSS class name prefix from leaking into host application styles

--- a/workspaces/lightspeed/plugins/lightspeed/report.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report.api.md
@@ -36,7 +36,7 @@ export const LightspeedDrawerStateExposer: (
 ) => null;
 
 // @public
-export const LightspeedFAB: () => JSX_2.Element;
+export const LightspeedFAB: () => JSX_2.Element | null;
 
 // @public
 export const LightspeedIcon: () => JSX_2.Element;

--- a/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
@@ -14,61 +14,44 @@
  * limitations under the License.
  */
 
-import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
 import Close from '@mui/icons-material/Close';
+import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles, StylesProvider } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { LightspeedFABIcon } from '../components/LightspeedIcon';
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
-import {
-  generateClassName,
-  generateClassNameV4,
-} from '../utils/generateClassName';
 
-const useStyles = makeStyles(theme => ({
-  fab: {
-    opacity: '1 !important',
-    backgroundColor: `${theme?.palette?.primary?.main ?? '#1976d2'} !important`,
-    color: `${theme?.palette?.primary?.contrastText ?? '#fff'} !important`,
-    boxShadow: `${
-      theme?.shadows?.[6] ??
-      '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)'
-    } !important`,
-  },
-  'fab-button': {
-    bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    alignItems: 'end',
-    zIndex: 200,
-    display: 'flex',
-    position: 'fixed',
-
-    // When ApplicationDrawer is docked, match main content inset
-    'body.docked-drawer-open &': {
-      transition: 'margin-right 0.3s ease',
-      marginRight: DOCKED_CONTENT_OFFSET,
-    },
-  },
-}));
-
-const LightspeedFABInner = () => {
+/**
+ * @alpha
+ * Lightspeed Floating action button to open/close the lightspeed chatbot
+ */
+export const LightspeedFAB = () => {
   const { t } = useTranslation();
   const { isChatbotActive, toggleChatbot, displayMode } =
     useLightspeedDrawerContext();
-  const fabButton = useStyles();
 
   if (displayMode === ChatbotDisplayMode.embedded) {
     return null;
   }
 
   return (
-    <div
-      className={fabButton['fab-button']}
+    <Box
+      sx={theme => ({
+        bottom: `calc(${theme.spacing(2)} + 1.5em)`,
+        right: `calc(${theme.spacing(2)} + 1.5em)`,
+        alignItems: 'end',
+        zIndex: 200,
+        display: 'flex',
+        position: 'fixed',
+        'body.docked-drawer-open &': {
+          transition: 'margin-right 0.3s ease',
+          marginRight: DOCKED_CONTENT_OFFSET,
+        },
+      })}
       id="lightspeed-fab"
       data-testid="lightspeed-fab"
     >
@@ -84,24 +67,20 @@ const LightspeedFABInner = () => {
           aria-label={
             isChatbotActive ? t('tooltip.fab.close') : t('tooltip.fab.open')
           }
-          className={fabButton.fab}
-          sx={{ borderRadius: '100% !important' }}
+          sx={theme => ({
+            borderRadius: '100% !important',
+            opacity: '1 !important',
+            backgroundColor: `${theme.palette?.primary?.main ?? '#1976d2'} !important`,
+            color: `${theme.palette?.primary?.contrastText ?? '#fff'} !important`,
+            boxShadow: `${
+              theme.shadows?.[6] ??
+              '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)'
+            } !important`,
+          })}
         >
           {isChatbotActive ? <Close fontSize="small" /> : <LightspeedFABIcon />}
         </Fab>
       </Tooltip>
-    </div>
+    </Box>
   );
 };
-
-/**
- * @alpha
- * Lightspeed Floating action button to open/close the lightspeed chatbot
- */
-export const LightspeedFAB = () => (
-  <StylesProvider generateClassName={generateClassName}>
-    <StylesProviderV4 generateClassName={generateClassNameV4}>
-      <LightspeedFABInner />
-    </StylesProviderV4>
-  </StylesProvider>
-);

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -1928,10 +1928,15 @@ export const LightspeedChat = ({
               minHeight: theme.spacing(6),
               paddingLeft: theme.spacing(2),
               paddingRight: theme.spacing(2),
+              '& .MuiTabs-flexContainer': {
+                gap: theme.spacing(2),
+              },
               '& [role="tab"]': {
                 fontWeight: 700,
                 textTransform: 'none',
                 opacity: 1,
+                padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+                borderRadius: theme.spacing(0.5),
                 '&:not([aria-selected="true"])': {
                   color: `${theme.palette.text.primary} !important`,
                 },

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -16,16 +16,11 @@
 
 import { PropsWithChildren } from 'react';
 
-import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
-import { makeStyles, StylesProvider } from '@mui/styles';
+import { makeStyles } from '@mui/styles';
 import { ChatbotModal } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedProviderState } from '../hooks/useLightspeedProviderState';
-import {
-  generateClassName,
-  generateClassNameV4,
-} from '../utils/generateClassName';
 import { LightspeedChatContainer } from './LightspeedChatContainer';
 import { LightspeedDrawerContext } from './LightspeedDrawerContext';
 
@@ -44,7 +39,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const LightspeedDrawerProviderInner = ({ children }: PropsWithChildren) => {
+/**
+ * @public
+ */
+export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => {
   const classes = useStyles();
   const { contextValue, shouldRenderOverlayModal, closeChatbot } =
     useLightspeedProviderState();
@@ -68,14 +66,3 @@ const LightspeedDrawerProviderInner = ({ children }: PropsWithChildren) => {
     </LightspeedDrawerContext.Provider>
   );
 };
-
-/**
- * @public
- */
-export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => (
-  <StylesProvider generateClassName={generateClassName}>
-    <StylesProviderV4 generateClassName={generateClassNameV4}>
-      <LightspeedDrawerProviderInner>{children}</LightspeedDrawerProviderInner>
-    </StylesProviderV4>
-  </StylesProvider>
-);

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
@@ -14,61 +14,44 @@
  * limitations under the License.
  */
 
-import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
 import Close from '@mui/icons-material/Close';
+import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles, StylesProvider } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
-import {
-  generateClassName,
-  generateClassNameV4,
-} from '../utils/generateClassName';
 import { LightspeedFABIcon } from './LightspeedIcon';
 
-const useStyles = makeStyles(theme => ({
-  fab: {
-    opacity: '1 !important',
-    backgroundColor: `${theme?.palette?.primary?.main ?? '#1976d2'} !important`,
-    color: `${theme?.palette?.primary?.contrastText ?? '#fff'} !important`,
-    boxShadow: `${
-      theme?.shadows?.[6] ??
-      '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)'
-    } !important`,
-  },
-  'fab-button': {
-    bottom: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    right: `calc(${theme?.spacing?.(2) ?? '16px'} + 1.5em)`,
-    alignItems: 'end',
-    zIndex: 200,
-    display: 'flex',
-    position: 'fixed',
-
-    // When ApplicationDrawer is docked, match main content inset
-    'body.docked-drawer-open &': {
-      transition: 'margin-right 0.3s ease',
-      marginRight: DOCKED_CONTENT_OFFSET,
-    },
-  },
-}));
-
-const LightspeedFABInner = () => {
+/**
+ * @public
+ * Lightspeed Floating action button to open/close the lightspeed chatbot
+ */
+export const LightspeedFAB = () => {
   const { t } = useTranslation();
   const { isChatbotActive, toggleChatbot, displayMode } =
     useLightspeedDrawerContext();
-  const fabButton = useStyles();
 
   if (displayMode === ChatbotDisplayMode.embedded) {
     return null;
   }
 
   return (
-    <div
-      className={fabButton['fab-button']}
+    <Box
+      sx={theme => ({
+        bottom: `calc(${theme.spacing(2)} + 1.5em)`,
+        right: `calc(${theme.spacing(2)} + 1.5em)`,
+        alignItems: 'end',
+        zIndex: 200,
+        display: 'flex',
+        position: 'fixed',
+        'body.docked-drawer-open &': {
+          transition: 'margin-right 0.3s ease',
+          marginRight: DOCKED_CONTENT_OFFSET,
+        },
+      })}
       id="lightspeed-fab"
       data-testid="lightspeed-fab"
     >
@@ -84,24 +67,20 @@ const LightspeedFABInner = () => {
           aria-label={
             isChatbotActive ? t('tooltip.fab.close') : t('tooltip.fab.open')
           }
-          className={fabButton.fab}
-          sx={{ borderRadius: '100% !important' }}
+          sx={theme => ({
+            borderRadius: '100% !important',
+            opacity: '1 !important',
+            backgroundColor: `${theme.palette?.primary?.main ?? '#1976d2'} !important`,
+            color: `${theme.palette?.primary?.contrastText ?? '#fff'} !important`,
+            boxShadow: `${
+              theme.shadows?.[6] ??
+              '0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)'
+            } !important`,
+          })}
         >
           {isChatbotActive ? <Close fontSize="small" /> : <LightspeedFABIcon />}
         </Fab>
       </Tooltip>
-    </div>
+    </Box>
   );
 };
-
-/**
- * @public
- * Lightspeed Floating action button to open/close the lightspeed chatbot
- */
-export const LightspeedFAB = () => (
-  <StylesProvider generateClassName={generateClassName}>
-    <StylesProviderV4 generateClassName={generateClassNameV4}>
-      <LightspeedFABInner />
-    </StylesProviderV4>
-  </StylesProvider>
-);


### PR DESCRIPTION
## Fixed 
- JIra : https://redhat.atlassian.net/browse/RHDHBUGS-3164
## Summary
- Replaced `makeStyles` + `StylesProvider` in both `LightspeedFAB` components (`src/components/` and `src/alpha/`) with MUI's `sx` prop
- Removed the seeded class name generator (`generateClassName`) from  LightSpeedDrawerProvider

## Problem
In RHDH cluster deployments, the `lightspeedFAB` module is registered as an `AppRootWrapperBlueprint` which wraps the **entire application** inside `LightspeedProvider` (i.e. `LightspeedDrawerProvider`). The `StylesProvider` with a `lightspeed` seed causes ALL child components' JSS classes to be prefixed with `lightspeed-`, breaking styles across every page.
This was not reproducible in local dev because JSS instance sharing differs between local and cluster environments.
## Fix
Convert the FAB's styles to MUI `sx` prop (emotion-based), eliminating the JSS dependency and the need for `StylesProvider` entirely. The FAB no longer injects a custom class name generator into the component tree.

## Test it in RHDH-local
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
