### PR TITLE
chore(cost-management): add changeset for additional CVE 

### DIFF
--- a/workspaces/cost-management/.changeset/patch-additional-cve-and-dep-fixes.md
+++ b/workspaces/cost-management/.changeset/patch-additional-cve-and-dep-fixes.md
@@ -1,0 +1,30 @@
+---
+'@red-hat-developer-hub/plugin-cost-management': patch
+'@red-hat-developer-hub/plugin-cost-management-backend': patch
+'@red-hat-developer-hub/plugin-cost-management-common': patch
+---
+
+fix: additional CVE patches and dependency updates for 2.2.1
+
+Covers the following changes merged after the initial CVE patch (558b7c3):
+
+- chore(deps): update rhdh cost management dependencies (patch) (#3000) — bumps
+  `@aws-sdk/core/fast-xml-parser` to 4.5.6, `request/form-data` to 2.5.5,
+  `request/tough-cookie` to 4.1.4, `typeorm` to 0.3.29, and `file-type` to 21.3.4
+  via yarn resolutions
+
+- fix: resolve lodash CVEs via workspace resolution (#3135) — pins lodash to 4.18.1
+  to address GHSA-r5fr-rjxr-66jc (Code Injection via _.template, CVSS 8.1) and
+  GHSA-f23m-r3pf-42rh (Prototype Pollution via _.unset/\_.omit, CVSS 6.5)
+
+- fix: update lodash direct deps to 4.18.1 to close Dependabot alerts (#3142) —
+  updates pinned lodash versions in individual plugin package.json files so
+  Dependabot can detect the fix for GHSA-r5fr-rjxr-66jc and GHSA-f23m-r3pf-42rh
+
+- fix: CVE patches for casbin/minimatch and fast-xml-parser (#3143) — adds
+  `casbin/minimatch` resolution to 7.4.8 and bumps `fast-xml-parser` to 5.7.3
+
+- fix: upgrade @backstage-community/plugin-rbac-backend to ^7.12.4 (#3161) —
+  upgrades rbac-backend and rbac-common to address a Backstage backend CVE
+
+- chore(deps): update linkifyjs to v4.3.3 (#3155) — patch version bump


### PR DESCRIPTION
## Hey, I just made a Pull Request!

add changeset for additional CVE and dep fixes in 2.2.1

Documents changes merged after 558b7c3 that were missing changeset entries:
- #3000: renovate patch dep bumps (fast-xml-parser, form-data, tough-cookie, typeorm, file-type)
- #3135: lodash CVE fix via workspace resolution (GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh)
- #3142: lodash direct dep updates to close Dependabot alerts
- #3143: casbin/minimatch + fast-xml-parser CVE patches
- #3161: backstage rbac-backend CVE upgrade to ^7.12.4
- #3155: linkifyjs update to v4.3.3



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
