### PR TITLE
fix: auto-switch to My Agents tab after creation and fix intent dialog reopen

### DIFF
--- a/workspaces/augment/plugins/augment/src/components/AugmentPage/ChatView.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AugmentPage/ChatView.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useCallback, useEffect, type Ref } from 'react';
+import { useState, useCallback, useEffect, useRef, type Ref } from 'react';
 import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
@@ -97,6 +97,8 @@ export function ChatView({
   const [currentAgent, setCurrentAgent] = useState<string | undefined>();
   const [showMarketplace, setShowMarketplace] = useState(true);
   const [marketplaceRefreshKey, setMarketplaceRefreshKey] = useState(0);
+  const [switchToMyAgents, setSwitchToMyAgents] = useState(0);
+  const justCreatedRef = useRef(false);
 
   // Agent creation state (all dialogs live in the front door)
   const [intentDialogOpen, setIntentDialogOpen] = useState(false);
@@ -201,6 +203,10 @@ export function ChatView({
   const handleWizardBack = useCallback(() => {
     setWizardOpen(false);
     setWizardDeployMethod(undefined);
+    if (justCreatedRef.current) {
+      justCreatedRef.current = false;
+      return;
+    }
     setIntentDialogOpen(true);
   }, []);
 
@@ -236,12 +242,14 @@ export function ChatView({
   }, []);
 
   const handleAgentCreated = useCallback(() => {
+    justCreatedRef.current = true;
     setWizardOpen(false);
     setWizardDeployMethod(undefined);
     setCreateSuccess(
       'Agent created successfully! It will appear in your agents list.',
     );
     setMarketplaceRefreshKey(k => k + 1);
+    setSwitchToMyAgents(k => k + 1);
   }, []);
 
   // --- Tool Creation Flow ---
@@ -322,6 +330,7 @@ export function ChatView({
               onOpenCommandCenter={handleSwitchToAdmin}
               onOpenGuidedTour={handleOpenGuidedTour}
               refreshKey={marketplaceRefreshKey}
+              switchToMyAgentsKey={switchToMyAgents}
             />
           </Box>
         )}

--- a/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
+++ b/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
@@ -50,6 +50,8 @@ interface MarketplacePageProps {
   onOpenCommandCenter?: () => void;
   onOpenGuidedTour?: () => void;
   refreshKey?: number;
+  /** When this key changes, automatically switch to the My Agents tab */
+  switchToMyAgentsKey?: number;
 }
 
 /**
@@ -66,6 +68,7 @@ export function MarketplacePage({
   onOpenCommandCenter,
   onOpenGuidedTour,
   refreshKey,
+  switchToMyAgentsKey,
 }: MarketplacePageProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
@@ -119,6 +122,12 @@ export function MarketplacePage({
       cancelled = true;
     };
   }, [api, refreshKey]);
+
+  useEffect(() => {
+    if (switchToMyAgentsKey && switchToMyAgentsKey > 0) {
+      setActiveTab('my-agents');
+    }
+  }, [switchToMyAgentsKey]);
 
   const frameworks = useMemo(() => {
     const set = new Set<string>();


### PR DESCRIPTION
## Summary
- After creating an agent, the Marketplace now auto-switches to the "My Agents" tab so the user immediately sees their new draft agent
- Fixes the intent dialog reopening after image-deploy: the wizard's `onClose` (`handleWizardBack`) was triggering `setIntentDialogOpen(true)` even after `onCreated` had already closed the wizard. A ref now suppresses the reopen.
- Adds `switchToMyAgentsKey` prop to `MarketplacePage` to allow external tab control

Part of Epic #3208

## Test plan
- [ ] Create an agent via image deploy → wizard closes, marketplace switches to My Agents tab
- [ ] Create an agent via source deploy → same behavior after build completes
- [ ] Intent dialog does NOT reopen after creation completes
- [ ] Clicking "Back" in wizard (without creating) still returns to intent dialog