### PR TITLE
fix: scope GET /agents to hide other users' non-production agents

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
@@ -177,6 +177,7 @@ export function registerAgentRoutes(
         version: cfg?.version ?? 0,
         promotedAt: cfg?.promotedAt,
         promotedBy: cfg?.promotedBy,
+        createdBy: cfg?.createdBy,
       };
     }
 
@@ -236,10 +237,18 @@ export function registerAgentRoutes(
       const { agents, sources } = await buildUnifiedAgentList();
       const publishedFilter = req.query.published;
 
-      const filtered =
+      let filtered =
         publishedFilter === 'true'
           ? agents.filter(a => a.published === true)
           : agents;
+
+      const isAdmin = await ctx.checkIsAdmin(req);
+      if (!isAdmin) {
+        const userRef = await ctx.getUserRef(req);
+        filtered = filtered.filter(
+          a => a.published === true || a.createdBy === userRef,
+        );
+      }
 
       res.json({ agents: filtered, sources });
     }),

--- a/workspaces/augment/plugins/augment-common/report.api.md
+++ b/workspaces/augment/plugins/augment-common/report.api.md
@@ -257,6 +257,7 @@ export interface ChatAgent {
   agentRole?: AgentRole;
   avatarUrl?: string;
   createdAt?: string;
+  createdBy?: string;
   description?: string;
   framework?: string;
   id: string;
@@ -281,6 +282,7 @@ export interface ChatAgentConfig {
   agentId: string;
   avatarUrl?: string;
   conversationStarters?: string[];
+  createdBy?: string;
   description?: string;
   displayName?: string;
   featured: boolean;

--- a/workspaces/augment/plugins/augment-common/src/types/shared.ts
+++ b/workspaces/augment/plugins/augment-common/src/types/shared.ts
@@ -404,6 +404,8 @@ export interface ChatAgentConfig {
   greeting?: string;
   /** Suggested prompts shown on the agent card and below the input */
   conversationStarters?: string[];
+  /** User ref of who originally created this agent config entry */
+  createdBy?: string;
 }
 
 /**
@@ -614,6 +616,8 @@ export interface ChatAgent {
   promotedBy?: string;
   /** Role of this agent in the orchestration topology */
   agentRole?: AgentRole;
+  /** User ref of who originally created this agent */
+  createdBy?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Non-admin users could previously see ALL agents including other users' drafts via `GET /agents`
- Now filters non-admin responses to only include **production agents** plus the **caller's own agents** (matched via `createdBy`)
- Adds `createdBy` field to `ChatAgentConfig` and `ChatAgent` interfaces
- Surfaces `createdBy` through `overlayConfig` in the unified agent list
- Admins continue to see all agents regardless

Part of Epic #3208

## Test plan
- [ ] Non-admin user calls `GET /agents` -- should see only production agents + their own drafts
- [ ] Admin user calls `GET /agents` -- should see all agents
- [ ] `GET /agents?published=true` still works for both roles