### PR TITLE
fix(orchestrator): restore status and date filters on workflow runs

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-graphql-filter-variable-types.md
+++ b/workspaces/orchestrator/.changeset/fix-graphql-filter-variable-types.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+Fix an issue where filtering workflow runs by status or date could show an error instead of results.

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/filterBuilder.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/filterBuilder.ts
@@ -111,23 +111,53 @@ function handleNestedFilter(
   return filterClause;
 }
 
-function handleBetweenOperator(filter: FieldFilter): FilterClause {
+function getGraphQLVariableType(
+  fieldName: string,
+  fieldDef: IntrospectionField | undefined,
+  type: ProcessType,
+  isArray: boolean,
+): string {
+  if (isEnumFilter(fieldName, type)) {
+    return isArray ? '[ProcessInstanceState!]' : 'ProcessInstanceState';
+  }
+
+  if (fieldDef?.type.name === TypeName.Date) {
+    return 'DateTime!';
+  }
+
+  if (isArray) {
+    return '[String!]';
+  }
+
+  return 'String';
+}
+
+function handleBetweenOperator(
+  filter: FieldFilter,
+  fieldDef: IntrospectionField | undefined,
+): FilterClause {
   if (!Array.isArray(filter.value) || filter.value.length !== 2) {
     throw new Error('Between operator requires an array of two elements');
   }
+  const paramType = getGraphQLVariableType(
+    filter.field,
+    fieldDef,
+    'ProcessInstance',
+    false,
+  );
   const filterClauseVariableArray: FilterClauseVariable[] = [];
   const clauseVariableName1 = `clauseVariable${nonSecureRandomAlphaNumeric()}`;
   const filterClauseVariable1: FilterClauseVariable = {
     clauseVariableName: clauseVariableName1,
     formattedValue: filter.value[0],
-    clauseVariableType: 'String',
+    clauseVariableType: paramType,
   };
 
   const clauseVariableName2 = `clauseVariable${nonSecureRandomAlphaNumeric()}`;
   const filterClauseVariable2: FilterClauseVariable = {
     clauseVariableName: clauseVariableName2,
     formattedValue: filter.value[1],
-    clauseVariableType: 'String',
+    clauseVariableType: paramType,
   };
 
   const clause = `${filter.field}: {${getGraphQLOperator(
@@ -193,14 +223,11 @@ function handleBinaryOperator(
     }
   }
   let formattedValue: any;
-  let paramType: string;
-  if (Array.isArray(binaryFilter.value)) {
-    formattedValue = binaryFilter.value.map(v =>
+  const isArray = Array.isArray(binaryFilter.value);
+  if (isArray) {
+    formattedValue = (binaryFilter.value as unknown[]).map((v: unknown) =>
       formatValue(binaryFilter.field, v, fieldDef, type),
     );
-    paramType = isEnumFilter(binaryFilter.field, type)
-      ? '[ProcessInstanceState!]'
-      : '[String!]';
   } else {
     formattedValue = formatValue(
       binaryFilter.field,
@@ -208,8 +235,13 @@ function handleBinaryOperator(
       fieldDef,
       type,
     );
-    paramType = 'String';
   }
+  const paramType = getGraphQLVariableType(
+    binaryFilter.field,
+    fieldDef,
+    type,
+    isArray,
+  );
 
   const clauseVariableName = `clauseVariable${nonSecureRandomAlphaNumeric()}`;
   const clause = `${binaryFilter.field}: {${getGraphQLOperator(binaryFilter.operator)}: $${clauseVariableName}}`;
@@ -273,7 +305,7 @@ export function buildFilterCondition(
     case FieldFilterOperatorEnum.IsNull:
       return handleIsNullOperator(filters);
     case FieldFilterOperatorEnum.Between:
-      return handleBetweenOperator(filters);
+      return handleBetweenOperator(filters, fieldDef);
     case FieldFilterOperatorEnum.Eq:
     case FieldFilterOperatorEnum.Like:
     case FieldFilterOperatorEnum.In:

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/filterBuilders.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/filterBuilders.test.ts
@@ -128,6 +128,7 @@ describe('column filters', () => {
     filter: Filter | undefined;
     expectedResult: string | FilterClause;
     expectedFormattedValue: Array<string | boolean | string[]>;
+    expectedVariableTypes?: string[];
   };
   describe('empty filter testcases', () => {
     const emptyFilterTestCases: FilterTestCase[] = [
@@ -519,6 +520,7 @@ describe('column filters', () => {
         ),
         expectedResult: `start: {equal: $variable1}`,
         expectedFormattedValue: [testDate1],
+        expectedVariableTypes: ['DateTime!'],
       },
       {
         name: 'returns correct filter for single date field with isNull operator (false as boolean)',
@@ -595,6 +597,7 @@ describe('column filters', () => {
         ]),
         expectedResult: `start: {between: {from: $variable1, to: $variable2}}`,
         expectedFormattedValue: [testDate1, testDate2],
+        expectedVariableTypes: ['DateTime!', 'DateTime!'],
       },
       {
         name: 'returns correct OR filter for multiple id fields with equal, isNull, and GT operators',
@@ -683,6 +686,7 @@ describe('column filters', () => {
         filter,
         expectedResult,
         expectedFormattedValue,
+        expectedVariableTypes,
       }) => {
         it(`${name}`, () => {
           const result = buildFilterCondition(
@@ -698,6 +702,9 @@ describe('column filters', () => {
               `$${item.clauseVariableName}`,
             );
             expect(item.formattedValue).toEqual(expectedFormattedValue[index]);
+            expect(item.clauseVariableType).toBe(
+              expectedVariableTypes?.[index] ?? item.clauseVariableType,
+            );
           });
           expect(formattedClause).toBe(result.clause);
         });
@@ -718,6 +725,7 @@ describe('column filters', () => {
         ),
         expectedResult: `state: {equal: $variable1}`,
         expectedFormattedValue: ['COMPLETED'],
+        expectedVariableTypes: ['ProcessInstanceState'],
       },
     ];
 
@@ -728,6 +736,7 @@ describe('column filters', () => {
         filter,
         expectedResult,
         expectedFormattedValue,
+        expectedVariableTypes,
       }) => {
         it(`${name}`, () => {
           const result = buildFilterCondition(
@@ -743,6 +752,9 @@ describe('column filters', () => {
               `$${item.clauseVariableName}`,
             );
             expect(item.formattedValue).toEqual(expectedFormattedValue[index]);
+            expect(item.clauseVariableType).toBe(
+              expectedVariableTypes?.[index] ?? item.clauseVariableType,
+            );
           });
           expect(formattedClause).toBe(result.clause);
         });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3225

### Summary

- Fixes an issue where filtering workflow runs by **status** or **date** could show an error instead of results
- Restores the correct filter types used when querying workflow instances after the recent query variable change


https://github.com/user-attachments/assets/6f563d62-4d69-44aa-bbb8-5d31a5032b6c




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
