### PR TITLE
chore: add install-dynamic-plugins workspace to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@
 /workspaces/extensions                              @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @christoph-jerolimov @karthikjeeyar
 /workspaces/global-header                           @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @ciiay @divyanshiGupta
 /workspaces/homepage                                @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @christoph-jerolimov @eswaraiahsapram
+/workspaces/install-dynamic-plugins                 @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-plugins
 /workspaces/lightspeed                              @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @redhat-developer/rhdh-ai @karthikjeeyar @rohitkrai03 @yangcao77
 /workspaces/mcp-integrations                        @redhat-developer/rhdh-plugins-maintainers @johnmcollier @gabemontero @thepetk @redhat-developer/rhdh-ai
 /workspaces/orchestrator                            @redhat-developer/rhdh-plugins-maintainers @lholmquist @lokanandaprabhu @redhat-developer/rhdh-plugins @karthikjeeyar @christoph-jerolimov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /workspaces/extensions                              @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @christoph-jerolimov @karthikjeeyar
 /workspaces/global-header                           @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @ciiay @divyanshiGupta
 /workspaces/homepage                                @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @christoph-jerolimov @eswaraiahsapram
-/workspaces/install-dynamic-plugins                 @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-install
+/workspaces/install-dynamic-plugins                 @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-plugins
 /workspaces/lightspeed                              @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @redhat-developer/rhdh-ai @karthikjeeyar @rohitkrai03 @yangcao77
 /workspaces/mcp-integrations                        @redhat-developer/rhdh-plugins-maintainers @johnmcollier @gabemontero @thepetk @redhat-developer/rhdh-ai
 /workspaces/orchestrator                            @redhat-developer/rhdh-plugins-maintainers @lholmquist @lokanandaprabhu @redhat-developer/rhdh-plugins @karthikjeeyar @christoph-jerolimov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /workspaces/extensions                              @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @christoph-jerolimov @karthikjeeyar
 /workspaces/global-header                           @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @ciiay @divyanshiGupta
 /workspaces/homepage                                @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @christoph-jerolimov @eswaraiahsapram
-/workspaces/install-dynamic-plugins                 @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-plugins
+/workspaces/install-dynamic-plugins                 @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-install
 /workspaces/lightspeed                              @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-ui @redhat-developer/rhdh-ai @karthikjeeyar @rohitkrai03 @yangcao77
 /workspaces/mcp-integrations                        @redhat-developer/rhdh-plugins-maintainers @johnmcollier @gabemontero @thepetk @redhat-developer/rhdh-ai
 /workspaces/orchestrator                            @redhat-developer/rhdh-plugins-maintainers @lholmquist @lokanandaprabhu @redhat-developer/rhdh-plugins @karthikjeeyar @christoph-jerolimov


### PR DESCRIPTION
## Description

Registers code ownership for the new `workspaces/install-dynamic-plugins` workspace in `.github/CODEOWNERS`, following the existing convention (entry inserted in alphabetical order):

```
/workspaces/install-dynamic-plugins                 @redhat-developer/rhdh-plugins-maintainers @redhat-developer/rhdh-plugins
```

The `rhdh-plugins` team owns the workspace, alongside the repo-wide `rhdh-plugins-maintainers` team that every workspace entry includes.