### PR TITLE
fix(cost-management): enable cluster/project RBAC filtering by registering dynamic permissions with RHDH (FLPATH-4207)

### DIFF
--- a/workspaces/cost-management/.changeset/fix-rbac-dynamic-permissions.md
+++ b/workspaces/cost-management/.changeset/fix-rbac-dynamic-permissions.md
@@ -1,0 +1,12 @@
+---
+'@red-hat-developer-hub/plugin-cost-management-backend': patch
+---
+
+fix: register dynamic RBAC permissions for cluster/project tiers (FLPATH-4207)
+
+Cluster-specific permissions (ros/<cluster>, ros/<cluster>/<project>) were created
+at runtime but never registered with createPermissionIntegrationRouter. The RHDH
+RBAC backend only evaluates registered permissions — unregistered ones get DENY by
+default, breaking the 3-tier RBAC model. Now fetches cluster/project data at router
+init and registers all dynamic permissions. Also improves secureProxy.ts error
+messages to include request path and error details.

--- a/workspaces/cost-management/plugins/cost-management-backend/src/routes/secureProxy.ts
+++ b/workspaces/cost-management/plugins/cost-management-backend/src/routes/secureProxy.ts
@@ -409,7 +409,12 @@ export const secureProxy: (options: RouterOptions) => RequestHandler =
       res.set('Content-Type', contentType);
       return res.send(await upstreamResponse.text());
     } catch (error) {
-      options.logger.error('Secure proxy error', error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      options.logger.error(
+        `Secure proxy error for path "${proxyPath}": ${errorMessage}`,
+        error instanceof Error ? { stack: error.stack } : {},
+      );
 
       if (error instanceof SsoAuthenticationError) {
         return res.status(502).json({
@@ -419,6 +424,8 @@ export const secureProxy: (options: RouterOptions) => RequestHandler =
         });
       }
 
-      return res.status(500).json({ error: 'Internal proxy error' });
+      return res
+        .status(500)
+        .json({ error: `Internal proxy error: ${errorMessage}` });
     }
   };

--- a/workspaces/cost-management/plugins/cost-management-backend/src/service/router.test.ts
+++ b/workspaces/cost-management/plugins/cost-management-backend/src/service/router.test.ts
@@ -18,7 +18,111 @@ import express from 'express';
 import request from 'supertest';
 import { mockServices } from '@backstage/backend-test-utils';
 
-import { createRouter } from './router';
+import {
+  createRouter,
+  extractStrings,
+  buildClusterProjectPermissions,
+} from './router';
+import type { BasicPermission } from '@backstage/plugin-permission-common';
+
+describe('extractStrings', () => {
+  it('returns values from a fulfilled result', () => {
+    const result: PromiseSettledResult<{
+      data?: { name: string; alias?: string }[];
+    }> = {
+      status: 'fulfilled',
+      value: {
+        data: [
+          { name: 'a', alias: 'x' },
+          { name: 'b' },
+          { name: 'c', alias: 'y' },
+        ],
+      },
+    };
+    const out = extractStrings(result, item => item.alias);
+    expect(out).toEqual(new Set(['x', 'y']));
+  });
+
+  it('returns empty set for rejected result', () => {
+    const result: PromiseSettledResult<{ data?: unknown[] }> = {
+      status: 'rejected',
+      reason: new Error('fail'),
+    };
+    expect(extractStrings(result, () => 'x')).toEqual(new Set());
+  });
+
+  it('returns empty set when data is undefined', () => {
+    const result: PromiseSettledResult<{ data?: unknown[] }> = {
+      status: 'fulfilled',
+      value: {},
+    };
+    expect(extractStrings(result, () => 'x')).toEqual(new Set());
+  });
+
+  it('deduplicates values', () => {
+    const result: PromiseSettledResult<{ data?: { v: string }[] }> = {
+      status: 'fulfilled',
+      value: { data: [{ v: 'a' }, { v: 'a' }, { v: 'b' }] },
+    };
+    expect(extractStrings(result, i => i.v)).toEqual(new Set(['a', 'b']));
+  });
+
+  it('skips falsy values from accessor', () => {
+    const result: PromiseSettledResult<{
+      data?: { v: string | undefined }[];
+    }> = {
+      status: 'fulfilled',
+      value: { data: [{ v: undefined }, { v: '' }, { v: 'ok' }] },
+    };
+    expect(extractStrings(result, i => i.v)).toEqual(new Set(['ok']));
+  });
+});
+
+describe('buildClusterProjectPermissions', () => {
+  const mockClusterFn = (c: string) =>
+    ({ name: `ros/${c}`, type: 'basic', attributes: {} } as BasicPermission);
+  const mockProjectFn = (c: string, p: string) =>
+    ({
+      name: `ros/${c}/${p}`,
+      type: 'basic',
+      attributes: {},
+    } as BasicPermission);
+
+  it('builds cluster + cluster/project combinations', () => {
+    const perms = buildClusterProjectPermissions(
+      new Set(['c1', 'c2']),
+      new Set(['p1']),
+      mockClusterFn,
+      mockProjectFn,
+    );
+    expect(perms.map(p => p.name)).toEqual([
+      'ros/c1',
+      'ros/c1/p1',
+      'ros/c2',
+      'ros/c2/p1',
+    ]);
+  });
+
+  it('returns only cluster perms when projects is empty', () => {
+    const perms = buildClusterProjectPermissions(
+      new Set(['c1']),
+      new Set(),
+      mockClusterFn,
+      mockProjectFn,
+    );
+    expect(perms.map(p => p.name)).toEqual(['ros/c1']);
+  });
+
+  it('returns empty array when clusters is empty', () => {
+    const perms = buildClusterProjectPermissions(
+      new Set(),
+      new Set(['p1']),
+      mockClusterFn,
+      mockProjectFn,
+    );
+    expect(perms).toEqual([]);
+  });
+});
 
 describe('createRouter', () => {
   let app: express.Express;

--- a/workspaces/cost-management/plugins/cost-management-backend/src/service/router.ts
+++ b/workspaces/cost-management/plugins/cost-management-backend/src/service/router.ts
@@ -84,6 +84,13 @@ async function fetchDynamicPermissions(
   try {
     const token = await getTokenFromApi(options);
 
+    // Fetch all known clusters and projects so we can register a permission
+    // for each one. limit:1000 is a high ceiling to capture all entries in a
+    // single request; the Cost Management API defaults to 10.
+    // This data is fetched once at plugin startup and determines which
+    // ros/<cluster> and cost/<cluster> permissions the RBAC backend will
+    // evaluate. Clusters or projects added after startup will not be
+    // recognised until the Backstage instance is restarted.
     const [rosData, costClusters, costProjects] = await Promise.allSettled([
       options.optimizationApi
         .getRecommendationList(

--- a/workspaces/cost-management/plugins/cost-management-backend/src/service/router.ts
+++ b/workspaces/cost-management/plugins/cost-management-backend/src/service/router.ts
@@ -18,26 +18,124 @@ import express from 'express';
 import Router from 'express-promise-router';
 import type { RouterOptions } from '../models/RouterOptions';
 import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
+import type { BasicPermission } from '@backstage/plugin-permission-common';
 import {
   rosPluginPermissions,
   rosApplyPermissions,
   costPluginPermissions,
+  rosClusterSpecificPermission,
+  rosClusterProjectPermission,
+  costClusterSpecificPermission,
+  costClusterProjectPermission,
 } from '@red-hat-developer-hub/plugin-cost-management-common/permissions';
 import { getAccess } from '../routes/access';
 import { getCostManagementAccess } from '../routes/costManagementAccess';
 import { secureProxy } from '../routes/secureProxy';
 import { applyRecommendation } from '../routes/applyRecommendation';
+import { getTokenFromApi } from '../util/tokenUtil';
+
+/**
+ * Fetches cluster and project data from the upstream APIs and builds
+ * permission objects for every ros/{cluster}, ros/{cluster}/{project},
+ * cost/{cluster}, and cost/{cluster}/{project} combination.
+ *
+ * These permissions must be registered with the permission integration
+ * router so that the RBAC backend recognises them as valid and evaluates
+ * the corresponding policies instead of returning DENY by default.
+ */
+async function fetchDynamicPermissions(
+  options: RouterOptions,
+): Promise<BasicPermission[]> {
+  const { logger } = options;
+  const permissions: BasicPermission[] = [];
+
+  try {
+    const token = await getTokenFromApi(options);
+
+    const [rosData, costClusters, costProjects] = await Promise.allSettled([
+      options.optimizationApi
+        .getRecommendationList(
+          { query: { limit: -1, orderHow: 'desc', orderBy: 'last_reported' } },
+          { token },
+        )
+        .then(r => r.json()),
+      options.costManagementApi
+        .searchOpenShiftClusters('', { token, limit: 1000 })
+        .then(r => r.json()),
+      options.costManagementApi
+        .searchOpenShiftProjects('', { token, limit: 1000 })
+        .then(r => r.json()),
+    ]);
+
+    const rosClusterNames = new Set<string>();
+    const rosProjects = new Set<string>();
+
+    if (rosData.status === 'fulfilled' && rosData.value?.data) {
+      for (const rec of rosData.value.data) {
+        if (rec.clusterAlias) rosClusterNames.add(rec.clusterAlias);
+        if (rec.project) rosProjects.add(rec.project);
+      }
+    }
+
+    for (const cluster of rosClusterNames) {
+      permissions.push(rosClusterSpecificPermission(cluster));
+      for (const project of rosProjects) {
+        permissions.push(rosClusterProjectPermission(cluster, project));
+      }
+    }
+
+    const costClusterNames = new Set<string>();
+    const costProjectNames = new Set<string>();
+
+    if (costClusters.status === 'fulfilled' && costClusters.value?.data) {
+      for (const c of costClusters.value.data as {
+        cluster_alias: string;
+      }[]) {
+        if (c.cluster_alias) costClusterNames.add(c.cluster_alias);
+      }
+    }
+    if (costProjects.status === 'fulfilled' && costProjects.value?.data) {
+      for (const p of costProjects.value.data as { value: string }[]) {
+        if (p.value) costProjectNames.add(p.value);
+      }
+    }
+
+    for (const cluster of costClusterNames) {
+      permissions.push(costClusterSpecificPermission(cluster));
+      for (const project of costProjectNames) {
+        permissions.push(costClusterProjectPermission(cluster, project));
+      }
+    }
+
+    logger.info(
+      `Registered ${permissions.length} dynamic RBAC permissions ` +
+        `(${rosClusterNames.size} ROS clusters, ${costClusterNames.size} cost clusters)`,
+    );
+  } catch (error) {
+    logger.warn(
+      'Could not fetch cluster/project data for dynamic permission registration. ' +
+        'Cluster-specific RBAC permissions will not be evaluated until the next refresh.',
+      error instanceof Error ? { error: error.message } : {},
+    );
+  }
+
+  return permissions;
+}
 
 /** @public */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const router = Router();
+
+  const dynamicPermissions = await fetchDynamicPermissions(options);
+
   const permissionsIntegrationRouter = createPermissionIntegrationRouter({
     permissions: [
       ...rosPluginPermissions,
       ...rosApplyPermissions,
       ...costPluginPermissions,
+      ...dynamicPermissions,
     ],
   });
 

--- a/workspaces/cost-management/plugins/cost-management-backend/src/service/router.ts
+++ b/workspaces/cost-management/plugins/cost-management-backend/src/service/router.ts
@@ -34,6 +34,39 @@ import { secureProxy } from '../routes/secureProxy';
 import { applyRecommendation } from '../routes/applyRecommendation';
 import { getTokenFromApi } from '../util/tokenUtil';
 
+/** @internal Visible for testing */
+export function extractStrings<T>(
+  result: PromiseSettledResult<{ data?: T[] }>,
+  accessor: (item: T) => string | undefined,
+): Set<string> {
+  const values = new Set<string>();
+  if (result.status !== 'fulfilled' || !result.value?.data) {
+    return values;
+  }
+  for (const item of result.value.data) {
+    const v = accessor(item);
+    if (v) values.add(v);
+  }
+  return values;
+}
+
+/** @internal Visible for testing */
+export function buildClusterProjectPermissions(
+  clusters: Set<string>,
+  projects: Set<string>,
+  clusterFn: (cluster: string) => BasicPermission,
+  projectFn: (cluster: string, project: string) => BasicPermission,
+): BasicPermission[] {
+  const perms: BasicPermission[] = [];
+  for (const cluster of clusters) {
+    perms.push(clusterFn(cluster));
+    for (const project of projects) {
+      perms.push(projectFn(cluster, project));
+    }
+  }
+  return perms;
+}
+
 /**
  * Fetches cluster and project data from the upstream APIs and builds
  * permission objects for every ros/{cluster}, ros/{cluster}/{project},
@@ -47,7 +80,6 @@ async function fetchDynamicPermissions(
   options: RouterOptions,
 ): Promise<BasicPermission[]> {
   const { logger } = options;
-  const permissions: BasicPermission[] = [];
 
   try {
     const token = await getTokenFromApi(options);
@@ -67,59 +99,46 @@ async function fetchDynamicPermissions(
         .then(r => r.json()),
     ]);
 
-    const rosClusterNames = new Set<string>();
-    const rosProjects = new Set<string>();
+    const rosClusterNames = extractStrings(rosData, r => r.clusterAlias);
+    const rosProjectNames = extractStrings(rosData, r => r.project);
+    const costClusterNames = extractStrings(
+      costClusters,
+      (c: { cluster_alias: string }) => c.cluster_alias,
+    );
+    const costProjectNames = extractStrings(
+      costProjects,
+      (p: { value: string }) => p.value,
+    );
 
-    if (rosData.status === 'fulfilled' && rosData.value?.data) {
-      for (const rec of rosData.value.data) {
-        if (rec.clusterAlias) rosClusterNames.add(rec.clusterAlias);
-        if (rec.project) rosProjects.add(rec.project);
-      }
-    }
-
-    for (const cluster of rosClusterNames) {
-      permissions.push(rosClusterSpecificPermission(cluster));
-      for (const project of rosProjects) {
-        permissions.push(rosClusterProjectPermission(cluster, project));
-      }
-    }
-
-    const costClusterNames = new Set<string>();
-    const costProjectNames = new Set<string>();
-
-    if (costClusters.status === 'fulfilled' && costClusters.value?.data) {
-      for (const c of costClusters.value.data as {
-        cluster_alias: string;
-      }[]) {
-        if (c.cluster_alias) costClusterNames.add(c.cluster_alias);
-      }
-    }
-    if (costProjects.status === 'fulfilled' && costProjects.value?.data) {
-      for (const p of costProjects.value.data as { value: string }[]) {
-        if (p.value) costProjectNames.add(p.value);
-      }
-    }
-
-    for (const cluster of costClusterNames) {
-      permissions.push(costClusterSpecificPermission(cluster));
-      for (const project of costProjectNames) {
-        permissions.push(costClusterProjectPermission(cluster, project));
-      }
-    }
+    const permissions = [
+      ...buildClusterProjectPermissions(
+        rosClusterNames,
+        rosProjectNames,
+        rosClusterSpecificPermission,
+        rosClusterProjectPermission,
+      ),
+      ...buildClusterProjectPermissions(
+        costClusterNames,
+        costProjectNames,
+        costClusterSpecificPermission,
+        costClusterProjectPermission,
+      ),
+    ];
 
     logger.info(
       `Registered ${permissions.length} dynamic RBAC permissions ` +
         `(${rosClusterNames.size} ROS clusters, ${costClusterNames.size} cost clusters)`,
     );
+
+    return permissions;
   } catch (error) {
     logger.warn(
       'Could not fetch cluster/project data for dynamic permission registration. ' +
         'Cluster-specific RBAC permissions will not be evaluated until the next refresh.',
       error instanceof Error ? { error: error.message } : {},
     );
+    return [];
   }
-
-  return permissions;
 }
 
 /** @public */


### PR DESCRIPTION
## Summary

Cluster-specific RBAC permissions (`ros/<cluster>`, `ros/<cluster>/<project>`, and their `cost/` equivalents) are created dynamically at runtime by `fetchDynamicPermissions()` but were **never registered** with `createPermissionIntegrationRouter`. RHDH's RBAC backend uses `PluginPermissionMetadataCollector` to validate permission names before evaluating them against Casbin policies — unregistered permissions default to **DENY**. This broke the entire 3-tier RBAC model: only `ros.plugin` (tier 1) ever worked.

> **Note — community Backstage vs RHDH:** The upstream community RBAC backend may evaluate Casbin policies by name matching alone. However, RHDH's distribution (`@red-hat-developer-hub/backstage-plugin-rbac-backend`) requires permissions to be registered via `createPermissionIntegrationRouter` for them to be recognized by the authorization flow. This is confirmed by the A/B test evidence below.

## Changes

**`router.ts`** — At router init, fetch cluster/project data from the upstream Cost Management APIs and register all `ros/<cluster>`, `ros/<cluster>/<project>`, `cost/<cluster>`, and `cost/<cluster>/<project>` permissions with the integration router. Uses `Promise.allSettled` so a partial failure (e.g. one API down) doesn't block other permissions from registering.

**`secureProxy.ts`** — Improved error logging and response messages. Previously returned opaque `"Internal proxy error"` for all non-SSO exceptions; now includes the request path and error details for easier debugging.

## A/B Test Evidence — Permission Registration

Tested on live RHDH 1.9 cluster (ocp-edge73-0, OCP 4.19). Queried `/api/permission/plugins/policies` with identical configuration, only swapping the plugin image:

**WITHOUT fix (stock 2.2.0):** cost-management plugin registers **3 permissions** — `ros.plugin`, `ros.apply`, `cost.plugin`. Zero dynamic permissions. Any `permissionsSvc.authorize()` call for `ros/ocp-edge73-0-xfvkt` returns DENY.

**WITH fix (2.2.0-rc.1):** cost-management plugin registers **174 permissions** — the same 3 static plus **171 dynamic** cluster/project permissions across **57 unique clusters**. Examples: `ros/ocp-edge73-0-xfvkt`, `ros/ocp-edge73-0-xfvkt/rhdh-operator`, `ros/ocp-test-mc8h6`, etc.

This confirms that `createPermissionIntegrationRouter` registration is required for RHDH's RBAC to evaluate these permissions. PRs #1996/#2102 correctly implemented the authorization logic (`filterAuthorizedClustersAndProjects` calling `authorize()` per cluster), but those calls always returned DENY because the permission names were not registered. This PR completes the circuit.

## Proof the fix works

Verified on a live RHDH instance (`ocp-edge73`) with OCI image `quay.io/gharden/cost-management-dynamic-plugins:2.2.0-rc.1`.

### Tier 1: `ros.plugin` — full access (396 containers, no filters)

![costmgmt-full-access-optimizations](https://github.com/hardengl/rhdh-plugins/releases/download/flpath-4207-proof/costmgmt-full-access-optimizations.png)

### No permissions — access denied

![costmgmt-no-access-optimizations](https://github.com/hardengl/rhdh-plugins/releases/download/flpath-4207-proof/costmgmt-no-access-optimizations.png)

### Tier 2: `ros/<cluster>` only — cluster-filtered (10 containers, down from 396)

![ro-cluster-only-optimizations](https://github.com/hardengl/rhdh-plugins/releases/download/flpath-4207-proof/ro-cluster-only-optimizations.png)

### Tier 3: `ros/<cluster>/<project>` only — cluster+project filtered

![ro-project-only-optimizations](https://github.com/hardengl/rhdh-plugins/releases/download/flpath-4207-proof/ro-project-only-optimizations.png)

### Backend audit logs

```
costmgmt-full-access: {"decision":"ALLOW","filters":{"clusters":[],"projects":[]}}            ← no filters
ro-cluster-only:      {"decision":"ALLOW","filters":{"clusters":["696794b9-..."],"projects":[]}}  ← cluster filter
ro-project-only:      {"decision":"ALLOW","filters":{"clusters":["696794b9-..."],"projects":["rhdh-operator"]}}
costmgmt-no-access:   {"decision":"DENY"}
```

## CI

[flightpath-ros #95](https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/CI/job/flightpath-ros/95/) — 84 passed, 2 failed (pre-existing), 4 skipped. 20 of 21 FLPATH-4207 RBAC tests passed; 1 failure ("full-access user should see data across clusters") is under investigation.

## Limitation

Dynamic permissions are registered once at startup. New clusters added after RHDH starts won't be recognized until the pod restarts. A periodic refresh mechanism would be a more complete solution.

## Related

- [FLPATH-4207](https://redhat.atlassian.net/browse/FLPATH-4207) — the bug
- [FLPATH-4209](https://redhat.atlassian.net/browse/FLPATH-4209) — fix documentation with full evidence