### PR TITLE
fix(theme): remove AppBar box shadow to avoid theming issue

### DIFF
--- a/workspaces/theme/.changeset/lovely-pears-refuse.md
+++ b/workspaces/theme/.changeset/lovely-pears-refuse.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Removed the box shadow from the AppBar component

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -174,17 +174,18 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
   }
 
   // MUI AppBar
-  if (options.appBar !== 'mui') {
-    components.MuiAppBar = {
-      styleOverrides: {
-        root: {
+  components.MuiAppBar = {
+    styleOverrides: {
+      root: {
+        boxShadow: 'none',
+        ...(options.appBar !== 'mui' && {
           backgroundColor: general.appBarBackgroundColor,
           backgroundImage: general.appBarBackgroundImage,
           outline: 'none',
-        },
+        }),
       },
-    };
-  }
+    },
+  };
 
   // MUI buttons
   // Don't disableRipple for MuiButtonBase as it will affect all the buttons


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes:
https://redhat.atlassian.net/browse/RHDHBUGS-3181

Remove box shadow in global header when `paper: mui` is set and the header is positioned `above-main-content`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## Before:

Light theme:
<img width="1920" height="929" alt="Global_header_with_Boxshadow" src="https://github.com/user-attachments/assets/7b34b44d-abdc-427e-b611-159ddf779027" />


**Dark theme:**  (Difficult to notice in black ground but it is there :), zoom in to see it )

<img width="520" height="133" alt="image" src="https://github.com/user-attachments/assets/0155c9e1-8c1c-4a23-9131-9846b3acc820" />

<img width="241" height="113" alt="image" src="https://github.com/user-attachments/assets/54d37fe4-f7ad-4c61-acdb-31c11bc87467" />


## After:

<img width="1896" height="87" alt="image" src="https://github.com/user-attachments/assets/ba60aa18-0dcf-483a-91fa-65ae95a0c4ba" />

<img width="1902" height="105" alt="image" src="https://github.com/user-attachments/assets/a7338ab2-28fe-42da-92a8-d6811816acbe" />



# How to test:

Use this config in RHDH to reproduce this.

RHDH app-config.yaml :


```
  branding:
    theme:
      light:
        variant: "rhdh"
        mode: "light"
        defaultPageTheme: default
        options:
          components: rhdh
          rippleEffect: off
          paper: mui  # This needs to be set
```


Global header mount point set to above-main-content
```

dynamicPlugins:
  frontend:
    red-hat-developer-hub.backstage-plugin-global-header:
      translationResources:
        - importName: globalHeaderTranslations
          ref: globalHeaderTranslationRef
      mountPoints:
        - mountPoint: application/header
          importName: GlobalHeader
          config:
            position: above-main-content # This needs to be set
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
