### PR TITLE
feat(orchestrator-form): hide wizard steps for conditional ui:hidden

### DIFF
--- a/workspaces/orchestrator/.changeset/conditional-step-hiding-operators.md
+++ b/workspaces/orchestrator/.changeset/conditional-step-hiding-operators.md
@@ -1,5 +1,5 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
 ---
 
 Hide wizard steps when conditional `ui:hidden` rules evaluate to true, and add `isNotEmptyList`/`notContains` operators for conditional hidden expressions.

--- a/workspaces/orchestrator/.changeset/conditional-step-hiding-operators.md
+++ b/workspaces/orchestrator/.changeset/conditional-step-hiding-operators.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': minor
+---
+
+Hide wizard steps when conditional `ui:hidden` rules evaluate to true, and add `isNotEmptyList`/`notContains` operators for conditional hidden expressions.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/report.api.md
@@ -37,6 +37,8 @@ export interface HiddenConditionObject {
   is?: JsonValue | JsonValue[];
   isEmpty?: boolean;
   isNot?: JsonValue | JsonValue[];
+  isNotEmptyList?: boolean;
+  notContains?: JsonValue;
   when: string;
 }
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -78,7 +78,7 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
       return undefined;
     }
 
-    return getActiveStepKey(schema, activeStep);
+    return getActiveStepKey(schema, activeStep, formData);
   };
 
   const onSubmit = async (_formData: JsonObject) => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
@@ -41,8 +41,8 @@ const StepperObjectField = ({
   const { t } = useTranslation();
 
   const sortedStepEntries = useMemo(
-    () => getSortedStepEntries(schema),
-    [schema],
+    () => getSortedStepEntries(schema, formData),
+    [schema, formData],
   );
   if (sortedStepEntries === undefined) {
     throw new Error(t('stepperObjectField.error'));

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/types/HiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/types/HiddenCondition.ts
@@ -42,6 +42,16 @@ export interface HiddenConditionObject {
    * Hide if the field is empty (undefined, null, empty string, or empty array)
    */
   isEmpty?: boolean;
+
+  /**
+   * Hide if the field is a non-empty array (when true) or an empty/non-array value (when false).
+   */
+  isNotEmptyList?: boolean;
+
+  /**
+   * Hide if the field value (an array) does NOT contain this value.
+   */
+  notContains?: JsonValue;
 }
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.test.ts
@@ -124,6 +124,69 @@ describe('evaluateHiddenCondition', () => {
       };
       expect(evaluateHiddenCondition(condition, nestedFormData)).toBe(true);
     });
+
+    it('should hide when list is non-empty (isNotEmptyList)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'items',
+        isNotEmptyList: true,
+      };
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: ['a'],
+        }),
+      ).toBe(true);
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: [],
+        }),
+      ).toBe(false);
+    });
+
+    it('should hide when list does not contain value (notContains)', () => {
+      const condition: HiddenConditionObject = {
+        when: 'items',
+        notContains: 'x',
+      };
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: ['a', 'b'],
+        }),
+      ).toBe(true);
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: ['a', 'x'],
+        }),
+      ).toBe(false);
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: 'not-a-list',
+        }),
+      ).toBe(false);
+    });
+
+    it('should AND multiple operators in one condition object', () => {
+      const condition: HiddenConditionObject = {
+        when: 'items',
+        isNotEmptyList: true,
+        notContains: 'x',
+      };
+
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: ['a', 'b'],
+        }),
+      ).toBe(true);
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: [],
+        }),
+      ).toBe(false);
+      expect(
+        evaluateHiddenCondition(condition, {
+          items: ['x'],
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('composite conditions', () => {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/evaluateHiddenCondition.ts
@@ -91,24 +91,56 @@ function evaluateConditionObject(
     rootFormData,
   );
 
+  let hasCondition = false;
+  let shouldHide = true;
+
   // Check isEmpty condition
   if (condition.isEmpty !== undefined) {
+    hasCondition = true;
     const empty = isEmptyValue(fieldValue);
-    return condition.isEmpty ? empty : !empty;
+    if (!(condition.isEmpty ? empty : !empty)) {
+      shouldHide = false;
+    }
   }
 
   // Check 'is' condition (hide if field equals any value)
   if (condition.is !== undefined) {
-    return matchesAny(fieldValue, condition.is);
+    hasCondition = true;
+    if (!matchesAny(fieldValue, condition.is)) {
+      shouldHide = false;
+    }
   }
 
   // Check 'isNot' condition (hide if field does NOT equal any value)
   if (condition.isNot !== undefined) {
-    return !matchesAny(fieldValue, condition.isNot);
+    hasCondition = true;
+    if (matchesAny(fieldValue, condition.isNot)) {
+      shouldHide = false;
+    }
+  }
+
+  // Check 'isNotEmptyList' condition
+  if (condition.isNotEmptyList !== undefined) {
+    hasCondition = true;
+    const isNonEmptyList = Array.isArray(fieldValue) && fieldValue.length > 0;
+    if (!(condition.isNotEmptyList ? isNonEmptyList : !isNonEmptyList)) {
+      shouldHide = false;
+    }
+  }
+
+  // Check 'notContains' condition (hide when array does not include value)
+  if (condition.notContains !== undefined) {
+    hasCondition = true;
+    const notContainsValue =
+      Array.isArray(fieldValue) &&
+      !fieldValue.some(item => matchesAny(item, condition.notContains!));
+    if (!notContainsValue) {
+      shouldHide = false;
+    }
   }
 
   // No valid condition found, don't hide
-  return false;
+  return hasCondition ? shouldHide : false;
 }
 
 /**

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/getSortedStepEntries.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/getSortedStepEntries.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import { JSONSchema7 } from 'json-schema';
+
+import { getActiveStepKey, getSortedStepEntries } from './getSortedStepEntries';
+
+describe('getSortedStepEntries', () => {
+  it('filters a step with conditional ui:hidden at the step level', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        step1: {
+          type: 'object',
+          properties: {
+            trigger: { type: 'string' },
+          },
+        },
+        step2: {
+          type: 'object',
+          'ui:hidden': { when: 'step1.trigger', is: 'hide' },
+          properties: {
+            detail: { type: 'string' },
+          },
+        } as JSONSchema7,
+      },
+    };
+
+    const formData: JsonObject = {
+      step1: { trigger: 'hide' },
+      step2: { detail: '' },
+    };
+
+    expect(getSortedStepEntries(schema, formData)?.map(([key]) => key)).toEqual(
+      ['step1'],
+    );
+  });
+
+  it('filters a step when all properties are conditionally hidden (local scope)', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        inputs: {
+          type: 'object',
+          properties: {
+            mode: { type: 'string', 'ui:hidden': true },
+            detailsA: {
+              type: 'string',
+              'ui:hidden': { when: 'mode', isNot: 'show' },
+            } as JSONSchema7,
+            detailsB: {
+              type: 'string',
+              'ui:hidden': { when: 'mode', isNot: 'show' },
+            } as JSONSchema7,
+          },
+        } as JSONSchema7,
+        summary: {
+          type: 'object',
+          properties: {
+            info: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const formData: JsonObject = {
+      inputs: {
+        mode: 'hide',
+        details: '',
+      },
+      summary: {
+        info: 'visible',
+      },
+    };
+
+    expect(getSortedStepEntries(schema, formData)?.map(([key]) => key)).toEqual(
+      ['summary'],
+    );
+  });
+
+  it('resolves active step key using filtered step list', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        step1: {
+          type: 'object',
+          properties: {
+            trigger: { type: 'string' },
+          },
+        },
+        step2: {
+          type: 'object',
+          'ui:hidden': { when: 'step1.trigger', is: 'hide' },
+          properties: {
+            detail: { type: 'string' },
+          },
+        } as JSONSchema7,
+        step3: {
+          type: 'object',
+          properties: {
+            final: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const formData: JsonObject = {
+      step1: { trigger: 'hide' },
+      step2: { detail: '' },
+      step3: { final: '' },
+    };
+
+    expect(getActiveStepKey(schema, 0, formData)).toBe('step1');
+    expect(getActiveStepKey(schema, 1, formData)).toBe('step3');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/getSortedStepEntries.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/getSortedStepEntries.ts
@@ -13,8 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { JsonObject } from '@backstage/types';
+
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import get from 'lodash/get';
+
+import { HiddenCondition } from '../types/HiddenCondition';
+import { evaluateHiddenCondition } from './evaluateHiddenCondition';
+
+const asJsonObject = (value: unknown): JsonObject | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonObject)
+    : undefined;
 
 /**
  * Get step entries from the schema sorted by the ui:order property.
@@ -23,10 +33,12 @@ import get from 'lodash/get';
  * Steps where ALL inputs are marked with ui:hidden: true are also automatically filtered out.
  *
  * @param schema - The schema to get the sorted step entries from.
+ * @param formData - Optional form data to evaluate conditional `ui:hidden` expressions.
  * @returns An array of [key, subSchema] pairs, a subSchema conforms a single wizard step.
  */
 export const getSortedStepEntries = (
   schema: JSONSchema7,
+  formData?: JsonObject,
 ): [string, JSONSchema7Definition][] | undefined => {
   if (!schema.properties) {
     return undefined;
@@ -51,13 +63,28 @@ export const getSortedStepEntries = (
 
   // Filter out hidden steps (fields with ui:hidden: true)
   // Also filter out steps where ALL inputs are hidden
-  sortedStepEntries = sortedStepEntries.filter(([_, subSchema]) => {
+  sortedStepEntries = sortedStepEntries.filter(([stepKey, subSchema]) => {
     if (typeof subSchema === 'boolean') {
       return true;
     }
 
+    const rootFormData = formData ?? {};
+    const localFormData = asJsonObject(formData?.[stepKey]) ?? rootFormData;
+
     // Check if step itself is explicitly hidden
-    if (get(subSchema, 'ui:hidden') === true) {
+    const stepHidden = get(subSchema, 'ui:hidden');
+    if (stepHidden === true) {
+      return false;
+    }
+    if (
+      typeof stepHidden === 'object' &&
+      stepHidden !== null &&
+      evaluateHiddenCondition(
+        stepHidden as HiddenCondition,
+        localFormData,
+        rootFormData,
+      )
+    ) {
       return false;
     }
 
@@ -71,7 +98,18 @@ export const getSortedStepEntries = (
           if (typeof prop === 'boolean') {
             return false;
           }
-          return get(prop, 'ui:hidden') === true;
+          const propHidden = get(prop, 'ui:hidden');
+          if (propHidden === true) {
+            return true;
+          }
+          if (typeof propHidden === 'object' && propHidden !== null) {
+            return evaluateHiddenCondition(
+              propHidden as HiddenCondition,
+              localFormData,
+              rootFormData,
+            );
+          }
+          return false;
         });
 
         if (allHidden) {
@@ -89,8 +127,9 @@ export const getSortedStepEntries = (
 export const getActiveStepKey = (
   schema: JSONSchema7,
   activeStep: number,
+  formData?: JsonObject,
 ): string => {
-  const sortedStepEntries = getSortedStepEntries(schema) ?? [];
+  const sortedStepEntries = getSortedStepEntries(schema, formData) ?? [];
   const activeKey = sortedStepEntries[activeStep]?.[0];
   if (!activeKey) {
     throw new Error(

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/useValidator.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/useValidator.ts
@@ -69,7 +69,7 @@ const useValidator = (isMultiStepSchema: boolean) => {
         return validationData;
       }
 
-      const activeKey = getActiveStepKey(_schema, activeStep);
+      const activeKey = getActiveStepKey(_schema, activeStep, formData);
       return {
         errors: validationData.errors.filter(err =>
           err.property?.startsWith(`.${activeKey}.`),

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -124,11 +124,11 @@ const _default: OverridableFrontendPlugin<
         defaultGroup?: [Error: `Use the 'group' param instead`];
         group?:
           | (
-              | 'operation'
               | 'overview'
               | 'documentation'
               | 'development'
               | 'deployment'
+              | 'operation'
               | 'observability'
             )
           | (string & {});

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -124,11 +124,11 @@ const _default: OverridableFrontendPlugin<
         defaultGroup?: [Error: `Use the 'group' param instead`];
         group?:
           | (
+              | 'operation'
               | 'overview'
               | 'documentation'
               | 'development'
               | 'deployment'
-              | 'operation'
               | 'observability'
             )
           | (string & {});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3224

- Fixes empty wizard steps when `ui:hidden` is conditional at the step level or when every field in a step is conditionally hidden.
- `getSortedStepEntries` previously only filtered steps with static `ui:hidden: true`. Conditional expressions were evaluated for individual fields but not when building the stepper, so users saw blank wizard pages.

-------------------

https://github.com/user-attachments/assets/fb5c59a6-8c57-4bfc-8594-5aae5341da7b

--------------------

------Workflow to test----

```
{
  "id": "test-conditional-step-hidden",
  "version": "1.0",
  "specVersion": "0.8",
  "name": "Test Conditional Step ui:hidden",
  "description": "Multi-step wizard for RHDHBUGS-3224: whole steps hidden via step-level ui:hidden or when every field in a step is conditionally hidden.",
  "dataInputSchema": "schemas/test-conditional-step-hidden__main-schema.json",
  "start": "PrintOutput",
  "functions": [
    {
      "name": "systemOut",
      "type": "custom",
      "operation": "sysout"
    }
  ],
  "states": [
    {
      "name": "PrintOutput",
      "type": "operation",
      "actions": [
        {
          "name": "printSystemOut",
          "functionRef": {
            "refName": "systemOut",
            "arguments": {
              "message": "."
            }
          }
        }
      ],
      "end": true
    }
  ]
}
```

```
{
  "$id": "classpath:/schemas/test-conditional-step-hidden__main-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Test Conditional Step ui:hidden",
  "description": "Manual QA for hiding entire wizard steps. Step 2 disappears when Step 1 trigger is hide. Step 3 disappears when Step 1 mode is idle (all fields in that step are conditionally hidden).",
  "type": "object",
  "ui:order": ["setup", "optionalDetails", "allHiddenWhenIdle", "confirm"],
  "properties": {
    "setup": {
      "type": "object",
      "title": "Step 1 — Setup",
      "description": "trigger=hide removes Step 2. mode=idle removes Step 3 (all fields hidden).",
      "properties": {
        "trigger": {
          "type": "string",
          "title": "Optional details step",
          "enum": ["show", "hide"],
          "default": "hide"
        },
        "mode": {
          "type": "string",
          "title": "Details step visibility",
          "enum": ["idle", "show"],
          "default": "idle"
        }
      },
      "required": ["trigger", "mode"]
    },
    "optionalDetails": {
      "type": "object",
      "title": "Step 2 — Optional details (step-level ui:hidden)",
      "description": "Hidden when Step 1 trigger is hide.",
      "ui:hidden": {
        "when": "setup.trigger",
        "is": "hide"
      },
      "properties": {
        "detail": {
          "type": "string",
          "title": "Detail"
        }
      }
    },
    "allHiddenWhenIdle": {
      "type": "object",
      "title": "Step 3 — All fields hidden when idle",
      "description": "When Step 1 mode is idle, both fields below are hidden and this step should leave the stepper.",
      "properties": {
        "detailsA": {
          "type": "string",
          "title": "Details A",
          "ui:hidden": {
            "when": "setup.mode",
            "isNot": "show"
          }
        },
        "detailsB": {
          "type": "string",
          "title": "Details B",
          "ui:hidden": {
            "when": "setup.mode",
            "isNot": "show"
          }
        }
      }
    },
    "confirm": {
      "type": "object",
      "title": "Step 4 — Confirm",
      "properties": {
        "notes": {
          "type": "string",
          "title": "Notes",
          "ui:widget": "textarea"
        }
      }
    }
  }
}
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
