### PR TITLE
fix(fullsend): use /sandbox/workspace/ mount paths (OpenShell 0.0.54+)

### DIFF
--- a/.fullsend/customized/harness/code.yaml
+++ b/.fullsend/customized/harness/code.yaml
@@ -24,20 +24,20 @@ post_script: scripts/post-code.sh
 
 host_files:
   - src: env/gcp-vertex.env
-    dest: /tmp/workspace/.env.d/gcp-vertex.env
+    dest: /sandbox/workspace/.env.d/gcp-vertex.env
     expand: true
   - src: env/code-agent.env
-    dest: /tmp/workspace/.env.d/code-agent.env
+    dest: /sandbox/workspace/.env.d/code-agent.env
     expand: true
   - src: ${GOOGLE_APPLICATION_CREDENTIALS}
-    dest: /tmp/workspace/.gcp-credentials.json
+    dest: /tmp/.gcp-credentials.json
   - src: ${GCP_OIDC_TOKEN_FILE}
-    dest: /tmp/workspace/.gcp-oidc-token
+    dest: /sandbox/workspace/.gcp-oidc-token
     optional: true
   - src: env/rhdh-toolchain.env
-    dest: /tmp/workspace/.env.d/rhdh-toolchain.env
+    dest: /sandbox/workspace/.env.d/rhdh-toolchain.env
   - src: env/yarn-proxy.env
-    dest: /tmp/workspace/.env.d/yarn-proxy.env
+    dest: /sandbox/workspace/.env.d/yarn-proxy.env
 
 skills:
   - skills/code-implementation

--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -31,22 +31,22 @@ post_script: scripts/post-fix.sh
 
 host_files:
   - src: env/gcp-vertex.env
-    dest: /tmp/workspace/.env.d/gcp-vertex.env
+    dest: /sandbox/workspace/.env.d/gcp-vertex.env
     expand: true
   - src: env/fix-agent.env
-    dest: /tmp/workspace/.env.d/fix-agent.env
+    dest: /sandbox/workspace/.env.d/fix-agent.env
     expand: true
   - src: ${GOOGLE_APPLICATION_CREDENTIALS}
-    dest: /tmp/workspace/.gcp-credentials.json
+    dest: /tmp/.gcp-credentials.json
   - src: ${REVIEW_BODY_FILE}
-    dest: /tmp/workspace/review-body.txt
+    dest: /sandbox/workspace/review-body.txt
   - src: ${GCP_OIDC_TOKEN_FILE}
-    dest: /tmp/workspace/.gcp-oidc-token
+    dest: /sandbox/workspace/.gcp-oidc-token
     optional: true
   - src: env/rhdh-toolchain.env
-    dest: /tmp/workspace/.env.d/rhdh-toolchain.env
+    dest: /sandbox/workspace/.env.d/rhdh-toolchain.env
   - src: env/yarn-proxy.env
-    dest: /tmp/workspace/.env.d/yarn-proxy.env
+    dest: /sandbox/workspace/.env.d/yarn-proxy.env
 
 skills:
   - skills/fix-review


### PR DESCRIPTION
## Summary

- Fix all `host_files` dest paths from stale `/tmp/workspace/` to `/sandbox/workspace/` — OpenShell 0.0.54 changed the workspace mount point, so `.env.d/` files were never sourced at sandbox startup
- This caused "Not logged in" errors because `gcp-vertex.env` (Claude API credentials) was invisible to the runtime
- Align GCP credentials path with rhdh-agentic: `/tmp/.gcp-credentials.json`
- Affects both `code.yaml` and `fix.yaml` harnesses

## Root cause

The sandbox sources env vars from `/sandbox/workspace/.env.d/*.env` at startup. All host_files were still mounting to `/tmp/workspace/.env.d/` (the pre-0.0.54 path), so no env vars — including API auth — reached the agent.

## Test plan

- [ ] Trigger `/fs-code` on an open issue and verify the agent authenticates (no "Not logged in")
- [ ] Verify `COREPACK_HOME`, `YARN_HTTP_PROXY`, and GCP credentials are all present in the sandbox env
- [ ] Trigger `/fs-fix` on a PR and verify the review body is readable at `/sandbox/workspace/review-body.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)