### PR TITLE
Enhance Delete Modal and error display

### DIFF
--- a/workspaces/dcm/.changeset/enhance-delete-dialog.md
+++ b/workspaces/dcm/.changeset/enhance-delete-dialog.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm': patch
+---
+
+Enhance the Delete Dialog UX: keep the dialog open on API errors and display them inline, disable the Delete button and show a loading spinner during submission to prevent double-clicks, use an error-red background for the Delete button, and suppress the external action alert for delete errors in favour of the in-dialog error banner.

--- a/workspaces/dcm/plugins/dcm/src/components/DcmDeleteDialog.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/DcmDeleteDialog.tsx
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-import { Button, Typography } from '@material-ui/core';
+import { Button, CircularProgress, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { DcmFormDialog } from './DcmFormDialog';
+
+const useStyles = makeStyles(theme => ({
+  deleteButton: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+    '&:hover': { backgroundColor: theme.palette.error.dark },
+    '&.Mui-disabled': { opacity: 0.6 },
+  },
+}));
 
 type Props = Readonly<{
   open: boolean;
@@ -23,6 +33,10 @@ type Props = Readonly<{
   onConfirm: () => void;
   resourceName: string;
   resourceLabel?: string;
+  /** When set, renders an error banner inside the dialog. */
+  error?: string | null;
+  /** When true, disables both buttons and shows a spinner on Delete. */
+  isSubmitting?: boolean;
 }>;
 
 /**
@@ -34,18 +48,38 @@ export function DcmDeleteDialog({
   onConfirm,
   resourceName,
   resourceLabel = 'item',
+  error,
+  isSubmitting = false,
 }: Props) {
+  const classes = useStyles();
   return (
     <DcmFormDialog
       open={open}
       onClose={onClose}
       title={`Delete ${resourceLabel}`}
+      error={error}
+      submitting={isSubmitting}
       actions={
         <>
-          <Button variant="contained" color="secondary" onClick={onConfirm}>
+          <Button
+            variant="contained"
+            className={classes.deleteButton}
+            disabled={isSubmitting}
+            onClick={onConfirm}
+            startIcon={
+              isSubmitting ? (
+                <CircularProgress size={16} color="inherit" />
+              ) : undefined
+            }
+          >
             Delete
           </Button>
-          <Button variant="outlined" color="primary" onClick={onClose}>
+          <Button
+            variant="outlined"
+            color="primary"
+            disabled={isSubmitting}
+            onClick={onClose}
+          >
             Cancel
           </Button>
         </>

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.test.ts
@@ -239,7 +239,7 @@ describe('useCrudTab', () => {
       expect(result.current.items.find(i => i.id === '2')).toBeUndefined();
     });
 
-    it('sets deleteError and closes dialog on failure', async () => {
+    it('sets deleteError and keeps dialog open on failure', async () => {
       const opts = makeOptions({
         deleteFn: jest.fn().mockRejectedValue(new Error('delete failed')),
       });
@@ -252,7 +252,9 @@ describe('useCrudTab', () => {
       await waitFor(() =>
         expect(result.current.deleteError).toBe('delete failed'),
       );
-      expect(result.current.deleteOpen).toBe(false);
+      // Dialog stays open so the user can see the error inline
+      expect(result.current.deleteOpen).toBe(true);
+      expect(result.current.deleteSubmitting).toBe(false);
       // Item should NOT be removed from the list
       expect(result.current.items.find(i => i.id === '1')).toBeDefined();
     });

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
@@ -229,6 +229,9 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
   const editSubmittingRef = useRef(editSubmitting);
   editSubmittingRef.current = editSubmitting;
 
+  const deleteSubmittingRef = useRef(deleteSubmitting);
+  deleteSubmittingRef.current = deleteSubmitting;
+
   const deletingItemRef = useRef(deletingItem);
   deletingItemRef.current = deletingItem;
 
@@ -360,6 +363,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
   }, []);
 
   const handleCloseDelete = useCallback(() => {
+    if (deleteSubmittingRef.current) return;
     setDeleteOpen(false);
     setDeletingItem(null);
     setDeleteError(null);

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
@@ -139,6 +139,7 @@ export interface UseCrudTabResult<T, F extends Record<string, unknown>> {
   // ── Delete dialog ──────────────────────────────────────────────────────────
   deleteOpen: boolean;
   deletingItem: T | null;
+  deleteSubmitting: boolean;
   deleteError: string | null;
   setDeleteError: React.Dispatch<React.SetStateAction<string | null>>;
   handleOpenDelete: (item: T) => void;
@@ -212,6 +213,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
   // ── Delete dialog ────────────────────────────────────────────────────────
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deletingItem, setDeletingItem] = useState<T | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   // Keep latest mutable values in refs so stable callbacks can read them.
@@ -368,16 +370,19 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     const item = deletingItemRef.current;
     if (!deleteFn || !item) return;
     const id = gId(item);
+    setDeleteSubmitting(true);
+    setDeleteError(null);
     deleteFn(id)
       .then(() => {
         setItems(removeItemById(id, gId));
         setDeleteOpen(false);
         setDeletingItem(null);
+        setDeleteSubmitting(false);
       })
       .catch(err => {
         setDeleteError(extractApiError(err));
-        setDeleteOpen(false);
-        setDeletingItem(null);
+        setDeleteSubmitting(false);
+        // dialog stays open so the user can see the error
       });
   }, []);
 
@@ -426,6 +431,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     // Delete
     deleteOpen,
     deletingItem,
+    deleteSubmitting,
     deleteError,
     setDeleteError,
     handleOpenDelete,

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
@@ -260,11 +260,8 @@ export function CatalogItemInstancesTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={crud.deleteError ?? rehydrateError}
-        onDismissActionError={() => {
-          crud.setDeleteError(null);
-          setRehydrateError(null);
-        }}
+        actionError={rehydrateError}
+        onDismissActionError={() => setRehydrateError(null)}
         search={crud.search}
         onSearchChange={crud.setSearch}
         page={crud.page}
@@ -317,6 +314,8 @@ export function CatalogItemInstancesTabContent() {
           crud.deletingItem?.display_name ?? crud.deletingItem?.uid ?? ''
         }
         resourceLabel="instance"
+        error={crud.deleteError}
+        isSubmitting={crud.deleteSubmitting}
       />
 
       <DcmSuccessSnackbar

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
@@ -319,8 +319,8 @@ export function CatalogItemsTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={crud.deleteError}
-        onDismissActionError={() => crud.setDeleteError(null)}
+        actionError={null}
+        onDismissActionError={undefined}
         search={crud.search}
         onSearchChange={crud.setSearch}
         page={crud.page}
@@ -390,6 +390,8 @@ export function CatalogItemsTabContent() {
           crud.deletingItem?.display_name ?? crud.deletingItem?.uid ?? ''
         }
         resourceLabel="catalog item"
+        error={crud.deleteError}
+        isSubmitting={crud.deleteSubmitting}
       />
     </>
   );

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.tsx
@@ -332,11 +332,8 @@ export function PoliciesTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={crud.deleteError ?? toggleError}
-        onDismissActionError={() => {
-          crud.setDeleteError(null);
-          setToggleError(null);
-        }}
+        actionError={toggleError}
+        onDismissActionError={() => setToggleError(null)}
         search={crud.search}
         onSearchChange={crud.setSearch}
         page={crud.page}
@@ -387,6 +384,8 @@ export function PoliciesTabContent() {
           crud.deletingItem?.display_name ?? crud.deletingItem?.id ?? ''
         }
         resourceLabel="policy"
+        error={crud.deleteError}
+        isSubmitting={crud.deleteSubmitting}
       />
     </>
   );

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
@@ -296,8 +296,8 @@ export function ProvidersTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={crud.deleteError}
-        onDismissActionError={() => crud.setDeleteError(null)}
+        actionError={null}
+        onDismissActionError={undefined}
         search={crud.search}
         onSearchChange={crud.setSearch}
         page={crud.page}
@@ -349,6 +349,8 @@ export function ProvidersTabContent() {
           crud.deletingItem?.display_name ?? crud.deletingItem?.name ?? ''
         }
         resourceLabel="provider"
+        error={crud.deleteError}
+        isSubmitting={crud.deleteSubmitting}
       />
     </>
   );


### PR DESCRIPTION
### Tickets

- FLPATH-4276 | [DCM] Delete dialog closes on failure losing user context
- FLPATH-4258 | [DCM] Delete confirmation button uses secondary color not destructive red
- FLPATH-4241 | [DCM] Delete dialog allows duplicate DELETE requests (no submitting guard)

---

### Changes

Enhance the Delete Dialog UX: keep the dialog open on API errors and display them inline, disable the Delete button and show a loading spinner during submission to prevent double-clicks, use an error-red background for the Delete button, and suppress the external action alert for delete errors in favour of the in-dialog error banner.