### PR TITLE
feat: add boost workspace to fullsend auto-review

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -2,7 +2,7 @@
 # Routes events to agent workflows via reusable-dispatch.yml.
 #
 # Agents enabled: triage, coder, review, fix
-# Review auto-triggers on PRs touching workspaces/scorecard/ only.
+# Review auto-triggers on PRs touching workspaces/boost/ or workspaces/scorecard/.
 # All other agents are reachable via /fs-* slash commands.
 #
 # Auth gate: slash commands are restricted to org members/collaborators.
@@ -29,6 +29,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, closed]
     paths:
+      - "workspaces/boost/**"
       - "workspaces/scorecard/**"
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
## Summary

- Adds `workspaces/boost/**` to the fullsend `pull_request_target` paths filter
- PRs touching the boost workspace will now auto-trigger the review agent

## Test plan

- [ ] Verify fullsend review agent triggers on a PR touching `workspaces/boost/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)