### PR TITLE
Add Successful CRUD SnackBar

### DIFF
--- a/workspaces/dcm/.changeset/crud-success-snackbars.md
+++ b/workspaces/dcm/.changeset/crud-success-snackbars.md
@@ -1,0 +1,9 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm': patch
+---
+
+Show a success snackbar after every CRUD operation in the Providers, Policies, and Catalog Items tabs.
+
+- Extended `useCrudTab` with optional `createSuccessMessage`, `editSuccessMessage`, and `deleteSuccessMessage` options and a `successMessage` / `clearSuccessMessage` pair in the returned result.
+- Wired `DcmSuccessSnackbar` into `ProvidersTabContent`, `PoliciesTabContent`, and `CatalogItemsTabContent` with contextual messages (e.g. "Provider registered successfully.", "Policy deleted successfully.").
+- Fixed a bug where deleting the last item on a non-zero page left the table showing "No records to display" instead of navigating back to the last valid page.

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
@@ -90,6 +90,12 @@ export interface UseCrudTabOptions<T, F extends Record<string, unknown>> {
    * Each table should use a unique key (e.g. `'providers'`, `'policies'`).
    */
   storageKey?: string;
+  /** Message shown in the success snackbar after a successful create. */
+  createSuccessMessage?: string;
+  /** Message shown in the success snackbar after a successful edit. */
+  editSuccessMessage?: string;
+  /** Message shown in the success snackbar after a successful delete. */
+  deleteSuccessMessage?: string;
 }
 
 type TouchedMap<F> = Partial<Record<keyof F, boolean>>;
@@ -147,6 +153,10 @@ export interface UseCrudTabResult<T, F extends Record<string, unknown>> {
   handleOpenDelete: (item: T) => void;
   handleCloseDelete: () => void;
   handleDeleteConfirm: () => void;
+
+  // ── Success snackbar ───────────────────────────────────────────────────────
+  successMessage: string | null;
+  clearSuccessMessage: () => void;
 }
 
 /**
@@ -220,6 +230,9 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
+  // ── Success snackbar ─────────────────────────────────────────────────────
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
   // Keep latest mutable values in refs so stable callbacks can read them.
   const createFormRef = useRef(createForm);
   createFormRef.current = createForm;
@@ -284,6 +297,19 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     return filtered.slice(start, start + pageSize);
   }, [filtered, page, pageSize]);
 
+  // Clamp the current page when items are removed (e.g. after a delete) and
+  // the page index points beyond the last valid page.
+  useEffect(() => {
+    if (page === 0) return;
+    const lastValidPage = Math.max(
+      0,
+      Math.ceil(filtered.length / pageSize) - 1,
+    );
+    if (page > lastValidPage) {
+      setPage(lastValidPage);
+    }
+  }, [filtered.length, page, pageSize]);
+
   const onPageChange = useCallback(
     (p: number, ps: number) => {
       setPage(p);
@@ -329,6 +355,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
         setCreateOpen(false);
         setCreateForm(ef());
         setCreateTouched({});
+        setSuccessMessage(optsRef.current.createSuccessMessage ?? null);
       })
       .catch(err => setCreateError(extractApiError(err)))
       .finally(() => setCreateSubmitting(false));
@@ -365,6 +392,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
         setEditOpen(false);
         setEditingId(null);
         setEditTouched({});
+        setSuccessMessage(optsRef.current.editSuccessMessage ?? null);
       })
       .catch(err => setEditError(extractApiError(err)))
       .finally(() => setEditSubmitting(false));
@@ -397,6 +425,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
         setDeleteOpen(false);
         setDeletingItem(null);
         setDeleteSubmitting(false);
+        setSuccessMessage(optsRef.current.deleteSuccessMessage ?? null);
       })
       .catch(err => {
         setDeleteError(extractApiError(err));
@@ -404,6 +433,8 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
         // dialog stays open so the user can see the error
       });
   }, []);
+
+  const clearSuccessMessage = useCallback(() => setSuccessMessage(null), []);
 
   return {
     // List
@@ -457,5 +488,9 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     handleOpenDelete,
     handleCloseDelete,
     handleDeleteConfirm,
+
+    // Success snackbar
+    successMessage,
+    clearSuccessMessage,
   };
 }

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
@@ -77,6 +77,7 @@ import type {
 import { catalogApiRef } from '../../apis';
 import { DcmCrudTabLayout } from '../../components/DcmCrudTabLayout';
 import { DcmDeleteDialog } from '../../components/DcmDeleteDialog';
+import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { createEditDeleteColumn } from '../../components/dcmTabListHelpers';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
 import { useCrudTab } from '../../hooks/useCrudTab';
@@ -123,6 +124,9 @@ export function CatalogItemsTabContent() {
     isValid: isCatalogItemFormValid,
     itemToForm: catalogItemToForm,
     storageKey: 'catalog-items',
+    createSuccessMessage: 'Catalog item created successfully.',
+    editSuccessMessage: 'Catalog item updated successfully.',
+    deleteSuccessMessage: 'Catalog item deleted successfully.',
   });
 
   const columns = useMemo<TableColumn<CatalogItem>[]>(
@@ -392,6 +396,11 @@ export function CatalogItemsTabContent() {
         resourceLabel="catalog item"
         error={crud.deleteError}
         isSubmitting={crud.deleteSubmitting}
+      />
+
+      <DcmSuccessSnackbar
+        message={crud.successMessage}
+        onClose={crud.clearSuccessMessage}
       />
     </>
   );

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.tsx
@@ -56,6 +56,7 @@ import { policyManagerApiRef } from '../../apis';
 import { DcmCrudTabLayout } from '../../components/DcmCrudTabLayout';
 import { DcmDeleteDialog } from '../../components/DcmDeleteDialog';
 import { DcmFormDialog } from '../../components/DcmFormDialog';
+import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { DcmFormDialogActions } from '../../components/DcmFormDialogActions';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
 import { useCrudTab } from '../../hooks/useCrudTab';
@@ -108,6 +109,9 @@ export function PoliciesTabContent() {
     isValid: isPolicyFormValid,
     itemToForm: policyToForm,
     storageKey: 'policies',
+    createSuccessMessage: 'Policy created successfully.',
+    editSuccessMessage: 'Policy updated successfully.',
+    deleteSuccessMessage: 'Policy deleted successfully.',
   });
 
   const { setItems, handleOpenEdit, handleOpenDelete } = crud;
@@ -386,6 +390,11 @@ export function PoliciesTabContent() {
         resourceLabel="policy"
         error={crud.deleteError}
         isSubmitting={crud.deleteSubmitting}
+      />
+
+      <DcmSuccessSnackbar
+        message={crud.successMessage}
+        onClose={crud.clearSuccessMessage}
       />
     </>
   );

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/components/PolicyFormFields.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/components/PolicyFormFields.tsx
@@ -161,8 +161,7 @@ export function PolicyFormFields({
       <TextField
         label="Rego code *"
         helperText={
-          regoErr ??
-          'OPA Rego evaluated by the Placement Manager. Must assign selected_provider to the name of a registered provider.'
+          regoErr ?? 'OPA Rego policy evaluated by the Placement Manager.'
         }
         error={Boolean(regoErr)}
         value={form.rego_code}
@@ -174,9 +173,7 @@ export function PolicyFormFields({
         variant="outlined"
         multiline
         rows={8}
-        placeholder={
-          'package dcm.placement\n\n# Replace "my-provider-name" with the name of a registered provider.\n# The Placement Manager requires selected_provider to be set.\nselected_provider := "my-provider-name"'
-        }
+        placeholder="package dcm.placement"
         inputProps={{ className: classes.regoInput }}
       />
 

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/policyFormTypes.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/policyFormTypes.test.ts
@@ -27,7 +27,7 @@ describe('validatePolicyForm', () => {
   const valid = () => ({
     ...emptyPolicyForm(),
     display_name: 'My Policy',
-    rego_code: 'package dcm\nselected_provider := "p1"',
+    rego_code: 'package dcm',
   });
 
   it('returns no errors for a valid form', () => {
@@ -99,7 +99,7 @@ describe('isPolicyFormValid', () => {
         description: '',
         policy_type: 'GLOBAL',
         priority: '500',
-        rego_code: 'package dcm.placement\nselected_provider := "p1"',
+        rego_code: 'package dcm.placement',
         enabled: true,
       }),
     ).toBe(true);
@@ -117,19 +117,6 @@ describe('isPolicyFormValid', () => {
       }),
     ).toBe(false);
   });
-
-  it('returns false when rego_code has no selected_provider', () => {
-    expect(
-      isPolicyFormValid({
-        display_name: 'My Policy',
-        description: '',
-        policy_type: 'GLOBAL',
-        priority: '500',
-        rego_code: 'package dcm.placement',
-        enabled: true,
-      }),
-    ).toBe(false);
-  });
 });
 
 describe('validateRegoCode', () => {
@@ -138,19 +125,11 @@ describe('validateRegoCode', () => {
   });
 
   it('returns undefined for valid Rego', () => {
-    expect(
-      validateRegoCode('package dcm.placement\nselected_provider := "p1"'),
-    ).toBeUndefined();
+    expect(validateRegoCode('package dcm.placement')).toBeUndefined();
   });
 
   it('flags missing package declaration', () => {
     expect(validateRegoCode('selected_provider := "p1"')).toMatch(/package/);
-  });
-
-  it('flags missing selected_provider', () => {
-    expect(validateRegoCode('package dcm.placement')).toMatch(
-      /selected_provider/,
-    );
   });
 
   it('flags Jinja-style non-Rego input', () => {

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/policyFormTypes.ts
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/policyFormTypes.ts
@@ -83,9 +83,6 @@ export function validateRegoCode(value: string): string | undefined {
   if (!hasPackage) {
     return 'Must contain a package declaration — e.g. "package dcm.placement"';
   }
-  if (!/\bselected_provider\b/.test(trimmed)) {
-    return 'Must reference selected_provider — e.g. selected_provider := "my-provider"';
-  }
   return undefined;
 }
 

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
@@ -45,6 +45,7 @@ import { catalogApiRef, providersApiRef } from '../../apis';
 import { DcmCrudTabLayout } from '../../components/DcmCrudTabLayout';
 import { DcmDeleteDialog } from '../../components/DcmDeleteDialog';
 import { DcmFormDialog } from '../../components/DcmFormDialog';
+import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { DcmFormDialogActions } from '../../components/DcmFormDialogActions';
 import { createEditDeleteColumn } from '../../components/dcmTabListHelpers';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
@@ -88,6 +89,9 @@ export function ProvidersTabContent() {
     isValid: isProviderFormValid,
     itemToForm: providerToForm,
     storageKey: 'providers',
+    createSuccessMessage: 'Provider registered successfully.',
+    editSuccessMessage: 'Provider updated successfully.',
+    deleteSuccessMessage: 'Provider deleted successfully.',
   });
 
   const columns = useMemo<TableColumn<Provider>[]>(
@@ -353,6 +357,11 @@ export function ProvidersTabContent() {
         resourceLabel="provider"
         error={crud.deleteError}
         isSubmitting={crud.deleteSubmitting}
+      />
+
+      <DcmSuccessSnackbar
+        message={crud.successMessage}
+        onClose={crud.clearSuccessMessage}
       />
     </>
   );


### PR DESCRIPTION
### Jira:

FLPATH-4253 | [DCM] No success feedback after CRUD operations

---

### Issues:

- Delete Record (Row) from the table displays empty Table (Instead of navigating to prev page)
- Fix Rego Code validation

---

### Changes:

Show a success snackbar after every CRUD operation in the Providers, Policies, and Catalog Items tabs.

- Extended `useCrudTab` with optional `createSuccessMessage`, `editSuccessMessage`, and `deleteSuccessMessage` options and a `successMessage` / `clearSuccessMessage` pair in the returned result.
- Wired `DcmSuccessSnackbar` into `ProvidersTabContent`, `PoliciesTabContent`, and `CatalogItemsTabContent` with contextual messages (e.g. "Provider registered successfully.", "Policy deleted successfully.").
- Fixed a bug where deleting the last item on a non-zero page left the table showing "No records to display" instead of navigating back to the last valid page.
