### PR TITLE
fix(augment): fix skills UI tabs, My Agents visibility, and dev-mode self-approval

### DIFF
--- a/workspaces/augment/plugins/augment-backend/src/middleware/security.ts
+++ b/workspaces/augment/plugins/augment-backend/src/middleware/security.ts
@@ -58,7 +58,14 @@ export function createSecurityMiddleware(deps: SecurityDeps) {
 
   async function getUserRef(req: express.Request): Promise<string> {
     if (securityConfig.mode === 'none') {
-      return GUEST_USER_REF;
+      try {
+        const credentials = await httpAuth.credentials(req, {
+          allow: ['user'],
+        });
+        return credentials.principal.userEntityRef;
+      } catch {
+        return GUEST_USER_REF;
+      }
     }
     const credentials = await httpAuth.credentials(req, { allow: ['user'] });
     return credentials.principal.userEntityRef;

--- a/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
+++ b/workspaces/augment/plugins/augment-backend/src/routes/agentRoutes.ts
@@ -538,9 +538,13 @@ export function registerAgentRoutes(
         const isAdminApprove =
           currentStage === 'pending' && nextStage === 'published';
 
+        const secMode =
+          ctx.config.getOptionalString('augment.security.mode') ||
+          'plugin-only';
         if (
           isAdminApprove &&
           !isWorkflowCallback &&
+          secMode !== 'none' &&
           existing?.createdBy &&
           existing.createdBy === userRef
         ) {

--- a/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/AgentCreateIntentDialog.tsx
+++ b/workspaces/augment/plugins/augment/src/components/AdminPanels/KagentiPanels/AgentCreateIntentDialog.tsx
@@ -341,6 +341,8 @@ export function AgentCreateIntentDialog({
           skillCount: data.skillCount ?? skillsSelected.length,
         };
 
+        onCreated?.();
+
         if (!data.deployed) {
           setDeployResult(makeResult('ready', partial));
           return;
@@ -386,7 +388,7 @@ export function AgentCreateIntentDialog({
         setSkillsDeploying(false);
       }
     },
-    [discoveryApi, fetchApi, skillsRuntimeId, skillsSelected],
+    [discoveryApi, fetchApi, skillsRuntimeId, skillsSelected, onCreated],
   );
 
   const handleSubOptionClick = useCallback(

--- a/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
+++ b/workspaces/augment/plugins/augment/src/components/Marketplace/MarketplacePage.tsx
@@ -171,9 +171,10 @@ export function MarketplacePage({
     () =>
       agents.filter(a => {
         if (a.createdBy === userRef) return true;
+        if (isAdmin && !a.published) return true;
         return false;
       }),
-    [agents, userRef],
+    [agents, userRef, isAdmin],
   );
 
   // Tools catalog: only deployed/published tools

--- a/workspaces/augment/plugins/augment/src/components/SkillsAgentCreation/SkillBrowser.tsx
+++ b/workspaces/augment/plugins/augment/src/components/SkillsAgentCreation/SkillBrowser.tsx
@@ -148,7 +148,20 @@ export function SkillBrowser({
         onChange={(_, v) => setActiveDomain(v as number)}
         variant="scrollable"
         scrollButtons="auto"
-        sx={{ mb: 2 }}
+        allowScrollButtonsMobile
+        sx={{
+          mb: 2,
+          minHeight: 36,
+          '& .MuiTab-root': {
+            minHeight: 36,
+            textTransform: 'none',
+            fontSize: '0.8125rem',
+            fontWeight: 500,
+            minWidth: 'auto',
+            px: 2,
+            mr: 0.5,
+          },
+        }}
       >
         {domains.map(d => (
           <Tab key={d} label={d} />


### PR DESCRIPTION
## Summary

Fixes regressions from #3235 observed on the live RHDH cluster and improves Skills Marketplace UX.

- **Self-approval 403 in dev mode**: The self-approval prevention added in #3235 blocks the only admin (`user:default/guest`) from approving agents when `security.mode: 'none'`. Fix: skip the check in dev mode where separation-of-duties is not applicable.

- **My Agents filter**: Admins should see all non-published agents (they manage the full fleet). The strict `createdBy === userRef` filter from #3235 hid unowned/legacy agents from admin view.

- **SkillBrowser category tabs squished**: The domain filter tabs (`All devops docs general human-resources...`) render without spacing because `SkillBrowser` was the only tab bar missing the `'& .MuiTab-root': { px: 2, mr: 0.5 }` overrides used everywhere else.

- **Skill agent not appearing in My Agents immediately**: After `POST /agents/from-skills` succeeds, the marketplace list only refreshed when the dialog closed. Now triggers refresh immediately after governance registration.

## Test plan

- [ ] On cluster with security.mode: none — admin can approve agents (no 403)
- [ ] Skill agents appear in My Agents tab immediately after creation
- [ ] SkillBrowser tabs show proper spacing between domain labels
- [ ] Non-admin users still only see their own agents in My Agents