### PR TITLE
feat: add polling refresh to ReviewQueue and OpsOverview

### DIFF
--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/OpsOverview.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/OpsOverview.tsx
@@ -56,25 +56,30 @@ export function OpsOverview({ namespace, onNavigate }: OpsOverviewProps) {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    Promise.all([
-      api.listAgents().catch(() => []),
-      api
-        .listKagentiTools(namespace)
-        .then(r => r.tools ?? [])
-        .catch(() => []),
-    ])
-      .then(([a, t]) => {
-        if (!cancelled) {
-          setAgents(a as ChatAgent[]);
-          setTools(t);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+    const load = () => {
+      setLoading(true);
+      Promise.all([
+        api.listAgents().catch(() => []),
+        api
+          .listKagentiTools(namespace)
+          .then(r => r.tools ?? [])
+          .catch(() => []),
+      ])
+        .then(([a, t]) => {
+          if (!cancelled) {
+            setAgents(a as ChatAgent[]);
+            setTools(t);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+    load();
+    const interval = setInterval(load, 30_000);
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
   }, [api, namespace]);
 

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/ReviewQueue.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/ReviewQueue.tsx
@@ -59,6 +59,8 @@ export function ReviewQueue() {
 
   useEffect(() => {
     loadAgents();
+    const interval = setInterval(loadAgents, 30_000);
+    return () => clearInterval(interval);
   }, [loadAgents]);
 
   const handleApprove = useCallback(


### PR DESCRIPTION
## Summary
- **ReviewQueue** now polls every 30 seconds for fresh agent data, so new review submissions appear without manual refresh
- **OpsOverview** queue count badge also refreshes every 30 seconds
- Previously both components fetched data once on mount and went stale until the admin navigated away and back
- The backend audit event for `draft→review` transitions is already emitted (added in earlier PRs)

Part of Epic #3208. Final PR in the Bulletproof Agent Lifecycle series.

## Test plan
- [ ] Open ReviewQueue → submit an agent for review from another tab → verify it appears within 30s
- [ ] Open OpsOverview → submit an agent → verify the queue count updates within 30s
- [ ] Verify no excessive API calls (only every 30s)
- [ ] Verify cleanup on unmount (no interval leaks)