### PR TITLE
feat(bulk-import,lightspeed): update legacy app titles to distinguish from NFS apps

### DIFF
--- a/workspaces/bulk-import/.changeset/bright-doors-glow.md
+++ b/workspaces/bulk-import/.changeset/bright-doors-glow.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Updated the dev page title to 'Bulk import For Legacy' to distinguish the legacy app entry.

--- a/workspaces/bulk-import/plugins/bulk-import/dev/legacy.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/dev/legacy.tsx
@@ -52,7 +52,7 @@ createDevApp()
         <BulkImportPage />
       </TestApiProvider>
     ),
-    title: 'Bulk import',
+    title: 'Bulk import For Legacy',
     path: '/bulk-import',
     icon: BulkImportIcon,
   })

--- a/workspaces/lightspeed/.changeset/calm-waves-drift.md
+++ b/workspaces/lightspeed/.changeset/calm-waves-drift.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Updated the chatbox header title to 'Developer Lightspeed For Legacy' to distinguish the legacy app entry.

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -197,7 +197,7 @@ export const lightspeedMessages = {
   'menu.newConversation': 'New Chat',
 
   // Chat-specific UI elements
-  'chatbox.header.title': 'Developer Lightspeed',
+  'chatbox.header.title': 'Developer Lightspeed For Legacy',
   'chatbox.search.placeholder': 'Search',
   'chatbox.provider.other': 'Other',
   'chatbox.emptyState.noPinnedChats': 'No pinned chats',


### PR DESCRIPTION
## Description
Updated UI titles in the bulk-import and lightspeed workspaces to append "For Legacy" suffix. This distinguishes the legacy app entries from the NFS (new frontend system) apps — the bulk-import dev page title is now "Bulk import For Legacy" and the lightspeed chatbox header is now "Developer Lightspeed For Legacy".

## Fixed
- TODO

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)