### PR TITLE
feat(augment): add createdBy field and scope My Agents to current user

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
@@ -177,6 +177,7 @@ export function registerAgentRoutes(
         version: cfg?.version ?? 0,
         promotedAt: cfg?.promotedAt,
         promotedBy: cfg?.promotedBy,
+        createdBy: cfg?.createdBy,
       };
     }
 

--- a/workspaces/augment/plugins/augment-common/report.api.md
+++ b/workspaces/augment/plugins/augment-common/report.api.md
@@ -257,6 +257,7 @@ export interface ChatAgent {
   agentRole?: AgentRole;
   avatarUrl?: string;
   createdAt?: string;
+  createdBy?: string;
   description?: string;
   framework?: string;
   id: string;
@@ -281,6 +282,7 @@ export interface ChatAgentConfig {
   agentId: string;
   avatarUrl?: string;
   conversationStarters?: string[];
+  createdBy?: string;
   description?: string;
   displayName?: string;
   featured: boolean;

--- a/workspaces/augment/plugins/augment-common/src/types/shared.ts
+++ b/workspaces/augment/plugins/augment-common/src/types/shared.ts
@@ -404,6 +404,8 @@ export interface ChatAgentConfig {
   greeting?: string;
   /** Suggested prompts shown on the agent card and below the input */
   conversationStarters?: string[];
+  /** User ref of who originally created this agent config entry */
+  createdBy?: string;
 }
 
 /**
@@ -614,6 +616,8 @@ export interface ChatAgent {
   promotedBy?: string;
   /** Role of this agent in the orchestration topology */
   agentRole?: AgentRole;
+  /** User ref of who originally created this agent */
+  createdBy?: string;
 }
 
 /**

--- a/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
+++ b/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
@@ -25,7 +25,7 @@ import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import { useTheme, alpha } from '@mui/material/styles';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, identityApiRef } from '@backstage/core-plugin-api';
 import type {
   ChatAgent,
   KagentiToolSummary,
@@ -70,6 +70,15 @@ export function MarketplacePage({
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const api = useApi(augmentApiRef);
+  const identityApi = useApi(identityApiRef);
+  const [userRef, setUserRef] = useState<string | undefined>();
+
+  useEffect(() => {
+    identityApi
+      .getBackstageIdentity()
+      .then(identity => setUserRef(identity.userEntityRef))
+      .catch(() => {});
+  }, [identityApi]);
 
   const [agents, setAgents] = useState<ChatAgent[]>([]);
   const [tools, setTools] = useState<
@@ -148,8 +157,10 @@ export function MarketplacePage({
     });
   }, [agents, search, selectedFramework]);
 
-  // My Agents: show ALL agents with their lifecycle stage visible
-  const myAgents = useMemo(() => agents, [agents]);
+  const myAgents = useMemo(
+    () => (userRef ? agents.filter(a => a.createdBy === userRef) : agents),
+    [agents, userRef],
+  );
 
   // Tools catalog: only deployed/published tools
   const exploreTools = useMemo(


### PR DESCRIPTION
## Summary

- Adds `createdBy` field to `ChatAgentConfig` and `ChatAgent` types
- Backend's `overlayConfig` now includes `createdBy` in the unified agent list
- Marketplace's "My Agents" tab now filters to show only agents created by the current user
- Gracefully falls back to showing all agents if user identity is unavailable

Part of the Agent Lifecycle Governance Epic (#3208).

## Test plan

- [ ] Create an agent as user A, verify it appears in user A's "My Agents" tab
- [ ] Log in as user B, verify user A's agent does NOT appear in user B's "My Agents" tab
- [ ] Both users should see all agents in the "Explore" tab
- [ ] If identity API is unavailable, all agents should show in "My Agents" as fallback