### PR TITLE
fix(lightspeed): bg-color of remove/delte buttons

### DIFF
--- a/workspaces/lightspeed/.changeset/tough-olives-drum.md
+++ b/workspaces/lightspeed/.changeset/tough-olives-drum.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Fixes background color of the remove/delete buttons

--- a/workspaces/lightspeed/plugins/lightspeed/src/index.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/index.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName =>
+  componentName.startsWith('v5-') ? componentName : `v5-${componentName}`,
+);
+
 export {
   lightspeedPlugin,
   LightspeedPage,


### PR DESCRIPTION
## summary

-  fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3188

how these changes fix the bug?  [backstage-doc](https://github.com/backstage/backstage/blob/master/packages/theme/src/unified/UnifiedThemeProvider.tsx#L44C1-L54C4)

### Before changes
<img width="1708" height="967" alt="Screenshot 2026-05-25 at 11 57 54 AM" src="https://github.com/user-attachments/assets/646b8076-592a-48d4-a163-b70ec1e990a4" />

### After changes (In RHDH)
 
<img width="657" height="266" alt="Screenshot 2026-06-10 at 12 20 01 AM" src="https://github.com/user-attachments/assets/f5a70ce7-7009-4f51-847c-0b41c5d13557" />
<img width="979" height="461" alt="Screenshot 2026-06-10 at 12 20 18 AM" src="https://github.com/user-attachments/assets/e5c82c25-21ce-45ac-adb1-0244cc1f3abe" />

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
