### PR TITLE
feat(augment): Phase 3 - admin dashboard polling without loading flash

### DIFF
--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/OpsOverview.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/OpsOverview.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import { useTheme, alpha } from '@mui/material/styles';
@@ -53,30 +53,34 @@ export function OpsOverview({ namespace, onNavigate }: OpsOverviewProps) {
   const [agents, setAgents] = useState<ChatAgent[]>([]);
   const [tools, setTools] = useState<KagentiToolSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const initialLoadDone = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
+  const loadData = useCallback(() => {
+    if (!initialLoadDone.current) {
+      setLoading(true);
+    }
     Promise.all([
-      api.listAgents().catch(() => []),
+      api.listAgents().catch(() => [] as ChatAgent[]),
       api
         .listKagentiTools(namespace)
         .then(r => r.tools ?? [])
-        .catch(() => []),
+        .catch(() => [] as KagentiToolSummary[]),
     ])
       .then(([a, t]) => {
-        if (!cancelled) {
-          setAgents(a as ChatAgent[]);
-          setTools(t);
-        }
+        setAgents(a);
+        setTools(t);
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        initialLoadDone.current = true;
+        setLoading(false);
       });
-    return () => {
-      cancelled = true;
-    };
   }, [api, namespace]);
+
+  useEffect(() => {
+    loadData();
+    const interval = setInterval(loadData, 30_000);
+    return () => clearInterval(interval);
+  }, [loadData]);
 
   const stats = useMemo(() => {
     const total = agents.length;

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/ReviewQueue.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/ReviewQueue.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -54,19 +54,28 @@ export function ReviewQueue() {
   const [rejectAgentId, setRejectAgentId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
 
+  const initialLoadDone = useRef(false);
+
   const loadAgents = useCallback(() => {
-    setLoading(true);
+    if (!initialLoadDone.current) {
+      setLoading(true);
+    }
     api
       .listAgents()
       .then(result =>
         setAgents(result.filter(a => a.lifecycleStage === 'review')),
       )
       .catch(() => {})
-      .finally(() => setLoading(false));
+      .finally(() => {
+        initialLoadDone.current = true;
+        setLoading(false);
+      });
   }, [api]);
 
   useEffect(() => {
     loadAgents();
+    const interval = setInterval(loadAgents, 30_000);
+    return () => clearInterval(interval);
   }, [loadAgents]);
 
   const handleApprove = useCallback(


### PR DESCRIPTION
## Summary

Phase 3 of the Deep-Dive Lifecycle Hardening plan. Adds 30-second polling to admin dashboards for real-time visibility. Depends on Phase 2 (PR #3223).

### Changes

**ReviewQueue**
- Added 30-second polling interval for automatic refresh of review queue agents
- Only shows loading skeleton on initial load, not on subsequent polls (fixes the flash)

**OpsOverview**
- Added 30-second polling interval for agent and tool data refresh
- Same loading flash fix: initial load shows skeleton, polls update silently

### Key fix
The previous PR G implementation called `setLoading(true)` on every poll cycle, causing a jarring skeleton flash every 30 seconds. This PR uses an `initialLoadDone` ref to ensure loading state is only shown on the first fetch.

## Test plan

- [ ] ReviewQueue refreshes automatically every 30 seconds
- [ ] OpsOverview refreshes automatically every 30 seconds
- [ ] Initial load shows loading skeleton
- [ ] Subsequent polls do NOT show loading skeleton (no flash)