### PR TITLE
fix: wire syncWorkflowToChatAgents on workflow publish

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/routes/workflow/versions.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/workflow/versions.ts
@@ -76,13 +76,13 @@ export function registerVersionRoutes(
         const user = await getUserRef(req);
         const { changelog } = req.body as { changelog?: string };
         try {
-          res.json(
-            await workflowService.publishWorkflow(
-              req.params.id,
-              user,
-              changelog,
-            ),
+          const version = await workflowService.publishWorkflow(
+            req.params.id,
+            user,
+            changelog,
           );
+          await workflowService.syncWorkflowToChatAgents(req.params.id, user);
+          res.json(version);
         } catch (err) {
           if (err instanceof NotFoundError) {
             notFound(res, 'Workflow');

--- a/workspaces/augment/plugins/augment-backend/src/services/WorkflowConfigService.ts
+++ b/workspaces/augment/plugins/augment-backend/src/services/WorkflowConfigService.ts
@@ -284,30 +284,31 @@ export class WorkflowConfigService {
 
     for (const node of agentNodes) {
       const data = node.data as Record<string, unknown>;
-      const agentId = `wf_${workflowId}_${node.id}`;
+      const agentId = `wf/${workflowId}/${node.id}`;
       workflowAgentIds.add(agentId);
 
-      const lifecycleStage =
-        workflow.status === 'published' ? 'production' : 'draft';
+      const isPublished = workflow.status === 'published';
+      const lifecycleStage = isPublished ? 'production' : 'draft';
 
-      const chatAgent = {
-        id: agentId,
-        name: (data.name as string) || node.id,
-        description: (data.handoffDescription as string) || '',
-        model: (data.model as string) || workflow.settings.defaultModel,
+      const chatAgentEntry: Record<string, unknown> = {
+        agentId,
+        published: isPublished,
+        visible: isPublished,
+        featured: false,
         lifecycleStage,
-        workflowId: workflow.id,
-        workflowVersion: workflow.version,
-        workflowNodeId: node.id,
+        version: workflow.version ?? 0,
+        displayName: (data.name as string) || node.id,
+        description: (data.handoffDescription as string) || '',
+        createdBy: user,
       };
 
       const idx = existingAgents.findIndex(
-        a => (a as Record<string, unknown>).id === agentId,
+        a => (a as Record<string, unknown>).agentId === agentId,
       );
       if (idx >= 0) {
-        existingAgents[idx] = chatAgent;
+        existingAgents[idx] = { ...existingAgents[idx], ...chatAgentEntry };
       } else {
-        existingAgents.push(chatAgent);
+        existingAgents.push(chatAgentEntry);
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes the dead `syncWorkflowToChatAgents` method in `WorkflowConfigService` which was never invoked
- Corrects schema mismatch: the method was producing objects with `id`/`name`/`model` fields but `ChatAgentConfig` expects `agentId`/`displayName` plus required `published`/`visible`/`featured` booleans
- Wires the sync call into the `POST /workflows/:id/publish` route so workflow agent nodes automatically appear in the chat agent catalog upon publish

Part of Epic #3208

## Test plan
- [ ] Create a workflow with agent nodes and publish it
- [ ] Verify chatAgents config contains entries for each agent node with correct `agentId` format (`wf/<workflowId>/<nodeId>`)
- [ ] Verify published workflow agents appear in the agent gallery
- [ ] Verify re-publishing updates existing entries rather than creating duplicates