### PR TITLE
fix(fullsend): set COREPACK_HOME so yarn and openspec work in sandbox

### DIFF
--- a/.fullsend/customized/env/rhdh-toolchain.env
+++ b/.fullsend/customized/env/rhdh-toolchain.env
@@ -1,0 +1,10 @@
+# Toolchain env vars for the RHDH custom sandbox image.
+# OpenShell does not preserve Docker ENV directives at runtime,
+# so container-specific config must be set here instead.
+#
+# This file is mounted via host_files WITHOUT expand: true —
+# values are hardcoded, not expanded from the runner environment.
+
+# corepack — pre-enabled in the image so yarn is on PATH immediately.
+# Must point to a writable directory (sandbox policy blocks /usr).
+export COREPACK_HOME=/tmp/corepack

--- a/.fullsend/customized/harness/code.yaml
+++ b/.fullsend/customized/harness/code.yaml
@@ -11,6 +11,7 @@
 # Customizations over upstream code.yaml:
 #   - image: rhdh custom image with yarn/corepack pre-installed
 #   - policy: custom code policy with repo.yarnpkg.com for corepack downloads
+#   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
 #   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
 agent: agents/code.md
 doc: docs/agents/code.md
@@ -33,6 +34,8 @@ host_files:
   - src: ${GCP_OIDC_TOKEN_FILE}
     dest: /tmp/workspace/.gcp-oidc-token
     optional: true
+  - src: env/rhdh-toolchain.env
+    dest: /tmp/workspace/.env.d/rhdh-toolchain.env
   - src: env/yarn-proxy.env
     dest: /tmp/workspace/.env.d/yarn-proxy.env
 

--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -11,6 +11,7 @@
 #
 # Customizations over upstream fix.yaml:
 #   - image: rhdh custom image with yarn/corepack pre-installed
+#   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
 #   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
 #   - skills: adds monorepo-workspace-routing for workspace navigation
 #   - policy: custom fix policy with yarn registry + pnpm binary allowlist
@@ -42,6 +43,8 @@ host_files:
   - src: ${GCP_OIDC_TOKEN_FILE}
     dest: /tmp/workspace/.gcp-oidc-token
     optional: true
+  - src: env/rhdh-toolchain.env
+    dest: /tmp/workspace/.env.d/rhdh-toolchain.env
   - src: env/yarn-proxy.env
     dest: /tmp/workspace/.env.d/yarn-proxy.env
 


### PR DESCRIPTION
## Summary

- Add `rhdh-toolchain.env` with `COREPACK_HOME=/tmp/corepack` — OpenShell strips Docker `ENV` directives at runtime, so the Containerfile's `COREPACK_HOME` is lost and corepack falls back to `/usr` (read-only under landlock)
- Mount `rhdh-toolchain.env` into `.env.d/` via `host_files` in both `code.yaml` and `fix.yaml` harnesses
- Mirrors the pattern already working in rhdh-agentic

## Test plan

- [ ] Trigger a `/fs-code` run and verify `COREPACK_HOME` appears in the sandbox env
- [ ] Verify `yarn --version` succeeds inside the sandbox
- [ ] Verify `openspec --version` succeeds inside the sandbox
- [ ] Trigger a `/fs-fix` run and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)