### PR TITLE
feat(augment): add DELETE route and UI button for draft agent cleanup

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
@@ -599,6 +599,51 @@ export function registerAgentRoutes(
   );
 
   // ---------------------------------------------------------------------------
+  // DELETE /agents/:agentId -- remove agent from chatAgents config
+  // Only draft agents can be deleted; other stages must be retired first.
+  // ---------------------------------------------------------------------------
+  router.delete(
+    '/agents/:agentId',
+    withRoute(
+      'DELETE /agents/:agentId',
+      'Failed to delete agent',
+      async (req, res) => {
+        const agentId = decodeURIComponent(req.params.agentId);
+        const userRef = await ctx.getUserRef(req);
+        const configs = await loadChatAgentConfigs();
+        const existing = configs.find(c => c.agentId === agentId);
+
+        const stage = normalizeLifecycleStage(existing?.lifecycleStage);
+        if (stage !== 'draft') {
+          const isAdmin = await ctx.checkIsAdmin(req);
+          if (!isAdmin) {
+            res.status(403).json({
+              error:
+                'Only admins can delete non-draft agents. ' +
+                'Non-admin users may only delete agents in "draft" stage.',
+            });
+            return;
+          }
+        }
+
+        const updated = configs.filter(c => c.agentId !== agentId);
+        await saveChatAgentConfigs(updated, userRef);
+
+        audit.log({
+          action: 'agent.lifecycle',
+          actor: userRef,
+          target: agentId,
+          outcome: 'success',
+          sourceIp: AuditLogger.extractIp(req),
+          meta: { from: stage, direction: 'delete' },
+        });
+        logger.info(`Agent "${agentId}" config deleted by ${userRef}`);
+        res.json({ success: true, agentId, deleted: true });
+      },
+    ),
+  );
+
+  // ---------------------------------------------------------------------------
   // PUT /agents/:agentId/config -- update agent display config
   // ---------------------------------------------------------------------------
   router.put(

--- a/workspaces/augment/plugins/augment/report.api.md
+++ b/workspaces/augment/plugins/augment/report.api.md
@@ -165,6 +165,7 @@ export interface AugmentApi {
   deleteAdminConfig(key: AdminConfigKey): Promise<{
     deleted: boolean;
   }>;
+  deleteAgentConfig(agentId: string): Promise<void>;
   // (undocumented)
   deleteDevSpacesWorkspace(namespace: string, name: string): Promise<void>;
   deleteDocument(

--- a/workspaces/augment/plugins/augment/src/api/AugmentApi.ts
+++ b/workspaces/augment/plugins/augment/src/api/AugmentApi.ts
@@ -100,6 +100,12 @@ export interface AugmentApi {
   ): Promise<{ lifecycleStage: string }>;
 
   /**
+   * Delete an agent's lifecycle config entry. For Kagenti agents, also call
+   * deleteKagentiAgent to remove the K8s deployment.
+   */
+  deleteAgentConfig(agentId: string): Promise<void>;
+
+  /**
    * Bulk publish or unpublish agents.
    */
   bulkPublishAgents(agentIds: string[], published: boolean): Promise<void>;
@@ -747,6 +753,12 @@ export class AugmentApiClient implements AugmentApi {
     const qs = options?.published ? '?published=true' : '';
     const data = await this.fetchJson<{ agents: ChatAgent[] }>(`/agents${qs}`);
     return data.agents ?? [];
+  }
+
+  async deleteAgentConfig(agentId: string): Promise<void> {
+    await this.fetchJson(`/agents/${encodeURIComponent(agentId)}`, {
+      method: 'DELETE',
+    });
   }
 
   async publishAgent(agentId: string): Promise<void> {

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/AgentLifecycleDetail.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/AgentLifecycleDetail.tsx
@@ -29,10 +29,16 @@ import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import { useTheme, alpha } from '@mui/material/styles';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ChatIcon from '@mui/icons-material/Chat';
 import PublishIcon from '@mui/icons-material/Publish';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
+import DeleteIcon from '@mui/icons-material/Delete';
 import {
   getLifecycleTransition,
   getLifecycleStep,
@@ -71,6 +77,7 @@ export interface AgentLifecycleDetailProps {
   agent: KagentiAgentSummary;
   onBack: () => void;
   onChatWithAgent?: (agentId: string) => void;
+  onDeleted?: () => void;
 }
 
 /**
@@ -81,11 +88,14 @@ export function AgentLifecycleDetail({
   agent,
   onBack,
   onChatWithAgent,
+  onDeleted,
 }: AgentLifecycleDetailProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const api = useApi(augmentApiRef);
   const [activeTab, setActiveTab] = useState<LifecycleTab>('overview');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
   const {
     agentCard,
@@ -155,6 +165,25 @@ export function AgentLifecycleDetail({
       setPublishLoading(false);
     }
   }, [api, agentId, nextTransition]);
+
+  const handleDelete = useCallback(async () => {
+    setDeleteLoading(true);
+    try {
+      await api.deleteKagentiAgent(agent.namespace, agent.name);
+      await api.deleteAgentConfig(agentId).catch(() => {});
+      setPublishToast('Agent deleted');
+      onDeleted?.();
+    } catch (err) {
+      setPublishToast(
+        `Delete failed: ${err instanceof Error ? err.message : 'Unknown'}`,
+      );
+    } finally {
+      setDeleteLoading(false);
+      setDeleteDialogOpen(false);
+    }
+  }, [api, agent.namespace, agent.name, agentId, onDeleted]);
+
+  const canDelete = lifecycleStage === 'draft';
 
   const currentStep = getLifecycleStep(lifecycleStage);
   const glass = glassSurface(theme, 6);
@@ -357,6 +386,27 @@ export function AgentLifecycleDetail({
                 Test
               </Button>
             )}
+            {canDelete && (
+              <Tooltip title="Delete this draft agent">
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={
+                    deleteLoading ? (
+                      <CircularProgress size={14} />
+                    ) : (
+                      <DeleteIcon />
+                    )
+                  }
+                  disabled={deleteLoading}
+                  onClick={() => setDeleteDialogOpen(true)}
+                  sx={{ textTransform: 'none', borderRadius: borderRadius.sm }}
+                >
+                  Delete
+                </Button>
+              </Tooltip>
+            )}
           </Box>
         </Box>
 
@@ -456,6 +506,31 @@ export function AgentLifecycleDetail({
       {activeTab === 'card' && (
         <AgentCardTab agentCard={agentCard} loading={loading} />
       )}
+
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+      >
+        <DialogTitle>Delete Agent</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Delete agent <strong>{displayName}</strong> ({agent.namespace}/
+            {agent.name})? This will remove the Kagenti deployment and its
+            lifecycle config entry. This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
+          <Button
+            onClick={handleDelete}
+            color="error"
+            variant="contained"
+            disabled={deleteLoading}
+          >
+            {deleteLoading ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <Snackbar
         open={!!publishToast}

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/KagentiAgentsPanel.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/KagentiAgentsPanel.tsx
@@ -305,6 +305,8 @@ export function KagentiAgentsPanel({
     setError(null);
     try {
       await api.deleteKagentiAgent(deleteTarget.namespace, deleteTarget.name);
+      const agentId = `${deleteTarget.namespace}/${deleteTarget.name}`;
+      await api.deleteAgentConfig(agentId).catch(() => {});
       setDeleteTarget(null);
       loadAgents();
     } catch (e) {


### PR DESCRIPTION
## Summary

- Adds `DELETE /agents/:agentId` backend route to remove chatAgents config entries (draft agents deletable by any user, non-draft requires admin)
- Adds `deleteAgentConfig` method to the frontend AugmentApi
- Adds a "Delete" button with confirmation dialog on `AgentLifecycleDetail` for draft-stage agents
- `KagentiAgentsPanel` delete handler now also cleans up the chatAgents config entry

Part of the Agent Lifecycle Governance Epic.

## Test plan

- [ ] Create a Kagenti agent via wizard, verify it appears in the agents panel
- [ ] Open the agent detail, verify "Delete" button appears (agent is in draft stage)
- [ ] Click Delete, confirm dialog, verify agent is removed from both Kagenti and config
- [ ] Promote an agent to "review", verify Delete button is no longer shown
- [ ] Delete an agent from KagentiAgentsPanel list view, verify chatAgents config is also cleaned up