### PR TITLE
feat(app-auth): Make signInPage config optional and derive from auth providers

### DIFF
--- a/workspaces/app-defaults/.changeset/tough-carpets-smell.md
+++ b/workspaces/app-defaults/.changeset/tough-carpets-smell.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-app-auth': minor
+---
+
+Make signInPage config optional and derive signInPage cards from configs defined under auth.providers

--- a/workspaces/app-defaults/plugins/app-auth/README.md
+++ b/workspaces/app-defaults/plugins/app-auth/README.md
@@ -10,3 +10,5 @@ RHDH sign-in page (multi-provider) and OIDC / Keycloak / PingFederate / Auth0 / 
 ## Config
 
 Root `signInPage` (string or string[]) selects which providers appear; see `config.d.ts`. Provider ids include `oidc`, `keycloak`, and `pingfederate` (OIDC-backed; backend `auth.providers` keys must match).
+
+By default, sign-in page follows the top-level keys under `auth.providers`. Set root `signInPage` (string or string[]) to override the list or order; see `config.d.ts`.

--- a/workspaces/app-defaults/plugins/app-auth/config.d.ts
+++ b/workspaces/app-defaults/plugins/app-auth/config.d.ts
@@ -16,7 +16,8 @@
 
 export interface Config {
   /**
-   * Sign-in provider id(s) to show on the RHDH sign-in page.
+   * Optional override for which sign-in provider buttons appear and in what order.
+   * When omitted, provider ids are taken from the keys of `auth.providers`.
    * @visibility frontend
    */
   signInPage?: string | string[];

--- a/workspaces/app-defaults/plugins/app-auth/src/components/SignInPage.tsx
+++ b/workspaces/app-defaults/plugins/app-auth/src/components/SignInPage.tsx
@@ -211,13 +211,18 @@ export function SignInPage(props: SignInPageProps): React.JSX.Element {
   }
   const isDevEnv = authEnvironment === 'development';
 
-  const signInPageConfig = configApi.getOptional<string | string[]>(
-    'signInPage',
-  );
-  const configValue = signInPageConfig ?? DEFAULT_PROVIDER;
-  const providerNames = Array.isArray(configValue)
-    ? configValue
-    : [configValue];
+  const signInPage = configApi.getOptional<string | string[]>('signInPage');
+  let providerNames: string[];
+  if (signInPage === undefined) {
+    const fromAuth =
+      configApi
+        .getOptionalConfig('auth.providers')
+        ?.keys()
+        ?.filter(providerId => providerId !== 'guest') ?? [];
+    providerNames = fromAuth.length > 0 ? fromAuth : [DEFAULT_PROVIDER];
+  } else {
+    providerNames = Array.isArray(signInPage) ? signInPage : [signInPage];
+  }
 
   const providers = createProviders(t);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Makes the root `signInPage` config optional
  - When unset, the sign-in page now builds its provider list from keys under `auth.providers` (excluding guest), falling back to GitHub if none are configured
  - Explicit `signInPage` config still overrides the list and maintains previous behaviour.

Fixes [RHIDP-13492](https://redhat.atlassian.net/browse/RHIDP-13492)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
