### PR TITLE
fix(orchestrator-form): evaluate conditional ui:hidden with scoped form data

### DIFF
--- a/workspaces/orchestrator/.changeset/conditional-ui-hidden-scoped-formdata.md
+++ b/workspaces/orchestrator/.changeset/conditional-ui-hidden-scoped-formdata.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+---
+
+Evaluate conditional `ui:hidden` using scoped form data so sibling `when` paths work on wizard steps.

--- a/workspaces/orchestrator/.changeset/conditional-ui-hidden-scoped-formdata.md
+++ b/workspaces/orchestrator/.changeset/conditional-ui-hidden-scoped-formdata.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
 ---
 
-Evaluate conditional `ui:hidden` using scoped form data so sibling `when` paths work on wizard steps.
+Remove unnecessary gaps from conditionally hidden form fields.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/HiddenObjectFieldTemplate.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/HiddenObjectFieldTemplate.tsx
@@ -76,8 +76,8 @@ const HiddenObjectFieldTemplate = (
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const rootFormData =
-    (formContext?.formData as JsonObject) || (formData as JsonObject) || {};
+  const rootFormData = (formContext?.formData as JsonObject) || {};
+  const localFormData = (formData as JsonObject) || rootFormData;
 
   return (
     <>
@@ -105,7 +105,11 @@ const HiddenObjectFieldTemplate = (
           const hiddenCondition = getHiddenCondition(uiSchema, element.name);
           const isHiddenByCondition =
             hiddenCondition !== undefined
-              ? evaluateHiddenCondition(hiddenCondition, rootFormData)
+              ? evaluateHiddenCondition(
+                  hiddenCondition,
+                  localFormData,
+                  rootFormData,
+                )
               : false;
           const isHidden = element.hidden || isHiddenByCondition;
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.test.ts
@@ -20,7 +20,10 @@ import {
   HiddenCondition,
   HiddenConditionObject,
 } from '../types/HiddenCondition';
-import { evaluateHiddenCondition } from './evaluateHiddenCondition';
+import {
+  evaluateHiddenCondition,
+  getValueForWhen,
+} from './evaluateHiddenCondition';
 
 describe('evaluateHiddenCondition', () => {
   describe('boolean conditions', () => {
@@ -183,6 +186,64 @@ describe('evaluateHiddenCondition', () => {
         ],
       };
       expect(evaluateHiddenCondition(condition, formData)).toBe(true);
+    });
+  });
+
+  describe('scoped form data (wizard step / object siblings)', () => {
+    const rootFormData: JsonObject = {
+      inputs: {
+        field1: 'show',
+        field2: 'ready',
+        conditionalDetail: 'value',
+      },
+      step2: {
+        other: 'x',
+      },
+    };
+
+    const stepLocalData = rootFormData.inputs as JsonObject;
+
+    it('getValueForWhen resolves sibling fields from local object data', () => {
+      expect(getValueForWhen('field1', stepLocalData, rootFormData)).toBe(
+        'show',
+      );
+      expect(getValueForWhen('field1', rootFormData)).toBeUndefined();
+    });
+
+    it('shows field3 when field1 is show and field2 is ready (local scope)', () => {
+      const condition: HiddenCondition = {
+        anyOf: [
+          { when: 'field1', isNot: 'show' },
+          { when: 'field2', isNot: 'ready' },
+        ],
+      };
+      expect(
+        evaluateHiddenCondition(condition, stepLocalData, rootFormData),
+      ).toBe(false);
+      expect(evaluateHiddenCondition(condition, rootFormData)).toBe(true);
+    });
+
+    it('hides field3 when field1 is hide or field2 is idle', () => {
+      const condition: HiddenCondition = {
+        anyOf: [
+          { when: 'field1', isNot: 'show' },
+          { when: 'field2', isNot: 'ready' },
+        ],
+      };
+      expect(
+        evaluateHiddenCondition(
+          condition,
+          { field1: 'hide', field2: 'ready' },
+          rootFormData,
+        ),
+      ).toBe(true);
+      expect(
+        evaluateHiddenCondition(
+          condition,
+          { field1: 'show', field2: 'idle' },
+          rootFormData,
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
@@ -17,6 +17,7 @@
 import { JsonObject, JsonValue } from '@backstage/types';
 
 import get from 'lodash/get';
+import has from 'lodash/has';
 
 import {
   HiddenCondition,
@@ -58,13 +59,37 @@ function matchesAny(
 }
 
 /**
+ * Resolves the value for a `when` path. Prefers the current object's form data
+ * (sibling fields in the same step/object), then falls back to root form data
+ * for cross-step paths such as `step1.field1`.
+ */
+export function getValueForWhen(
+  when: string,
+  localFormData: JsonObject,
+  rootFormData?: JsonObject,
+): JsonValue | undefined {
+  if (has(localFormData, when)) {
+    return get(localFormData, when);
+  }
+  if (rootFormData !== undefined && rootFormData !== localFormData) {
+    return get(rootFormData, when);
+  }
+  return get(localFormData, when);
+}
+
+/**
  * Evaluate a simple condition object
  */
 function evaluateConditionObject(
   condition: HiddenConditionObject,
-  formData: JsonObject,
+  localFormData: JsonObject,
+  rootFormData?: JsonObject,
 ): boolean {
-  const fieldValue = get(formData, condition.when);
+  const fieldValue = getValueForWhen(
+    condition.when,
+    localFormData,
+    rootFormData,
+  );
 
   // Check isEmpty condition
   if (condition.isEmpty !== undefined) {
@@ -91,19 +116,20 @@ function evaluateConditionObject(
  */
 function evaluateCompositeCondition(
   condition: HiddenConditionComposite,
-  formData: JsonObject,
+  localFormData: JsonObject,
+  rootFormData?: JsonObject,
 ): boolean {
   // Evaluate 'allOf' (AND logic - all must be true)
   if (condition.allOf) {
     return condition.allOf.every(subCondition =>
-      evaluateHiddenCondition(subCondition, formData),
+      evaluateHiddenCondition(subCondition, localFormData, rootFormData),
     );
   }
 
   // Evaluate 'anyOf' (OR logic - at least one must be true)
   if (condition.anyOf) {
     return condition.anyOf.some(subCondition =>
-      evaluateHiddenCondition(subCondition, formData),
+      evaluateHiddenCondition(subCondition, localFormData, rootFormData),
     );
   }
 
@@ -114,10 +140,14 @@ function evaluateCompositeCondition(
 /**
  * Evaluate a hidden condition
  * Returns true if the field should be hidden
+ *
+ * @param localFormData - Form data for the current object (sibling field scope)
+ * @param rootFormData - Optional root form data for cross-step/cross-object `when` paths
  */
 export function evaluateHiddenCondition(
   condition: HiddenCondition,
-  formData: JsonObject,
+  localFormData: JsonObject,
+  rootFormData?: JsonObject,
 ): boolean {
   // Handle boolean (static)
   if (typeof condition === 'boolean') {
@@ -126,12 +156,12 @@ export function evaluateHiddenCondition(
 
   // Handle simple condition object
   if ('when' in condition) {
-    return evaluateConditionObject(condition, formData);
+    return evaluateConditionObject(condition, localFormData, rootFormData);
   }
 
   // Handle composite condition
   if ('allOf' in condition || 'anyOf' in condition) {
-    return evaluateCompositeCondition(condition, formData);
+    return evaluateCompositeCondition(condition, localFormData, rootFormData);
   }
 
   // Unknown condition type, don't hide

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.test.ts
@@ -236,6 +236,52 @@ describe('mapSchemaToData', () => {
     expect(result).toEqual(expectedResult);
   });
 
+  it('should include conditionally hidden schema fields not present in form data when includeHiddenFields is true', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        inputs: {
+          type: 'object',
+          title: 'Step 1',
+          properties: {
+            field1: {
+              type: 'string',
+              title: 'Field 1',
+            },
+            conditionalDetail: {
+              type: 'string',
+              title: 'Field 3',
+              'ui:hidden': {
+                anyOf: [{ when: 'field1', isNot: 'show' }],
+              },
+            } as JSONSchema7,
+          },
+        },
+      },
+    };
+
+    const data = {
+      inputs: {
+        field1: 'hide',
+      },
+    };
+
+    expect(generateReviewTableData(schema, data)).toEqual({
+      'Step 1': {
+        'Field 1': 'hide',
+      },
+    });
+
+    expect(
+      generateReviewTableData(schema, data, { includeHiddenFields: true }),
+    ).toEqual({
+      'Step 1': {
+        'Field 1': 'hide',
+        'Field 3': undefined,
+      },
+    });
+  });
+
   it('should exclude nested hidden fields from review table', () => {
     const schema: JSONSchema7 = {
       type: 'object',

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/generateReviewTableData.ts
@@ -18,11 +18,37 @@ import { JsonObject, JsonValue } from '@backstage/types';
 
 import type { JSONSchema7 } from 'json-schema';
 import { JsonSchema, Draft07 as JSONSchema } from 'json-schema-library';
+import get from 'lodash/get';
 
 import { isJsonObject } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 
 import { HiddenCondition } from '../types/HiddenCondition';
 import { evaluateHiddenCondition } from './evaluateHiddenCondition';
+
+/** Parent object form data for sibling `when` paths (e.g. `inputs.field1`). */
+function getScopedFormData(
+  schemaKey: string,
+  rootFormState: JsonObject,
+): { localFormData: JsonObject; rootFormData: JsonObject } {
+  const rootFormData = rootFormState;
+  if (!schemaKey) {
+    return { localFormData: rootFormData, rootFormData };
+  }
+  const parts = schemaKey.split('/');
+  if (parts.length === 1) {
+    const local = get(rootFormData, parts[0]);
+    return {
+      localFormData: isJsonObject(local) ? local : rootFormData,
+      rootFormData,
+    };
+  }
+  const parentPath = parts.slice(0, -1).join('.');
+  const local = get(rootFormData, parentPath);
+  return {
+    localFormData: isJsonObject(local) ? local : rootFormData,
+    rootFormData,
+  };
+}
 
 export function processSchema(
   key: string,
@@ -47,7 +73,12 @@ export function processSchema(
     if (!includeHiddenFields && uiHidden !== undefined) {
       // Handle both static boolean and condition objects
       const hiddenCondition = uiHidden as HiddenCondition;
-      const isHidden = evaluateHiddenCondition(hiddenCondition, formState);
+      const { localFormData, rootFormData } = getScopedFormData(key, formState);
+      const isHidden = evaluateHiddenCondition(
+        hiddenCondition,
+        localFormData,
+        rootFormData,
+      );
       if (isHidden) {
         return {};
       }
@@ -57,24 +88,32 @@ export function processSchema(
       return { [name]: '******' };
     }
 
-    if (isJsonObject(value)) {
-      // Recurse nested objects
-      const nestedValue = Object.entries(value).reduce(
-        (prev, [nestedKey, _nestedValue]) => {
-          const curKey = key ? `${key}/${nestedKey}` : nestedKey;
-          return {
-            ...prev,
-            ...processSchema(
-              curKey,
-              _nestedValue,
-              schema,
-              formState,
-              includeHiddenFields,
-            ),
-          };
-        },
-        {},
-      );
+    if (isJsonObject(value) || definitionInSchema.properties) {
+      const dataObj = isJsonObject(value) ? value : {};
+      const schemaProperties = definitionInSchema.properties ?? {};
+      const nestedKeys = includeHiddenFields
+        ? [
+            ...new Set([
+              ...Object.keys(schemaProperties),
+              ...Object.keys(dataObj),
+            ]),
+          ]
+        : Object.keys(dataObj);
+
+      // Recurse nested objects; include schema-only keys when showing hidden fields
+      const nestedValue = nestedKeys.reduce<JsonObject>((prev, nestedKey) => {
+        const curKey = key ? `${key}/${nestedKey}` : nestedKey;
+        return {
+          ...prev,
+          ...processSchema(
+            curKey,
+            dataObj[nestedKey],
+            schema,
+            formState,
+            includeHiddenFields,
+          ),
+        };
+      }, {});
 
       // Skip if all nested fields are hidden (resulting in empty object)
       if (Object.keys(nestedValue).length === 0) {


### PR DESCRIPTION

## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3186

### Summary

- Evaluate `ui:hidden` conditions against the **current object/step** form data (sibling `when` paths like `field1`), with fallback to root form data for cross-step paths (e.g. `inputs.field1` or `step1.exists`).
- Fix the review step **Show hidden parameters** toggle so schema fields that were never written to `formData` (because they were hidden on the form) still appear when the toggle is enabled.
- Add unit tests for scoped condition evaluation and review table generation.

-------------------------------

https://github.com/user-attachments/assets/f62a8ac5-c2b7-4bb8-b968-a125ef0f5341

-------------------------------


-----To test---

```
{
  "id": "test-conditional-ui-hidden-gap",
  "version": "1.0",
  "specVersion": "0.8",
  "name": "Test Conditional ui:hidden Layout Gap",
  "description": "Wizard step with two visible fields and a third field hidden via sibling when paths (field1, field2). Use to verify layout gaps before/after scoped formData evaluation.",
  "dataInputSchema": "schemas/test-conditional-ui-hidden-gap__main-schema.json",
  "start": "PrintOutput",
  "functions": [
    {
      "name": "systemOut",
      "type": "custom",
      "operation": "sysout"
    }
  ],
  "states": [
    {
      "name": "PrintOutput",
      "type": "operation",
      "actions": [
        {
          "name": "printSystemOut",
          "functionRef": {
            "refName": "systemOut",
            "arguments": {
              "message": "inputs: .inputs"
            }
          }
        }
      ],
      "end": true
    }
  ]
}
```

```
{
  "$id": "classpath:/schemas/test-conditional-ui-hidden-gap__main-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Test Conditional ui:hidden Layout Gap",
  "description": "Reproduces layout gaps when a conditionally hidden field uses sibling when paths (field1, field2) inside a wizard step. Before the scoped formData fix, field 3 stays in the grid when hidden.",
  "type": "object",
  "properties": {
    "inputs": {
      "type": "object",
      "title": "Step 1 - Sibling when paths",
      "description": "Set Field 1 to hide and/or Field 2 to idle. Field 3 should be hidden; check for a blank gap below Field 2. Set Field 1 to show and Field 2 to ready to reveal Field 3.",
      "properties": {
        "field1": {
          "type": "string",
          "title": "Field 1 - Mode",
          "description": "Use show to allow Field 3 to appear (with Field 2 ready).",
          "enum": ["hide", "show"],
          "default": "hide"
        },
        "field2": {
          "type": "string",
          "title": "Field 2 - Status",
          "description": "Use ready together with Field 1 show to reveal Field 3.",
          "enum": ["idle", "ready"],
          "default": "idle"
        },
        "conditionalDetail": {
          "type": "string",
          "title": "Field 3 - Detail (conditional)",
          "description": "Hidden unless Field 1 is show and Field 2 is ready. Uses sibling when paths (not inputs.field1).",
          "ui:widget": "ActiveText",
          "ui:hidden": {
            "anyOf": [
              { "when": "field1", "isNot": "show" },
              { "when": "field2", "isNot": "ready" }
            ]
          },
          "ui:props": {
            "ui:text": "## Field 3 is visible\n\n- **Field 1:** $${{current.inputs.field1}}\n- **Field 2:** $${{current.inputs.field2}}"
          }
        }
      },
      "required": ["field1", "field2"]
    }
  }
}
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
