### PR TITLE
chore(app-defaults): add pingfederate and keycloak signInPage support

### DIFF
--- a/workspaces/app-defaults/.changeset/humble-bushes-write.md
+++ b/workspaces/app-defaults/.changeset/humble-bushes-write.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-app-auth': patch
+---
+
+Supports the upstream Keycloak and PingFederate auth providers in the sign-in page.

--- a/workspaces/app-defaults/plugins/app-auth/README.md
+++ b/workspaces/app-defaults/plugins/app-auth/README.md
@@ -1,6 +1,6 @@
 # @red-hat-developer-hub/backstage-plugin-app-auth
 
-RHDH sign-in page (multi-provider) and OIDC / Auth0 / SAML frontend OAuth2 APIs for the **new frontend system**, registered against `pluginId: 'app'`.
+RHDH sign-in page (multi-provider) and OIDC / Keycloak / PingFederate / Auth0 / SAML frontend OAuth2 APIs for the **new frontend system**, registered against `pluginId: 'app'`.
 
 ## Usage
 
@@ -9,4 +9,4 @@ RHDH sign-in page (multi-provider) and OIDC / Auth0 / SAML frontend OAuth2 APIs 
 
 ## Config
 
-Root `signInPage` (string or string[]) selects which providers appear; see `config.d.ts`.
+Root `signInPage` (string or string[]) selects which providers appear; see `config.d.ts`. Provider ids include `oidc`, `keycloak`, and `pingfederate` (OIDC-backed; backend `auth.providers` keys must match).

--- a/workspaces/app-defaults/plugins/app-auth/report-alpha.api.md
+++ b/workspaces/app-defaults/plugins/app-auth/report-alpha.api.md
@@ -29,7 +29,13 @@ export type CustomAuthApiRefType = OAuthApi &
   SessionApi;
 
 // @alpha
+export const keycloakAuthApiRef: ApiRef<CustomAuthApiRefType>;
+
+// @alpha
 export const oidcAuthApiRef: ApiRef<CustomAuthApiRefType>;
+
+// @alpha
+export const pingfederateAuthApiRef: ApiRef<CustomAuthApiRefType>;
 
 // @alpha
 export const samlAuthApiRef: ApiRef<CustomAuthApiRefType>;
@@ -63,6 +69,10 @@ export const signInTranslationRef: TranslationRef<
     readonly 'signIn.providers.google.message': 'Sign in using Google';
     readonly 'signIn.providers.oidc.title': 'OIDC';
     readonly 'signIn.providers.oidc.message': 'Sign in using OIDC';
+    readonly 'signIn.providers.keycloak.title': 'Keycloak';
+    readonly 'signIn.providers.keycloak.message': 'Sign in using Keycloak';
+    readonly 'signIn.providers.pingfederate.title': 'PingFederate';
+    readonly 'signIn.providers.pingfederate.message': 'Sign in using PingFederate';
     readonly 'signIn.providers.okta.title': 'Okta';
     readonly 'signIn.providers.okta.message': 'Sign in using Okta';
     readonly 'signIn.providers.onelogin.title': 'OneLogin';

--- a/workspaces/app-defaults/plugins/app-auth/src/AuthApiRefs.ts
+++ b/workspaces/app-defaults/plugins/app-auth/src/AuthApiRefs.ts
@@ -45,6 +45,25 @@ export const oidcAuthApiRef: ApiRef<CustomAuthApiRefType> = createApiRef({
 });
 
 /**
+ * Keycloak auth API for the RHDH multi-provider sign-in page (OIDC-backed).
+ *
+ * @alpha
+ */
+export const keycloakAuthApiRef: ApiRef<CustomAuthApiRefType> = createApiRef({
+  id: 'internal.auth.keycloak',
+});
+
+/**
+ * PingFederate auth API for the RHDH multi-provider sign-in page (OIDC-backed).
+ *
+ * @alpha
+ */
+export const pingfederateAuthApiRef: ApiRef<CustomAuthApiRefType> =
+  createApiRef({
+    id: 'internal.auth.pingfederate',
+  });
+
+/**
  * Auth0 auth API for the RHDH multi-provider sign-in page.
  *
  * @alpha

--- a/workspaces/app-defaults/plugins/app-auth/src/appAuthModule.tsx
+++ b/workspaces/app-defaults/plugins/app-auth/src/appAuthModule.tsx
@@ -26,7 +26,13 @@ import {
 } from '@backstage/frontend-plugin-api';
 import appPlugin from '@backstage/plugin-app';
 
-import { auth0AuthApiRef, oidcAuthApiRef, samlAuthApiRef } from './AuthApiRefs';
+import {
+  auth0AuthApiRef,
+  keycloakAuthApiRef,
+  oidcAuthApiRef,
+  pingfederateAuthApiRef,
+  samlAuthApiRef,
+} from './AuthApiRefs';
 import { SignInPage } from './components/SignInPage';
 
 const oidcAuthApi = ApiBlueprint.make({
@@ -47,6 +53,56 @@ const oidcAuthApi = ApiBlueprint.make({
           provider: {
             id: 'oidc',
             title: 'OIDC',
+            icon: () => null,
+          },
+          environment: configApi.getOptionalString('auth.environment'),
+        }),
+    }),
+});
+
+const keycloakAuthApi = ApiBlueprint.make({
+  name: 'keycloak-auth',
+  params: defineParams =>
+    defineParams({
+      api: keycloakAuthApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        oauthRequestApi: oauthRequestApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
+        OAuth2.create({
+          configApi,
+          discoveryApi,
+          oauthRequestApi: oauthRequestApi,
+          provider: {
+            id: 'keycloak',
+            title: 'Keycloak',
+            icon: () => null,
+          },
+          environment: configApi.getOptionalString('auth.environment'),
+        }),
+    }),
+});
+
+const pingfederateAuthApi = ApiBlueprint.make({
+  name: 'pingfederate-auth',
+  params: defineParams =>
+    defineParams({
+      api: pingfederateAuthApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        oauthRequestApi: oauthRequestApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
+        OAuth2.create({
+          configApi,
+          discoveryApi,
+          oauthRequestApi: oauthRequestApi,
+          provider: {
+            id: 'pingfederate',
+            title: 'PingFederate',
             icon: () => null,
           },
           environment: configApi.getOptionalString('auth.environment'),
@@ -111,12 +167,19 @@ const signInPageOverride = appPlugin.getExtension('sign-in-page:app').override({
 });
 
 /**
- * RHDH app sign-in page plus OIDC, Auth0, and SAML OAuth2 frontend APIs (`pluginId: app`).
+ * RHDH app sign-in page plus OIDC, Keycloak, PingFederate, Auth0, and SAML OAuth2 frontend APIs (`pluginId: app`).
  * Default-export this module for dynamic frontend loading.
  *
  * @alpha
  */
 export const appAuthModule = createFrontendModule({
   pluginId: 'app',
-  extensions: [signInPageOverride, oidcAuthApi, auth0AuthApi, samlAuthApi],
+  extensions: [
+    signInPageOverride,
+    oidcAuthApi,
+    keycloakAuthApi,
+    pingfederateAuthApi,
+    auth0AuthApi,
+    samlAuthApi,
+  ],
 });

--- a/workspaces/app-defaults/plugins/app-auth/src/components/SignInPage.tsx
+++ b/workspaces/app-defaults/plugins/app-auth/src/components/SignInPage.tsx
@@ -39,7 +39,9 @@ import Typography from '@mui/material/Typography';
 
 import {
   auth0AuthApiRef,
+  keycloakAuthApiRef,
   oidcAuthApiRef,
+  pingfederateAuthApiRef,
   samlAuthApiRef,
 } from '../AuthApiRefs';
 import { signInTranslationRef } from '../translations/signIn';
@@ -130,6 +132,24 @@ const createProviders = (t: (key: string, params?: any) => string) =>
         title: t('signIn.providers.oidc.title'),
         message: t('signIn.providers.oidc.message'),
         apiRef: oidcAuthApiRef,
+      },
+    ],
+    [
+      'keycloak',
+      {
+        id: 'keycloak-auth-provider',
+        title: t('signIn.providers.keycloak.title'),
+        message: t('signIn.providers.keycloak.message'),
+        apiRef: keycloakAuthApiRef,
+      },
+    ],
+    [
+      'pingfederate',
+      {
+        id: 'pingfederate-auth-provider',
+        title: t('signIn.providers.pingfederate.title'),
+        message: t('signIn.providers.pingfederate.message'),
+        apiRef: pingfederateAuthApiRef,
       },
     ],
     [

--- a/workspaces/app-defaults/plugins/app-auth/src/translations/signIn.ts
+++ b/workspaces/app-defaults/plugins/app-auth/src/translations/signIn.ts
@@ -74,6 +74,14 @@ export const signInTranslationRef = createTranslationRef({
           title: 'OIDC',
           message: 'Sign in using OIDC',
         },
+        keycloak: {
+          title: 'Keycloak',
+          message: 'Sign in using Keycloak',
+        },
+        pingfederate: {
+          title: 'PingFederate',
+          message: 'Sign in using PingFederate',
+        },
         okta: {
           title: 'Okta',
           message: 'Sign in using Okta',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Supports the upstream [Keycloak](https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/auth-backend-module-keycloak) and [PingFederate](https://github.com/backstage/community-plugins/tree/main/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider) auth providers in the sign-in page. 

Fixes [RHIDP-13669](https://redhat.atlassian.net/browse/RHIDP-13669)

<img width="1211" height="317" alt="image" src="https://github.com/user-attachments/assets/fee4e8c4-8b22-4b6b-b9ad-33b9af491bbb" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
