### PR TITLE
Security: Sanitize Lightspeed Core error responses

### DIFF
--- a/workspaces/lightspeed/.changeset/long-penguins-rhyme.md
+++ b/workspaces/lightspeed/.changeset/long-penguins-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
+---
+
+Security: Sanitize LCS error responses to prevent information disclosure

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -258,7 +258,13 @@ describe('lightspeed router tests', () => {
           return new HttpResponse(
             JSON.stringify({
               error: {
-                message: 'Internal server error',
+                message:
+                  'Model gpt-4-0613 failed with OpenAI API error: rate limit exceeded for organization org-abc123',
+              },
+              detail: {
+                cause: 'OpenAIError: Rate limit reached',
+                provider: 'openai',
+                model_id: 'gpt-4-0613',
               },
             }),
             {
@@ -279,6 +285,12 @@ describe('lightspeed router tests', () => {
       expect(response.body.error).toContain(
         'Error from lightspeed-core server',
       );
+      // Verify internal details are NOT exposed
+      expect(response.body.error).not.toContain('gpt-4');
+      expect(response.body.error).not.toContain('OpenAI');
+      expect(response.body.error).not.toContain('org-abc123');
+      expect(response.body.error).not.toContain('openai');
+      expect(response.body.error).not.toContain('rate limit');
     });
   });
 
@@ -407,7 +419,12 @@ describe('lightspeed router tests', () => {
           return new HttpResponse(
             JSON.stringify({
               error: {
-                message: 'Internal server error',
+                message:
+                  'Database connection failed at /app/db/postgres.py:142',
+              },
+              detail: {
+                cause: 'PostgreSQL connection timeout',
+                trace_id: 'req_xyz789',
               },
             }),
             {
@@ -432,6 +449,11 @@ describe('lightspeed router tests', () => {
       expect(response.body.error).toContain(
         'Error from lightspeed-core server',
       );
+      // Verify internal details are NOT exposed
+      expect(response.body.error).not.toContain('Database');
+      expect(response.body.error).not.toContain('postgres.py');
+      expect(response.body.error).not.toContain('PostgreSQL');
+      expect(response.body.error).not.toContain('req_xyz789');
     });
   });
 

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -247,7 +247,9 @@ describe('lightspeed router tests', () => {
         });
 
       expect(response.statusCode).toEqual(404);
-      expect(response.body.error).toContain('not found');
+      expect(response.body.error).toContain(
+        'Error from lightspeed-core server',
+      );
     });
 
     it('should handle upstream server errors properly', async () => {

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -66,6 +66,30 @@ interface StaticMcpServer {
 }
 
 /**
+ * Sanitizes Lightspeed Core Service (LCS) error responses to prevent
+ * information disclosure. Logs full error details server-side for debugging
+ * while returning only generic messages to clients.
+ *
+ * @param errorBody - The error response body from LCS
+ * @param logger - Logger instance for server-side logging
+ * @param context - Context string describing the operation (e.g., "sending feedback")
+ * @returns Generic error message safe to return to clients
+ */
+function sanitizeLcsError(
+  errorBody: any,
+  logger: any,
+  context: string,
+): string {
+  // Log full error details server-side for debugging
+  logger.error(
+    `Error from lightspeed-core server while ${context}: ${JSON.stringify(errorBody)}`,
+  );
+
+  // Return only generic message to client (no internal LCS details)
+  return `Error from lightspeed-core server while ${context}`;
+}
+
+/**
  * Build MCP-HEADERS for LCS.  Format matches the LCS "client" auth model:
  *   { "server-name": { "Authorization": "<token>" } }
  *
@@ -565,13 +589,15 @@ export async function createRouter(
       );
 
       if (!fetchResponse.ok) {
-        // Read the error body
         const errorBody = await fetchResponse.json();
-        const errormsg = `Error from lightspeed-core server: ${errorBody.error?.message || errorBody?.detail?.cause || 'Unknown error'}`;
-        logger.error(errormsg);
+        const sanitizedError = sanitizeLcsError(
+          errorBody,
+          logger,
+          'sending feedback',
+        );
 
         response.status(fetchResponse.status).json({
-          error: errormsg,
+          error: sanitizedError,
         });
 
         return;
@@ -612,9 +638,12 @@ export async function createRouter(
       );
       if (!fetchResponse.ok) {
         const errorBody = await fetchResponse.json();
-        const errormsg = `Error from lightspeed-core server: ${errorBody.error?.message || errorBody?.detail?.cause || 'Unknown error'}`;
-        logger.error(errormsg);
-        response.status(fetchResponse.status).json({ error: errormsg });
+        const sanitizedError = sanitizeLcsError(
+          errorBody,
+          logger,
+          'interrupting query',
+        );
+        response.status(fetchResponse.status).json({ error: sanitizedError });
         return;
       }
       response.status(fetchResponse.status).json(await fetchResponse.json());
@@ -687,13 +716,15 @@ export async function createRouter(
         );
 
         if (!fetchResponse.ok) {
-          // Read the error body
           const errorBody = await fetchResponse.json();
-          const errormsg = `Error from lightspeed-core server: ${errorBody.error?.message || errorBody?.detail?.cause || 'Unknown error'}`;
-          logger.error(errormsg);
+          const sanitizedError = sanitizeLcsError(
+            errorBody,
+            logger,
+            'processing query',
+          );
 
           response.status(fetchResponse.status).json({
-            error: errormsg,
+            error: sanitizedError,
           });
 
           return;
@@ -741,13 +772,15 @@ export async function createRouter(
           },
         );
         if (!fetchResponse.ok) {
-          // Read the error body
           const errorBody = await fetchResponse.json();
-          const errormsg = `Error from lightspeed-core server: ${errorBody.error?.message || errorBody?.detail?.cause || 'Unknown error'}`;
-          logger.error(errormsg);
+          const sanitizedError = sanitizeLcsError(
+            errorBody,
+            logger,
+            'updating conversation',
+          );
 
           response.status(fetchResponse.status).json({
-            error: errormsg,
+            error: sanitizedError,
           });
           return;
         }

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -56,6 +56,7 @@ import {
   QueryRequestBody,
   RouterOptions,
 } from './types';
+import { sanitizeLCSError } from './utils';
 import { isAllowedProxyPath, validateCompletionsRequest } from './validation';
 
 const SKIP_USER_ID_ENDPOINTS = new Set(['/v1/models', '/v1/shields']);
@@ -63,30 +64,6 @@ const SKIP_USER_ID_ENDPOINTS = new Set(['/v1/models', '/v1/shields']);
 interface StaticMcpServer {
   name: string;
   token?: string;
-}
-
-/**
- * Sanitizes Lightspeed Core Service (LCS) error responses to prevent
- * information disclosure. Logs full error details server-side for debugging
- * while returning only generic messages to clients.
- *
- * @param errorBody - The error response body from LCS
- * @param logger - Logger instance for server-side logging
- * @param context - Context string describing the operation (e.g., "sending feedback")
- * @returns Generic error message safe to return to clients
- */
-function sanitizeLcsError(
-  errorBody: any,
-  logger: any,
-  context: string,
-): string {
-  // Log full error details server-side for debugging
-  logger.error(
-    `Error from lightspeed-core server while ${context}: ${JSON.stringify(errorBody)}`,
-  );
-
-  // Return only generic message to client (no internal LCS details)
-  return `Error from lightspeed-core server while ${context}`;
 }
 
 /**
@@ -590,7 +567,7 @@ export async function createRouter(
 
       if (!fetchResponse.ok) {
         const errorBody = await fetchResponse.json();
-        const sanitizedError = sanitizeLcsError(
+        const sanitizedError = sanitizeLCSError(
           errorBody,
           logger,
           'sending feedback',
@@ -638,7 +615,7 @@ export async function createRouter(
       );
       if (!fetchResponse.ok) {
         const errorBody = await fetchResponse.json();
-        const sanitizedError = sanitizeLcsError(
+        const sanitizedError = sanitizeLCSError(
           errorBody,
           logger,
           'interrupting query',
@@ -717,7 +694,7 @@ export async function createRouter(
 
         if (!fetchResponse.ok) {
           const errorBody = await fetchResponse.json();
-          const sanitizedError = sanitizeLcsError(
+          const sanitizedError = sanitizeLCSError(
             errorBody,
             logger,
             'processing query',
@@ -773,7 +750,7 @@ export async function createRouter(
         );
         if (!fetchResponse.ok) {
           const errorBody = await fetchResponse.json();
-          const sanitizedError = sanitizeLcsError(
+          const sanitizedError = sanitizeLCSError(
             errorBody,
             logger,
             'updating conversation',

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -56,7 +56,7 @@ import {
   QueryRequestBody,
   RouterOptions,
 } from './types';
-import { sanitizeLCSError } from './utils';
+import { handleLCSFetchError } from './utils';
 import { isAllowedProxyPath, validateCompletionsRequest } from './validation';
 
 const SKIP_USER_ID_ENDPOINTS = new Set(['/v1/models', '/v1/shields']);
@@ -566,17 +566,12 @@ export async function createRouter(
       );
 
       if (!fetchResponse.ok) {
-        const errorBody = await fetchResponse.json();
-        const sanitizedError = sanitizeLCSError(
-          errorBody,
+        await handleLCSFetchError(
+          fetchResponse,
           logger,
           'sending feedback',
+          response,
         );
-
-        response.status(fetchResponse.status).json({
-          error: sanitizedError,
-        });
-
         return;
       }
 
@@ -614,13 +609,12 @@ export async function createRouter(
         },
       );
       if (!fetchResponse.ok) {
-        const errorBody = await fetchResponse.json();
-        const sanitizedError = sanitizeLCSError(
-          errorBody,
+        await handleLCSFetchError(
+          fetchResponse,
           logger,
           'interrupting query',
+          response,
         );
-        response.status(fetchResponse.status).json({ error: sanitizedError });
         return;
       }
       response.status(fetchResponse.status).json(await fetchResponse.json());
@@ -693,17 +687,12 @@ export async function createRouter(
         );
 
         if (!fetchResponse.ok) {
-          const errorBody = await fetchResponse.json();
-          const sanitizedError = sanitizeLCSError(
-            errorBody,
+          await handleLCSFetchError(
+            fetchResponse,
             logger,
             'processing query',
+            response,
           );
-
-          response.status(fetchResponse.status).json({
-            error: sanitizedError,
-          });
-
           return;
         }
 
@@ -749,16 +738,12 @@ export async function createRouter(
           },
         );
         if (!fetchResponse.ok) {
-          const errorBody = await fetchResponse.json();
-          const sanitizedError = sanitizeLCSError(
-            errorBody,
+          await handleLCSFetchError(
+            fetchResponse,
             logger,
             'updating conversation',
+            response,
           );
-
-          response.status(fetchResponse.status).json({
-            error: sanitizedError,
-          });
           return;
         }
 

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { sanitizeLCSError } from './utils';
+import { handleLCSFetchError, sanitizeLCSError } from './utils';
 
 describe('sanitizeLCSError', () => {
   const mockLogger = {
@@ -101,6 +101,68 @@ describe('sanitizeLCSError', () => {
     expect(result).toBe(
       'Error from lightspeed-core server while updating conversation',
     );
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});
+
+describe('handleLCSFetchError', () => {
+  const mockLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle fetch response with JSON body', async () => {
+    const mockFetchResponse = {
+      ok: false,
+      status: 500,
+      json: jest.fn().mockResolvedValue({
+        error: { message: 'Database error' },
+      }),
+    } as unknown as Response;
+
+    await handleLCSFetchError(
+      mockFetchResponse,
+      mockLogger,
+      'processing query',
+      mockResponse,
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: 'Error from lightspeed-core server while processing query',
+    });
+  });
+
+  it('should handle fetch response without JSON body', async () => {
+    const mockFetchResponse = {
+      ok: false,
+      status: 503,
+      json: jest.fn().mockRejectedValue(new Error('Not JSON')),
+    } as unknown as Response;
+
+    await handleLCSFetchError(
+      mockFetchResponse,
+      mockLogger,
+      'sending feedback',
+      mockResponse,
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(503);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: 'Error from lightspeed-core server while sending feedback',
+    });
     expect(mockLogger.error).toHaveBeenCalled();
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sanitizeLCSError } from './utils';
+
+describe('sanitizeLCSError', () => {
+  const mockLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return generic error message to client', () => {
+    const errorBody = {
+      error: {
+        message:
+          'Model gpt-4-0613 failed with OpenAI API error: rate limit exceeded',
+      },
+      detail: {
+        cause: 'OpenAIError: Rate limit reached',
+      },
+    };
+
+    const result = sanitizeLCSError(errorBody, mockLogger, 'processing query');
+
+    expect(result).toBe(
+      'Error from lightspeed-core server while processing query',
+    );
+  });
+
+  it('should log full error details server-side', () => {
+    const errorBody = {
+      error: {
+        message: 'Database connection failed',
+      },
+      detail: {
+        cause: 'PostgreSQL connection timeout',
+      },
+    };
+
+    sanitizeLCSError(errorBody, mockLogger, 'sending feedback');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      `Error from lightspeed-core server while sending feedback: ${JSON.stringify(errorBody)}`,
+    );
+  });
+
+  it('should not expose internal details in return value', () => {
+    const errorBody = {
+      error: {
+        message:
+          'Model gpt-4-0613 failed with organization org-abc123 rate limit',
+      },
+      detail: {
+        cause: 'OpenAIError',
+        provider: 'openai',
+        model_id: 'gpt-4-0613',
+      },
+    };
+
+    const result = sanitizeLCSError(
+      errorBody,
+      mockLogger,
+      'interrupting query',
+    );
+
+    expect(result).not.toContain('gpt-4');
+    expect(result).not.toContain('org-abc123');
+    expect(result).not.toContain('openai');
+    expect(result).not.toContain('OpenAIError');
+  });
+
+  it('should handle empty error body', () => {
+    const errorBody = {};
+
+    const result = sanitizeLCSError(
+      errorBody,
+      mockLogger,
+      'updating conversation',
+    );
+
+    expect(result).toBe(
+      'Error from lightspeed-core server while updating conversation',
+    );
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.ts
@@ -65,9 +65,15 @@ export async function handleLCSFetchError(
   fetchResponse: Response,
   logger: LoggerService,
   context: string,
-  response: any,
+  response: { status: (code: number) => { json: (body: any) => void } },
 ): Promise<void> {
-  const errorBody = await fetchResponse.json();
+  let errorBody: LCSErrorResponse;
+  try {
+    errorBody = await fetchResponse.json();
+  } catch {
+    // If LCS doesn't return JSON or doesn't have a body, use empty object
+    errorBody = {};
+  }
   const sanitizedError = sanitizeLCSError(errorBody, logger, context);
   response.status(fetchResponse.status).json({ error: sanitizedError });
 }

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.ts
@@ -51,3 +51,23 @@ export function sanitizeLCSError(
   // Return only generic message to client (no internal LCS details)
   return `Error from lightspeed-core server while ${context}`;
 }
+
+/**
+ * Handles LCS fetch errors by sanitizing the error response and sending it to the client.
+ * This helper eliminates code duplication across multiple endpoints.
+ *
+ * @param fetchResponse - The failed fetch response from LCS
+ * @param logger - Logger instance for server-side logging
+ * @param context - Context string describing the operation
+ * @param response - Express response object
+ */
+export async function handleLCSFetchError(
+  fetchResponse: Response,
+  logger: LoggerService,
+  context: string,
+  response: any,
+): Promise<void> {
+  const errorBody = await fetchResponse.json();
+  const sanitizedError = sanitizeLCSError(errorBody, logger, context);
+  response.status(fetchResponse.status).json({ error: sanitizedError });
+}

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/utils.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+/**
+ * Interface for Lightspeed Core Service error response structure
+ */
+export interface LCSErrorResponse {
+  error?: {
+    message?: string;
+  };
+  detail?: {
+    cause?: string;
+  };
+}
+
+/**
+ * Sanitizes Lightspeed Core Service (LCS) error responses to prevent
+ * information disclosure. Logs full error details server-side for debugging
+ * while returning only generic messages to clients.
+ *
+ * @param errorBody - The error response body from LCS
+ * @param logger - Logger instance for server-side logging
+ * @param context - Context string describing the operation (e.g., "sending feedback")
+ * @returns Generic error message safe to return to clients
+ */
+export function sanitizeLCSError(
+  errorBody: LCSErrorResponse,
+  logger: LoggerService,
+  context: string,
+): string {
+  // Log full error details server-side for debugging
+  logger.error(
+    `Error from lightspeed-core server while ${context}: ${JSON.stringify(errorBody)}`,
+  );
+
+  // Return only generic message to client (no internal LCS details)
+  return `Error from lightspeed-core server while ${context}`;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an information disclosure vulnerability where error responses from Lightspeed Core were leaking internal details to clients.

**The issue:**
When LCS returns errors, we were forwarding the full error message to clients, which could include model names, provider info, org IDs, stack traces, etc. Not great for security.

**What I changed:**
- Added a `sanitizeLcsError()` function that logs the full error server-side but only returns a generic message to the client
- Updated the error handling in 4 endpoints: `/v1/feedback`, `/v1/query/interrupt`, `/v1/query`, and `/v2/conversations/:id`
- Updated tests to make sure we're not leaking internal details

**Example:**
Before: `{"error": "Error from lightspeed-core server: Model gpt-4-0613 failed with OpenAI API error: rate limit exceeded for organization org-abc123"}`

After: `{"error": "Error from lightspeed-core server while processing query"}`

Full error details are still logged on the server for debugging.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
