### PR TITLE
fix(scorecard): replace uuid dependency with Node.js built-in crypto.randomUUID

### DIFF
--- a/workspaces/scorecard/.changeset/brave-baths-strive.md
+++ b/workspaces/scorecard/.changeset/brave-baths-strive.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend': patch
+---
+
+Replace deprecated uuid dependency with the Node.js built-in `crypto.randomUUID`.

--- a/workspaces/scorecard/.changeset/ninety-squids-move.md
+++ b/workspaces/scorecard/.changeset/ninety-squids-move.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-node': patch
+---
+
+Remove unused uuid dependency

--- a/workspaces/scorecard/plugins/scorecard-backend/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend/package.json
@@ -49,7 +49,6 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "knex": "^3.1.0",
-    "uuid": "^9.0.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/CleanupExpiredMetricsTask.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/CleanupExpiredMetricsTask.test.ts
@@ -20,10 +20,6 @@ import { mockDatabaseMetricValues } from '../../../__fixtures__/mockDatabaseMetr
 import { CLEANUP_EXPIRED_METRICS_ID } from '../constants';
 import { daysToMilliseconds } from './utils';
 
-jest.mock('uuid', () => ({
-  v4: jest.fn(() => 'test-uuid-1234'),
-}));
-
 jest.mock('./utils', () => ({
   daysToMilliseconds: jest.fn((days: number) => days * 24 * 60 * 60 * 1000),
 }));

--- a/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/CleanupExpiredMetricsTask.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/CleanupExpiredMetricsTask.ts
@@ -19,8 +19,8 @@ import {
   SchedulerService,
   SchedulerServiceTaskScheduleDefinition,
 } from '@backstage/backend-plugin-api';
+import { randomUUID } from 'node:crypto';
 import { CLEANUP_EXPIRED_METRICS_ID } from '../constants';
-import { v4 as uuid } from 'uuid';
 import { daysToMilliseconds } from './utils';
 import type { Config } from '@backstage/config';
 import { SchedulerTask, SchedulerOptions } from '../types';
@@ -63,7 +63,7 @@ export class CleanupExpiredMetricsTask implements SchedulerTask {
       fn: async () => {
         const logger = this.logger.child({
           taskId: CLEANUP_EXPIRED_METRICS_ID,
-          taskInstanceId: uuid(),
+          taskInstanceId: randomUUID(),
         });
 
         try {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/scheduler/tasks/PullMetricsByProviderTask.ts
@@ -26,8 +26,8 @@ import type { Config } from '@backstage/config';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { MetricProvider } from '@red-hat-developer-hub/backstage-plugin-scorecard-node';
 import { isMetricIdDisabled } from '../../utils/metricUtils';
+import { randomUUID } from 'node:crypto';
 import { normalizeOwnerRef } from '../../utils/normalizeOwnerRef';
-import { v4 as uuid } from 'uuid';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { DbMetricValueCreate } from '../../database/types';
 import { SchedulerOptions, SchedulerTask } from '../types';
@@ -93,7 +93,7 @@ export class PullMetricsByProviderTask implements SchedulerTask {
         const logger = this.logger.child({
           class: this.constructor.name,
           taskId: this.providerId,
-          taskInstanceId: uuid(),
+          taskInstanceId: randomUUID(),
         });
 
         try {

--- a/workspaces/scorecard/plugins/scorecard-node/package.json
+++ b/workspaces/scorecard/plugins/scorecard-node/package.json
@@ -46,8 +46,7 @@
     "@backstage/catalog-model": "^1.7.7",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-catalog-node": "^2.1.0",
-    "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^",
-    "uuid": "^9.0.1"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.1",

--- a/workspaces/scorecard/yarn.lock
+++ b/workspaces/scorecard/yarn.lock
@@ -12325,7 +12325,6 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.1.0"
     supertest: "npm:^6.2.4"
-    uuid: "npm:^9.0.1"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
@@ -12351,7 +12350,6 @@ __metadata:
     "@backstage/plugin-catalog-node": "npm:^2.1.0"
     "@backstage/types": "npm:^1.2.2"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
-    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes task https://redhat.atlassian.net/browse/RHIDP-14849

Update deprecated and 3 year old uuid library. This replaces #2884

The uuid package is no longer needed — Node.js provides crypto.randomUUID natively.

This removes the dependency from both scorecard-backend and scorecard-node.

This is aligned with https://github.com/backstage/backstage/pull/34035

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
