### PR TITLE
fix(x2a): show correct phase duration and attempt count

### DIFF
--- a/workspaces/x2a/.changeset/beige-schools-cry.md
+++ b/workspaces/x2a/.changeset/beige-schools-cry.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+'@red-hat-developer-hub/backstage-plugin-x2a-common': patch
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+---
+
+Show attempt counter for repeated executions of phases.

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi.yaml
@@ -905,6 +905,13 @@ components:
         commitId:
           type: string
           description: Git commit SHA produced by this job
+        attemptCount:
+          type: integer
+          description: Number of restarts (attempts) for this projectId+moduleId+phase combination. Calculated value, not persisted in DB.
+        firstAttemptAt:
+          type: string
+          format: date-time
+          description: When the very first attempt for this phase was started.
 
     ArtifactType:
       type: string

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/models/Job.model.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/models/Job.model.ts
@@ -65,4 +65,12 @@ export interface Job {
    * Git commit SHA produced by this job
    */
   commitId?: string;
+  /**
+   * Number of restarts (attempts) for this projectId+moduleId+phase combination. Calculated value, not persisted in DB.
+   */
+  attemptCount?: number;
+  /**
+   * When the very first attempt for this phase was started.
+   */
+  firstAttemptAt?: Date;
 }

--- a/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/schema/openapi/generated/router.ts
@@ -1298,6 +1298,15 @@ export const spec = {
           "commitId": {
             "type": "string",
             "description": "Git commit SHA produced by this job"
+          },
+          "attemptCount": {
+            "type": "integer",
+            "description": "Number of restarts (attempts) for this projectId+moduleId+phase combination. Calculated value, not persisted in DB."
+          },
+          "firstAttemptAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the very first attempt for this phase was started."
           }
         }
       },

--- a/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/index.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/index.ts
@@ -95,6 +95,18 @@ export class X2ADatabaseService implements X2ADatabaseServiceApi {
   }
 
   /**
+   * Attaches attemptCount and firstAttemptAt to a Job object (mutates in place).
+   */
+  private attachAttemptStats(
+    job: Job | undefined,
+    stats: { count: number; firstStartedAt: Date | undefined } | undefined,
+  ): void {
+    if (!job || !stats) return;
+    job.attemptCount = stats.count;
+    job.firstAttemptAt = stats.firstStartedAt;
+  }
+
+  /**
    * Enriches a project with migration plan and status (used by listProjects and getProject).
    */
   private async enrichProject(project: Project): Promise<void> {
@@ -117,6 +129,14 @@ export class X2ADatabaseService implements X2ADatabaseServiceApi {
     );
 
     project.initJob = removeSensitiveFromJob(lastInitJob);
+
+    if (project.initJob) {
+      const stats = await this.#jobOps.getPhaseAttemptStats({
+        projectId,
+        phase: 'init',
+      });
+      this.attachAttemptStats(project.initJob, stats);
+    }
   }
 
   // Projects (facade enriches basic objects when needed)
@@ -348,6 +368,22 @@ export class X2ADatabaseService implements X2ADatabaseServiceApi {
       module.migrate = removeSensitiveFromJob(lastMigrateJobsOfModule[0]);
       module.publish = removeSensitiveFromJob(lastPublishJobsOfModule[0]);
 
+      // Attach attempt stats per phase
+      const phases = ['analyze', 'migrate', 'publish'] as const;
+      await Promise.all(
+        phases.map(async phase => {
+          const job = module[phase];
+          if (job) {
+            const stats = await this.#jobOps.getPhaseAttemptStats({
+              projectId: module.projectId,
+              moduleId: id,
+              phase,
+            });
+            this.attachAttemptStats(job, stats);
+          }
+        }),
+      );
+
       return enrichModuleWithJobStatus(module, {
         analyze: module.analyze,
         migrate: module.migrate,
@@ -401,6 +437,10 @@ export class X2ADatabaseService implements X2ADatabaseServiceApi {
       ),
     );
 
+    const attemptStatsMap = await this.#jobOps.batchPhaseAttemptStats({
+      projectId,
+    });
+
     const response: Array<Module> = modules.map((module, idxModule) => {
       const analyze = removeSensitiveFromJob(
         lastAnalyzeJobsOfModules[idxModule][0],
@@ -411,6 +451,12 @@ export class X2ADatabaseService implements X2ADatabaseServiceApi {
       const publish = removeSensitiveFromJob(
         lastPublishJobsOfModules[idxModule][0],
       );
+
+      const moduleStats = attemptStatsMap.get(module.id);
+      this.attachAttemptStats(analyze, moduleStats?.get('analyze'));
+      this.attachAttemptStats(migrateJob, moduleStats?.get('migrate'));
+      this.attachAttemptStats(publish, moduleStats?.get('publish'));
+
       const lastJobs = { analyze, migrate: migrateJob, publish };
       return enrichModuleWithJobStatus(module, lastJobs);
     });

--- a/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/jobOperations.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/jobOperations.ts
@@ -366,6 +366,87 @@ export class JobOperations {
     return this.getJob({ id });
   }
 
+  /**
+   * Returns attempt count and first-attempt timestamp for a single
+   * (projectId, moduleId, phase) combination.
+   */
+  async getPhaseAttemptStats({
+    projectId,
+    moduleId,
+    phase,
+  }: {
+    projectId: string;
+    moduleId?: string | null;
+    phase: MigrationPhase;
+  }): Promise<{ count: number; firstStartedAt: Date | undefined }> {
+    const row = await this.#dbClient('jobs')
+      .where('project_id', projectId)
+      .modify(qb => {
+        if (moduleId) {
+          qb.where('module_id', moduleId);
+        } else if (Phase.from(phase).isProjectPhase()) {
+          qb.whereNull('module_id');
+        }
+      })
+      .where('phase', phase)
+      .select(
+        this.#dbClient.raw('COUNT(*) as count'),
+        this.#dbClient.raw('MIN(started_at) as first_started_at'),
+      )
+      .first();
+
+    const count = Number(row?.count ?? 0);
+    const firstStartedAt = row?.first_started_at
+      ? new Date(row.first_started_at as string | Date)
+      : undefined;
+
+    return { count, firstStartedAt };
+  }
+
+  /**
+   * Batch-fetches attempt stats for every (module_id, phase) pair in a
+   * project. Returns a nested map: moduleId -> phase -> stats.
+   * One SQL query regardless of the number of modules.
+   */
+  async batchPhaseAttemptStats({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<
+    Map<
+      string,
+      Map<string, { count: number; firstStartedAt: Date | undefined }>
+    >
+  > {
+    const rows: Array<Record<string, unknown>> = await this.#dbClient('jobs')
+      .where('project_id', projectId)
+      .whereNotNull('module_id')
+      .groupBy('module_id', 'phase')
+      .select(
+        'module_id',
+        'phase',
+        this.#dbClient.raw('COUNT(*) as count'),
+        this.#dbClient.raw('MIN(started_at) as first_started_at'),
+      );
+
+    const result = new Map<
+      string,
+      Map<string, { count: number; firstStartedAt: Date | undefined }>
+    >();
+    for (const row of rows) {
+      const modId = row.module_id as string;
+      const phase = row.phase as string;
+      if (!result.has(modId)) {
+        result.set(modId, new Map());
+      }
+      result.get(modId)!.set(phase, {
+        count: Number(row.count),
+        firstStartedAt: new Date(row.first_started_at as string | Date),
+      });
+    }
+    return result;
+  }
+
   async deleteJob({ id }: { id: string }): Promise<number> {
     this.#logger.info(`deleteJob called for id: ${id}`);
 

--- a/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/jobs.test.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/X2ADatabaseService/jobs.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { mockCredentials } from '@backstage/backend-test-utils';
-
 import {
   Artifact,
   toSorted,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+
+import { mockServices, mockCredentials } from '@backstage/backend-test-utils';
 
 import {
   artifactsFromValues,
@@ -32,6 +32,7 @@ import {
   tearDownDatabases,
 } from '../../__testUtils__';
 import { delay } from '../../utils';
+import { JobOperations } from './jobOperations';
 
 describe('X2ADatabaseService – jobs', () => {
   afterEach(async () => {
@@ -770,6 +771,151 @@ describe('X2ADatabaseService – jobs', () => {
           'artifact2.json',
         ]);
       },
+    );
+  });
+});
+
+describe('JobOperations – phase attempt stats', () => {
+  afterEach(async () => {
+    await tearDownDatabases();
+  });
+
+  describe('getPhaseAttemptStats', () => {
+    it.each(supportedDatabaseIds)(
+      'returns count and firstStartedAt for a single phase - %p',
+      async databaseId => {
+        const { client } = await createDatabase(databaseId);
+        const service = createService(client);
+        const jobOps = new JobOperations(mockServices.logger.mock(), client);
+        const credentials = mockCredentials.user();
+        const project = await service.createProject(
+          {
+            name: 'Test Project',
+            description: 'D',
+            ...defaultProjectRepoFields,
+          },
+          { credentials },
+        );
+        const module = await service.createModule({
+          name: 'Mod',
+          sourcePath: '/mod',
+          projectId: project.id,
+        });
+
+        const firstJob = await service.createJob({
+          projectId: project.id,
+          moduleId: module.id,
+          phase: 'analyze',
+          startedAt: new Date('2024-01-01T10:00:00Z'),
+        });
+        await service.createJob({
+          projectId: project.id,
+          moduleId: module.id,
+          phase: 'analyze',
+          startedAt: new Date('2024-01-01T11:00:00Z'),
+        });
+        await service.createJob({
+          projectId: project.id,
+          moduleId: module.id,
+          phase: 'analyze',
+          startedAt: new Date('2024-01-01T12:00:00Z'),
+        });
+
+        const stats = await jobOps.getPhaseAttemptStats({
+          projectId: project.id,
+          moduleId: module.id,
+          phase: 'analyze',
+        });
+
+        expect(stats.count).toBe(3);
+        expect(stats.firstStartedAt).toBeInstanceOf(Date);
+        expect(stats.firstStartedAt!.toISOString()).toBe(
+          firstJob.startedAt.toISOString(),
+        );
+      },
+      LONG_TEST_TIMEOUT,
+    );
+
+    it.each(supportedDatabaseIds)(
+      'returns count 0 when no jobs exist - %p',
+      async databaseId => {
+        const { client } = await createDatabase(databaseId);
+        const jobOps = new JobOperations(mockServices.logger.mock(), client);
+
+        const stats = await jobOps.getPhaseAttemptStats({
+          projectId: nonExistentId,
+          moduleId: nonExistentId,
+          phase: 'analyze',
+        });
+
+        expect(stats.count).toBe(0);
+        expect(stats.firstStartedAt).toBeUndefined();
+      },
+      LONG_TEST_TIMEOUT,
+    );
+  });
+
+  describe('batchPhaseAttemptStats', () => {
+    it.each(supportedDatabaseIds)(
+      'returns stats grouped by module and phase - %p',
+      async databaseId => {
+        const { client } = await createDatabase(databaseId);
+        const service = createService(client);
+        const jobOps = new JobOperations(mockServices.logger.mock(), client);
+        const credentials = mockCredentials.user();
+        const project = await service.createProject(
+          {
+            name: 'Test Project',
+            description: 'D',
+            ...defaultProjectRepoFields,
+          },
+          { credentials },
+        );
+        const mod1 = await service.createModule({
+          name: 'Mod1',
+          sourcePath: '/mod1',
+          projectId: project.id,
+        });
+        const mod2 = await service.createModule({
+          name: 'Mod2',
+          sourcePath: '/mod2',
+          projectId: project.id,
+        });
+
+        await service.createJob({
+          projectId: project.id,
+          moduleId: mod1.id,
+          phase: 'analyze',
+        });
+        await delay(5);
+        await service.createJob({
+          projectId: project.id,
+          moduleId: mod1.id,
+          phase: 'analyze',
+        });
+        await delay(5);
+        await service.createJob({
+          projectId: project.id,
+          moduleId: mod1.id,
+          phase: 'migrate',
+        });
+        await delay(5);
+        await service.createJob({
+          projectId: project.id,
+          moduleId: mod2.id,
+          phase: 'analyze',
+        });
+
+        const statsMap = await jobOps.batchPhaseAttemptStats({
+          projectId: project.id,
+        });
+
+        expect(statsMap.get(mod1.id)?.get('analyze')?.count).toBe(2);
+        expect(statsMap.get(mod1.id)?.get('migrate')?.count).toBe(1);
+        expect(statsMap.get(mod2.id)?.get('analyze')?.count).toBe(1);
+        expect(statsMap.get(mod2.id)?.get('migrate')).toBeUndefined();
+      },
+      LONG_TEST_TIMEOUT,
     );
   });
 });

--- a/workspaces/x2a/plugins/x2a-common/client/src/schema/openapi/generated/models/Job.model.ts
+++ b/workspaces/x2a/plugins/x2a-common/client/src/schema/openapi/generated/models/Job.model.ts
@@ -65,4 +65,12 @@ export interface Job {
    * Git commit SHA produced by this job
    */
   commitId?: string;
+  /**
+   * Number of restarts (attempts) for this projectId+moduleId+phase combination. Calculated value, not persisted in DB.
+   */
+  attemptCount?: number;
+  /**
+   * When the very first attempt for this phase was started.
+   */
+  firstAttemptAt?: Date;
 }

--- a/workspaces/x2a/plugins/x2a-common/report.api.md
+++ b/workspaces/x2a/plugins/x2a-common/report.api.md
@@ -182,9 +182,11 @@ export const IN_MEMORY_SORT_WARN_THRESHOLD = 100;
 // @public (undocumented)
 export interface Job {
     artifacts?: Array<Artifact>;
+    attemptCount?: number;
     commitId?: string;
     errorDetails?: string;
     finishedAt?: Date;
+    firstAttemptAt?: Date;
     id: string;
     k8sJobName: string;
     moduleId?: string;

--- a/workspaces/x2a/plugins/x2a/report.api.md
+++ b/workspaces/x2a/plugins/x2a/report.api.md
@@ -140,6 +140,8 @@ readonly "modulePage.phases.republishInstructions": string;
 readonly "modulePage.phases.rerunPublish": string;
 readonly "modulePage.phases.runError": string;
 readonly "modulePage.phases.cancelError": string;
+readonly "modulePage.phases.attempts": string;
+readonly "modulePage.phases.totalElapsed": string;
 readonly "modulePage.phases.commitId": string;
 readonly "modulePage.phases.viewLog": string;
 readonly "modulePage.phases.hideLog": string;

--- a/workspaces/x2a/plugins/x2a/src/components/ModuleTable/TimingCell.test.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModuleTable/TimingCell.test.tsx
@@ -134,4 +134,29 @@ describe('TimingCell', () => {
 
     expect(screen.getByText('Running for 12m 10s')).toBeInTheDocument();
   });
+
+  it('uses telemetry-based duration when telemetry is present', () => {
+    jest.setSystemTime(new Date('2024-01-01T12:35:00Z'));
+
+    const lastJob: Job = {
+      id: 'job-1',
+      projectId: 'proj-1',
+      phase: 'migrate',
+      status: 'success',
+      k8sJobName: 'k8s-job-1',
+      startedAt: new Date('2024-01-01T12:00:00Z'),
+      finishedAt: new Date('2024-01-01T12:30:00Z'),
+      telemetry: {
+        summary: 'ok',
+        phase: 'migrate',
+        startedAt: new Date('2024-01-01T12:23:00Z'),
+        endedAt: new Date('2024-01-01T12:30:00Z'),
+      },
+    };
+
+    render(<TimingCell lastJob={lastJob} />);
+    expect(
+      screen.getByText('Finished 5m ago (took 7m 0s)'),
+    ).toBeInTheDocument();
+  });
 });

--- a/workspaces/x2a/plugins/x2a/src/components/ModuleTable/TimingCell.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModuleTable/TimingCell.tsx
@@ -22,7 +22,7 @@ import {
 import { makeStyles } from '@material-ui/core';
 
 import { useTranslation } from '../../hooks/useTranslation';
-import { formatRelativeTime } from '../tools';
+import { formatRelativeTime, getEffectiveDurationSeconds } from '../tools';
 
 const useStyles = makeStyles(theme => ({
   timing: {
@@ -56,6 +56,7 @@ export const TimingCell = ({ lastJob }: { lastJob: Job | undefined }) => {
     t,
     lastJob.startedAt,
     lastJob.finishedAt,
+    getEffectiveDurationSeconds(lastJob),
   );
   return <div className={classes.timing}>{timingText}</div>;
 };

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.test.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.test.tsx
@@ -161,6 +161,156 @@ describe('PhaseDetails', () => {
     });
   });
 
+  describe('telemetry-based duration', () => {
+    it('uses telemetry timestamps for duration when available', async () => {
+      const phase: Job = {
+        id: 'job-1',
+        projectId: 'proj-1',
+        phase: 'migrate',
+        status: 'success',
+        k8sJobName: 'k8s-job-1',
+        startedAt: new Date('2024-01-01T12:00:00Z'),
+        finishedAt: new Date('2024-01-01T12:29:00Z'),
+        telemetry: {
+          summary: 'ok',
+          phase: 'migrate',
+          startedAt: new Date('2024-01-01T12:22:00Z'),
+          endedAt: new Date('2024-01-01T12:29:00Z'),
+        },
+      };
+
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={phase}
+            projectId="proj-1"
+            phaseName="migrate"
+            moduleId="mod-1"
+          />,
+        );
+      });
+
+      const durationField = screen.getByTestId('item-field-Duration');
+      expect(durationField.textContent).toContain('7m 0s');
+      expect(durationField.textContent).not.toContain('29m');
+    });
+  });
+
+  describe('attempt count', () => {
+    it('shows attempt count when attemptCount is set', async () => {
+      const phase: Job = {
+        id: 'job-1',
+        projectId: 'proj-1',
+        phase: 'analyze',
+        status: 'success',
+        k8sJobName: 'k8s-job-1',
+        startedAt: new Date('2024-01-01T12:00:00Z'),
+        finishedAt: new Date('2024-01-01T12:02:30Z'),
+        attemptCount: 3,
+      };
+
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={phase}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+
+      const attemptsField = screen.getByTestId('item-field-Attempts');
+      expect(attemptsField.textContent).toContain('3');
+    });
+
+    it('shows "1" when attemptCount is not set but phase exists', async () => {
+      const phase: Job = {
+        id: 'job-1',
+        projectId: 'proj-1',
+        phase: 'analyze',
+        status: 'success',
+        k8sJobName: 'k8s-job-1',
+        startedAt: new Date('2024-01-01T12:00:00Z'),
+        finishedAt: new Date('2024-01-01T12:02:30Z'),
+      };
+
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={phase}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+
+      const attemptsField = screen.getByTestId('item-field-Attempts');
+      expect(attemptsField.textContent).toContain('1');
+    });
+
+    it('shows total elapsed as separate field when attemptCount > 1 and firstAttemptAt is set', async () => {
+      const phase: Job = {
+        id: 'job-1',
+        projectId: 'proj-1',
+        phase: 'migrate',
+        status: 'success',
+        k8sJobName: 'k8s-job-1',
+        startedAt: new Date('2024-01-01T12:20:00Z'),
+        finishedAt: new Date('2024-01-01T12:30:00Z'),
+        attemptCount: 3,
+        firstAttemptAt: new Date('2024-01-01T12:00:00Z'),
+      };
+
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={phase}
+            projectId="proj-1"
+            phaseName="migrate"
+            moduleId="mod-1"
+          />,
+        );
+      });
+
+      const attemptsField = screen.getByTestId('item-field-Attempts');
+      expect(attemptsField.textContent).toContain('3');
+
+      const totalElapsedField = screen.getByTestId('item-field-Total Elapsed');
+      expect(totalElapsedField.textContent).toContain('30m 0s');
+    });
+
+    it('shows "-" for total elapsed when attemptCount is 1', async () => {
+      const phase: Job = {
+        id: 'job-1',
+        projectId: 'proj-1',
+        phase: 'analyze',
+        status: 'success',
+        k8sJobName: 'k8s-job-1',
+        startedAt: new Date('2024-01-01T12:00:00Z'),
+        finishedAt: new Date('2024-01-01T12:02:30Z'),
+        attemptCount: 1,
+        firstAttemptAt: new Date('2024-01-01T12:00:00Z'),
+      };
+
+      await act(async () => {
+        render(
+          <PhaseDetails
+            phase={phase}
+            projectId="proj-1"
+            phaseName="analyze"
+            moduleId="mod-1"
+          />,
+        );
+      });
+
+      const totalElapsedField = screen.getByTestId('item-field-Total Elapsed');
+      expect(totalElapsedField.textContent).toContain('-');
+      expect(totalElapsedField.textContent).not.toMatch(/\d+[smhd]/);
+    });
+  });
+
   describe('log streaming', () => {
     it('fetches module log with streaming: true and displays a single-chunk line', async () => {
       mockModulesModuleIdLogGet.mockResolvedValue(

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
@@ -38,6 +38,7 @@ import {
   canCancelPhase,
   downloadLogFile,
   formatDuration,
+  getEffectiveDurationSeconds,
   humanizeDate,
   secondsBetween,
 } from './tools';
@@ -179,10 +180,23 @@ export const PhaseDetails = (
   const { phase, projectId, phaseName, onRunPhase, onCancelPhase } = props;
   const moduleId = 'moduleId' in props ? props.moduleId : undefined;
 
+  const durationSeconds = phase
+    ? getEffectiveDurationSeconds(phase)
+    : undefined;
   const duration =
-    phase?.startedAt && phase?.finishedAt
-      ? formatDuration(t, secondsBetween(phase.startedAt, phase.finishedAt))
-      : empty;
+    durationSeconds === undefined ? empty : formatDuration(t, durationSeconds);
+
+  const attemptCount = phase?.attemptCount ?? (phase ? 1 : undefined);
+  const totalDuration =
+    attemptCount &&
+    attemptCount > 1 &&
+    phase?.firstAttemptAt &&
+    phase?.finishedAt
+      ? formatDuration(
+          t,
+          secondsBetween(phase.firstAttemptAt, phase.finishedAt),
+        )
+      : undefined;
 
   const canRunPhase = phase?.status !== 'running';
 
@@ -247,32 +261,48 @@ export const PhaseDetails = (
         />
       </Grid>
 
-      <Grid item xs={2}>
+      <Grid item xs={3}>
         <ItemField
           label={t('modulePage.phases.startedAt')}
           value={phase?.startedAt ? humanizeDate(phase.startedAt) : empty}
         />
       </Grid>
-      <Grid item xs={2}>
+      <Grid item xs={3}>
         <ItemField label={t('modulePage.phases.duration')} value={duration} />
       </Grid>
-      <Grid item xs={2}>
+      <Grid item xs={3}>
+        <ItemField
+          label={t('modulePage.phases.attempts')}
+          value={String(attemptCount ?? empty)}
+        />
+      </Grid>
+      <Grid item xs={3}>
+        <ItemField
+          label={t('modulePage.phases.totalElapsed')}
+          value={totalDuration || empty}
+        />
+      </Grid>
+
+      <Grid item xs={3}>
         <ItemField
           label={t('modulePage.phases.k8sJobName')}
           value={phase?.k8sJobName || empty}
         />
       </Grid>
-      <Grid item xs={2}>
+      <Grid item xs={3}>
         <ItemField
           label={t('modulePage.phases.id')}
           value={phase?.id || empty}
         />
       </Grid>
-      <Grid item xs={2}>
+      <Grid item xs={3}>
         <ItemField
           label={t('modulePage.phases.commitId')}
           value={phase?.commitId || empty}
         />
+      </Grid>
+      <Grid item xs={3}>
+        {/* space holder */}
       </Grid>
 
       {phase && (

--- a/workspaces/x2a/plugins/x2a/src/components/tools/formatRelativeTime.test.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/formatRelativeTime.test.ts
@@ -23,10 +23,12 @@ import x2aPluginTranslationEs from '../../translations/es';
 import x2aPluginTranslationDe from '../../translations/de';
 import x2aPluginTranslationFr from '../../translations/fr';
 import x2aPluginTranslationIt from '../../translations/it';
+import { Job } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 import {
   formatDuration,
   formatRelativeTime,
   formatTimeAgo,
+  getEffectiveDurationSeconds,
 } from './formatRelativeTime';
 
 const t = mockT as unknown as TFuncX2A;
@@ -461,5 +463,85 @@ describe('locale-specific compositions', () => {
     ) as unknown as TFuncX2A;
     const result = formatRelativeTime(tEs, startedAt, undefined);
     expect(result).toBe('En ejecución desde hace 2d 3h');
+  });
+});
+
+describe('formatRelativeTime with durationOverrideSeconds', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('uses durationOverrideSeconds for the "took" part when provided', () => {
+    const startedAt = new Date('2024-01-01T11:00:00Z');
+    const finishedAt = new Date('2024-01-01T11:55:00Z');
+    const result = formatRelativeTime(t, startedAt, finishedAt, 420);
+    expect(result).toBe('Finished 5m ago (took 7m 0s)');
+  });
+
+  it('falls back to computed duration when override is undefined', () => {
+    const startedAt = new Date('2024-01-01T11:40:00Z');
+    const finishedAt = new Date('2024-01-01T11:55:00Z');
+    const result = formatRelativeTime(t, startedAt, finishedAt, undefined);
+    expect(result).toBe('Finished 5m ago (took 15m 0s)');
+  });
+
+  it('does not affect running display', () => {
+    const startedAt = new Date('2024-01-01T11:57:30Z');
+    const result = formatRelativeTime(t, startedAt, undefined, 999);
+    expect(result).toBe('Running for 2m 30s');
+  });
+});
+
+describe('getEffectiveDurationSeconds', () => {
+  const baseJob: Job = {
+    id: 'job-1',
+    projectId: 'proj-1',
+    phase: 'analyze',
+    status: 'success',
+    k8sJobName: 'k8s-job-1',
+    startedAt: new Date('2024-01-01T12:00:00Z'),
+    finishedAt: new Date('2024-01-01T12:30:00Z'),
+  };
+
+  it('returns job-level duration when no telemetry', () => {
+    expect(getEffectiveDurationSeconds(baseJob)).toBe(1800);
+  });
+
+  it('returns telemetry-based duration when telemetry is present', () => {
+    const job: Job = {
+      ...baseJob,
+      telemetry: {
+        summary: 'ok',
+        phase: 'analyze',
+        startedAt: new Date('2024-01-01T12:20:00Z'),
+        endedAt: new Date('2024-01-01T12:27:00Z'),
+      },
+    };
+    expect(getEffectiveDurationSeconds(job)).toBe(420);
+  });
+
+  it('uses telemetry.startedAt with job.finishedAt when telemetry.endedAt is missing', () => {
+    const job: Job = {
+      ...baseJob,
+      telemetry: {
+        summary: 'ok',
+        phase: 'analyze',
+        startedAt: new Date('2024-01-01T12:20:00Z'),
+      },
+    };
+    expect(getEffectiveDurationSeconds(job)).toBe(600);
+  });
+
+  it('returns undefined when job has no finishedAt and no telemetry', () => {
+    const runningJob: Job = {
+      ...baseJob,
+      finishedAt: undefined,
+    };
+    expect(getEffectiveDurationSeconds(runningJob)).toBeUndefined();
   });
 });

--- a/workspaces/x2a/plugins/x2a/src/components/tools/formatRelativeTime.ts
+++ b/workspaces/x2a/plugins/x2a/src/components/tools/formatRelativeTime.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Job } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+
 import { TFuncX2A } from '../../hooks/useTranslation';
 
 const num2str = (n: number) => n.toString();
@@ -101,15 +103,31 @@ export const secondsBetween = (from: Date, to: Date): number => {
 };
 
 /**
+ * Returns the effective execution duration in seconds for a job,
+ * preferring telemetry timestamps (actual pod execution time) over
+ * the job-level timestamps which may aggregate multiple k8s pod retries.
+ */
+export const getEffectiveDurationSeconds = (job: Job): number | undefined => {
+  const start = job.telemetry?.startedAt ?? job.startedAt;
+  const end = job.telemetry?.endedAt ?? job.finishedAt;
+  if (!start || !end) return undefined;
+  return secondsBetween(start, end);
+};
+
+/**
  * Formats relative timing as a status string:
  * - No start time: "-"
  * - Running (no finish time): "Running for 2m 30s"
  * - Finished: "Finished 5m ago (took 15m 0s)"
+ *
+ * @param durationOverrideSeconds - if provided, overrides the "took" duration
+ *   (e.g. telemetry-based duration that excludes k8s pod restart time).
  */
 export const formatRelativeTime = (
   t: TFuncX2A,
   startedAt: Date | undefined,
   finishedAt: Date | undefined,
+  durationOverrideSeconds?: number,
 ): string => {
   if (!startedAt) {
     return t('time.jobTiming.noStartTime');
@@ -121,6 +139,8 @@ export const formatRelativeTime = (
   }
 
   const timeAgo = formatTimeAgo(t, finishedAt);
-  const duration = formatDuration(t, secondsBetween(startedAt, finishedAt));
+  const durationSec =
+    durationOverrideSeconds ?? secondsBetween(startedAt, finishedAt);
+  const duration = formatDuration(t, durationSec);
   return t('time.jobTiming.finished' as any, { timeAgo, duration });
 };

--- a/workspaces/x2a/plugins/x2a/src/translations/de.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/de.ts
@@ -189,6 +189,8 @@ const x2aPluginTranslationDe = createTranslationMessages({
       'Fehler beim Ausführen der Phase für das Modul',
     'modulePage.phases.cancelError':
       'Fehler beim Abbrechen der Phase für das Modul',
+    'modulePage.phases.attempts': 'Versuche',
+    'modulePage.phases.totalElapsed': 'Gesamtdauer',
     'modulePage.phases.commitId': 'Letzte Commit-ID',
     'modulePage.phases.viewLog': 'Log anzeigen',
     'modulePage.phases.hideLog': 'Log ausblenden',

--- a/workspaces/x2a/plugins/x2a/src/translations/es.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/es.ts
@@ -190,6 +190,8 @@ const x2aPluginTranslationEs = createTranslationMessages({
     'modulePage.phases.cancel': 'Cancelar',
     'modulePage.phases.runError': 'Error al ejecutar la fase para el módulo',
     'modulePage.phases.cancelError': 'Error al cancelar la fase para el módulo',
+    'modulePage.phases.attempts': 'Intentos',
+    'modulePage.phases.totalElapsed': 'Tiempo total',
     'modulePage.phases.commitId': 'Último ID de commit',
     'modulePage.phases.viewLog': 'Ver registro',
     'modulePage.phases.hideLog': 'Ocultar registro',

--- a/workspaces/x2a/plugins/x2a/src/translations/fr.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/fr.ts
@@ -190,6 +190,8 @@ const x2aPluginTranslationFr = createTranslationMessages({
       "Échec de l'exécution de la phase pour le module",
     'modulePage.phases.cancelError':
       "Échec de l'annulation de la phase pour le module",
+    'modulePage.phases.attempts': 'Tentatives',
+    'modulePage.phases.totalElapsed': 'Durée totale',
     'modulePage.phases.commitId': 'Dernier ID de commit',
     'modulePage.phases.viewLog': 'Voir le journal',
     'modulePage.phases.hideLog': 'Masquer le journal',

--- a/workspaces/x2a/plugins/x2a/src/translations/it.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/it.ts
@@ -192,6 +192,8 @@ const x2aPluginTranslationIt = createTranslationMessages({
       "Errore nell'esecuzione della fase per il modulo",
     'modulePage.phases.cancelError':
       "Errore nell'annullamento della fase per il modulo",
+    'modulePage.phases.attempts': 'Tentativi',
+    'modulePage.phases.totalElapsed': 'Durata totale',
     'modulePage.phases.commitId': 'Ultimo ID commit',
     'modulePage.phases.viewLog': 'Visualizza log',
     'modulePage.phases.hideLog': 'Nascondi log',

--- a/workspaces/x2a/plugins/x2a/src/translations/ref.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/ref.ts
@@ -134,6 +134,8 @@ export const x2aPluginMessages = {
       cancel: 'Cancel',
       runError: 'Failed to run phase for module',
       cancelError: 'Failed to cancel phase for module',
+      attempts: 'Attempts',
+      totalElapsed: 'Total Elapsed',
       commitId: 'Last Commit ID',
       viewLog: 'View Log',
       hideLog: 'Hide Log',


### PR DESCRIPTION
Fixes: FLPATH-3525

Use telemetry timestamps for phase duration instead of aggregated job-level times that include failed pod restarts.

Add attemptCount and firstAttemptAt enrichment fields to the Job schema.

Display attempts and total elapsed time as separate fields in PhaseDetails.

---

<img width="2331" height="1101" alt="Screenshot From 2026-05-25 16-11-02" src="https://github.com/user-attachments/assets/e237d131-4f66-4d92-9845-df08c950d6a1" />
