### PR TITLE
feat(bulk-import): update page title in translation ref

### DIFF
--- a/workspaces/bulk-import/.changeset/bright-doors-glow.md
+++ b/workspaces/bulk-import/.changeset/bright-doors-glow.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Updated the page title in the bulk-import translation ref

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
@@ -19,7 +19,7 @@ import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
 // CRITICAL: Export messages separately for testing
 export const bulkImportMessages = {
   page: {
-    title: 'Bulk import',
+    title: 'Bulk import New',
     subtitle: 'Import entities to Red Hat Developer Hub',
     addRepositoriesTitle: 'Add repositories',
     importEntitiesTitle: 'Import entities',


### PR DESCRIPTION
## Description
Updated the page title in the bulk-import plugin's translation reference file from "Bulk import" to "Bulk import New". This change affects the displayed title on the bulk-import page across all locales that fall back to the reference translation.

## Fixed
- TODO — Jira ticket link

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)