### PR TITLE
refactor(lightspeed): add middleware for resolving user identity

### DIFF
--- a/workspaces/lightspeed/.changeset/nasty-vans-film.md
+++ b/workspaces/lightspeed/.changeset/nasty-vans-film.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
+---
+
+add middleware for identity resolution

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/express.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/express.d.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BackstageCredentials } from '@backstage/backend-plugin-api';
+
+// Populated by the identity middleware for use in route handlers.
+declare module 'express-serve-static-core' {
+  interface Request {
+    credentials?: BackstageCredentials;
+    userEntityRef?: string;
+  }
+}

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Request } from 'express';
+
+import { getIdentity } from './getIdentity';
+
+describe('getIdentity', () => {
+  it('returns credentials and userEntityRef when both are set', () => {
+    const req = {
+      credentials: { $$type: '@backstage/BackstageCredentials' },
+      userEntityRef: 'user:default/guest',
+    } as unknown as Request;
+
+    const result = getIdentity(req);
+
+    expect(result.credentials).toBe(req.credentials);
+    expect(result.userEntityRef).toBe('user:default/guest');
+  });
+
+  it('throws when credentials is missing', () => {
+    const req = {
+      userEntityRef: 'user:default/guest',
+    } as unknown as Request;
+
+    expect(() => getIdentity(req)).toThrow('Identity middleware did not run');
+  });
+
+  it('throws when userEntityRef is missing', () => {
+    const req = {
+      credentials: { $$type: '@backstage/BackstageCredentials' },
+    } as unknown as Request;
+
+    expect(() => getIdentity(req)).toThrow('Identity middleware did not run');
+  });
+
+  it('throws when both credentials and userEntityRef are missing', () => {
+    const req = {} as unknown as Request;
+
+    expect(() => getIdentity(req)).toThrow('Identity middleware did not run');
+  });
+});

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.ts
@@ -20,7 +20,7 @@ import type {
   LoggerService,
   UserInfoService,
 } from '@backstage/backend-plugin-api';
-import { NotAllowedError } from '@backstage/errors';
+import { AuthenticationError, NotAllowedError } from '@backstage/errors';
 
 import type { Request, RequestHandler } from 'express';
 
@@ -48,12 +48,15 @@ export function createIdentityMiddleware(
       req.userEntityRef = user.userEntityRef;
       return next();
     } catch (error) {
-      logger.error('Identity resolution failed for request');
+      logger.error('Identity resolution failed for request', error);
 
       if (error instanceof NotAllowedError) {
         return res.status(403).json({ error: 'Forbidden' });
       }
-      return res.status(401).json({ error: 'Unauthorized' });
+      if (error instanceof AuthenticationError) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
   };
 }

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  BackstageCredentials,
+  HttpAuthService,
+  LoggerService,
+  UserInfoService,
+} from '@backstage/backend-plugin-api';
+
+import type { Request, RequestHandler } from 'express';
+
+/**
+ * Creates an Express middleware that resolves Backstage identity once per
+ * request and attaches `req.credentials` and `req.userEntityRef`.
+ *
+ * A guard check skips resolution if both fields are already populated,
+ * making it safe for multiple routers to apply independently.
+ */
+export function createIdentityMiddleware(
+  httpAuth: HttpAuthService,
+  userInfo: UserInfoService,
+  logger: LoggerService,
+): RequestHandler {
+  return async (req, res, next) => {
+    if (req.credentials && req.userEntityRef) {
+      return next();
+    }
+
+    try {
+      const credentials = await httpAuth.credentials(req);
+      const user = await userInfo.getUserInfo(credentials);
+      req.credentials = credentials;
+      req.userEntityRef = user.userEntityRef;
+      return next();
+    } catch (error) {
+      logger.error('Identity resolution failed for request');
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  };
+}
+
+/**
+ * Extracts identity fields from the request, narrowing the types.
+ * Throws if the identity middleware has not run.
+ */
+export function getIdentity(req: Request): {
+  credentials: BackstageCredentials;
+  userEntityRef: string;
+} {
+  if (!req.credentials || !req.userEntityRef) {
+    throw new Error(
+      'Identity middleware did not run — credentials/userEntityRef missing on request',
+    );
+  }
+  return { credentials: req.credentials, userEntityRef: req.userEntityRef };
+}

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/middleware/getIdentity.ts
@@ -20,6 +20,7 @@ import type {
   LoggerService,
   UserInfoService,
 } from '@backstage/backend-plugin-api';
+import { NotAllowedError } from '@backstage/errors';
 
 import type { Request, RequestHandler } from 'express';
 
@@ -48,6 +49,10 @@ export function createIdentityMiddleware(
       return next();
     } catch (error) {
       logger.error('Identity resolution failed for request');
+
+      if (error instanceof NotAllowedError) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
       return res.status(401).json({ error: 'Unauthorized' });
     }
   };

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouter.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouter.test.ts
@@ -33,6 +33,7 @@ const mockUserId = 'user:default/guest';
 describe('Notebooks Router', () => {
   const server = setupServer(...lightspeedCoreHandlers);
   let app: express.Application;
+  let httpAuth: ReturnType<typeof mockServices.httpAuth>;
 
   beforeAll(() => {
     // Only intercept Llama Stack requests, bypass local Express app requests
@@ -76,7 +77,7 @@ describe('Notebooks Router', () => {
       },
     });
 
-    const httpAuth = mockServices.httpAuth();
+    httpAuth = mockServices.httpAuth();
     const userInfo = mockServices.userInfo.mock({
       getUserInfo: async () => ({
         userEntityRef: mockUserId,
@@ -359,7 +360,7 @@ describe('Notebooks Router', () => {
         },
       });
 
-      const httpAuth = mockServices.httpAuth();
+      const deniedHttpAuth = mockServices.httpAuth();
       const userInfo = mockServices.userInfo.mock({
         getUserInfo: async () => ({
           userEntityRef: mockUserId,
@@ -373,7 +374,7 @@ describe('Notebooks Router', () => {
       const router = await createNotebooksRouter({
         logger,
         config,
-        httpAuth,
+        httpAuth: deniedHttpAuth,
         userInfo,
         permissions,
       });
@@ -449,6 +450,23 @@ describe('Notebooks Router', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.error).toBe('query is required');
+    });
+  });
+
+  describe('Identity Deduplication', () => {
+    it('should resolve identity only once for chained middleware route', async () => {
+      const credentialsSpy = jest.spyOn(httpAuth, 'credentials');
+
+      const createRes = await request(app)
+        .post('/notebooks/v1/sessions')
+        .send({ name: 'Dedup Test' });
+      const sessionId = createRes.body.session.session_id;
+
+      credentialsSpy.mockClear();
+
+      await request(app).get(`/notebooks/v1/sessions/${sessionId}/documents`);
+
+      expect(credentialsSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouter.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouter.test.ts
@@ -334,6 +334,95 @@ describe('Notebooks Router', () => {
     });
   });
 
+  describe('Permission Denied (403)', () => {
+    let deniedApp: express.Application;
+
+    beforeEach(async () => {
+      const logger = mockServices.logger.mock();
+      const config = mockServices.rootConfig({
+        data: {
+          lightspeed: {
+            servicePort: 7007,
+            notebooks: {
+              enabled: true,
+              queryDefaults: {
+                model: 'test-model',
+                provider_id: 'test-provider',
+              },
+              sessionDefaults: {
+                provider_id: 'test-notebooks',
+                embedding_model: 'test-embedding-model',
+                embedding_dimension: 768,
+              },
+            },
+          },
+        },
+      });
+
+      const httpAuth = mockServices.httpAuth();
+      const userInfo = mockServices.userInfo.mock({
+        getUserInfo: async () => ({
+          userEntityRef: mockUserId,
+          ownershipEntityRefs: [mockUserId],
+        }),
+      });
+      const permissions = mockServices.permissions.mock({
+        authorize: async () => [{ result: AuthorizeResult.DENY }],
+      });
+
+      const router = await createNotebooksRouter({
+        logger,
+        config,
+        httpAuth,
+        userInfo,
+        permissions,
+      });
+
+      deniedApp = express();
+      deniedApp.use(router);
+    });
+
+    it('POST /v1/sessions returns 403', async () => {
+      const response = await request(deniedApp)
+        .post('/notebooks/v1/sessions')
+        .send({ name: 'Test Session' });
+
+      expect(response.status).toBe(403);
+    });
+
+    it('GET /v1/sessions returns 403', async () => {
+      const response = await request(deniedApp).get('/notebooks/v1/sessions');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('GET /v1/sessions/:sessionId returns 403', async () => {
+      const response = await request(deniedApp).get(
+        '/notebooks/v1/sessions/some-session-id',
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it('PUT /v1/sessions/:sessionId/documents returns 403', async () => {
+      const response = await request(deniedApp)
+        .put('/notebooks/v1/sessions/some-session-id/documents')
+        .field('title', 'Test')
+        .field('fileType', 'txt')
+        .attach('file', Buffer.from('Content'), 'test.txt');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('POST /v1/sessions/:sessionId/query returns 403', async () => {
+      const response = await request(deniedApp)
+        .post('/notebooks/v1/sessions/some-session-id/query')
+        .send({ query: 'What is this about?' });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
   describe('Query Endpoint', () => {
     let sessionId: string;
 

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -37,6 +37,10 @@ import {
   NOTEBOOKS_SYSTEM_PROMPT,
   upload,
 } from '../constant';
+import {
+  createIdentityMiddleware,
+  getIdentity,
+} from '../middleware/getIdentity';
 import { userPermissionAuthorization } from '../permission';
 import { isValidFileType, parseFileContent } from './documents/documentHelpers';
 import { DocumentService } from './documents/documentService';
@@ -94,19 +98,13 @@ export async function createNotebooksRouter(
 
   const authorizer = userPermissionAuthorization(permissions);
 
-  const getUserId = async (req: any): Promise<string> => {
-    const credentials = await httpAuth.credentials(req);
-    const user = await userInfo.getUserInfo(credentials);
-    return user.userEntityRef;
-  };
-
   const requireNotebooksPermission = async (
     req: any,
     res: any,
     next: any,
   ): Promise<void> => {
     try {
-      const credentials = await httpAuth.credentials(req);
+      const { credentials } = getIdentity(req);
       await authorizer.authorizeUser(
         lightspeedNotebooksUsePermission,
         credentials,
@@ -120,9 +118,9 @@ export async function createNotebooksRouter(
   const requireSessionOwnership =
     () => async (req: any, res: any, next: any) => {
       try {
+        const { userEntityRef } = getIdentity(req);
         const { sessionId } = req.params;
-        const userId = await getUserId(req);
-        await sessionService.readSession(sessionId, userId);
+        await sessionService.readSession(sessionId, userEntityRef);
         next();
       } catch (error) {
         handleError(
@@ -138,8 +136,8 @@ export async function createNotebooksRouter(
     (handler: (req: any, res: any, userId: string) => Promise<void>) =>
     async (req: any, res: any, next: any) => {
       try {
-        const userId = await getUserId(req);
-        await handler(req, res, userId);
+        const { userEntityRef } = getIdentity(req);
+        await handler(req, res, userEntityRef);
       } catch (error) {
         next(error);
       }
@@ -262,6 +260,10 @@ export async function createNotebooksRouter(
   };
 
   notebooksRouter.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  notebooksRouter.use(
+    '/v1',
+    createIdentityMiddleware(httpAuth, userInfo, logger),
+  );
   notebooksRouter.use('/v1', requireNotebooksPermission);
 
   notebooksRouter.post(

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -748,6 +748,86 @@ describe('lightspeed router tests', () => {
     });
   });
 
+  describe('GET /notebook-conversation-ids', () => {
+    it('returns conversation IDs for the authenticated user', async () => {
+      rcs.use(
+        http.get(`${LOCAL_LCS_ADDR}/v1/vector-stores`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 'vs-1',
+                name: 'session-1',
+                metadata: {
+                  user_id: mockUserId,
+                  conversation_id: 'conv-abc',
+                },
+              },
+              {
+                id: 'vs-2',
+                name: 'session-2',
+                metadata: {
+                  user_id: mockUserId,
+                  conversation_id: 'conv-def',
+                },
+              },
+              {
+                id: 'vs-3',
+                name: 'other-user-session',
+                metadata: {
+                  user_id: 'user:default/other',
+                  conversation_id: 'conv-other',
+                },
+              },
+              {
+                id: 'vs-4',
+                name: 'no-conv-id',
+                metadata: {
+                  user_id: mockUserId,
+                  conversation_id: null,
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      const backendServer = await startBackendServer();
+      const response = await request(backendServer).get(
+        '/api/lightspeed/notebook-conversation-ids',
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.conversation_ids).toEqual(['conv-abc', 'conv-def']);
+    });
+
+    it('returns empty array when user has no notebook sessions', async () => {
+      rcs.use(
+        http.get(`${LOCAL_LCS_ADDR}/v1/vector-stores`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 'vs-1',
+                name: 'other-session',
+                metadata: {
+                  user_id: 'user:default/other',
+                  conversation_id: 'conv-other',
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      const backendServer = await startBackendServer();
+      const response = await request(backendServer).get(
+        '/api/lightspeed/notebook-conversation-ids',
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.conversation_ids).toEqual([]);
+    });
+  });
+
   describe('proxy path allowlist', () => {
     it('should return 404 for non-allowlisted path /v1/admin', async () => {
       const backendServer = await startBackendServer();

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -44,6 +44,10 @@ import {
   McpValidationResult,
 } from './mcp-server-types';
 import { McpServerValidator } from './mcp-server-validator';
+import {
+  createIdentityMiddleware,
+  getIdentity,
+} from './middleware/getIdentity';
 import { VectorStoresOperator } from './notebooks/VectorStoresOperator';
 import { userPermissionAuthorization } from './permission';
 import { createTokenEncryptor } from './token-encryption';
@@ -185,6 +189,20 @@ export async function createRouter(
   });
   router.use(permissionIntegrationRouter);
 
+  const identityMiddleware = createIdentityMiddleware(
+    httpAuth,
+    userInfo,
+    logger,
+  );
+  router.use((req, res, next) => {
+    // Middleware mounts to notebooks router independently
+    // so we skip it here
+    if (req.path.startsWith('/notebooks')) {
+      return next();
+    }
+    return identityMiddleware(req, res, next);
+  });
+
   const authorizer = userPermissionAuthorization(permissions);
 
   // ─── MCP Server Management Endpoints ────────────────────────────────
@@ -193,11 +211,10 @@ export async function createRouter(
 
   router.get('/mcp-servers', async (req, res) => {
     try {
-      const credentials = await httpAuth.credentials(req);
+      const { credentials, userEntityRef } = getIdentity(req);
       await authorizer.authorizeUser(lightspeedMcpReadPermission, credentials);
-      const user = await userInfo.getUserInfo(credentials);
 
-      const userSettings = await settingsStore.listByUser(user.userEntityRef);
+      const userSettings = await settingsStore.listByUser(userEntityRef);
       const settingsMap = new Map(userSettings.map(s => [s.server_name, s]));
 
       const hasAllUrls = staticServers.every(s => lcsUrlCache.has(s.name));
@@ -231,7 +248,7 @@ export async function createRouter(
 
   router.post('/mcp-servers/validate', async (req, res) => {
     try {
-      const credentials = await httpAuth.credentials(req);
+      const { credentials } = getIdentity(req);
       await authorizer.authorizeUser(lightspeedMcpReadPermission, credentials);
 
       const { url, token } = req.body;
@@ -268,12 +285,11 @@ export async function createRouter(
 
   router.post('/mcp-servers/:name/validate', async (req, res) => {
     try {
-      const credentials = await httpAuth.credentials(req);
+      const { credentials, userEntityRef } = getIdentity(req);
       await authorizer.authorizeUser(
         lightspeedMcpManagePermission,
         credentials,
       );
-      const user = await userInfo.getUserInfo(credentials);
 
       const { name } = req.params;
       const server = staticServers.find(s => s.name === name);
@@ -296,7 +312,7 @@ export async function createRouter(
         return;
       }
 
-      const setting = await settingsStore.get(name, user.userEntityRef);
+      const setting = await settingsStore.get(name, userEntityRef);
       const effectiveToken = setting?.token || server.token;
       if (!effectiveToken) {
         res
@@ -310,7 +326,7 @@ export async function createRouter(
 
       await settingsStore.updateStatus(
         name,
-        user.userEntityRef,
+        userEntityRef,
         status,
         validation.toolCount,
       );
@@ -333,12 +349,11 @@ export async function createRouter(
 
   router.patch('/mcp-servers/:name', async (req, res) => {
     try {
-      const credentials = await httpAuth.credentials(req);
+      const { credentials, userEntityRef } = getIdentity(req);
       await authorizer.authorizeUser(
         lightspeedMcpManagePermission,
         credentials,
       );
-      const user = await userInfo.getUserInfo(credentials);
 
       const { name } = req.params;
       const server = staticServers.find(s => s.name === name);
@@ -366,7 +381,7 @@ export async function createRouter(
         return;
       }
 
-      const setting = await settingsStore.upsert(name, user.userEntityRef, {
+      const setting = await settingsStore.upsert(name, userEntityRef, {
         enabled: hasEnabledField ? enabled : undefined,
         token: hasTokenField ? token : undefined,
       });
@@ -384,7 +399,7 @@ export async function createRouter(
           : 'error';
         await settingsStore.updateStatus(
           name,
-          user.userEntityRef,
+          userEntityRef,
           newStatus,
           validation.toolCount,
         );
@@ -418,9 +433,7 @@ export async function createRouter(
   // Returns conversation IDs associated with notebook sessions for filtering
   router.get('/notebook-conversation-ids', async (req, res) => {
     try {
-      const credentials = await httpAuth.credentials(req);
-      const user = await userInfo.getUserInfo(credentials);
-      const userId = user.userEntityRef;
+      const { userEntityRef } = getIdentity(req);
 
       const vectorStoresPage = await vectorStoresOperator.vectorStores.list();
       const vectorStores = vectorStoresPage.data || [];
@@ -432,7 +445,7 @@ export async function createRouter(
         const conversationId = store.metadata?.conversation_id as string | null;
 
         // Only include this user's sessions with a conversation_id
-        if (sessionUserId === userId && conversationId) {
+        if (sessionUserId === userEntityRef && conversationId) {
           conversationIds.push(conversationId);
         }
       }
@@ -468,12 +481,9 @@ export async function createRouter(
       return res.status(404).json({ error: 'Requested path is not available' });
     }
 
-    // TODO: parse server_id from req.body and get URL and token when multi-server is supported
-    const credentials = await httpAuth.credentials(req);
-    const user = await userInfo.getUserInfo(credentials);
-    const userEntity = user.userEntityRef;
+    const { credentials, userEntityRef } = getIdentity(req);
 
-    logger.info(`receives call from user: ${userEntity}`);
+    logger.info(`receives call from user: ${userEntityRef}`);
     try {
       if (req.method === 'GET') {
         await authorizer.authorizeUser(
@@ -508,7 +518,7 @@ export async function createRouter(
         let newPath = path;
 
         // Add user_id
-        const userQueryParam = `user_id=${encodeURIComponent(userEntity)}`;
+        const userQueryParam = `user_id=${encodeURIComponent(userEntityRef)}`;
         newPath = path.includes('?')
           ? `${path}&${userQueryParam}`
           : `${path}?${userQueryParam}`;
@@ -533,17 +543,15 @@ export async function createRouter(
 
   router.post('/v1/feedback', async (request, response) => {
     try {
-      const credentials = await httpAuth.credentials(request);
-      const user = await userInfo.getUserInfo(credentials);
-      const user_id = user.userEntityRef;
+      const { credentials, userEntityRef } = getIdentity(request);
 
-      logger.info(`/v1/feedback receives call from user: ${user_id}`);
+      logger.info(`/v1/feedback receives call from user: ${userEntityRef}`);
 
       await authorizer.authorizeUser(
         lightspeedChatCreatePermission,
         credentials,
       );
-      const userQueryParam = `user_id=${encodeURIComponent(user_id)}`;
+      const userQueryParam = `user_id=${encodeURIComponent(userEntityRef)}`;
       const requestBody = JSON.stringify(request.body);
       const fetchResponse = await fetch(
         `${lightspeedCoreBaseUrl}/v1/feedback?${userQueryParam}`,
@@ -585,14 +593,12 @@ export async function createRouter(
 
   router.post('/v1/query/interrupt', async (request, response) => {
     try {
-      const credentials = await httpAuth.credentials(request);
-      const userEntity = await userInfo.getUserInfo(credentials);
-      const user_id = userEntity.userEntityRef;
+      const { credentials, userEntityRef } = getIdentity(request);
       await authorizer.authorizeUser(
         lightspeedChatCreatePermission,
         credentials,
       );
-      const userQueryParam = `user_id=${encodeURIComponent(user_id)}`;
+      const userQueryParam = `user_id=${encodeURIComponent(userEntityRef)}`;
       const requestBody = JSON.stringify(request.body);
       const fetchResponse = await fetch(
         `${lightspeedCoreBaseUrl}/v1/streaming_query/interrupt?${userQueryParam}`,
@@ -629,11 +635,9 @@ export async function createRouter(
     async (request, response) => {
       const { provider }: Pick<QueryRequestBody, 'provider'> = request.body;
       try {
-        const credentials = await httpAuth.credentials(request);
-        const user = await userInfo.getUserInfo(credentials);
-        const user_id = user.userEntityRef;
+        const { credentials, userEntityRef } = getIdentity(request);
 
-        logger.info(`/v1/query receives call from user: ${user_id}`);
+        logger.info(`/v1/query receives call from user: ${userEntityRef}`);
 
         await authorizer.authorizeUser(
           lightspeedChatCreatePermission,
@@ -653,7 +657,7 @@ export async function createRouter(
           request.body.vector_store_ids = [lightspeed_vector_store_id];
         }
 
-        const userQueryParam = `user_id=${encodeURIComponent(user_id)}`;
+        const userQueryParam = `user_id=${encodeURIComponent(userEntityRef)}`;
         request.body.media_type = 'application/json'; // set media_type to receive start and end event
         // if system_prompt is defined in lightspeed config
         // set system_prompt to override the default rhdh system prompt
@@ -667,7 +671,7 @@ export async function createRouter(
         const mcpHeadersValue = await buildMcpHeaders(
           staticServers,
           settingsStore,
-          user_id,
+          userEntityRef,
         );
 
         const fetchResponse = await fetch(
@@ -717,9 +721,7 @@ export async function createRouter(
     '/v2/conversations/:conversation_id',
     async (request, response) => {
       try {
-        const credentials = await httpAuth.credentials(request);
-        const user = await userInfo.getUserInfo(credentials);
-        const user_id = user.userEntityRef;
+        const { credentials, userEntityRef } = getIdentity(request);
         const conversation_id = request.params.conversation_id;
 
         const requestBody = JSON.stringify(request.body);
@@ -727,7 +729,7 @@ export async function createRouter(
           lightspeedChatCreatePermission,
           credentials,
         );
-        const userQueryParam = `user_id=${encodeURIComponent(user_id)}`;
+        const userQueryParam = `user_id=${encodeURIComponent(userEntityRef)}`;
         const fetchResponse = await fetch(
           `${lightspeedCoreBaseUrl}/v2/conversations/${conversation_id}?${userQueryParam}`,
           {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Moves the resolution of the user identity to a middleware step, this reduces a lot of the duplicated resolving code and makes it easier to extend for tasks in 2.1.0. This adds the user identity to the individual request by extending the Express Request type, so it is easy to reference.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
