### PR TITLE
fix(bulk-import): prevent approval tool resetting to GitHub on link clicks

### DIFF
--- a/workspaces/bulk-import/.changeset/gentle-foxes-leap.md
+++ b/workspaces/bulk-import/.changeset/gentle-foxes-leap.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Fixed approval tool selection resetting to GitHub when clicking Preview file by preventing unintended router navigation that stripped the approvalTool query parameter from the URL.

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/AddRepositories/SelectRepositories.tsx
@@ -52,7 +52,13 @@ export const SelectRepositories = ({
         data-testid="no-repositories"
       >
         {t('addRepositories.allRepositoriesAdded')}{' '}
-        <Link to="" onClick={() => onOrgRowSelected(orgData)}>
+        <Link
+          to=""
+          onClick={e => {
+            e.preventDefault();
+            onOrgRowSelected(orgData);
+          }}
+        >
           {t('common.view')}
         </Link>
       </Typography>
@@ -66,7 +72,13 @@ export const SelectRepositories = ({
     return (
       <Typography component="span" data-testid="select-repositories">
         {t('addRepositories.noSelection')}{' '}
-        <Link to="" onClick={() => onOrgRowSelected(orgData)}>
+        <Link
+          to=""
+          onClick={e => {
+            e.preventDefault();
+            onOrgRowSelected(orgData);
+          }}
+        >
           {t('common.select')}
         </Link>
       </Typography>
@@ -76,7 +88,13 @@ export const SelectRepositories = ({
     <Typography component="span" data-testid="edit-repositories">
       {Object.keys(orgData.selectedRepositories || [])?.length}/
       {(orgData?.totalReposInOrg || 0) - addedRepositoriesCount}{' '}
-      <Link onClick={() => onOrgRowSelected(orgData)} to="">
+      <Link
+        to=""
+        onClick={e => {
+          e.preventDefault();
+          onOrgRowSelected(orgData);
+        }}
+      >
         {t('common.edit')}
       </Link>
     </Typography>

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFile.tsx
@@ -80,9 +80,12 @@ export const PreviewFile = ({ data }: { data: AddRepositoryData }) => {
 
           <Link
             to={errorMessage.showRepositoryLink ? data.repoUrl || '' : ''}
-            onClick={() =>
-              errorMessage.showRepositoryLink ? null : openDrawer(data)
-            }
+            onClick={e => {
+              if (!errorMessage.showRepositoryLink) {
+                e.preventDefault();
+                openDrawer(data);
+              }
+            }}
             data-testid="edit-pull-request"
           >
             {errorMessage.showRepositoryLink ? (
@@ -107,7 +110,10 @@ export const PreviewFile = ({ data }: { data: AddRepositoryData }) => {
           <Link
             to=""
             style={{ marginLeft: '4px' }}
-            onClick={() => openDrawer(data)}
+            onClick={e => {
+              e.preventDefault();
+              openDrawer(data);
+            }}
             data-testid={
               Object.keys(data?.selectedRepositories || []).length > 1
                 ? 'preview-files'

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/PreviewFile/PreviewFileSidebarDrawerContent.tsx
@@ -201,7 +201,14 @@ export const PreviewFileSidebarDrawerContent = ({
         >
           {t('common.save')}
         </Button>
-        <Link to="" variant="button" onClick={onCancel}>
+        <Link
+          to=""
+          variant="button"
+          onClick={e => {
+            e.preventDefault();
+            onCancel();
+          }}
+        >
           <Button variant="outlined">{t('common.cancel')}</Button>
         </Link>
       </Box>


### PR DESCRIPTION
## Description
When GitLab is selected as the Approval Tool in the Bulk Import plugin and the user clicks "Preview file",  the `approvalTool=GITLAB` URL query parameter was being stripped by React Router navigation triggered by `<Link to="">`. This caused the form to reinitialize with GitHub as the default, switching the entire page back to GitHub.

This fix adds `e.preventDefault()` to the `onClick` handlers on these `<Link to="">` elements to prevent the unintended navigation while preserving the intended click behavior (opening drawers, selecting orgs, etc.).

## Fixed
- [RHDHBUGS-3345](https://redhat.atlassian.net/browse/RHDHBUGS-3345)

## UI Before changes

https://github.com/user-attachments/assets/30d7a327-71f0-441d-b358-eafd139cdc9e

## UI after changes 

https://github.com/user-attachments/assets/fa8f84ea-c2a5-4d0e-94b7-be8f08cff1bd



## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)