### PR TITLE
feat(augment): auto-create chatAgents entry on Kagenti agent deploy

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/router.ts
+++ b/workspaces/augment/plugins/augment-backend/src/router.ts
@@ -411,7 +411,7 @@ export async function createRouter({
 
   // Provider-specific routes (only when provider has providerRoutes capability)
   if (providerDescriptor?.capabilities.providerRoutes) {
-    registerKagentiRoutes(ctx);
+    registerKagentiRoutes(ctx, adminConfig);
     registerKagentiSandboxRoutes(ctx);
     registerKagentiAdminRoutes(ctx);
     logger.info('Provider-specific routes registered');

--- a/workspaces/augment/plugins/augment-backend/src/routes/kagentiAgentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/kagentiAgentRoutes.ts
@@ -15,6 +15,7 @@
  */
 
 import { InputError } from '@backstage/errors';
+import type { ChatAgentConfig } from '@red-hat-developer-hub/backstage-plugin-augment-common';
 import { validatePublicUrl } from './validatePublicUrl';
 import type { KagentiRouteRegistrarContext } from './kagentiRoutes';
 import { getVisibleNamespaces } from '../providers/kagenti/kagentiNamespaceUtils';
@@ -206,6 +207,39 @@ export function registerKagentiAgentRoutes(
           throw new InputError('namespace is required and must be a string');
         }
         const result = await api.createAgent(req.body);
+
+        if (result.success && ctx.adminConfig) {
+          const agentId = `${req.body.namespace}/${req.body.name}`;
+          try {
+            const userRef = await ctx.getUserRef(req).catch(() => 'anonymous');
+            const raw = await ctx.adminConfig.get('chatAgents');
+            const configs: ChatAgentConfig[] = Array.isArray(raw)
+              ? (raw as ChatAgentConfig[])
+              : [];
+            if (!configs.some(c => c.agentId === agentId)) {
+              configs.push({
+                agentId,
+                lifecycleStage: 'draft',
+                published: false,
+                visible: false,
+                featured: false,
+                version: 0,
+                promotedAt: new Date().toISOString(),
+                promotedBy: userRef,
+                createdBy: userRef,
+              });
+              await ctx.adminConfig.set('chatAgents', configs, userRef);
+              logger.info(
+                `Auto-created chatAgents entry for ${agentId} (draft) by ${userRef}`,
+              );
+            }
+          } catch (syncErr) {
+            logger.warn(
+              `Failed to auto-create chatAgents entry for ${agentId}: ${syncErr instanceof Error ? syncErr.message : syncErr}`,
+            );
+          }
+        }
+
         res.json(result);
       },
     ),
@@ -222,6 +256,29 @@ export function registerKagentiAgentRoutes(
       async (req, res) => {
         const { namespace, name } = req.params;
         const result = await api.deleteAgent(namespace, name);
+
+        if (ctx.adminConfig) {
+          const agentId = `${namespace}/${name}`;
+          try {
+            const userRef = await ctx.getUserRef(req).catch(() => 'anonymous');
+            const raw = await ctx.adminConfig.get('chatAgents');
+            const configs: ChatAgentConfig[] = Array.isArray(raw)
+              ? (raw as ChatAgentConfig[])
+              : [];
+            const updated = configs.filter(c => c.agentId !== agentId);
+            if (updated.length !== configs.length) {
+              await ctx.adminConfig.set('chatAgents', updated, userRef);
+              logger.info(
+                `Cleaned up chatAgents entry for deleted agent ${agentId}`,
+              );
+            }
+          } catch (syncErr) {
+            logger.warn(
+              `Failed to clean up chatAgents for ${agentId}: ${syncErr instanceof Error ? syncErr.message : syncErr}`,
+            );
+          }
+        }
+
         res.json(result);
       },
     ),

--- a/workspaces/augment/plugins/augment-backend/src/routes/kagentiRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/kagentiRoutes.ts
@@ -20,6 +20,7 @@ import { createWithRoute } from './routeWrapper';
 import type { RouteContext } from './types';
 import type { KagentiProvider } from '../providers/kagenti';
 import type { KagentiApiClient } from '../providers/kagenti';
+import type { AdminConfigService } from '../services/AdminConfigService';
 import { registerKagentiAgentRoutes } from './kagentiAgentRoutes';
 import { registerKagentiToolRoutes } from './kagentiToolRoutes';
 import { registerKagentiConfigRoutes } from './kagentiConfigRoutes';
@@ -32,6 +33,8 @@ export interface KagentiRouteRegistrarContext {
   logger: LoggerService;
   kagenti: KagentiProvider;
   api: KagentiApiClient;
+  adminConfig?: AdminConfigService;
+  getUserRef: (req: express.Request) => Promise<string>;
   withRoute: ReturnType<typeof createWithRoute>;
   validateNamespaceParam: express.RequestHandler;
   requireAdminAccess: express.RequestHandler;
@@ -43,7 +46,10 @@ export interface KagentiRouteRegistrarContext {
  *
  * These routes are always registered when the active provider is 'kagenti'.
  */
-export function registerKagentiRoutes(ctx: RouteContext): void {
+export function registerKagentiRoutes(
+  ctx: RouteContext,
+  adminConfig?: AdminConfigService,
+): void {
   const {
     router,
     logger,
@@ -105,6 +111,8 @@ export function registerKagentiRoutes(ctx: RouteContext): void {
     logger,
     kagenti,
     api,
+    adminConfig,
+    getUserRef,
     withRoute,
     validateNamespaceParam,
     requireAdminAccess,

--- a/workspaces/augment/plugins/augment-common/report.api.md
+++ b/workspaces/augment/plugins/augment-common/report.api.md
@@ -281,6 +281,7 @@ export interface ChatAgentConfig {
   agentId: string;
   avatarUrl?: string;
   conversationStarters?: string[];
+  createdBy?: string;
   description?: string;
   displayName?: string;
   featured: boolean;

--- a/workspaces/augment/plugins/augment-common/src/types/shared.ts
+++ b/workspaces/augment/plugins/augment-common/src/types/shared.ts
@@ -404,6 +404,8 @@ export interface ChatAgentConfig {
   greeting?: string;
   /** Suggested prompts shown on the agent card and below the input */
   conversationStarters?: string[];
+  /** User ref of who originally created this agent config entry */
+  createdBy?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When a Kagenti agent is created via `POST /kagenti/agents`, the handler now auto-creates a `chatAgents` config entry with `lifecycleStage: "draft"` and `createdBy` set to the current user
- When a Kagenti agent is deleted via `DELETE /kagenti/agents/:ns/:name`, the handler also cleans up the corresponding `chatAgents` config entry
- Adds `createdBy` field to `ChatAgentConfig` type in augment-common

This bridges the gap between Kagenti infrastructure deployment and the lifecycle governance system, unblocking the "submit for review" flow for newly deployed agents.

Part of the Agent Lifecycle Governance Epic.

## Test plan

- [ ] Create a new agent via the Kagenti wizard
- [ ] Verify the agent appears in the lifecycle stepper with "draft" stage
- [ ] Click "Submit for Review" and verify the lifecycle transitions to "review"
- [ ] Delete the agent from Kagenti and verify the chatAgents entry is also removed