### PR TITLE
Add Boolean Field Support, Confirm Rehydrate and Required Service Type

### DIFF
--- a/workspaces/dcm/.changeset/fix-catalog-form-ux.md
+++ b/workspaces/dcm/.changeset/fix-catalog-form-ux.md
@@ -1,0 +1,10 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm': patch
+---
+
+Fix form UX issues in the Catalog Items and Catalog Item Instances screens.
+
+- Catalog Items: service_type is now required; the field shows a validation error and blocks submission when no service type is selected.
+- Catalog Item Instances: the Create button is now disabled when the form is invalid, consistent with other tabs.
+- Catalog Item Instances: clicking the Rehydrate icon now shows a confirmation dialog warning that rehydrating may assign a new resource ID.
+- Catalog Item Instances: fields with a boolean schema type now render as a Switch instead of a plain text input.

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
@@ -17,7 +17,19 @@
 import { useCallback, useMemo, useState } from 'react';
 import { TableColumn } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { Box, Chip, IconButton, Tooltip, Typography } from '@material-ui/core';
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import AutorenewIcon from '@material-ui/icons/Autorenew';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -70,6 +82,8 @@ export function CatalogItemInstancesTabContent() {
   const [rehydratingId, setRehydratingId] = useState<string | null>(null);
   const [rehydrateError, setRehydrateError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [rehydrateConfirmInst, setRehydrateConfirmInst] =
+    useState<CatalogItemInstance | null>(null);
 
   const crud = useCrudTab<CatalogItemInstance, InstanceForm>({
     loadFn: async () => {
@@ -97,7 +111,7 @@ export function CatalogItemInstancesTabContent() {
 
   const { handleOpenDelete, setItems } = crud;
 
-  const handleRehydrate = useCallback(
+  const executeRehydrate = useCallback(
     async (inst: CatalogItemInstance) => {
       const id = inst.uid ?? '';
       if (!id) return;
@@ -116,6 +130,10 @@ export function CatalogItemInstancesTabContent() {
     },
     [catalogApi, setItems],
   );
+
+  const handleRehydrate = useCallback((inst: CatalogItemInstance) => {
+    setRehydrateConfirmInst(inst);
+  }, []);
 
   const catalogItemName = useCallback(
     (id: string) => {
@@ -292,7 +310,7 @@ export function CatalogItemInstancesTabContent() {
             onCancel={crud.handleCloseCreate}
             submitLabel="Create"
             submitting={crud.createSubmitting}
-            disabled={false}
+            disabled={!isInstanceFormValid(crud.createForm)}
           />
         }
       >
@@ -323,6 +341,42 @@ export function CatalogItemInstancesTabContent() {
         message={successMessage}
         onClose={() => setSuccessMessage(null)}
       />
+
+      <Dialog
+        open={Boolean(rehydrateConfirmInst)}
+        onClose={() => setRehydrateConfirmInst(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Rehydrate instance?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Rehydrating{' '}
+            <strong>
+              {rehydrateConfirmInst?.display_name ??
+                rehydrateConfirmInst?.uid ??
+                'this instance'}
+            </strong>{' '}
+            will re-provision the resource and may assign a new resource ID.
+            This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRehydrateConfirmInst(null)}>Cancel</Button>
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => {
+              if (rehydrateConfirmInst) {
+                executeRehydrate(rehydrateConfirmInst);
+              }
+              setRehydrateConfirmInst(null);
+            }}
+          >
+            Rehydrate
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/components/InstanceFormFields.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/components/InstanceFormFields.tsx
@@ -24,6 +24,7 @@ import {
   MenuItem,
   OutlinedInput,
   Select,
+  Switch,
   TextField,
   Typography,
 } from '@material-ui/core';
@@ -217,8 +218,10 @@ export function InstanceFormFields({
               );
             }
 
+            const schemaType = row.schemaType?.toLowerCase();
+
             /* Integer / number field → numeric text input */
-            if (row.schemaType === 'integer' || row.schemaType === 'number') {
+            if (schemaType === 'integer' || schemaType === 'number') {
               return (
                 <TextField
                   key={row.path}
@@ -231,11 +234,36 @@ export function InstanceFormFields({
                   size="small"
                   type="number"
                   inputProps={{
-                    step: row.schemaType === 'integer' ? 1 : 'any',
+                    step: schemaType === 'integer' ? 1 : 'any',
                     min: row.schemaMin,
                     max: row.schemaMax,
                   }}
                 />
+              );
+            }
+
+            /* Boolean field → Switch (label left, switch right) */
+            if (schemaType === 'boolean') {
+              return (
+                <Box
+                  key={row.path}
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="space-between"
+                >
+                  <Box>
+                    <Typography variant="body2">{row.displayName}</Typography>
+                    <Typography variant="caption" color="textSecondary">
+                      {helperText}
+                    </Typography>
+                  </Box>
+                  <Switch
+                    checked={row.value === 'true'}
+                    onChange={e => setUserValue(i, String(e.target.checked))}
+                    color="primary"
+                    size="small"
+                  />
+                </Box>
               );
             }
 

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/instanceFormTypes.ts
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/instanceFormTypes.ts
@@ -99,7 +99,8 @@ function extractSchemaInfo(
   field: FieldConfiguration,
 ): Pick<UserValueRow, 'schemaType' | 'enumValues' | 'schemaMin' | 'schemaMax'> {
   const schema = field.validation_schema ?? {};
-  const schemaType = typeof schema.type === 'string' ? schema.type : undefined;
+  const schemaType =
+    typeof schema.type === 'string' ? schema.type.toLowerCase() : undefined;
   const enumValues =
     Array.isArray(schema.enum) &&
     schema.enum.every(v => typeof v === 'string' || typeof v === 'number')

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/catalogItemFormTypes.ts
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/catalogItemFormTypes.ts
@@ -54,11 +54,16 @@ const catalogItemSchema = yup.object({
       /^v\d+(?:(?:alpha|beta)\d*)?$/,
       'Must follow the pattern v<number>[alpha|beta][number] — e.g. v1, v1alpha1',
     ),
+  service_type: yup.string().required('Service type is required'),
 });
 
 const { validate: validateScalar } = createYupValidator<CatalogItemForm>(
   catalogItemSchema,
-  f => ({ display_name: f.display_name, api_version: f.api_version }),
+  f => ({
+    display_name: f.display_name,
+    api_version: f.api_version,
+    service_type: f.service_type,
+  }),
 );
 
 export function validateCatalogItemForm(

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/components/CatalogItemFormFields.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/components/CatalogItemFormFields.tsx
@@ -329,18 +329,24 @@ export function CatalogItemFormFields({
         size="small"
         fullWidth
         disabled={isEditMode}
+        error={Boolean(
+          !isEditMode &&
+            (touched.service_type || submitAttempted) &&
+            errors.service_type,
+        )}
       >
-        <InputLabel shrink>Service type</InputLabel>
+        <InputLabel shrink>Service type *</InputLabel>
         <Select
           value={form.service_type}
-          onChange={e =>
+          onChange={e => {
             setForm(prev => ({
               ...prev,
               service_type: e.target.value as string,
-            }))
-          }
+            }));
+            setTouched(prev => ({ ...prev, service_type: true }));
+          }}
           displayEmpty
-          input={<OutlinedInput notched label="Service type" />}
+          input={<OutlinedInput notched label="Service type *" />}
         >
           <MenuItem value="">
             <em>None</em>
@@ -352,7 +358,11 @@ export function CatalogItemFormFields({
           ))}
         </Select>
         <FormHelperText>
-          {serviceTypeHelperText(isEditMode, serviceTypes.length)}
+          {!isEditMode &&
+          (touched.service_type || submitAttempted) &&
+          errors.service_type
+            ? errors.service_type
+            : serviceTypeHelperText(isEditMode, serviceTypes.length)}
         </FormHelperText>
       </FormControl>
 


### PR DESCRIPTION
### Tickets:

- FLPATH-4254 | [DCM] Catalog item service_type not marked as required in form
- FLPATH-4265 | [DCM] Instance create form submit button always enabled
- FLPATH-4267 | [DCM] Rehydrate has no confirmation dialog
- FLPATH-4266 | [DCM] Boolean schema fields render as plain text inputs

---

### Changes:

Fix form UX issues in the Catalog Items and Catalog Item Instances screens.

- Catalog Items: service_type is now required; the field shows a validation error and blocks submission when no service type is selected.
- Catalog Item Instances: the Create button is now disabled when the form is invalid, consistent with other tabs.
- Catalog Item Instances: clicking the Rehydrate icon now shows a confirmation dialog warning that rehydrating may assign a new resource ID.
- Catalog Item Instances: fields with a boolean schema type now render as a Switch instead of a plain text input.