### PR TITLE
fix(lightspeed): improve chat history sidebar UI and delete modal styling

### DIFF
--- a/workspaces/lightspeed/.changeset/gentle-birds-march.md
+++ b/workspaces/lightspeed/.changeset/gentle-birds-march.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Improve chat history sidebar UI: add icons to chat action menu, fix sidebar icon alignment, improve delete modal styling with rounded corners and chat name in title, keep New Chat button always visible but disabled, and update empty state messages.

--- a/workspaces/lightspeed/e2e-tests/lightspeed.conversation.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.conversation.test.ts
@@ -336,6 +336,9 @@ test.describe('Lightspeed conversation', () => {
     test('Verify thinking section is displayed in bot response', async () => {
       await mockChatHistoryWithRedactedThinking(sharedPage);
       await sharedPage.reload();
+      await sharedPage.waitForSelector('.pf-chatbot__message--bot', {
+        timeout: 10000,
+      });
       const botMessage = sharedPage.locator('.pf-chatbot__message--bot').last();
       await expect(botMessage).toBeVisible();
       await expect(

--- a/workspaces/lightspeed/e2e-tests/lightspeed.conversation.test.ts
+++ b/workspaces/lightspeed/e2e-tests/lightspeed.conversation.test.ts
@@ -250,7 +250,7 @@ test.describe('Lightspeed conversation', () => {
         await verifyChatRenamed(sharedPage, testChatName);
         await openChatContextMenuByName(sharedPage, testChatName, translations);
         await selectDeleteAction(sharedPage, translations);
-        await verifyDeleteConfirmation(sharedPage, translations);
+        await verifyDeleteConfirmation(sharedPage, translations, testChatName);
         await cancelChatDeletion(sharedPage, translations);
         await verifyChatRenamed(sharedPage, testChatName);
 

--- a/workspaces/lightspeed/e2e-tests/utils/chatManagement.ts
+++ b/workspaces/lightspeed/e2e-tests/utils/chatManagement.ts
@@ -198,7 +198,7 @@ export const verifyDeleteConfirmation = async (
     chatName,
   );
   await expect(page.locator('#delete-modal')).toContainText(title);
-  await expect(page.locator('#delete-modal-body-confirmation')).toContainText(
+  await expect(page.locator('#delete-modal-confirmation')).toContainText(
     translations['conversation.delete.confirm.message'],
   );
   await expect(page.getByLabel(title)).toMatchAriaSnapshot(`
@@ -331,15 +331,16 @@ export const verifyEmptySearchResults = async (
   page: Page,
   translations: LightspeedMessages,
 ) => {
-  await expect(page.locator('.pf-v6-c-drawer__panel-main'))
-    .toMatchAriaSnapshot(`
-    - heading "${translations['conversation.category.pinnedChats']}"
-    - menu:
-      - menuitem "${translations['chatbox.emptyState.noPinnedChats']}" 
-    - heading "${translations['conversation.category.recent']}"
-    - menu:
-      - menuitem "${translations['common.noSearchResults']}" 
-    `);
+  await expect(
+    page.getByRole('menuitem', {
+      name: translations['chatbox.emptyState.noPinnedChats'],
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('menuitem', {
+      name: translations['common.noSearchResults'],
+    }),
+  ).toBeVisible();
 };
 
 export const verifyNoResultsFoundMessage = async (

--- a/workspaces/lightspeed/e2e-tests/utils/chatManagement.ts
+++ b/workspaces/lightspeed/e2e-tests/utils/chatManagement.ts
@@ -15,7 +15,7 @@
  */
 
 import { Page, expect } from '@playwright/test';
-import { LightspeedMessages } from './translations';
+import { LightspeedMessages, evaluateMessage } from './translations';
 
 export const openChatContextMenu = async (page: Page, chatIndex = 0) => {
   await page
@@ -191,16 +191,17 @@ export const selectDeleteAction = async (
 export const verifyDeleteConfirmation = async (
   page: Page,
   translations: LightspeedMessages,
+  chatName = '',
 ) => {
-  await expect(page.locator('#delete-modal')).toContainText(
+  const title = evaluateMessage(
     translations['conversation.delete.confirm.title'],
+    chatName,
   );
+  await expect(page.locator('#delete-modal')).toContainText(title);
   await expect(page.locator('#delete-modal-body-confirmation')).toContainText(
     translations['conversation.delete.confirm.message'],
   );
-  await expect(
-    page.getByLabel(translations['conversation.delete.confirm.title']),
-  ).toMatchAriaSnapshot(`
+  await expect(page.getByLabel(title)).toMatchAriaSnapshot(`
     - button "${translations['conversation.delete.confirm.action']}"
     - button "${translations['common.cancel']}"
     `);

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/CollapsedHistoryStrip.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/CollapsedHistoryStrip.tsx
@@ -26,14 +26,13 @@ type IconProps = {
 
 export const PencilIcon = ({ className }: IconProps) => (
   <svg
-    className={className}
+    className={`pf-v6-svg${className ? ` ${className}` : ''}`}
     viewBox="0 0 512 512"
     fill="currentColor"
     aria-hidden="true"
     role="img"
     width="1em"
     height="1em"
-    style={{ width: 16, height: 16 }}
   >
     <path d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z" />
   </svg>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/CollapsedHistoryStrip.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/CollapsedHistoryStrip.tsx
@@ -16,27 +16,10 @@
 
 import { makeStyles } from '@material-ui/core';
 import { Button, Tooltip } from '@patternfly/react-core';
+import { PenIcon } from '@patternfly/react-icons';
 
 import { useTranslation } from '../hooks/useTranslation';
 import { SidebarExpandIcon } from './notebooks/SidebarCollapseIcon';
-
-type IconProps = {
-  className?: string;
-};
-
-export const PencilIcon = ({ className }: IconProps) => (
-  <svg
-    className={`pf-v6-svg${className ? ` ${className}` : ''}`}
-    viewBox="0 0 512 512"
-    fill="currentColor"
-    aria-hidden="true"
-    role="img"
-    width="1em"
-    height="1em"
-  >
-    <path d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z" />
-  </svg>
-);
 
 const useStyles = makeStyles(theme => ({
   strip: {
@@ -118,7 +101,7 @@ export const CollapsedHistoryStrip = ({
           aria-label={t('tooltip.quickNewChat')}
           isDisabled={newChatDisabled}
         >
-          <PencilIcon />
+          <PenIcon />
         </Button>
       </Tooltip>
     </div>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
@@ -31,11 +31,13 @@ import { useTranslation } from '../hooks/useTranslation';
 export const DeleteModal = ({
   isOpen,
   conversationId,
+  chatName,
   onClose,
   onConfirm,
 }: {
   isOpen: boolean;
   conversationId: string;
+  chatName?: string;
   onClose: () => void;
   onConfirm: () => void;
 }) => {
@@ -66,19 +68,18 @@ export const DeleteModal = ({
       onClose={onClose}
       aria-labelledby="delete-modal"
       aria-describedby="delete-modal-confiramtion"
+      fullWidth
+      PaperProps={{
+        sx: { borderRadius: 4 },
+      }}
     >
       <DialogTitle sx={{ p: '16px 20px', fontStyle: 'inherit' }}>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-          }}
-        >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pr: 5 }}>
           <Typography component="span" sx={{ fontWeight: 'bold' }}>
-            {t('conversation.delete.confirm.title')}
+            {t('conversation.delete.confirm.title' as any, {
+              chatName: chatName || '',
+            })}
           </Typography>
-
           <IconButton
             aria-label="close"
             onClick={onClose}
@@ -86,8 +87,8 @@ export const DeleteModal = ({
             size="large"
             sx={{
               position: 'absolute',
-              right: 1,
-              top: 1,
+              right: 8,
+              top: 8,
               color: 'text.primary',
             }}
           >
@@ -99,22 +100,26 @@ export const DeleteModal = ({
         {t('conversation.delete.confirm.message')}
       </DialogContent>
       {isError && (
-        <Box maxWidth="650px" marginLeft="20px" marginRight="20px">
+        <Box sx={{ maxWidth: 650, mx: 2.5 }}>
           <Alert severity="error">{String(error)}</Alert>
         </Box>
       )}
-      <DialogActions style={{ justifyContent: 'left', padding: '20px' }}>
+      <DialogActions sx={{ justifyContent: 'left', p: 2.5, gap: 1 }}>
         <Button
-          key="confirm"
           variant="contained"
           color="error"
+          sx={{ textTransform: 'none', borderRadius: 999 }}
           onClick={handleDeleteConversation}
-          style={{ marginRight: '16px' }}
           disabled={isPending}
         >
           {t('conversation.delete.confirm.action')}
         </Button>
-        <Button key="cancel" variant="outlined" onClick={onClose}>
+        <Button
+          key="cancel"
+          variant="outlined"
+          sx={{ textTransform: 'none', borderRadius: 999 }}
+          onClick={onClose}
+        >
           {t('common.cancel')}
         </Button>
       </DialogActions>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
@@ -17,13 +17,13 @@
 import CloseIcon from '@mui/icons-material/Close';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
+import { Button } from '@patternfly/react-core';
 
 import { useDeleteConversation } from '../hooks';
 import { useTranslation } from '../hooks/useTranslation';
@@ -106,20 +106,13 @@ export const DeleteModal = ({
       )}
       <DialogActions sx={{ justifyContent: 'left', p: 2.5, gap: 1 }}>
         <Button
-          variant="contained"
-          color="error"
-          sx={{ textTransform: 'none', borderRadius: 999 }}
+          variant="danger"
           onClick={handleDeleteConversation}
-          disabled={isPending}
+          isDisabled={isPending}
         >
           {t('conversation.delete.confirm.action')}
         </Button>
-        <Button
-          key="cancel"
-          variant="outlined"
-          sx={{ textTransform: 'none', borderRadius: 999 }}
-          onClick={onClose}
-        >
+        <Button variant="link" onClick={onClose}>
           {t('common.cancel')}
         </Button>
       </DialogActions>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/DeleteModal.tsx
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-import CloseIcon from '@mui/icons-material/Close';
-import Alert from '@mui/material/Alert';
-import Box from '@mui/material/Box';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import IconButton from '@mui/material/IconButton';
-import Typography from '@mui/material/Typography';
-import { Button } from '@patternfly/react-core';
+import {
+  Alert,
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
 
 import { useDeleteConversation } from '../hooks';
 import { useTranslation } from '../hooks/useTranslation';
@@ -63,48 +61,32 @@ export const DeleteModal = ({
   };
 
   return (
-    <Dialog
-      open={isOpen}
+    <Modal
+      variant="small"
+      isOpen={isOpen}
       onClose={onClose}
       aria-labelledby="delete-modal"
-      aria-describedby="delete-modal-confiramtion"
-      fullWidth
-      PaperProps={{
-        sx: { borderRadius: 4 },
-      }}
+      aria-describedby="delete-modal-confirmation"
     >
-      <DialogTitle sx={{ p: '16px 20px', fontStyle: 'inherit' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pr: 5 }}>
-          <Typography component="span" sx={{ fontWeight: 'bold' }}>
-            {t('conversation.delete.confirm.title' as any, {
-              chatName: chatName || '',
-            })}
-          </Typography>
-          <IconButton
-            aria-label="close"
-            onClick={onClose}
-            title={t('common.close')}
-            size="large"
-            sx={{
-              position: 'absolute',
-              right: 8,
-              top: 8,
-              color: 'text.primary',
-            }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </Box>
-      </DialogTitle>
-      <DialogContent id="delete-modal-body-confirmation">
+      <ModalHeader
+        title={t('conversation.delete.confirm.title' as any, {
+          chatName: chatName || '',
+        })}
+        labelId="delete-modal"
+        descriptorId="delete-modal-confirmation"
+      />
+      <ModalBody id="delete-modal-confirmation">
         {t('conversation.delete.confirm.message')}
-      </DialogContent>
-      {isError && (
-        <Box sx={{ maxWidth: 650, mx: 2.5 }}>
-          <Alert severity="error">{String(error)}</Alert>
-        </Box>
-      )}
-      <DialogActions sx={{ justifyContent: 'left', p: 2.5, gap: 1 }}>
+        {isError && (
+          <Alert
+            variant="danger"
+            isInline
+            title={String(error)}
+            className="pf-v6-u-mt-md"
+          />
+        )}
+      </ModalBody>
+      <ModalFooter>
         <Button
           variant="danger"
           onClick={handleDeleteConversation}
@@ -115,7 +97,7 @@ export const DeleteModal = ({
         <Button variant="link" onClick={onClose}>
           {t('common.cancel')}
         </Button>
-      </DialogActions>
-    </Dialog>
+      </ModalFooter>
+    </Modal>
   );
 };

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -341,8 +341,10 @@ const useStyles = makeStyles(theme => ({
     paddingRight: theme.spacing(1.5),
   },
   footer: {
-    backgroundColor:
-      'var(--pf-t--global--background--color--floating--default)',
+    '&.pf-chatbot__footer': {
+      backgroundColor:
+        'var(--pf-t--global--background--color--floating--default) !important',
+    },
     '&>.pf-chatbot__footer-container': {
       width: '95% !important',
       maxWidth: 'unset !important',

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -71,10 +71,13 @@ import {
   type AlertProps,
 } from '@patternfly/react-core';
 import {
+  PenIcon,
   PlusIcon,
   SearchIcon,
   SortAmountDownAltIcon,
   SortAmountDownIcon,
+  ThumbtackIcon,
+  TrashIcon,
 } from '@patternfly/react-icons';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -534,8 +537,12 @@ const useStyles = makeStyles(theme => ({
         display: 'none',
       },
     '& .pf-v6-c-drawer__close, & .pf-v5-c-drawer__close': {
-      marginTop: -48,
-      marginRight: -24,
+      marginTop: 0,
+      marginRight: 0,
+    },
+    '& .pf-v6-c-drawer__head, & .pf-v5-c-drawer__head': {
+      paddingInlineStart: 'var(--pf-t--global--spacer--md)',
+      paddingInlineEnd: 'var(--pf-t--global--spacer--md)',
     },
     '& .pf-v6-c-drawer__close .pf-v6-c-button svg, & .pf-v5-c-drawer__close .pf-v5-c-button svg':
       {
@@ -556,8 +563,22 @@ const useStyles = makeStyles(theme => ({
           backgroundColor: 'currentColor',
         },
       },
+    '& .pf-chatbot__heading-container': {
+      paddingInlineStart: 'var(--pf-t--global--spacer--md)',
+      paddingInlineEnd: 'var(--pf-t--global--spacer--md)',
+    },
+    '& .pf-chatbot__menu-item-header > .pf-v6-c-menu__group-title': {
+      '--pf-v6-c-menu__group-title--PaddingInlineStart':
+        'var(--pf-t--global--spacer--md)',
+      '--pf-v6-c-menu__group-title--PaddingInlineEnd':
+        'var(--pf-t--global--spacer--md)',
+    },
     '& .pf-chatbot__menu-item': {
       cursor: 'pointer',
+      '--pf-v6-c-menu__item--PaddingInlineStart':
+        'var(--pf-t--global--spacer--md)',
+      '--pf-v6-c-menu__item--PaddingInlineEnd':
+        'var(--pf-t--global--spacer--md)',
     },
     '& .pf-chatbot__menu-item .pf-v6-c-menu-toggle, & .pf-chatbot__menu-item .pf-v5-c-menu-toggle':
       {
@@ -1139,6 +1160,7 @@ export const LightspeedChat = ({
           <>
             <DropdownItem
               isDisabled={!hasUpdateAccess}
+              icon={<PenIcon />}
               onClick={() =>
                 openChatRenameModal(conversationSummary.conversation_id)
               }
@@ -1149,6 +1171,7 @@ export const LightspeedChat = ({
               <>
                 {isChatFavorite ? (
                   <DropdownItem
+                    icon={<ThumbtackIcon />}
                     onClick={() =>
                       unpinChat(conversationSummary.conversation_id)
                     }
@@ -1157,6 +1180,7 @@ export const LightspeedChat = ({
                   </DropdownItem>
                 ) : (
                   <DropdownItem
+                    icon={<ThumbtackIcon />}
                     onClick={() => pinChat(conversationSummary.conversation_id)}
                   >
                     {t('conversation.addToPinnedChats')}
@@ -1166,6 +1190,7 @@ export const LightspeedChat = ({
             )}
             <DropdownItem
               isDisabled={!hasDeleteAccess}
+              icon={<TrashIcon />}
               onClick={() =>
                 openDeleteModal(conversationSummary.conversation_id)
               }
@@ -1249,6 +1274,10 @@ export const LightspeedChat = ({
                   noIcon: true,
                   additionalProps: {
                     isDisabled: true,
+                    style: {
+                      fontStyle: 'italic',
+                      opacity: 0.6,
+                    },
                   },
                 },
               ];
@@ -1271,6 +1300,10 @@ export const LightspeedChat = ({
                   noIcon: true,
                   additionalProps: {
                     isDisabled: true,
+                    style: {
+                      fontStyle: 'italic',
+                      opacity: 0.6,
+                    },
                   },
                 },
               ];
@@ -1826,6 +1859,13 @@ export const LightspeedChat = ({
         <DeleteModal
           isOpen={isDeleteModalOpen}
           conversationId={targetConversationId}
+          chatName={(() => {
+            const name =
+              conversations.find(
+                c => c.conversation_id === targetConversationId,
+              )?.topic_summary ?? '';
+            return name.length > 100 ? `${name.slice(0, 100)}...` : name;
+          })()}
           onClose={() => setIsDeleteModalOpen(false)}
           onConfirm={handleDeleteConversation}
         />
@@ -2023,10 +2063,11 @@ export const LightspeedChat = ({
               activeItemId={viewConversationId}
               onSelectActiveItem={onSelectActiveItem}
               conversations={filterConversations(filterValue)}
-              onNewChat={newChatCreated ? undefined : onNewChat}
+              onNewChat={onNewChat}
               newChatButtonText={t('button.newChat')}
               newChatButtonProps={{
                 icon: isFullscreenMode ? <PencilIcon /> : <PlusIcon />,
+                isDisabled: newChatCreated,
               }}
               handleTextInputChange={handleFilter}
               searchInputPlaceholder={t('chatbox.search.placeholder')}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -541,8 +541,8 @@ const useStyles = makeStyles(theme => ({
       marginRight: 0,
     },
     '& .pf-v6-c-drawer__head, & .pf-v5-c-drawer__head': {
-      paddingInlineStart: 'var(--pf-t--global--spacer--md)',
-      paddingInlineEnd: 'var(--pf-t--global--spacer--md)',
+      paddingInlineStart: 'var(--pf-t--global--spacer--lg)',
+      paddingInlineEnd: 'var(--pf-t--global--spacer--lg)',
     },
     '& .pf-v6-c-drawer__close .pf-v6-c-button svg, & .pf-v5-c-drawer__close .pf-v5-c-button svg':
       {
@@ -564,8 +564,8 @@ const useStyles = makeStyles(theme => ({
         },
       },
     '& .pf-chatbot__heading-container': {
-      paddingInlineStart: 'var(--pf-t--global--spacer--md)',
-      paddingInlineEnd: 'var(--pf-t--global--spacer--md)',
+      paddingInlineStart: 'var(--pf-t--global--spacer--lg)',
+      paddingInlineEnd: 'var(--pf-t--global--spacer--lg)',
     },
     '& .pf-chatbot__menu-item-header > .pf-v6-c-menu__group-title': {
       '--pf-v6-c-menu__group-title--PaddingInlineStart':

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -117,7 +117,7 @@ import {
 } from '../utils/lightspeed-chatbox-utils';
 import Attachment from './Attachment';
 import { useFileAttachmentContext } from './AttachmentContext';
-import { CollapsedHistoryStrip, PencilIcon } from './CollapsedHistoryStrip';
+import { CollapsedHistoryStrip } from './CollapsedHistoryStrip';
 import { DeleteModal } from './DeleteModal';
 import FilePreview from './FilePreview';
 import { LightspeedChatBox } from './LightspeedChatBox';
@@ -515,10 +515,10 @@ const useStyles = makeStyles(theme => ({
         transition: 'none !important',
       },
   },
-  // TODO: These PatternFly drawer overrides are needed because PF Chatbot doesn't
-  // provide clean APIs for custom expand/collapse icons and positioning.
-  // Remove once PatternFly supports these features.
-  // See: https://github.com/patternfly/chatbot/issues/834
+  // TODO: These PF Chatbot overrides are fragile (version-specific class names).
+  // Remove once the upstream issues are addressed:
+  // - https://github.com/patternfly/chatbot/issues/834 (custom close/collapse icon & positioning)
+  // - https://github.com/patternfly/chatbot/issues/848 (sidebar padding & spacing customization)
   fullscreenChatLayout: {
     display: 'flex',
     flexDirection: 'row',
@@ -538,14 +538,17 @@ const useStyles = makeStyles(theme => ({
       {
         display: 'none',
       },
+    // TODO(#834): Remove close button overrides once PF supports custom icon/positioning
     '& .pf-v6-c-drawer__close, & .pf-v5-c-drawer__close': {
       marginTop: 0,
       marginRight: 0,
     },
+    // TODO(#848): Remove drawer head padding overrides once PF exposes drawerHeadProps
     '& .pf-v6-c-drawer__head, & .pf-v5-c-drawer__head': {
       paddingInlineStart: 'var(--pf-t--global--spacer--lg)',
       paddingInlineEnd: 'var(--pf-t--global--spacer--lg)',
     },
+    // TODO(#834): Remove icon replacement hack once PF supports drawerCloseButtonProps.icon
     '& .pf-v6-c-drawer__close .pf-v6-c-button svg, & .pf-v5-c-drawer__close .pf-v5-c-button svg':
       {
         display: 'none',
@@ -565,10 +568,12 @@ const useStyles = makeStyles(theme => ({
           backgroundColor: 'currentColor',
         },
       },
+    // TODO(#848): Remove heading padding overrides once PF exposes drawerHeadProps
     '& .pf-chatbot__heading-container': {
       paddingInlineStart: 'var(--pf-t--global--spacer--lg)',
       paddingInlineEnd: 'var(--pf-t--global--spacer--lg)',
     },
+    // TODO(#848): Remove menu item padding overrides once PF exposes menuItemPaddingInline
     '& .pf-chatbot__menu-item-header > .pf-v6-c-menu__group-title': {
       '--pf-v6-c-menu__group-title--PaddingInlineStart':
         'var(--pf-t--global--spacer--md)',
@@ -582,6 +587,7 @@ const useStyles = makeStyles(theme => ({
       '--pf-v6-c-menu__item--PaddingInlineEnd':
         'var(--pf-t--global--spacer--md)',
     },
+    // TODO(#848): Remove menu toggle hover hack once PF supports menuToggleVisibility
     '& .pf-chatbot__menu-item .pf-v6-c-menu-toggle, & .pf-chatbot__menu-item .pf-v5-c-menu-toggle':
       {
         opacity: 0,
@@ -1227,6 +1233,13 @@ export const LightspeedChat = ({
     [conversations, notebookConversationIds],
   );
 
+  const deleteChatName = useMemo(
+    () =>
+      conversations.find(c => c.conversation_id === targetConversationId)
+        ?.topic_summary ?? '',
+    [conversations, targetConversationId],
+  );
+
   const categorizedMessages = useMemo(
     () =>
       getCategorizeMessages(
@@ -1861,13 +1874,7 @@ export const LightspeedChat = ({
         <DeleteModal
           isOpen={isDeleteModalOpen}
           conversationId={targetConversationId}
-          chatName={(() => {
-            const name =
-              conversations.find(
-                c => c.conversation_id === targetConversationId,
-              )?.topic_summary ?? '';
-            return name.length > 100 ? `${name.slice(0, 100)}...` : name;
-          })()}
+          chatName={deleteChatName}
           onClose={() => setIsDeleteModalOpen(false)}
           onConfirm={handleDeleteConversation}
         />
@@ -2068,7 +2075,7 @@ export const LightspeedChat = ({
               onNewChat={onNewChat}
               newChatButtonText={t('button.newChat')}
               newChatButtonProps={{
-                icon: isFullscreenMode ? <PencilIcon /> : <PlusIcon />,
+                icon: <PenIcon />,
                 isDisabled: newChatCreated,
               }}
               handleTextInputChange={handleFilter}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/CollapsedHistoryStrip.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/CollapsedHistoryStrip.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { mockUseTranslation } from '../../test-utils/mockTranslations';
-import { CollapsedHistoryStrip, PencilIcon } from '../CollapsedHistoryStrip';
+import { CollapsedHistoryStrip } from '../CollapsedHistoryStrip';
 
 jest.mock('../../hooks/useTranslation', () => ({
   useTranslation: jest.fn(() => mockUseTranslation()),
@@ -116,31 +116,5 @@ describe('CollapsedHistoryStrip', () => {
     fireEvent.click(newChatButton);
 
     expect(mockOnNewChat).not.toHaveBeenCalled();
-  });
-});
-
-describe('PencilIcon', () => {
-  it('should render the PencilIcon SVG', () => {
-    const { container } = render(<PencilIcon />);
-
-    const svg = container.querySelector('svg');
-    expect(svg).toBeInTheDocument();
-    expect(svg).toHaveAttribute('width', '1em');
-    expect(svg).toHaveAttribute('height', '1em');
-    expect(svg).toHaveAttribute('viewBox', '0 0 512 512');
-  });
-
-  it('should apply className when provided', () => {
-    const { container } = render(<PencilIcon className="custom-class" />);
-
-    const svg = container.querySelector('svg');
-    expect(svg).toHaveClass('custom-class');
-  });
-
-  it('should have pf-v6-svg class for consistent sizing', () => {
-    const { container } = render(<PencilIcon />);
-
-    const svg = container.querySelector('svg');
-    expect(svg).toHaveClass('pf-v6-svg');
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/CollapsedHistoryStrip.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/CollapsedHistoryStrip.test.tsx
@@ -137,10 +137,10 @@ describe('PencilIcon', () => {
     expect(svg).toHaveClass('custom-class');
   });
 
-  it('should have correct inline size style', () => {
+  it('should have pf-v6-svg class for consistent sizing', () => {
     const { container } = render(<PencilIcon />);
 
     const svg = container.querySelector('svg');
-    expect(svg).toHaveStyle({ width: '16px', height: '16px' });
+    expect(svg).toHaveClass('pf-v6-svg');
   });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
@@ -147,8 +147,7 @@ describe('DeleteModal', () => {
       />,
     );
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
-    expect(screen.getByText(/Error/i)).toBeInTheDocument();
+    expect(screen.getByText(/Delete failed/i)).toBeInTheDocument();
   });
 
   test('should not call onConfirm when delete fails', async () => {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/DeleteModal.test.tsx
@@ -40,6 +40,7 @@ describe('DeleteModal', () => {
   const onClose = jest.fn();
   const onConfirm = jest.fn();
   const conversationId = 'test-conversation-id';
+  const chatName = 'Test Chat';
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -59,13 +60,14 @@ describe('DeleteModal', () => {
         onClose={onClose}
         onConfirm={onConfirm}
         conversationId={conversationId}
+        chatName={chatName}
       />,
     );
 
-    expect(screen.getByText('Delete chat?')).toBeInTheDocument();
+    expect(screen.getByText(`Delete "${chatName}"?`)).toBeInTheDocument();
     expect(
       screen.getByText(
-        "You'll no longer see this chat here. This will also delete related activity like prompts, responses, and feedback from your Lightspeed Activity.",
+        "You'll no longer see this chat here. This will also delete related activity like prompts, responses, and feedback.",
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
@@ -79,6 +81,7 @@ describe('DeleteModal', () => {
         onClose={onClose}
         onConfirm={onConfirm}
         conversationId={conversationId}
+        chatName={chatName}
       />,
     );
 
@@ -92,6 +95,7 @@ describe('DeleteModal', () => {
         onClose={onClose}
         onConfirm={onConfirm}
         conversationId={conversationId}
+        chatName={chatName}
       />,
     );
 
@@ -109,6 +113,7 @@ describe('DeleteModal', () => {
         onClose={onClose}
         onConfirm={onConfirm}
         conversationId={conversationId}
+        chatName={chatName}
       />,
     );
 
@@ -138,6 +143,7 @@ describe('DeleteModal', () => {
         onClose={onClose}
         onConfirm={onConfirm}
         conversationId={conversationId}
+        chatName={chatName}
       />,
     );
 
@@ -160,6 +166,7 @@ describe('DeleteModal', () => {
         onClose={onClose}
         onConfirm={onConfirm}
         conversationId={conversationId}
+        chatName={chatName}
       />,
     );
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -1095,7 +1095,7 @@ describe('LightspeedChat', () => {
       ).toBeInTheDocument();
     });
 
-    it('should show PencilIcon in new chat button in fullscreen mode', async () => {
+    it('should show PenIcon in new chat button in fullscreen mode', async () => {
       mockUseConversations.mockReturnValue({
         data: [
           {

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -315,7 +315,7 @@ describe('LightspeedChat', () => {
     await waitFor(() => {
       expect(screen.getByText('Developer Lightspeed')).toBeInTheDocument();
 
-      expect(screen.queryByText('New chat')).not.toBeInTheDocument();
+      expect(screen.getByText('New chat').closest('button')).toBeDisabled();
       expect(JSON.parse(localStorage.getItem(localStorageKey)!)).toEqual({});
     });
   });

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -169,7 +169,7 @@ describe('LightspeedPage', () => {
     const { result } = renderHook(() => useTranslation());
 
     expect(
-      result.current.t('conversation.delete.confirm.title', {
+      result.current.t('conversation.delete.confirm.title' as any, {
         chatName: 'test',
       }),
     ).toBe('Delete "test"?');

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedPage.test.tsx
@@ -168,11 +168,13 @@ describe('LightspeedPage', () => {
   it('should translate conversation messages correctly', () => {
     const { result } = renderHook(() => useTranslation());
 
-    expect(result.current.t('conversation.delete.confirm.title')).toBe(
-      'Delete chat?',
-    );
+    expect(
+      result.current.t('conversation.delete.confirm.title', {
+        chatName: 'test',
+      }),
+    ).toBe('Delete "test"?');
     expect(result.current.t('conversation.delete.confirm.message')).toBe(
-      "You'll no longer see this chat here. This will also delete related activity like prompts, responses, and feedback from your Lightspeed Activity.",
+      "You'll no longer see this chat here. This will also delete related activity like prompts, responses, and feedback.",
     );
   });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -40,7 +40,7 @@ const lightspeedTranslationDe = createTranslationMessages({
     'attach.menu.description': 'Eine JSON-, YAML- oder TXT-Datei anhängen',
     'attach.menu.title': 'Anhängen',
     'button.newChat': 'Neuer Chat',
-    'chatbox.emptyState.noPinnedChats': 'Keine angehefteten Chats',
+    'chatbox.emptyState.noPinnedChats': 'Chats anheften, um sie oben zu halten',
     'chatbox.emptyState.noRecentChats': 'Keine letzten Chats',
     'chatbox.emptyState.noResults.body':
       'Passen Sie Ihre Suchanfrage an, und versuchen Sie es erneut. Überprüfen Sie Ihre Rechtschreibung, oder versuchen Sie es mit einem allgemeineren Begriff.',
@@ -70,8 +70,8 @@ const lightspeedTranslationDe = createTranslationMessages({
     'conversation.delete': 'Löschen',
     'conversation.delete.confirm.action': 'Löschen',
     'conversation.delete.confirm.message':
-      'Dieser Chat wird hier nicht mehr angezeigt. Dadurch werden auch zugehörige Aktivitäten wie Prompts, Antworten und Feedback aus Ihrer Lightspeed-Aktivität gelöscht.',
-    'conversation.delete.confirm.title': 'Chat löschen?',
+      'Dieser Chat wird hier nicht mehr angezeigt. Dadurch werden auch zugehörige Aktivitäten wie Prompts, Antworten und Feedback gelöscht.',
+    'conversation.delete.confirm.title': '"{{chatName}}" löschen?',
     'conversation.removeFromPinnedChats': 'Lösen',
     'conversation.rename': 'Umbenennen',
     'conversation.rename.confirm.action': 'Umbenennen',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -40,7 +40,7 @@ const lightspeedTranslationEs = createTranslationMessages({
     'attach.menu.description': 'Adjuntar un archivo JSON, YAML o TXT',
     'attach.menu.title': 'Adjuntar',
     'button.newChat': 'Nuevo chat',
-    'chatbox.emptyState.noPinnedChats': 'No hay chats fijados',
+    'chatbox.emptyState.noPinnedChats': 'Fija chats para mantenerlos arriba',
     'chatbox.emptyState.noRecentChats': 'No hay chats recientes',
     'chatbox.emptyState.noResults.body':
       'Ajuste su solicitud de búsqueda y vuelva a intentarlo. Revise la ortografía o pruebe con un término más general.',
@@ -70,8 +70,8 @@ const lightspeedTranslationEs = createTranslationMessages({
     'conversation.delete': 'Eliminar',
     'conversation.delete.confirm.action': 'Eliminar',
     'conversation.delete.confirm.message':
-      'Ya no verás este chat aquí. Esto también eliminará la actividad relacionada, como indicaciones, respuestas y comentarios de la actividad de Lightspeed.',
-    'conversation.delete.confirm.title': '¿Eliminar chat?',
+      'Ya no verás este chat aquí. Esto también eliminará la actividad relacionada, como indicaciones, respuestas y comentarios.',
+    'conversation.delete.confirm.title': '¿Eliminar "{{chatName}}"?',
     'conversation.removeFromPinnedChats': 'Quitar fijación',
     'conversation.rename': 'Cambiar el nombre',
     'conversation.rename.confirm.action': 'Cambiar el nombre',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -40,7 +40,8 @@ const lightspeedTranslationFr = createTranslationMessages({
     'attach.menu.description': 'Attacher un fichier JSON, YAML ou TXT',
     'attach.menu.title': 'Attacher',
     'button.newChat': 'Nouvelle Conversation',
-    'chatbox.emptyState.noPinnedChats': 'Aucune conversation épinglée',
+    'chatbox.emptyState.noPinnedChats':
+      'Épinglez des conversations pour les garder en haut',
     'chatbox.emptyState.noRecentChats': 'Aucune conversation récente',
     'chatbox.emptyState.noResults.body':
       'Ajuster votre recherche et essayer à nouveau. Vérifier votre orthographe et essayez un terme plus général.',
@@ -69,8 +70,8 @@ const lightspeedTranslationFr = createTranslationMessages({
     'conversation.delete': 'Supprimer',
     'conversation.delete.confirm.action': 'Supprimer',
     'conversation.delete.confirm.message':
-      'Vous ne verrez plus cette conversation ici. Cela supprimera également les activités associées comme les prompts, réponses, et commentaires de votre activité Lightspeed.',
-    'conversation.delete.confirm.title': 'Supprimer cette conversation ?',
+      'Vous ne verrez plus cette conversation ici. Cela supprimera également les activités associées comme les prompts, réponses, et commentaires.',
+    'conversation.delete.confirm.title': 'Supprimer "{{chatName}}" ?',
     'conversation.removeFromPinnedChats': 'Détacher',
     'conversation.rename': 'Renommer',
     'conversation.rename.confirm.action': 'Renommer',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -40,7 +40,7 @@ const lightspeedTranslationIt = createTranslationMessages({
     'attach.menu.description': 'Allega un file JSON, YAML o TXT',
     'attach.menu.title': 'Allega',
     'button.newChat': 'Nuova chat',
-    'chatbox.emptyState.noPinnedChats': 'Nessuna chat bloccata',
+    'chatbox.emptyState.noPinnedChats': 'Fissa le chat per mantenerle in alto',
     'chatbox.emptyState.noRecentChats': 'Nessuna chat recente',
     'chatbox.emptyState.noResults.body':
       "Modificare la query di ricerca e riprovare. Controllare l'ortografia o provare un termine più generico.",
@@ -69,8 +69,8 @@ const lightspeedTranslationIt = createTranslationMessages({
     'conversation.delete': 'Elimina',
     'conversation.delete.confirm.action': 'Elimina',
     'conversation.delete.confirm.message':
-      'Questa chat non sarà più visibile qui. Dalla tua attività Lightspeed verranno eliminate anche le attività correlate, come prompt, risposte e feedback.',
-    'conversation.delete.confirm.title': 'Eliminare la chat?',
+      'Questa chat non sarà più visibile qui. Verranno eliminate anche le attività correlate, come prompt, risposte e feedback.',
+    'conversation.delete.confirm.title': 'Eliminare "{{chatName}}"?',
     'conversation.removeFromPinnedChats': 'Sblocca',
     'conversation.rename': 'Rinomina',
     'conversation.rename.confirm.action': 'Rinomina',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -40,7 +40,7 @@ const lightspeedTranslationJa = createTranslationMessages({
     'attach.menu.description': 'JSON、YAML、または TXT ファイルを添付',
     'attach.menu.title': '添付',
     'button.newChat': '新しいチャット',
-    'chatbox.emptyState.noPinnedChats': '固定したチャットがありません',
+    'chatbox.emptyState.noPinnedChats': 'チャットを固定して上部に表示',
     'chatbox.emptyState.noRecentChats': '最近のチャットがありません',
     'chatbox.emptyState.noResults.body':
       '検索クエリーを調整して再試行してください。スペルを確認するか、より一般的な用語をお試しください。',
@@ -69,8 +69,8 @@ const lightspeedTranslationJa = createTranslationMessages({
     'conversation.delete': '削除',
     'conversation.delete.confirm.action': '削除',
     'conversation.delete.confirm.message':
-      'このチャットはここに表示されなくなります。Lightspeed Activity からのプロンプト、回答、フィードバックなど、関連アクティビティーも削除されます。',
-    'conversation.delete.confirm.title': 'チャットを削除しますか?',
+      'このチャットはここに表示されなくなります。プロンプト、回答、フィードバックなど、関連アクティビティーも削除されます。',
+    'conversation.delete.confirm.title': '"{{chatName}}" を削除しますか?',
     'conversation.removeFromPinnedChats': '固定解除',
     'conversation.rename': '名前の変更',
     'conversation.rename.confirm.action': '名前の変更',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -154,9 +154,9 @@ export const lightspeedMessages = {
     'Can you guide me through the first steps to start using Developer Hub as a developer, like exploring the Software Catalog and adding my service?',
 
   // Conversation history
-  'conversation.delete.confirm.title': 'Delete chat?',
+  'conversation.delete.confirm.title': 'Delete "{{chatName}}"?',
   'conversation.delete.confirm.message':
-    "You'll no longer see this chat here. This will also delete related activity like prompts, responses, and feedback from your Lightspeed Activity.",
+    "You'll no longer see this chat here. This will also delete related activity like prompts, responses, and feedback.",
   'conversation.delete.confirm.action': 'Delete',
   'conversation.rename.confirm.title': 'Rename chat?',
   'conversation.rename.confirm.action': 'Rename',
@@ -205,7 +205,7 @@ export const lightspeedMessages = {
   'chatbox.header.title': 'Developer Lightspeed',
   'chatbox.search.placeholder': 'Search',
   'chatbox.provider.other': 'Other',
-  'chatbox.emptyState.noPinnedChats': 'No pinned chats',
+  'chatbox.emptyState.noPinnedChats': 'Pin chats to keep them on top',
   'chatbox.emptyState.noRecentChats': 'No recent chats',
   'chatbox.emptyState.noResults.title': 'No results found',
   'chatbox.emptyState.noResults.body':

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/lightspeed-chatbox-utils.tsx
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import PushPinIcon from '@mui/icons-material/PushPin';
 import { Conversation, SourcesCardProps } from '@patternfly/chatbot';
 import { Spinner } from '@patternfly/react-core';
+import { ThumbtackIcon } from '@patternfly/react-icons';
 
 import {
   BaseMessage,
@@ -321,8 +321,8 @@ export const getCategorizeMessages = (
       categorizedMessages[pinnedChatsKey].push({
         ...message,
         icon: (
-          <PushPinIcon
-            sx={{
+          <ThumbtackIcon
+            style={{
               width: '1rem',
               height: '1rem',
               display: 'flex',


### PR DESCRIPTION
## Description
1. Add icons to the chat action menu (Rename, Pin/Unpin, Delete)
2. Fix sidebar icon alignment 
    - Drawer Collapse Icon and sort icon on same vertical line 
    - New Chat Button and Drawer Collapse Icon on same horizontal line
    - New Chat, Search Box, Pinned Chat, Chat on same vertical line.
3. Improve the delete confirmation modal with rounded styling and chat name in the title (100 characters), removed `from your Lightspeed Activity` from description. 

4. Keep the "New Chat" button always visible but disabled when a new chat is open
5. Update empty state messages for pinned and recent chats, updated the styles.

## Fixed
- https://redhat.atlassian.net/browse/RHDHBUGS-3066

## UI after Fix
### Light Theme
https://github.com/user-attachments/assets/92a19387-a6e3-44c0-910d-5a1dbfa7fd90
### Dark Theme

https://github.com/user-attachments/assets/96935fae-9451-4d06-a0a6-f86163a5f573


## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)


