### PR TITLE
fix(homepage): show empty state when no default widgets are returned

### DIFF
--- a/workspaces/homepage/.changeset/rich-insects-sip.md
+++ b/workspaces/homepage/.changeset/rich-insects-sip.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dynamic-home-page': patch
+---
+
+When default widgets are configured, but no widgets (an empty array) is returned show an empty state. Rename the translations from cards to widgets and remove thw moint point hint from the error messages. (Some translations will be improved witht he next translations update.)

--- a/workspaces/homepage/.changeset/rich-insects-sip.md
+++ b/workspaces/homepage/.changeset/rich-insects-sip.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-dynamic-home-page': patch
 ---
 
-When default widgets are configured, but no widgets (an empty array) is returned show an empty state. Rename the translations from cards to widgets and remove thw moint point hint from the error messages. (Some translations will be improved witht he next translations update.)
+When default widgets are configured, but no widgets (an empty array) is returned show an empty state. Rename the translations from cards to widgets and remove the mount point hint from the error messages. (Some translations will be improved with the next translations update.)

--- a/workspaces/homepage/plugins/dynamic-home-page/src/components/HomePage.tsx
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/components/HomePage.tsx
@@ -46,6 +46,8 @@ export const HomePage = ({
   let content: React.ReactNode;
   if (loading) {
     content = <Progress />;
+  } else if (defaultWidgets && defaultWidgets.length === 0 && !customizable) {
+    content = <EmptyState title={t('homePage.empty')} missing="content" />;
   } else if (defaultWidgets && defaultWidgets.length > 0) {
     if (customizable) {
       content = (

--- a/workspaces/homepage/plugins/dynamic-home-page/src/translations/de.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/translations/de.ts
@@ -27,8 +27,7 @@ const homepageTranslationDe = createTranslationMessages({
     'header.welcome': 'Willkommen zurück!',
     'header.welcomePersonalized': 'Willkommen zurück, {{name}}!',
     'header.local': 'Lokal',
-    'homePage.empty':
-      'Keine Homepage-Karten (Einbindungspunkte) konfiguriert oder gefunden.',
+    'homePage.empty': 'Keine Homepage-Karten konfiguriert oder gefunden.',
     'search.placeholder': 'Suchen',
     'quickAccess.title': 'Schnellzugriff',
     'quickAccess.fetchError': 'Daten konnten nicht abgerufen werden.',

--- a/workspaces/homepage/plugins/dynamic-home-page/src/translations/fr.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/translations/fr.ts
@@ -27,8 +27,7 @@ const homepageTranslationFr = createTranslationMessages({
     'header.welcome': 'Content de vous revoir!',
     'header.welcomePersonalized': 'Bienvenue {{name}} !',
     'header.local': 'Locale',
-    'homePage.empty':
-      "Aucune carte de page d'accueil (points de montage) configurée ou trouvée.",
+    'homePage.empty': "Aucune carte de page d'accueil configurée ou trouvée.",
     'search.placeholder': 'Recherche',
     'quickAccess.title': 'Accès rapide',
     'quickAccess.fetchError': 'Impossible de récupérer les données.',

--- a/workspaces/homepage/plugins/dynamic-home-page/src/translations/it.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/translations/it.ts
@@ -27,8 +27,7 @@ const homepageTranslationIt = createTranslationMessages({
     'header.welcome': 'Bentornato/a!',
     'header.welcomePersonalized': 'Bentornato/a, {{name}}!',
     'header.local': 'Locale',
-    'homePage.empty':
-      'Nessuna scheda home page (punto di montaggio) configurata o trovata.',
+    'homePage.empty': 'Nessuna scheda home page configurata o trovata.',
     'search.placeholder': 'Ricerca',
     'quickAccess.title': 'Accesso rapido',
     'quickAccess.fetchError': 'Impossibile recuperare i dati.',

--- a/workspaces/homepage/plugins/dynamic-home-page/src/translations/ja.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/translations/ja.ts
@@ -27,8 +27,7 @@ const homepageTranslationJa = createTranslationMessages({
     'header.welcome': 'おかえりなさい!',
     'header.welcomePersonalized': 'おかえりなさい、{{name}}!',
     'header.local': 'ローカル',
-    'homePage.empty':
-      'ホームページカード (マウントポイント) が設定されていないか見つかりません。',
+    'homePage.empty': 'ホームページカード が設定されていないか見つかりません。',
     'search.placeholder': '検索',
     'quickAccess.title': 'クイックアクセス',
     'quickAccess.fetchError': 'データを取得できませんでした。',

--- a/workspaces/homepage/plugins/dynamic-home-page/src/translations/ref.ts
+++ b/workspaces/homepage/plugins/dynamic-home-page/src/translations/ref.ts
@@ -29,7 +29,7 @@ export const homepageMessages = {
     local: 'Local',
   },
   homePage: {
-    empty: 'No home page cards (mount points) configured or found.',
+    empty: 'No home page widgets configured or found.',
   },
   search: {
     placeholder: 'Search',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow-up on #3137

When `homepage.defaultWidgets` is configured but no card is returned, show this error page:

<img width="1600" height="911" alt="image" src="https://github.com/user-attachments/assets/da2c924b-760a-4b7f-89fc-0989914d7a91" />

Instead of this fallback:

<img width="1714" height="911" alt="image" src="https://github.com/user-attachments/assets/d5a21635-5e57-4140-8c77-5a90629f8ecb" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
