### PR TITLE
chore(install-dynamic-plugins): clarify the workspace-root package.json is internal

### DIFF
--- a/workspaces/install-dynamic-plugins/package.json
+++ b/workspaces/install-dynamic-plugins/package.json
@@ -2,6 +2,7 @@
   "name": "@internal/install-dynamic-plugins",
   "version": "0.0.0",
   "private": true,
+  "description": "Internal workspace root — not published. The publishable package is @red-hat-developer-hub/cli-module-install-dynamic-plugins, located at ./packages/install-dynamic-plugins.",
   "engines": {
     "node": "22 || 24"
   },


### PR DESCRIPTION
## Summary

One-line documentation change to the **workspace-root** `package.json` (`@internal/install-dynamic-plugins`) so anyone landing on the file directly from a GitHub link sees right away that this is the internal yarn workspace container — not the published artifact.

The publishable package, **`@red-hat-developer-hub/cli-module-install-dynamic-plugins`**, lives at `./packages/install-dynamic-plugins/` and is already on the npm registry as `0.2.0`.

## What this PR changes

```diff
   "name": "@internal/install-dynamic-plugins",
   "version": "0.0.0",
   "private": true,
+  "description": "Internal workspace root — not published. The publishable package is @red-hat-developer-hub/cli-module-install-dynamic-plugins, located at ./packages/install-dynamic-plugins.",
```

That's it. One line.

## Why

The `@internal/*` scope and `"private": true` already prevent publishing, but neither shows up on the GitHub file preview at the URL someone gets when they deep-link to that file. A reviewer who lands there can briefly think the workspace was published under the wrong namespace. The `description` field renders at the top of the file and removes that ambiguity.

## Why not change the workspace-root name to `@red-hat-developer-hub/...`?

Every other workspace in this repo uses the `@internal/*` scope for its workspace-root container (`@internal/extensions`, `@internal/dcm`, `@internal/homepage`, `@internal/translations`, …). Diverging from that convention for one workspace would create more confusion, not less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)