### PR TITLE
fix(scorecard): restrict entities to components in filecheck module

### DIFF
--- a/workspaces/scorecard/.changeset/dirty-symbols-mate.md
+++ b/workspaces/scorecard/.changeset/dirty-symbols-mate.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-filecheck': patch
+---
+
+Restrict filecheck metric collection to Component catalog entities by adding a kind: component catalog filter.

--- a/workspaces/scorecard/.changeset/dirty-symbols-mate.md
+++ b/workspaces/scorecard/.changeset/dirty-symbols-mate.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-filecheck': patch
 ---
 
-Restrict filecheck metric collection to Component catalog entities by adding a kind: component catalog filter.
+**BREAKING**: Restrict filecheck metric collection to Component catalog entities by adding a kind: component catalog filter.

--- a/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/README.md
@@ -75,7 +75,7 @@ If no files are configured, no metrics are registered and the module has no effe
 
 ### Entity Requirements
 
-Entities must have the `backstage.io/source-location` annotation set (typically added automatically by the catalog ingestion process):
+Only **Component** entities are checked. They must have the `backstage.io/source-location` annotation set (typically added automatically by the catalog ingestion process):
 
 ```yaml
 # catalog-info.yaml

--- a/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/src/metricProviders/FilecheckMetricProvider.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/src/metricProviders/FilecheckMetricProvider.test.ts
@@ -274,6 +274,7 @@ describe('FilecheckMetricProvider', () => {
 
     it('should return correct catalog filter', () => {
       expect(provider?.getCatalogFilter()).toEqual({
+        kind: 'component',
         'metadata.annotations.backstage.io/source-location': expect.any(Symbol),
       });
     });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/src/metricProviders/FilecheckMetricProvider.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/src/metricProviders/FilecheckMetricProvider.ts
@@ -72,6 +72,7 @@ export class FilecheckMetricProvider implements MetricProvider<'boolean'> {
 
   getCatalogFilter(): Record<string, string | symbol | (string | symbol)[]> {
     return {
+      kind: 'component',
       'metadata.annotations.backstage.io/source-location':
         CATALOG_FILTER_EXISTS,
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The filecheck scorecard module currently pulls metrics for all entities that contain the `backstage.io/source-location `annotation. Since this annotation is automatically added by backstage, filecheck pulls metric even for entities where it is not needed, eg. entities of type Package, and therefore does a lot of requests and pulls a lot of unnecessary data. While the change in this PR is not the final solution for this and further work will need to be done to check the performance issues of the filecheck module (Jira ticket created [here](https://redhat.atlassian.net/browse/RHDHBUGS-3334)), it restrics the entity type being pulled to Components only. This will help pull less data and especially unblock the failing e2e tests. 

Related to: [RHDHBUGS-3197](https://redhat.atlassian.net/browse/RHDHBUGS-3197)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
