### PR TITLE
fix(chore): add yarn start:debug option to packages.json

### DIFF
--- a/workspaces/boost/package.json
+++ b/workspaces/boost/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "backstage-cli repo start",
+    "start:debug": "backstage-cli repo start --inspect",
     "build:all": "backstage-cli repo build --all",
     "build:api-reports": "yarn build:api-reports:only --tsc",
     "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type,ae-undocumented --validate-release-tags",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

turns out `backstage-cli repo start` has the --inspect option @durandom 

I was able to validate it in other workspaces which had workable code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ n/a] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ n/a] Added or Updated documentation
- [ n/a] Tests for new functionality and regression tests for bug fixes
- [ n/a] Screenshots attached (for UI changes)
