### PR TITLE
feat(orchestrator-form): evaluate conditional ui:hidden at step level…

### DIFF
--- a/workspaces/orchestrator/.changeset/conditional-step-hiding.md
+++ b/workspaces/orchestrator/.changeset/conditional-step-hiding.md
@@ -1,0 +1,16 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+---
+
+Evaluate conditional `ui:hidden` at the wizard step level and add `notContains`/`isNotEmptyList` operators.
+
+Previously, `getSortedStepEntries` only checked for static `ui:hidden: true` when filtering wizard steps. Conditional `ui:hidden` expressions (`anyOf`, `allOf`, `when`/`is`/`isNot`/`isEmpty`) were only evaluated at the individual field level, causing steps with conditional hidden logic to render as empty pages.
+
+Additionally, `evaluateConditionObject` used early-return logic that only evaluated the first matching operator, preventing multiple operators from being combined with AND semantics.
+
+This change:
+
+- Adds `notContains` and `isNotEmptyList` operators to `HiddenConditionObject`
+- Refactors `evaluateConditionObject` to AND all specified operators
+- Evaluates conditional `ui:hidden` objects at both the step level and the "all properties hidden" level
+- Passes `formData` to step filtering so steps react to form data changes

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -78,7 +78,7 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
       return undefined;
     }
 
-    return getActiveStepKey(schema, activeStep);
+    return getActiveStepKey(schema, activeStep, formData);
   };
 
   const onSubmit = async (_formData: JsonObject) => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
@@ -41,8 +41,8 @@ const StepperObjectField = ({
   const { t } = useTranslation();
 
   const sortedStepEntries = useMemo(
-    () => getSortedStepEntries(schema),
-    [schema],
+    () => getSortedStepEntries(schema, formData),
+    [schema, formData],
   );
   if (sortedStepEntries === undefined) {
     throw new Error(t('stepperObjectField.error'));

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/types/HiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/types/HiddenCondition.ts
@@ -42,6 +42,20 @@ export interface HiddenConditionObject {
    * Hide if the field is empty (undefined, null, empty string, or empty array)
    */
   isEmpty?: boolean;
+
+  /**
+   * Hide if the field value is a non-empty list (when true) or empty list (when false).
+   * Useful in combination with notContains to check "list is non-empty AND does not contain X".
+   */
+  isNotEmptyList?: boolean;
+
+  /**
+   * Hide if the field value (expected to be an array) does NOT contain this value.
+   * When the field value is an array and does not include the specified value, the condition is met.
+   * If the field value is not an array, the condition is not met.
+   * Typically combined with isNotEmptyList for "non-empty list that doesn't contain X" patterns.
+   */
+  notContains?: JsonValue;
 }
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
@@ -58,32 +58,51 @@ function matchesAny(
 }
 
 /**
- * Evaluate a simple condition object
+ * Evaluate a simple condition object.
+ * All specified operators are ANDed together — every operator present must
+ * evaluate to true for the field to be hidden.
  */
 function evaluateConditionObject(
   condition: HiddenConditionObject,
   formData: JsonObject,
 ): boolean {
   const fieldValue = get(formData, condition.when);
+  let result = true;
+  let hasCondition = false;
 
-  // Check isEmpty condition
+  // Check isEmpty condition (hide if field is empty / not empty)
   if (condition.isEmpty !== undefined) {
+    hasCondition = true;
     const empty = isEmptyValue(fieldValue);
-    return condition.isEmpty ? empty : !empty;
+    if (!(condition.isEmpty ? empty : !empty)) result = false;
   }
 
   // Check 'is' condition (hide if field equals any value)
   if (condition.is !== undefined) {
-    return matchesAny(fieldValue, condition.is);
+    hasCondition = true;
+    if (!matchesAny(fieldValue, condition.is)) result = false;
   }
 
   // Check 'isNot' condition (hide if field does NOT equal any value)
   if (condition.isNot !== undefined) {
-    return !matchesAny(fieldValue, condition.isNot);
+    hasCondition = true;
+    if (matchesAny(fieldValue, condition.isNot)) result = false;
   }
 
-  // No valid condition found, don't hide
-  return false;
+  // Check 'isNotEmptyList' condition (hide if field is a non-empty array)
+  if (condition.isNotEmptyList !== undefined) {
+    hasCondition = true;
+    const isNonEmptyList = Array.isArray(fieldValue) && fieldValue.length > 0;
+    if (condition.isNotEmptyList ? !isNonEmptyList : isNonEmptyList) result = false;
+  }
+
+  // Check 'notContains' condition (hide if array does NOT contain value)
+  if (condition.notContains !== undefined) {
+    hasCondition = true;
+    if (Array.isArray(fieldValue) && fieldValue.includes(condition.notContains)) result = false;
+  }
+
+  return hasCondition ? result : false;
 }
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/getSortedStepEntries.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/getSortedStepEntries.ts
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { JsonObject } from '@backstage/types';
+
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import get from 'lodash/get';
+
+import { HiddenCondition } from '../types/HiddenCondition';
+import { evaluateHiddenCondition } from './evaluateHiddenCondition';
 
 /**
  * Get step entries from the schema sorted by the ui:order property.
@@ -23,10 +28,12 @@ import get from 'lodash/get';
  * Steps where ALL inputs are marked with ui:hidden: true are also automatically filtered out.
  *
  * @param schema - The schema to get the sorted step entries from.
+ * @param formData - Optional form data for evaluating conditional ui:hidden expressions.
  * @returns An array of [key, subSchema] pairs, a subSchema conforms a single wizard step.
  */
 export const getSortedStepEntries = (
   schema: JSONSchema7,
+  formData?: JsonObject,
 ): [string, JSONSchema7Definition][] | undefined => {
   if (!schema.properties) {
     return undefined;
@@ -57,8 +64,18 @@ export const getSortedStepEntries = (
     }
 
     // Check if step itself is explicitly hidden
-    if (get(subSchema, 'ui:hidden') === true) {
+    const uiHidden = get(subSchema, 'ui:hidden');
+    if (uiHidden === true) {
       return false;
+    }
+    if (
+      typeof uiHidden === 'object' &&
+      uiHidden !== null &&
+      formData
+    ) {
+      if (evaluateHiddenCondition(uiHidden as HiddenCondition, formData)) {
+        return false;
+      }
     }
 
     // Check if ALL inputs within this step are hidden
@@ -71,7 +88,18 @@ export const getSortedStepEntries = (
           if (typeof prop === 'boolean') {
             return false;
           }
-          return get(prop, 'ui:hidden') === true;
+          const propHidden = get(prop, 'ui:hidden');
+          if (propHidden === true) {
+            return true;
+          }
+          if (
+            typeof propHidden === 'object' &&
+            propHidden !== null &&
+            formData
+          ) {
+            return evaluateHiddenCondition(propHidden as HiddenCondition, formData);
+          }
+          return false;
         });
 
         if (allHidden) {
@@ -89,8 +117,9 @@ export const getSortedStepEntries = (
 export const getActiveStepKey = (
   schema: JSONSchema7,
   activeStep: number,
+  formData?: JsonObject,
 ): string => {
-  const sortedStepEntries = getSortedStepEntries(schema) ?? [];
+  const sortedStepEntries = getSortedStepEntries(schema, formData) ?? [];
   const activeKey = sortedStepEntries[activeStep]?.[0];
   if (!activeKey) {
     throw new Error(


### PR DESCRIPTION
## What

Evaluate conditional `ui:hidden` expressions during wizard step filtering and add two new condition operators (`notContains`, `isNotEmptyList`) to `HiddenConditionObject`.

## Why

`getSortedStepEntries` only checks for static `ui:hidden: true` when filtering wizard steps. Conditional `ui:hidden` expressions (`anyOf`, `allOf`, `when`/`is`/`isNot`/`isEmpty`) are only evaluated at the individual field level by `FieldTemplate`, not during step filtering.

This means a step whose `ui:hidden` is a conditional object (or whose properties all have conditional `ui:hidden`) is never filtered out of the wizard stepper, resulting in **empty pages being shown**.

Additionally, `evaluateConditionObject` uses early-return logic which only evaluates the first matching operator in a condition object. This prevents combining multiple operators (e.g., `isNotEmptyList` + `notContains`) in a single condition with AND semantics.

## Changes

- **`HiddenCondition.ts`** — Add `notContains` and `isNotEmptyList` fields to `HiddenConditionObject`
- **`evaluateHiddenCondition.ts`** — Refactor `evaluateConditionObject` to AND all specified operators instead of early-returning on the first match; add evaluation for `isNotEmptyList` and `notContains`
- **`getSortedStepEntries.ts`** — Add optional `formData` parameter to `getSortedStepEntries` and `getActiveStepKey`; use `evaluateHiddenCondition` to evaluate conditional `ui:hidden` objects at both the step level and the "all properties hidden" level
- **`StepperObjectField.tsx`** — Pass `formData` to `getSortedStepEntries` so step filtering is reactive to form data changes
- **`OrchestratorFormWrapper.tsx`** — Pass `formData` to `getActiveStepKey`

## How to test

1. Create a workflow schema with a step that has a conditional `ui:hidden` (e.g., `{ when: "someField", is: "someValue" }`) at the step level
2. Verify the step is hidden/shown dynamically as the referenced field value changes
3. Create a step where all properties have conditional `ui:hidden` — verify the step disappears when all properties evaluate to hidden
4. Test the new operators:
   - `isNotEmptyList: true` hides when the field is a non-empty array
   - `notContains: "x"` hides when the array does not contain `"x"`
   - Combine both for "non-empty list that doesn't contain X" patterns