### PR TITLE
fix(augment): harden agent lifecycle governance and fix self-approval bug

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/parsers/chatRequestParsers.ts
+++ b/workspaces/augment/plugins/augment-backend/src/parsers/chatRequestParsers.ts
@@ -86,6 +86,14 @@ export function parseChatRequest(body: unknown): ChatRequest {
   if (sessionId !== undefined && typeof sessionId !== 'string') {
     throw new InputError('sessionId must be a string');
   }
+  if (
+    typeof sessionId === 'string' &&
+    (sessionId.length > 128 || !/^[a-zA-Z0-9_-]+$/.test(sessionId))
+  ) {
+    throw new InputError(
+      'sessionId must be 1-128 characters, alphanumeric with hyphens/underscores only',
+    );
+  }
   if (model !== undefined && typeof model !== 'string') {
     throw new InputError('model must be a string');
   }

--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.test.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.test.ts
@@ -1205,20 +1205,20 @@ describe('agentRoutes', () => {
               published: false,
               visible: false,
               featured: false,
-              createdBy: 'user:default/admin',
+              createdBy: 'user:default/alice',
             },
           ],
         },
       });
 
-      // draft → pending
+      // draft → pending (alice submitted, admin approves)
       let res = await request(app)
         .put('/agents/e2ebot/promote')
         .send({ targetStage: 'pending' });
       expect(res.status).toBe(200);
       expect(res.body.lifecycleStage).toBe('pending');
 
-      // pending → published
+      // pending → published (admin approves alice's agent)
       res = await request(app)
         .put('/agents/e2ebot/promote')
         .send({ targetStage: 'published' });

--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
@@ -538,6 +538,19 @@ export function registerAgentRoutes(
         const isAdminApprove =
           currentStage === 'pending' && nextStage === 'published';
 
+        if (
+          isAdminApprove &&
+          !isWorkflowCallback &&
+          existing?.createdBy &&
+          existing.createdBy === userRef
+        ) {
+          res.status(403).json({
+            error:
+              'Cannot approve your own submission. A different admin must approve this agent.',
+          });
+          return;
+        }
+
         // In SonataFlow mode, admin approve sends CloudEvent instead of
         // applying the transition directly. The workflow will callback later
         // with X-Augment-Workflow-Callback: true to apply it.
@@ -737,6 +750,26 @@ export function registerAgentRoutes(
           res.status(404).json({ error: notFoundMsg });
           return;
         }
+
+        if (
+          dir === 'publish' &&
+          approvalService?.enabled &&
+          existing.approvalWorkflowInstanceId
+        ) {
+          await approvalService.sendDecision(
+            existing.approvalWorkflowInstanceId,
+            true,
+            userRef,
+          );
+          res.json({
+            success: true,
+            agentId,
+            lifecycleStage: normalizeLifecycleStage(existing.lifecycleStage),
+            workflowDecisionSent: true,
+          });
+          return;
+        }
+
         const result = await applyLifecycleTransition({
           configs,
           agentId,
@@ -890,6 +923,23 @@ export function registerAgentRoutes(
         const agentId = decodeURIComponent(req.params.agentId);
         const userRef = await ctx.getUserRef(req);
         const configs = await loadChatAgentConfigs();
+        const existing = configs.find(c => c.agentId === agentId);
+        if (!existing) {
+          res
+            .status(404)
+            .json({ error: 'Agent not found in lifecycle config.' });
+          return;
+        }
+        const isRequestOwner = existing.createdBy === userRef;
+        if (!isRequestOwner) {
+          const isAdmin = await ctx.checkIsAdmin(req);
+          if (!isAdmin) {
+            res.status(403).json({
+              error: 'You can only request unpublish for agents you created.',
+            });
+            return;
+          }
+        }
         const result = await applyLifecycleTransition({
           configs,
           agentId,
@@ -901,8 +951,8 @@ export function registerAgentRoutes(
           logger,
           req,
         });
-        const existing = configs.find(c => c.agentId === agentId);
-        if (existing) existing.pendingAction = 'unpublish';
+        const updated = configs.find(c => c.agentId === agentId);
+        if (updated) updated.pendingAction = 'unpublish';
         await saveChatAgentConfigs(configs, userRef);
 
         let workflowInstanceId: string | undefined;
@@ -941,7 +991,14 @@ export function registerAgentRoutes(
         const userRef = await ctx.getUserRef(req);
         const configs = await loadChatAgentConfigs();
         const existing = configs.find(c => c.agentId === agentId);
-        if (existing?.createdBy && existing.createdBy !== userRef) {
+        if (!existing) {
+          res
+            .status(404)
+            .json({ error: 'Agent not found in lifecycle config.' });
+          return;
+        }
+        const isOwner = existing.createdBy === userRef;
+        if (!isOwner) {
           const isAdmin = await ctx.checkIsAdmin(req);
           if (!isAdmin) {
             res

--- a/workspaces/augment/plugins/augment-backend/src/routes/chatRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/chatRoutes.ts
@@ -60,6 +60,7 @@ function buildSafetyResponse(
 function setupSseStream(
   res: Response,
   logger: LoggerService,
+  onDisconnect?: () => void,
 ): {
   abortController: AbortController;
   clientDisconnectedRef: { current: boolean };
@@ -77,6 +78,7 @@ function setupSseStream(
   res.on('close', () => {
     clientDisconnectedRef.current = true;
     abortController.abort();
+    onDisconnect?.();
     logger.info('Client disconnected from stream');
   });
   return { abortController, clientDisconnectedRef };
@@ -314,6 +316,11 @@ async function resolveConversationId(
     );
     if (!ownerSession) {
       throw new InputError('Conversation not found or access denied');
+    }
+    if (ownerSession.id !== sessionId) {
+      throw new InputError(
+        'Session ID does not match the conversation. Use the correct session.',
+      );
     }
     return { resolvedConversationId, userRef };
   }
@@ -652,13 +659,14 @@ export function registerChatRoutes(
       sessionId,
     } = parsedRequest;
 
+    const heartbeat = new SseHeartbeat(res);
     const { abortController, clientDisconnectedRef } = setupSseStream(
       res,
       logger,
+      () => heartbeat.stop(),
     );
     const { forward, streamedTextRef, streamMetadataRef } =
       createStreamEventForwarder(res, clientDisconnectedRef, logger);
-    const heartbeat = new SseHeartbeat(res);
     heartbeat.start();
 
     try {

--- a/workspaces/augment/plugins/augment-backend/src/routes/toolLifecycleRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/toolLifecycleRoutes.ts
@@ -178,6 +178,25 @@ export function registerToolLifecycleRoutes(
             return;
           }
         }
+        if (isSubmitForReview && !existing) {
+          res.status(404).json({
+            error:
+              'Tool not found in lifecycle config. ' +
+              'Only tools you have created can be submitted for review.',
+          });
+          return;
+        }
+        if (
+          isSubmitForReview &&
+          existing &&
+          (existing as { createdBy?: string }).createdBy &&
+          (existing as { createdBy?: string }).createdBy !== userRef
+        ) {
+          res.status(403).json({
+            error: 'You can only promote tools you created.',
+          });
+          return;
+        }
 
         const now = new Date().toISOString();
         const isProd = isPublishedStage(nextStage);
@@ -198,7 +217,8 @@ export function registerToolLifecycleRoutes(
             version: 1,
             promotedAt: now,
             promotedBy: userRef,
-          });
+            createdBy: userRef,
+          } as ChatToolConfig & { createdBy: string });
         }
 
         await saveChatToolConfigs(configs, userRef);
@@ -318,6 +338,14 @@ export function registerToolLifecycleRoutes(
         const userRef = await ctx.getUserRef(req);
         const configs = await loadChatToolConfigs();
         const existing = configs.find(c => c.toolId === toolId);
+        const currentStage = normalizeLifecycleStage(existing?.lifecycleStage);
+
+        if (!isValidTransition(currentStage, 'published')) {
+          throw new InputError(
+            `Cannot publish tool from "${currentStage}". Tool must be in "pending" stage to be published.`,
+          );
+        }
+
         const now = new Date().toISOString();
 
         if (existing) {

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/AgentLifecycleDetail.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/AgentLifecycleDetail.tsx
@@ -25,16 +25,11 @@ import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Tooltip from '@mui/material/Tooltip';
-import Stepper from '@mui/material/Stepper';
-import Step from '@mui/material/Step';
-import StepLabel from '@mui/material/StepLabel';
-import { useTheme, alpha } from '@mui/material/styles';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ChatIcon from '@mui/icons-material/Chat';
 import PublishIcon from '@mui/icons-material/Publish';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -43,6 +38,12 @@ import {
   getLifecycleTransition,
   getLifecycleStep,
 } from './lifecycleTransitions';
+import {
+  LifecycleActionButtons,
+  useWithdrawHandler,
+  useLifecycleAction,
+} from './LifecycleActionButtons';
+import { LifecycleDetailShell } from './LifecycleDetailShell';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { useApi } from '@backstage/core-plugin-api';
 import type { KagentiAgentSummary } from '@red-hat-developer-hub/backstage-plugin-augment-common';
@@ -55,7 +56,6 @@ import { AgentResourceTab } from './AgentResourceTab';
 import { AgentCardTab } from './AgentCardTab';
 import { useKagentiAgentDetail } from './useKagentiAgentDetail';
 import {
-  glassSurface,
   borderRadius,
   typeScale,
   animations,
@@ -65,8 +65,6 @@ import { CONTENT_MAX_WIDTH } from '../shared/commandCenterStyles';
 import { InlineAgentChat } from '../shared/InlineAgentChat';
 
 type LifecycleTab = 'overview' | 'design' | 'test' | 'build' | 'card';
-
-const LIFECYCLE_STAGES = ['Draft', 'Pending', 'Published', 'Archived'];
 
 export interface AgentLifecycleDetailProps {
   agent: KagentiAgentSummary;
@@ -87,8 +85,6 @@ export function AgentLifecycleDetail({
   onDeleted,
   isAdmin = false,
 }: AgentLifecycleDetailProps) {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === 'dark';
   const api = useApi(augmentApiRef);
   const [activeTab, setActiveTab] = useState<LifecycleTab>('overview');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -144,28 +140,15 @@ export function AgentLifecycleDetail({
     };
   }, [lifecycleStage]);
 
-  const handleLifecycleAction = useCallback(async () => {
-    setPublishLoading(true);
-    try {
-      if (nextTransition.action === 'demote') {
-        const result = await api.demoteAgent(agentId, nextTransition.target);
-        setLifecycleStage(result.lifecycleStage);
-        setPublishToast(`Agent moved to ${result.lifecycleStage}`);
-      } else {
-        const result = await api.promoteAgent(agentId, nextTransition.target);
-        setLifecycleStage(result.lifecycleStage);
-        setPublishToast(
-          `Agent moved to ${result.lifecycleStage} (v${result.version})`,
-        );
-      }
-    } catch (err) {
-      setPublishToast(
-        `Failed: ${err instanceof Error ? err.message : 'Unknown'}`,
-      );
-    } finally {
-      setPublishLoading(false);
-    }
-  }, [api, agentId, nextTransition]);
+  const { handleAction: handleLifecycleAction } = useLifecycleAction({
+    api,
+    agentId,
+    action: nextTransition.action,
+    target: nextTransition.target,
+    setLoading: setPublishLoading,
+    setToast: setPublishToast,
+    onStageChange: setLifecycleStage,
+  });
 
   const handleDelete = useCallback(async () => {
     setDeleteLoading(true);
@@ -184,10 +167,17 @@ export function AgentLifecycleDetail({
     }
   }, [api, agent.namespace, agent.name, agentId, onDeleted]);
 
+  const { handleWithdraw } = useWithdrawHandler({
+    api,
+    agentId,
+    onSuccess: () => setLifecycleStage('draft'),
+    setToast: setPublishToast,
+    setLoading: setPublishLoading,
+  });
+
   const canDelete = lifecycleStage === 'draft';
 
   const currentStep = getLifecycleStep(lifecycleStage);
-  const glass = glassSurface(theme, 6);
 
   return (
     <Box
@@ -199,33 +189,7 @@ export function AgentLifecycleDetail({
         '@media (prefers-reduced-motion: reduce)': reducedMotion,
       }}
     >
-      {/* Breadcrumb back */}
-      <Button
-        size="small"
-        startIcon={<ArrowBackIcon sx={{ fontSize: 16 }} />}
-        onClick={onBack}
-        sx={{
-          textTransform: 'none',
-          mb: 1.5,
-          color: theme.palette.primary.main,
-          fontWeight: 500,
-        }}
-      >
-        Agents
-      </Button>
-
-      {/* Agent Header Card */}
-      <Box
-        sx={{
-          ...glass,
-          borderRadius: borderRadius.lg,
-          p: 3,
-          mb: 3,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 2,
-        }}
-      >
+      <LifecycleDetailShell onBack={onBack} currentStep={currentStep}>
         {/* Top: Name + Status + Actions */}
         <Box
           sx={{
@@ -310,118 +274,30 @@ export function AgentLifecycleDetail({
               flexShrink: 0,
             }}
           >
-            {isAdmin ? (
-              <>
-                {lifecycleStage !== 'archived' && (
-                  <Tooltip title={nextTransition.label}>
-                    <Button
-                      size="small"
-                      variant={nextTransition.variant}
-                      color={nextTransition.color}
-                      startIcon={
-                        publishLoading ? (
-                          <CircularProgress size={14} />
-                        ) : (
-                          nextTransition.icon
-                        )
-                      }
-                      disabled={publishLoading}
-                      onClick={handleLifecycleAction}
-                      sx={{
-                        textTransform: 'none',
-                        fontWeight: 600,
-                        fontSize: '0.8rem',
-                        borderRadius: borderRadius.sm,
-                      }}
-                    >
-                      {nextTransition.label}
-                    </Button>
-                  </Tooltip>
-                )}
-                {lifecycleStage === 'archived' && (
-                  <Tooltip title="Reactivate this agent to draft status">
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      color="inherit"
-                      startIcon={
-                        publishLoading ? (
-                          <CircularProgress size={14} />
-                        ) : (
-                          <PublishIcon />
-                        )
-                      }
-                      disabled={publishLoading}
-                      onClick={handleLifecycleAction}
-                      sx={{
-                        textTransform: 'none',
-                        fontWeight: 600,
-                        fontSize: '0.8rem',
-                        borderRadius: borderRadius.sm,
-                      }}
-                    >
-                      Reactivate
-                    </Button>
-                  </Tooltip>
-                )}
-                {hasBuild && (
-                  <Tooltip title="Trigger a new container image build">
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      startIcon={<PlayArrowIcon />}
-                      disabled={buildTriggering}
-                      onClick={() => void handleTriggerBuild()}
-                      sx={{
-                        textTransform: 'none',
-                        borderRadius: borderRadius.sm,
-                      }}
-                    >
-                      {buildTriggering ? 'Building...' : 'Rebuild'}
-                    </Button>
-                  </Tooltip>
-                )}
-              </>
-            ) : (
-              <>
-                {lifecycleStage === 'draft' && (
-                  <Tooltip title="Submit this agent for admin review">
-                    <Button
-                      size="small"
-                      variant="contained"
-                      color="primary"
-                      startIcon={
-                        publishLoading ? (
-                          <CircularProgress size={14} />
-                        ) : (
-                          <PublishIcon />
-                        )
-                      }
-                      disabled={publishLoading}
-                      onClick={handleLifecycleAction}
-                      sx={{
-                        textTransform: 'none',
-                        fontWeight: 600,
-                        fontSize: '0.8rem',
-                        borderRadius: borderRadius.sm,
-                      }}
-                    >
-                      Submit for Review
-                    </Button>
-                  </Tooltip>
-                )}
-                {lifecycleStage !== 'draft' && (
-                  <Chip
-                    label={lifecycleStage}
-                    size="small"
-                    color="default"
-                    sx={{
-                      textTransform: 'capitalize',
-                      fontWeight: 600,
-                    }}
-                  />
-                )}
-              </>
+            <LifecycleActionButtons
+              lifecycleStage={lifecycleStage}
+              isAdmin={isAdmin}
+              loading={publishLoading}
+              onSubmitForReview={handleLifecycleAction}
+              onWithdraw={handleWithdraw}
+              onReactivate={handleLifecycleAction}
+            />
+            {isAdmin && hasBuild && (
+              <Tooltip title="Trigger a new container image build">
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<PlayArrowIcon />}
+                  disabled={buildTriggering}
+                  onClick={() => void handleTriggerBuild()}
+                  sx={{
+                    textTransform: 'none',
+                    borderRadius: borderRadius.sm,
+                  }}
+                >
+                  {buildTriggering ? 'Building...' : 'Rebuild'}
+                </Button>
+              </Tooltip>
             )}
             {onChatWithAgent && (
               <Button
@@ -457,30 +333,7 @@ export function AgentLifecycleDetail({
             )}
           </Box>
         </Box>
-
-        {/* Lifecycle Progress Stepper */}
-        <Box sx={{ mt: 1 }}>
-          <Stepper
-            activeStep={currentStep}
-            alternativeLabel
-            sx={{
-              '& .MuiStepLabel-label': {
-                fontSize: typeScale.caption.fontSize,
-                fontWeight: 500,
-              },
-              '& .MuiStepConnector-line': {
-                borderColor: alpha(theme.palette.divider, isDark ? 0.3 : 0.2),
-              },
-            }}
-          >
-            {LIFECYCLE_STAGES.map(label => (
-              <Step key={label}>
-                <StepLabel>{label}</StepLabel>
-              </Step>
-            ))}
-          </Stepper>
-        </Box>
-      </Box>
+      </LifecycleDetailShell>
 
       {lifecycleStage === 'draft' && rejectionReason && (
         <Alert severity="warning" sx={{ mb: 2 }}>

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/LifecycleActionButtons.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/LifecycleActionButtons.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import PublishIcon from '@mui/icons-material/Publish';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
+import { borderRadius } from '../../../theme/tokens';
+
+const actionBtnSx = {
+  textTransform: 'none' as const,
+  fontWeight: 600,
+  fontSize: '0.8rem',
+  borderRadius: borderRadius.sm,
+};
+
+export interface LifecycleActionButtonsProps {
+  readonly lifecycleStage: string;
+  readonly isAdmin: boolean;
+  readonly loading: boolean;
+  readonly onSubmitForReview: () => void;
+  readonly onWithdraw: () => void;
+  readonly onReactivate: () => void;
+}
+
+export interface UseLifecycleActionOptions {
+  api: {
+    promoteAgent(
+      agentId: string,
+      target?: string,
+    ): Promise<{ lifecycleStage: string; version?: number }>;
+    demoteAgent(
+      agentId: string,
+      target?: string,
+    ): Promise<{ lifecycleStage: string }>;
+  };
+  agentId: string;
+  action: 'promote' | 'demote';
+  target: string;
+  setLoading: (v: boolean) => void;
+  setToast: (msg: string) => void;
+  onStageChange: (stage: string) => void;
+}
+
+export function useLifecycleAction({
+  api,
+  agentId,
+  action,
+  target,
+  setLoading,
+  setToast,
+  onStageChange,
+}: UseLifecycleActionOptions) {
+  const handleAction = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (action === 'demote') {
+        const result = await api.demoteAgent(agentId, target);
+        onStageChange(result.lifecycleStage);
+        setToast(`Agent moved to ${result.lifecycleStage}`);
+      } else {
+        const result = await api.promoteAgent(agentId, target);
+        onStageChange(result.lifecycleStage);
+        setToast(
+          `Agent moved to ${result.lifecycleStage} (v${result.version})`,
+        );
+      }
+    } catch (err) {
+      setToast(`Failed: ${err instanceof Error ? err.message : 'Unknown'}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, agentId, action, target, setLoading, setToast, onStageChange]);
+
+  return { handleAction };
+}
+
+export interface UseWithdrawOptions {
+  api: { withdrawAgent(agentId: string): Promise<void> };
+  agentId: string;
+  onSuccess: () => void;
+  setToast: (msg: string) => void;
+  setLoading: (v: boolean) => void;
+}
+
+export function useWithdrawHandler({
+  api,
+  agentId,
+  onSuccess,
+  setToast,
+  setLoading,
+}: UseWithdrawOptions) {
+  const handleWithdraw = useCallback(async () => {
+    setLoading(true);
+    try {
+      await api.withdrawAgent(agentId);
+      onSuccess();
+      setToast('Agent withdrawn to draft');
+    } catch (err) {
+      setToast(`Failed: ${err instanceof Error ? err.message : 'Unknown'}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, agentId, onSuccess, setToast, setLoading]);
+
+  return { handleWithdraw };
+}
+
+export function LifecycleActionButtons({
+  lifecycleStage,
+  isAdmin,
+  loading,
+  onSubmitForReview,
+  onWithdraw,
+  onReactivate,
+}: LifecycleActionButtonsProps) {
+  return (
+    <>
+      {lifecycleStage === 'draft' && (
+        <Tooltip title="Submit this agent for admin review">
+          <Button
+            size="small"
+            variant="contained"
+            color="primary"
+            startIcon={
+              loading ? <CircularProgress size={14} /> : <PublishIcon />
+            }
+            disabled={loading}
+            onClick={onSubmitForReview}
+            sx={actionBtnSx}
+          >
+            Submit for Review
+          </Button>
+        </Tooltip>
+      )}
+      {lifecycleStage === 'pending' && (
+        <Tooltip title="Withdraw this agent back to draft">
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            startIcon={
+              loading ? <CircularProgress size={14} /> : <CloudOffIcon />
+            }
+            disabled={loading}
+            onClick={onWithdraw}
+            sx={actionBtnSx}
+          >
+            Withdraw
+          </Button>
+        </Tooltip>
+      )}
+      {lifecycleStage === 'published' && (
+        <Chip
+          label="Published"
+          size="small"
+          color="success"
+          sx={{ fontWeight: 600 }}
+        />
+      )}
+      {lifecycleStage === 'archived' && isAdmin && (
+        <Tooltip title="Reactivate this agent to draft status">
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            startIcon={
+              loading ? <CircularProgress size={14} /> : <PublishIcon />
+            }
+            disabled={loading}
+            onClick={onReactivate}
+            sx={actionBtnSx}
+          >
+            Reactivate
+          </Button>
+        </Tooltip>
+      )}
+    </>
+  );
+}

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/LifecycleDetailShell.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/LifecycleDetailShell.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import { useTheme, alpha } from '@mui/material/styles';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { glassSurface, borderRadius, typeScale } from '../../../theme/tokens';
+
+const LIFECYCLE_STAGES = ['Draft', 'Pending', 'Published', 'Archived'];
+
+interface LifecycleDetailShellProps {
+  readonly onBack: () => void;
+  readonly backLabel?: string;
+  readonly currentStep: number;
+  readonly children: ReactNode;
+}
+
+export function LifecycleDetailShell({
+  onBack,
+  backLabel = 'Agents',
+  currentStep,
+  children,
+}: LifecycleDetailShellProps) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const glass = glassSurface(theme, 6);
+
+  return (
+    <>
+      <Button
+        size="small"
+        startIcon={<ArrowBackIcon sx={{ fontSize: 16 }} />}
+        onClick={onBack}
+        sx={{
+          textTransform: 'none',
+          mb: 1.5,
+          color: theme.palette.primary.main,
+          fontWeight: 500,
+        }}
+      >
+        {backLabel}
+      </Button>
+
+      <Box
+        sx={{
+          ...glass,
+          borderRadius: borderRadius.lg,
+          p: 3,
+          mb: 3,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        {children}
+
+        <Box sx={{ mt: 1 }}>
+          <Stepper
+            activeStep={currentStep}
+            alternativeLabel
+            sx={{
+              '& .MuiStepLabel-label': {
+                fontSize: typeScale.caption.fontSize,
+                fontWeight: 500,
+              },
+              '& .MuiStepConnector-line': {
+                borderColor: alpha(theme.palette.divider, isDark ? 0.3 : 0.2),
+              },
+            }}
+          >
+            {LIFECYCLE_STAGES.map(label => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/WorkflowAgentDetail.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/WorkflowAgentDetail.tsx
@@ -25,11 +25,8 @@ import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Tooltip from '@mui/material/Tooltip';
-import Stepper from '@mui/material/Stepper';
-import Step from '@mui/material/Step';
-import StepLabel from '@mui/material/StepLabel';
 import Skeleton from '@mui/material/Skeleton';
-import { useTheme, alpha } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ChatIcon from '@mui/icons-material/Chat';
 import PublishIcon from '@mui/icons-material/Publish';
@@ -41,6 +38,11 @@ import {
   getLifecycleTransition,
   getLifecycleStep,
 } from './lifecycleTransitions';
+import {
+  LifecycleActionButtons,
+  useWithdrawHandler,
+} from './LifecycleActionButtons';
+import { LifecycleDetailShell } from './LifecycleDetailShell';
 import {
   useApi,
   discoveryApiRef,
@@ -64,13 +66,12 @@ import { InlineAgentChat } from '../shared/InlineAgentChat';
 
 type DetailTab = 'overview' | 'test';
 
-const LIFECYCLE_STAGES = ['Draft', 'Pending', 'Published', 'Archived'];
-
 export interface WorkflowAgentDetailProps {
   agentId: string;
   onBack: () => void;
   onChatWithAgent?: (agentId: string) => void;
   onEditInBuilder?: (agentId: string) => void;
+  isAdmin?: boolean;
 }
 
 /**
@@ -97,6 +98,7 @@ export function WorkflowAgentDetail({
   onBack,
   onChatWithAgent,
   onEditInBuilder,
+  isAdmin = false,
 }: WorkflowAgentDetailProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
@@ -214,6 +216,23 @@ export function WorkflowAgentDetail({
     }
   }, [api, agentId, nextTransition]);
 
+  const { handleWithdraw } = useWithdrawHandler({
+    api,
+    agentId,
+    onSuccess: () =>
+      setAgent(prev =>
+        prev
+          ? {
+              ...prev,
+              lifecycleStage:
+                'draft' as import('@red-hat-developer-hub/backstage-plugin-augment-common').AgentLifecycleStage,
+            }
+          : prev,
+      ),
+    setToast: setPublishToast,
+    setLoading: setPublishLoading,
+  });
+
   const handleDelete = useCallback(async () => {
     setDeleteLoading(true);
     try {
@@ -307,32 +326,7 @@ export function WorkflowAgentDetail({
         '@media (prefers-reduced-motion: reduce)': reducedMotion,
       }}
     >
-      <Button
-        size="small"
-        startIcon={<ArrowBackIcon sx={{ fontSize: 16 }} />}
-        onClick={onBack}
-        sx={{
-          textTransform: 'none',
-          mb: 1.5,
-          color: theme.palette.primary.main,
-          fontWeight: 500,
-        }}
-      >
-        Agents
-      </Button>
-
-      {/* Agent Header Card */}
-      <Box
-        sx={{
-          ...glass,
-          borderRadius: borderRadius.lg,
-          p: 3,
-          mb: 3,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 2,
-        }}
-      >
+      <LifecycleDetailShell onBack={onBack} currentStep={currentStep}>
         <Box
           sx={{
             display: 'flex',
@@ -413,58 +407,14 @@ export function WorkflowAgentDetail({
               flexShrink: 0,
             }}
           >
-            {lifecycleStage !== 'archived' && (
-              <Tooltip title={nextTransition.label}>
-                <Button
-                  size="small"
-                  variant={nextTransition.variant}
-                  color={nextTransition.color}
-                  startIcon={
-                    publishLoading ? (
-                      <CircularProgress size={14} />
-                    ) : (
-                      nextTransition.icon
-                    )
-                  }
-                  disabled={publishLoading}
-                  onClick={handleLifecycleAction}
-                  sx={{
-                    textTransform: 'none',
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    borderRadius: borderRadius.sm,
-                  }}
-                >
-                  {nextTransition.label}
-                </Button>
-              </Tooltip>
-            )}
-            {lifecycleStage === 'archived' && (
-              <Tooltip title="Reactivate this agent to draft status">
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="inherit"
-                  startIcon={
-                    publishLoading ? (
-                      <CircularProgress size={14} />
-                    ) : (
-                      <PublishIcon />
-                    )
-                  }
-                  disabled={publishLoading}
-                  onClick={handleLifecycleAction}
-                  sx={{
-                    textTransform: 'none',
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    borderRadius: borderRadius.sm,
-                  }}
-                >
-                  Reactivate
-                </Button>
-              </Tooltip>
-            )}
+            <LifecycleActionButtons
+              lifecycleStage={lifecycleStage}
+              isAdmin={isAdmin}
+              loading={publishLoading}
+              onSubmitForReview={handleLifecycleAction}
+              onWithdraw={handleWithdraw}
+              onReactivate={handleLifecycleAction}
+            />
             {lifecycleStage === 'draft' &&
               onEditInBuilder &&
               agent?.framework === 'workflow-builder' && (
@@ -556,30 +506,7 @@ export function WorkflowAgentDetail({
             </Alert>
           )}
         </Box>
-
-        {/* Lifecycle Progress Stepper */}
-        <Box sx={{ mt: 1 }}>
-          <Stepper
-            activeStep={currentStep}
-            alternativeLabel
-            sx={{
-              '& .MuiStepLabel-label': {
-                fontSize: typeScale.caption.fontSize,
-                fontWeight: 500,
-              },
-              '& .MuiStepConnector-line': {
-                borderColor: alpha(theme.palette.divider, isDark ? 0.3 : 0.2),
-              },
-            }}
-          >
-            {LIFECYCLE_STAGES.map(label => (
-              <Step key={label}>
-                <StepLabel>{label}</StepLabel>
-              </Step>
-            ))}
-          </Stepper>
-        </Box>
-      </Box>
+      </LifecycleDetailShell>
 
       {/* Tabs */}
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>

--- a/workspaces/augment/plugins/augment/src/components/AugmentPage/ChatView.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AugmentPage/ChatView.tsx
@@ -533,6 +533,7 @@ export function ChatView({
               agentId={detailOrchAgentId}
               onBack={handleCloseDetail}
               onChatWithAgent={handleChatWithAgent}
+              isAdmin={isAdmin}
               onEditInBuilder={async wfId => {
                 try {
                   const baseUrl = await discoveryApi.getBaseUrl('augment');

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/CommandBar.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/CommandBar.tsx
@@ -182,7 +182,7 @@ export function CommandBar({
             onClick={onOpenGuidedTours}
             sx={{
               textTransform: 'none',
-              fontSize: '0.82rem',
+              fontSize: '0.875rem',
               fontWeight: 500,
               color: theme.palette.text.secondary,
               px: 1.5,
@@ -200,7 +200,7 @@ export function CommandBar({
           onClick={onBackToMarketplace}
           sx={{
             textTransform: 'none',
-            fontSize: '0.82rem',
+            fontSize: '0.875rem',
             fontWeight: 500,
             color: theme.palette.text.secondary,
             px: 1,

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/MetricTile.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/MetricTile.tsx
@@ -118,7 +118,7 @@ export function MetricTile({
       <Typography
         variant="caption"
         sx={{
-          fontSize: '0.68rem',
+          fontSize: '0.75rem',
           fontWeight: 600,
           textTransform: 'uppercase',
           letterSpacing: '0.06em',
@@ -155,7 +155,7 @@ export function MetricTile({
       {subtitle && (
         <Typography
           sx={{
-            fontSize: '0.65rem',
+            fontSize: '0.75rem',
             color: 'text.secondary',
             mt: 0.75,
             lineHeight: 1.3,
@@ -172,7 +172,7 @@ export function MetricTile({
       {onClick && (
         <Typography
           sx={{
-            fontSize: '0.6rem',
+            fontSize: '0.7rem',
             color: alpha(color, 0.7),
             mt: 0.5,
             fontWeight: 600,

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/OpsOverview.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/OpsOverview.tsx
@@ -220,7 +220,7 @@ export function OpsOverview({ namespace, onNavigate }: OpsOverviewProps) {
                 sx={{
                   textTransform: 'none',
                   fontWeight: 600,
-                  fontSize: '0.72rem',
+                  fontSize: '0.78rem',
                   borderRadius: 2,
                   borderColor: alpha(LIFECYCLE_COLORS.pending, 0.4),
                   color: LIFECYCLE_COLORS.pending,
@@ -240,7 +240,7 @@ export function OpsOverview({ namespace, onNavigate }: OpsOverviewProps) {
               sx={{
                 textTransform: 'none',
                 fontWeight: 600,
-                fontSize: '0.72rem',
+                fontSize: '0.78rem',
                 borderRadius: 2,
                 color: 'text.secondary',
                 borderColor: alpha(
@@ -262,7 +262,7 @@ export function OpsOverview({ namespace, onNavigate }: OpsOverviewProps) {
               sx={{
                 textTransform: 'none',
                 fontWeight: 600,
-                fontSize: '0.72rem',
+                fontSize: '0.78rem',
                 borderRadius: 2,
                 color: 'text.secondary',
                 borderColor: alpha(

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/ReviewQueue.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/ReviewQueue.tsx
@@ -29,6 +29,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTheme, alpha } from '@mui/material/styles';
 import { useApi } from '@backstage/core-plugin-api';
 import type { ChatAgent } from '@red-hat-developer-hub/backstage-plugin-augment-common';
+import { normalizeLifecycleStage } from '@red-hat-developer-hub/backstage-plugin-augment-common';
 import { augmentApiRef } from '../../api';
 import {
   pageTitleSx,
@@ -63,7 +64,11 @@ export function ReviewQueue() {
     api
       .listAgents()
       .then(result =>
-        setAgents(result.filter(a => a.lifecycleStage === 'pending')),
+        setAgents(
+          result.filter(
+            a => normalizeLifecycleStage(a.lifecycleStage) === 'pending',
+          ),
+        ),
       )
       .catch(() => {})
       .finally(() => {

--- a/workspaces/augment/plugins/augment/src/components/CommandCenter/ToolReviewQueue.tsx
+++ b/workspaces/augment/plugins/augment/src/components/CommandCenter/ToolReviewQueue.tsx
@@ -28,6 +28,7 @@ import type {
   KagentiToolSummary,
   AgentLifecycleStage,
 } from '@red-hat-developer-hub/backstage-plugin-augment-common';
+import { normalizeLifecycleStage } from '@red-hat-developer-hub/backstage-plugin-augment-common';
 import { augmentApiRef } from '../../api';
 import {
   pageTitleSx,
@@ -61,7 +62,11 @@ export function ToolReviewQueue() {
     api
       .listToolsWithLifecycle()
       .then(result =>
-        setTools(result.filter(t => t.lifecycleStage === 'pending')),
+        setTools(
+          result.filter(
+            t => normalizeLifecycleStage(t.lifecycleStage) === 'pending',
+          ),
+        ),
       )
       .catch(() => {})
       .finally(() => setLoading(false));

--- a/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
+++ b/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
@@ -171,9 +171,6 @@ export function MarketplacePage({
     () =>
       agents.filter(a => {
         if (a.createdBy === userRef) return true;
-        if (a.governanceRegistered && a.lifecycleStage !== 'published')
-          return true;
-        if (!a.governanceRegistered) return true;
         return false;
       }),
     [agents, userRef],
@@ -191,8 +188,12 @@ export function MarketplacePage({
     [tools],
   );
 
-  // My Tools: show ALL tools with lifecycle badges
-  const myTools = useMemo(() => tools, [tools]);
+  // My Tools: show only tools created by the current user
+  const myTools = useMemo(
+    () =>
+      tools.filter(t => (t as { createdBy?: string }).createdBy === userRef),
+    [tools, userRef],
+  );
 
   const handleChat = useCallback(
     (agentId: string) => {


### PR DESCRIPTION
## Summary

- Removes "Approve and Publish" button from front-door agent detail views (all agent types). Approval now exclusively lives in the Command Center Review Queue.
- Adds "Withdraw" button for pending agents (uses correct `/withdraw` endpoint accessible to non-admin creators).
- Adds ownership/admin gate to `request-unpublish` — prevents any authenticated user from taking published agents offline.
- Prevents self-approval: the admin who submitted an agent cannot approve their own submission.
- Aligns `/publish` shortcut with SonataFlow workflow (delegates instead of bypassing).
- Adds ownership check + phantom-draft guard to tool promote endpoint.
- Adds `isValidTransition` enforcement to tool publish (must be in pending stage).
- Validates `sessionId` format in chat request parser (prevents injection of malformed IDs).
- Validates `sessionId` ↔ `conversationId` consistency to prevent context mismatch.
- Stops SSE heartbeat timer on client disconnect (prevents timer leak).
- Uses `normalizeLifecycleStage` in Review Queue filters for legacy stage compatibility.
- Fixes My Agents/My Tools marketplace filters to only show the current user's own resources.
- Fixes undersized text in Command Center dashboard tiles and navigation bar.

## Security Fixes

| Severity | Issue | Fix |
|----------|-------|-----|
| Critical | Any user could unpublish any published agent | Added ownership/admin gate |
| Critical | My Agents/Tools showed other users' drafts | Filtered by `createdBy` |
| High | Withdraw allowed on unowned agents | Require `createdBy === userRef` or admin |
| High | Tool promote had no ownership check | Added ownership + phantom-draft guard |
| High | Tool publish bypassed lifecycle validation | Added `isValidTransition` |
| High | `/publish` bypassed SonataFlow workflow | Delegates to workflow when active |
| Medium | Self-approval possible | Blocked submitter from approving own agent |
| Medium | Session ID not validated in chat | Added format validation |
| Medium | Heartbeat timer leak on disconnect | Stop on `res.close` |

## Test plan

- [ ] As non-admin: create agent → submit for review → verify "Withdraw" button shown (not "Approve and Publish")
- [ ] As admin: verify "Approve and Publish" only appears in Command Center Review Queue
- [ ] As non-admin: verify My Agents only shows agents you created
- [ ] As admin: verify cannot approve own submission (returns 403)
- [ ] Verify `PUT /agents/:id/request-unpublish` returns 403 for non-owner non-admin
- [ ] Verify Command Center dashboard text is readable (labels, subtitles, Tours/Marketplace)
- [ ] Verify tool promote returns 403 for non-owner
- [ ] Verify tool publish from draft returns 400 (must be pending first)