### PR TITLE
fix(lightspeed): delete-button-bg-color

### DIFF
--- a/workspaces/lightspeed/.changeset/fix-delete-button-bg-color.md
+++ b/workspaces/lightspeed/.changeset/fix-delete-button-bg-color.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+fix(lightspeed): use theme-aware error color for delete buttons in notebook modals

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteDocumentModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteDocumentModal.tsx
@@ -61,6 +61,11 @@ const useStyles = makeStyles(theme => ({
   removeButton: {
     textTransform: 'none',
     borderRadius: 999,
+    backgroundColor: theme.palette.error?.main || '#b1380b',
+    color: theme.palette.error?.contrastText || '#fff',
+    '&:hover': {
+      backgroundColor: theme.palette.error?.dark || '#731f00',
+    },
   },
   cancelButton: {
     textTransform: 'none',
@@ -127,7 +132,6 @@ export const DeleteDocumentModal = ({
       <DialogActions className={classes.dialogActions}>
         <Button
           variant="contained"
-          color="error"
           className={classes.removeButton}
           onClick={onConfirm}
         >

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteNotebookModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DeleteNotebookModal.tsx
@@ -68,6 +68,11 @@ const useStyles = makeStyles(theme => ({
   deleteButton: {
     textTransform: 'none',
     borderRadius: 999,
+    backgroundColor: theme.palette.error?.main || '#b1380b',
+    color: theme.palette.error?.contrastText || '#fff',
+    '&:hover': {
+      backgroundColor: theme.palette.error?.dark || '#731f00',
+    },
   },
   cancelButton: {
     textTransform: 'none',
@@ -144,7 +149,6 @@ export const DeleteNotebookModal = ({
       <DialogActions className={classes.dialogActions}>
         <Button
           variant="contained"
-          color="error"
           className={classes.deleteButton}
           onClick={handleDelete}
         >


### PR DESCRIPTION
Summary
  
  - Fixed delete button background color in DeleteNotebookModal and DeleteDocumentModal to use
  theme-aware error colors instead of relying on MUI's color="error" prop
  - The RHDH theme (@red-hat-developer-hub/backstage-plugin-theme) does not define palette.error,
  so color="error" falls back to MUI's default (#d32f2f) which differs from the expected RHDH
  error color (#b1380b)
  - Buttons now explicitly use theme.palette.error?.main || '#b1380b' with a fallback, ensuring
  correct appearance in both RHDH and the dev workspace

  Why

  The RHDH theme currently does not define the following error palette colors:
  - palette.error.main
  - palette.error.dark
  - palette.error.contrastText

  These need to be defined in the RHDH theme (@red-hat-developer-hub/backstage-plugin-theme) so
  that any component using color="error" or theme.palette.error gets the correct RHDH-branded
  colors instead of MUI defaults. The expected values are:
  - palette.error.main: #b1380b
  - palette.error.dark: #731f00
  - palette.error.contrastText: #fff
  
  Once the RHDH theme defines these, the hardcoded fallbacks in this PR become redundant safety
  nets.

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
