### PR TITLE
FLPATH-4272 | [DCM] Hardcoded colors may break dark mode

### DIFF
--- a/workspaces/dcm/.changeset/fix-hardcoded-colors-dark-mode.md
+++ b/workspaces/dcm/.changeset/fix-hardcoded-colors-dark-mode.md
@@ -1,0 +1,9 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm': patch
+---
+
+Replace hardcoded colors and shadows with theme-aware values for dark mode support.
+
+- ProviderStatus: chip border now uses `theme.palette.divider` instead of `rgba(0,0,0,0.2)`
+- CopyButton: "copied" checkmark color now uses `theme.palette.success.main` instead of `#28a745`
+- dcmStyles: overview card box-shadow is suppressed in dark mode via `theme.palette.type` check

--- a/workspaces/dcm/plugins/dcm/src/components/dcmStyles.ts
+++ b/workspaces/dcm/plugins/dcm/src/components/dcmStyles.ts
@@ -300,7 +300,10 @@ export const useDcmStyles = makeStyles(theme => ({
     '& .MuiPaper-root': {
       border: `1px solid ${theme.palette.divider}`,
       borderRadius: theme.shape.borderRadius,
-      boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)',
+      boxShadow:
+        theme.palette.type === 'dark'
+          ? 'none'
+          : '0 1px 2px rgba(0, 0, 0, 0.06)',
       backgroundColor: theme.palette.background.paper,
     },
   },

--- a/workspaces/dcm/plugins/dcm/src/components/dcmStyles.ts
+++ b/workspaces/dcm/plugins/dcm/src/components/dcmStyles.ts
@@ -15,6 +15,7 @@
  */
 
 import { makeStyles } from '@material-ui/core/styles';
+import { isDarkMode } from './dcmTheme';
 
 /**
  * Single shared style hook for the DCM plugin.
@@ -300,10 +301,7 @@ export const useDcmStyles = makeStyles(theme => ({
     '& .MuiPaper-root': {
       border: `1px solid ${theme.palette.divider}`,
       borderRadius: theme.shape.borderRadius,
-      boxShadow:
-        theme.palette.type === 'dark'
-          ? 'none'
-          : '0 1px 2px rgba(0, 0, 0, 0.06)',
+      boxShadow: isDarkMode(theme) ? 'none' : '0 1px 2px rgba(0, 0, 0, 0.06)',
       backgroundColor: theme.palette.background.paper,
     },
   },

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/components/CatalogItemFormFields.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/components/CatalogItemFormFields.tsx
@@ -46,7 +46,7 @@ import { load as loadYaml } from 'js-yaml';
 
 const useStyles = makeStyles(theme => ({
   fieldRow: {
-    background: 'rgba(0,0,0,0.03)',
+    background: theme.palette.action.hover,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(1.25, 1.5),
   },

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/components/CopyButton.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/components/CopyButton.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
   },
   copiedIcon: {
     fontSize: 14,
-    color: '#28a745',
+    color: theme.palette.success.main,
   },
   failedIcon: {
     fontSize: 14,

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/components/ProviderStatus.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/components/ProviderStatus.tsx
@@ -24,12 +24,12 @@ import {
 } from '@backstage/core-components';
 import { Box, makeStyles, Typography } from '@material-ui/core';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   chip: {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    border: '1px solid rgba(0,0,0,0.2)',
+    border: `1px solid ${theme.palette.divider}`,
     borderRadius: 16,
     padding: '2px 10px 2px 6px',
     gap: 4,
@@ -43,7 +43,7 @@ const useStyles = makeStyles({
       height: '0.875rem !important',
     },
   },
-});
+}));
 
 /**
  * Maps a provider `health_status` string to a Backstage Status component.


### PR DESCRIPTION

Replace hardcoded colors and shadows with theme-aware values for dark mode support.

- ProviderStatus: chip border now uses `theme.palette.divider` instead of `rgba(0,0,0,0.2)`
- CopyButton: "copied" checkmark color now uses `theme.palette.success.main` instead of `#28a745`
- dcmStyles: overview card box-shadow is suppressed in dark mode via `theme.palette.type` check