### PR TITLE
fix: add ownership checks to promote and delete agent routes

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
@@ -299,6 +299,18 @@ export function registerAgentRoutes(
             });
             return;
           }
+        } else {
+          const isAdmin = await ctx.checkIsAdmin(req);
+          if (
+            !isAdmin &&
+            existing?.createdBy &&
+            existing.createdBy !== userRef
+          ) {
+            res.status(403).json({
+              error: 'You can only submit your own agents for review.',
+            });
+            return;
+          }
         }
 
         const now = new Date().toISOString();
@@ -426,6 +438,55 @@ export function registerAgentRoutes(
         });
         logger.info(`Agent "${agentId}" demoted to ${nextStage} by ${userRef}`);
         res.json({ success: true, agentId, lifecycleStage: nextStage });
+      },
+    ),
+  );
+
+  // ---------------------------------------------------------------------------
+  // DELETE /agents/:agentId -- remove a draft agent's config entry
+  // Non-admin callers can only delete agents they created.
+  // ---------------------------------------------------------------------------
+  router.delete(
+    '/agents/:agentId',
+    withRoute(
+      'DELETE /agents/:agentId',
+      'Failed to delete agent',
+      async (req, res) => {
+        const agentId = decodeURIComponent(req.params.agentId);
+        const userRef = await ctx.getUserRef(req);
+        const configs = await loadChatAgentConfigs();
+        const existing = configs.find(c => c.agentId === agentId);
+
+        if (!existing) {
+          throw new InputError(`Agent "${agentId}" not found in config.`);
+        }
+
+        const stage = normalizeLifecycleStage(existing.lifecycleStage);
+        if (stage !== 'draft') {
+          throw new InputError(
+            `Only draft agents can be deleted. Agent "${agentId}" is in stage "${stage}".`,
+          );
+        }
+
+        const isAdmin = await ctx.checkIsAdmin(req);
+        if (!isAdmin && existing.createdBy && existing.createdBy !== userRef) {
+          res.status(403).json({
+            error: 'You can only delete your own agents.',
+          });
+          return;
+        }
+
+        const updated = configs.filter(c => c.agentId !== agentId);
+        await saveChatAgentConfigs(updated, userRef);
+        audit.log({
+          action: 'agent.delete',
+          actor: userRef,
+          target: agentId,
+          outcome: 'success',
+          sourceIp: AuditLogger.extractIp(req),
+        });
+        logger.info(`Draft agent "${agentId}" deleted by ${userRef}`);
+        res.json({ success: true, agentId });
       },
     ),
   );

--- a/workspaces/augment/plugins/augment-backend/src/services/AuditLogger.ts
+++ b/workspaces/augment/plugins/augment-backend/src/services/AuditLogger.ts
@@ -25,6 +25,7 @@ export type AuditAction =
   | 'tool.approval'
   | 'tool.lifecycle'
   | 'agent.lifecycle'
+  | 'agent.delete'
   | 'document.upload'
   | 'document.delete'
   | 'admin.login';

--- a/workspaces/augment/plugins/augment-common/report.api.md
+++ b/workspaces/augment/plugins/augment-common/report.api.md
@@ -257,6 +257,7 @@ export interface ChatAgent {
   agentRole?: AgentRole;
   avatarUrl?: string;
   createdAt?: string;
+  createdBy?: string;
   description?: string;
   framework?: string;
   id: string;
@@ -281,6 +282,7 @@ export interface ChatAgentConfig {
   agentId: string;
   avatarUrl?: string;
   conversationStarters?: string[];
+  createdBy?: string;
   description?: string;
   displayName?: string;
   featured: boolean;

--- a/workspaces/augment/plugins/augment-common/src/types/shared.ts
+++ b/workspaces/augment/plugins/augment-common/src/types/shared.ts
@@ -404,6 +404,8 @@ export interface ChatAgentConfig {
   greeting?: string;
   /** Suggested prompts shown on the agent card and below the input */
   conversationStarters?: string[];
+  /** User ref of who originally created this agent config entry */
+  createdBy?: string;
 }
 
 /**

--- a/workspaces/augment/plugins/augment/report.api.md
+++ b/workspaces/augment/plugins/augment/report.api.md
@@ -162,6 +162,7 @@ export interface AugmentApi {
   createVectorStore(
     config?: Record<string, unknown>,
   ): Promise<VectorStoreCreateResult>;
+  deleteAgentConfig(agentId: string): Promise<void>;
   deleteAdminConfig(key: AdminConfigKey): Promise<{
     deleted: boolean;
   }>;

--- a/workspaces/augment/plugins/augment/src/api/AugmentApi.ts
+++ b/workspaces/augment/plugins/augment/src/api/AugmentApi.ts
@@ -115,6 +115,11 @@ export interface AugmentApi {
   ): Promise<void>;
 
   /**
+   * Delete a draft agent's configuration entry.
+   */
+  deleteAgentConfig(agentId: string): Promise<void>;
+
+  /**
    * List tools with lifecycle overlay in a provider-agnostic format.
    */
   listToolsWithLifecycle(options?: { published?: boolean }): Promise<
@@ -804,6 +809,12 @@ export class AugmentApiClient implements AugmentApi {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(config),
+    });
+  }
+
+  async deleteAgentConfig(agentId: string): Promise<void> {
+    await this.fetchJson(`/agents/${encodeURIComponent(agentId)}`, {
+      method: 'DELETE',
     });
   }
 


### PR DESCRIPTION
## Summary
- On `draft→review` promote: verifies `createdBy` matches caller for non-admins, preventing users from submitting other people's drafts for review
- Adds `DELETE /agents/:agentId` route that only allows deletion of draft agents, with ownership verification for non-admin callers (admins can delete any draft)
- Adds `deleteAgentConfig` to frontend `AugmentApi` interface and implementation
- Adds `createdBy` field to `ChatAgentConfig` type (prerequisite for ownership checks)
- Returns 403 with clear error messages: "You can only submit/delete your own agents"

Part of Epic #3208

## Test plan
- [ ] Non-admin user attempts to promote another user's draft → gets 403
- [ ] Non-admin user promotes their own draft → succeeds
- [ ] Non-admin user attempts to delete another user's draft → gets 403
- [ ] Non-admin user deletes their own draft → succeeds
- [ ] Admin can promote/delete any agent regardless of ownership
- [ ] Attempting to delete a non-draft agent → gets InputError