### PR TITLE
FLPATH-4242 | [DCM] Search does not reset pagination - shows empty table when matches exist

### DIFF
--- a/workspaces/dcm/.changeset/fix-pagination-reset-on-search.md
+++ b/workspaces/dcm/.changeset/fix-pagination-reset-on-search.md
@@ -1,0 +1,15 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm': patch
+---
+
+Fix pagination not resetting to page 1 when a search/filter is applied.
+
+When a user navigates to a later page and then types in the search field, the
+table would appear empty because the page index was left pointing past the end
+of the now-smaller filtered result set.
+
+All table components now reset to page 0 whenever the search or filter value
+changes, consistent with the existing behaviour in `DcmEntitiesCard`.
+
+Affected tabs: Providers, Policies, Catalog Items, Catalog Item Instances,
+Resources, Service Types, Service Specs, Environments, and Request History.

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
@@ -190,6 +190,10 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     options.storageKey ?? '',
   );
 
+  useEffect(() => {
+    setPage(0);
+  }, [search]);
+
   // ── Create dialog ────────────────────────────────────────────────────────
   const [createOpen, setCreateOpen] = useState(false);
   const [createForm, setCreateForm] = useState<F>(() => options.emptyForm());

--- a/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.tsx
@@ -54,6 +54,10 @@ export function ResourcesTabContent() {
     load();
   }, [load]);
 
+  useEffect(() => {
+    setPage(0);
+  }, [search]);
+
   const filtered = useMemo(() => {
     if (!search.trim()) return instances;
     const q = search.toLowerCase();

--- a/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.tsx
@@ -59,6 +59,10 @@ export function ServiceTypesTabContent() {
     load();
   }, [load]);
 
+  useEffect(() => {
+    setPage(0);
+  }, [search]);
+
   const filtered = useMemo(() => {
     if (!search.trim()) return serviceTypes;
     const q = search.toLowerCase();


### PR DESCRIPTION
FLPATH-4242 | [DCM] Search does not reset pagination - shows empty table when matches exist