### PR TITLE
fix(bulk-import): fix French localization in Preview PR drawer

### DIFF
--- a/workspaces/bulk-import/.changeset/fix-french-pr-drawer-labels.md
+++ b/workspaces/bulk-import/.changeset/fix-french-pr-drawer-labels.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Fixed French localization bug in the Preview PR side drawer where the title label displayed an unresolved `{{outil}}` placeholder instead of the translated tool name. Also improved French word order for the title, body, and details labels to use natural "Noun de {{tool}}" phrasing.

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/de.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/de.ts
@@ -117,7 +117,7 @@ const bulkImportTranslationDe = createTranslationMessages({
       'Pull Request konnte nicht abgerufen werden. Unten wurde ein neues YAML generiert.',
     'previewFile.invalidEntityYaml':
       'Der YAML-Code der Entity in Ihrem Pull Request ist ungültig (leere Datei oder fehlende Werte für apiVersion, kind oder metadata.name). Unten wurde ein neues YAML generiert.',
-    'previewFile.keyValuePlaceholder': 'Schlüssel1: Wert2; Schlüssel2: Wert2',
+    'previewFile.keyValuePlaceholder': 'Schlüssel1: Wert1; Schlüssel2: Wert2',
     'previewFile.prCreationUnsuccessful':
       'Die PR-Erstellung war für einige Repositorys nicht erfolgreich. Klicken Sie auf „Bearbeiten“, um den Grund anzuzeigen.',
     'previewFile.preview': 'Vorschau',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/es.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/es.ts
@@ -118,7 +118,7 @@ const bulkImportTranslationEs = createTranslationMessages({
       'No se pudo obtener la solicitud de extracción. Se generó una nueva entidad YAML a continuación.',
     'previewFile.invalidEntityYaml':
       'La entidad YAML de su solicitud de extracción no es válida (archivo vacío o falta apiVersion, kind o metadata.name). Se generó una nueva entidad YAML a continuación.',
-    'previewFile.keyValuePlaceholder': 'key1: value2; key2: value2',
+    'previewFile.keyValuePlaceholder': 'clave1: valor1; clave2: valor2',
     'previewFile.prCreationUnsuccessful':
       'La creación de PR no se realizó correctamente en algunos repositorios. Haga clic en `Modificar` para ver el motivo.',
     'previewFile.preview': 'Vista previa',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
@@ -127,14 +127,14 @@ const bulkImportTranslationFr = createTranslationMessages({
     'previewFile.previewFile': "Fichier d'aperçu",
     'previewFile.previewFiles': 'Aperçu des fichiers',
     'previewFile.pullRequest.annotations': 'Annotations',
-    'previewFile.pullRequest.bodyLabel': '{{tool}} corps',
+    'previewFile.pullRequest.bodyLabel': 'Corps de {{tool}}',
     'previewFile.pullRequest.bodyPlaceholder':
       'Un texte descriptif compatible avec Markdown',
     'previewFile.pullRequest.codeOwnersWarning':
       'ATTENTION : Cette opération peut échouer si aucun fichier CODEOWNERS n’est trouvé à l’emplacement cible.',
     'previewFile.pullRequest.componentNameLabel': 'Nom du composant créé',
     'previewFile.pullRequest.componentNamePlaceholder': 'Nom du composant',
-    'previewFile.pullRequest.details': '{{tool}} détails',
+    'previewFile.pullRequest.details': 'Détails de {{tool}}',
     'previewFile.pullRequest.entityConfiguration': "Configuration de l'entité",
     'previewFile.pullRequest.entityOwnerHelper':
       'Sélectionnez un propriétaire dans la liste ou saisissez une référence à un groupe ou à un utilisateur.',
@@ -148,7 +148,7 @@ const bulkImportTranslationFr = createTranslationMessages({
     'previewFile.pullRequest.serviceNowTicket': 'Ticket ServiceNow',
     'previewFile.pullRequest.spec': 'Spéc.',
     'previewFile.pullRequest.title': 'Demande d’extraction',
-    'previewFile.pullRequest.titleLabel': '{{outil}} titre',
+    'previewFile.pullRequest.titleLabel': 'Titre de {{tool}}',
     'previewFile.pullRequest.titlePlaceholder':
       "Ajouter des fichiers de descripteurs d'entités du catalogue Backstage",
     'previewFile.pullRequest.useCodeOwnersFile':

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts
@@ -120,7 +120,7 @@ const bulkImportTranslationFr = createTranslationMessages({
       "Impossible de récupérer la requête d'extraction. Un nouveau fichier YAML a été généré ci-dessous.",
     'previewFile.invalidEntityYaml':
       "L'entité YAML dans votre demande d'extraction est invalide (fichier vide ou apiVersion, kind ou metadata.name manquants). Un nouveau fichier YAML a été généré ci-dessous.",
-    'previewFile.keyValuePlaceholder': 'key1: value2; key2: value2',
+    'previewFile.keyValuePlaceholder': 'clé1: valeur1; clé2: valeur2',
     'previewFile.prCreationUnsuccessful':
       'La création de R a échoué pour certains référentiels. Cliquez sur « Modifier » pour voir la raison.',
     'previewFile.preview': 'Aperçu',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/it.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/it.ts
@@ -118,7 +118,7 @@ const bulkImportTranslationIt = createTranslationMessages({
       'Impossibile estrarre la richiesta pull. Un nuovo YAML è stato generato di seguito.',
     'previewFile.invalidEntityYaml':
       "L'entità YAML nella tua richiesta pull non è valida (file vuoto oppure mancano apiVersion, kind o metadata.name). Un nuovo YAML è stato generato di seguito.",
-    'previewFile.keyValuePlaceholder': 'key1: value2; key2: value2',
+    'previewFile.keyValuePlaceholder': 'chiave1: valore1; chiave2: valore2',
     'previewFile.prCreationUnsuccessful':
       'La creazione della pull request non è andata a buon fine per alcuni repository. Fai clic su "Modifica" per visualizzare il motivo.',
     'previewFile.preview': 'Anteprima',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ja.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ja.ts
@@ -117,7 +117,7 @@ const bulkImportTranslationJa = createTranslationMessages({
       'プルリクエストの取得に失敗しました。以下に新しい YAML が生成されました。',
     'previewFile.invalidEntityYaml':
       'プルリクエスト内のエンティティー YAML が無効です (ファイルが空であるか、apiVersion、kind、または metadata.name がありません)。以下に新しい YAML が生成されました。',
-    'previewFile.keyValuePlaceholder': 'key1: value2; key2: value2',
+    'previewFile.keyValuePlaceholder': 'キー1: 値1; キー2: 値2',
     'previewFile.prCreationUnsuccessful':
       '一部のリポジトリーで PR の作成に失敗しました。理由を確認するには、`編集` をクリックしてください。',
     'previewFile.preview': 'プレビュー',

--- a/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/translations/ref.ts
@@ -222,7 +222,7 @@ export const bulkImportMessages = {
     pullRequestText: 'pull request',
     viewRepository: 'View repository',
     closeDrawer: 'Close the drawer',
-    keyValuePlaceholder: 'key1: value2; key2: value2',
+    keyValuePlaceholder: 'key1: value1; key2: value2',
     useSemicolonSeparator: 'Use semicolon to separate {{label}}',
     preview: 'Preview',
     pullRequest: {


### PR DESCRIPTION
## Summary

- Fixed the `titleLabel` French translation which used `{{outil}}` (French for "tool") instead of the correct interpolation variable `{{tool}}`, causing unresolved placeholder text in the Preview PR side drawer.
- Improved French word order for `titleLabel`, `bodyLabel`, and `details` labels from English-style `"{{tool}} noun"` to natural French `"Noun de {{tool}}"`.

## Bug

[RHDHBUGS-2206](https://redhat.atlassian.net/browse/RHDHBUGS-2206) — When French is selected as preferred language, some labels on the Preview PR side drawer display in `{{outil}}` format instead of the translated tool name.

## UI before changes
<img width="1312" height="716" alt="test_1 8_French_localization_bug_1" src="https://github.com/user-attachments/assets/4635992e-9b32-40c2-a75b-ce57ed6eb9e4" />

## UI after changes 
<img width="2560" height="1440" alt="S_ 2026-06-08 at 9 03 26 PM (2)" src="https://github.com/user-attachments/assets/e1ef87dc-27f3-4e61-b909-f6a1fd0ffc88" />

## Changes

**File:** `workspaces/bulk-import/plugins/bulk-import/src/translations/fr.ts`

| Key | Before | After |
|-----|--------|-------|
| `previewFile.pullRequest.titleLabel` | `{{outil}} titre` | `Titre de {{tool}}` |
| `previewFile.pullRequest.bodyLabel` | `{{tool}} corps` | `Corps de {{tool}}` |
| `previewFile.pullRequest.details` | `{{tool}} détails` | `Détails de {{tool}}` |

## Test plan

- [ ] Set preferred language to French in Settings
- [ ] Navigate to Bulk Import, select a repository, and open the Preview PR side drawer
- [ ] Verify the section heading shows "Détails de Demande d'extraction" (not `{{outil}}` or `{{tool}}`)
- [ ] Verify the title field label shows "Titre de Demande d'extraction"
- [ ] Verify the body field label shows "Corps de Demande d'extraction"
- [ ] Verify other languages (English, German, Spanish, Italian, Japanese) are unaffected

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
