### PR TITLE
Add stream error handlers to prevent process crashes

### DIFF
--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -471,12 +471,15 @@ export async function createNotebooksRouter(
       };
 
       for (let retries = 0; retries <= MAX_QUERY_RETRIES; retries++) {
+        const abortController = new AbortController();
+
         const response = await fetch(
           `${lightspeedBaseUrl}/v1/responses?user_id=${encodeURIComponent(userId)}`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(lightspeedRequest),
+            signal: abortController.signal,
           },
         );
 
@@ -528,7 +531,6 @@ export async function createNotebooksRouter(
             userId,
           );
 
-          // Handle stream errors (RHIDP-13064)
           body.on('error', (error: Error) => {
             logger.error(
               `Upstream stream error while processing notebook query: ${error}`,
@@ -538,6 +540,7 @@ export async function createNotebooksRouter(
                 .status(500)
                 .json({ status: 'error', error: 'Stream error occurred' });
             }
+            abortController.abort();
             transformStream.destroy();
           });
 
@@ -551,15 +554,16 @@ export async function createNotebooksRouter(
                 error: 'Processing error occurred',
               });
             }
+            body.destroy();
+            abortController.abort();
           });
 
-          // Handle client disconnection (RHIDP-13064)
           res.on('error', (error: Error) => {
             logger.warn(
               `Client disconnected while processing notebook query: ${error}`,
             );
+            abortController.abort();
             body.destroy();
-            transformStream.destroy();
           });
 
           body.pipe(transformStream).pipe(res);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -535,12 +535,12 @@ export async function createNotebooksRouter(
             logger.error(
               `Upstream stream error while processing notebook query: ${error}`,
             );
-            if (!res.headersSent) {
+            if (res.headersSent) {
+              res.destroy();
+            } else {
               res
                 .status(500)
                 .json({ status: 'error', error: 'Stream error occurred' });
-            } else {
-              res.destroy();
             }
             abortController.abort();
             transformStream.destroy();
@@ -550,13 +550,13 @@ export async function createNotebooksRouter(
             logger.error(
               `Transform stream error while processing notebook query: ${error}`,
             );
-            if (!res.headersSent) {
+            if (res.headersSent) {
+              res.destroy();
+            } else {
               res.status(500).json({
                 status: 'error',
                 error: 'Processing error occurred',
               });
-            } else {
-              res.destroy();
             }
             body.destroy();
             abortController.abort();

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -522,9 +522,47 @@ export async function createNotebooksRouter(
 
         if (response.body) {
           const body = Readable.fromWeb(response.body as any);
-          body
-            .pipe(createResponsesApiTransform(session, sessionId, userId))
-            .pipe(res);
+          const transformStream = createResponsesApiTransform(
+            session,
+            sessionId,
+            userId,
+          );
+
+          // Handle stream errors (RHIDP-13064)
+          body.on('error', error => {
+            logger.error(
+              `Upstream stream error while processing notebook query: ${error}`,
+            );
+            if (!res.headersSent) {
+              res
+                .status(500)
+                .json({ status: 'error', error: 'Stream error occurred' });
+            }
+            transformStream.destroy();
+          });
+
+          transformStream.on('error', error => {
+            logger.error(
+              `Transform stream error while processing notebook query: ${error}`,
+            );
+            if (!res.headersSent) {
+              res.status(500).json({
+                status: 'error',
+                error: 'Processing error occurred',
+              });
+            }
+          });
+
+          // Handle client disconnection (RHIDP-13064)
+          res.on('error', error => {
+            logger.warn(
+              `Client disconnected while processing notebook query: ${error}`,
+            );
+            body.destroy();
+            transformStream.destroy();
+          });
+
+          body.pipe(transformStream).pipe(res);
         }
         break;
       }

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -539,6 +539,8 @@ export async function createNotebooksRouter(
               res
                 .status(500)
                 .json({ status: 'error', error: 'Stream error occurred' });
+            } else {
+              res.destroy();
             }
             abortController.abort();
             transformStream.destroy();
@@ -553,17 +555,21 @@ export async function createNotebooksRouter(
                 status: 'error',
                 error: 'Processing error occurred',
               });
+            } else {
+              res.destroy();
             }
             body.destroy();
             abortController.abort();
           });
 
-          res.on('error', (error: Error) => {
-            logger.warn(
-              `Client disconnected while processing notebook query: ${error}`,
-            );
-            abortController.abort();
-            body.destroy();
+          res.on('close', () => {
+            if (!res.writableFinished) {
+              logger.warn(
+                'Client disconnected while processing notebook query',
+              );
+              abortController.abort();
+              body.destroy();
+            }
           });
 
           body.pipe(transformStream).pipe(res);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -529,7 +529,7 @@ export async function createNotebooksRouter(
           );
 
           // Handle stream errors (RHIDP-13064)
-          body.on('error', error => {
+          body.on('error', (error: Error) => {
             logger.error(
               `Upstream stream error while processing notebook query: ${error}`,
             );
@@ -541,7 +541,7 @@ export async function createNotebooksRouter(
             transformStream.destroy();
           });
 
-          transformStream.on('error', error => {
+          transformStream.on('error', (error: Error) => {
             logger.error(
               `Transform stream error while processing notebook query: ${error}`,
             );
@@ -554,7 +554,7 @@ export async function createNotebooksRouter(
           });
 
           // Handle client disconnection (RHIDP-13064)
-          res.on('error', error => {
+          res.on('error', (error: Error) => {
             logger.warn(
               `Client disconnected while processing notebook query: ${error}`,
             );

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -569,6 +569,7 @@ export async function createNotebooksRouter(
               );
               abortController.abort();
               body.destroy();
+              transformStream.destroy();
             }
           });
 

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -1013,6 +1013,33 @@ describe('lightspeed router tests', () => {
     });
   });
 
+  describe('POST /v1/query stream error handling', () => {
+    it('returns 500 when upstream stream errors', async () => {
+      const backendServer = await startBackendServer();
+      rcs.use(
+        http.post(`${LOCAL_LCS_ADDR}/v1/streaming_query`, () => {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.error(new Error('Connection reset'));
+            },
+          });
+          return new HttpResponse(stream, {
+            headers: { 'Content-Type': 'text/plain' },
+          });
+        }),
+      );
+      const response = await request(backendServer)
+        .post('/api/lightspeed/v1/query')
+        .send({
+          model: mockModel,
+          provider: 'test-server',
+          query: 'Hello',
+        });
+      expect(response.statusCode).toEqual(500);
+      expect(response.body.error).toContain('Stream error occurred');
+    });
+  });
+
   // Locks in the 500 contract when the permission service itself fails
   // (e.g. network error) as opposed to a deliberate DENY. Ensures the
   // middleware responds with a generic error rather than leaking internals.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -654,6 +654,23 @@ export async function createRouter(
         // Pipe the response back to the original response
         if (fetchResponse.body) {
           const nodeStream = Readable.fromWeb(fetchResponse.body as any);
+
+          // Handle stream errors (RHIDP-13064)
+          nodeStream.on('error', error => {
+            logger.error(
+              `Upstream stream error while processing query: ${error}`,
+            );
+            if (!response.headersSent) {
+              response.status(500).json({ error: 'Stream error occurred' });
+            }
+          });
+
+          // Handle client disconnection (RHIDP-13064)
+          response.on('error', error => {
+            logger.warn(`Client disconnected while processing query: ${error}`);
+            nodeStream.destroy();
+          });
+
           nodeStream.pipe(response);
         }
       } catch (error) {

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -629,6 +629,8 @@ export async function createRouter(
           userEntityRef,
         );
 
+        const abortController = new AbortController();
+
         const fetchResponse = await fetch(
           `${lightspeedCoreBaseUrl}/v1/streaming_query?${userQueryParam}`,
           {
@@ -638,6 +640,7 @@ export async function createRouter(
               'MCP-HEADERS': mcpHeadersValue,
             },
             body: requestBody,
+            signal: abortController.signal,
           },
         );
 
@@ -655,7 +658,6 @@ export async function createRouter(
         if (fetchResponse.body) {
           const nodeStream = Readable.fromWeb(fetchResponse.body as any);
 
-          // Handle stream errors (RHIDP-13064)
           nodeStream.on('error', (error: Error) => {
             logger.error(
               `Upstream stream error while processing query: ${error}`,
@@ -663,12 +665,13 @@ export async function createRouter(
             if (!response.headersSent) {
               response.status(500).json({ error: 'Stream error occurred' });
             }
+            abortController.abort();
           });
 
-          // Handle client disconnection (RHIDP-13064)
           response.on('error', (error: Error) => {
             logger.warn(`Client disconnected while processing query: ${error}`);
             nodeStream.destroy();
+            abortController.abort();
           });
 
           nodeStream.pipe(response);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -664,14 +664,18 @@ export async function createRouter(
             );
             if (!response.headersSent) {
               response.status(500).json({ error: 'Stream error occurred' });
+            } else {
+              response.destroy();
             }
             abortController.abort();
           });
 
-          response.on('error', (error: Error) => {
-            logger.warn(`Client disconnected while processing query: ${error}`);
-            nodeStream.destroy();
-            abortController.abort();
+          response.on('close', () => {
+            if (!response.writableFinished) {
+              logger.warn('Client disconnected while processing query');
+              nodeStream.destroy();
+              abortController.abort();
+            }
           });
 
           nodeStream.pipe(response);

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -662,10 +662,10 @@ export async function createRouter(
             logger.error(
               `Upstream stream error while processing query: ${error}`,
             );
-            if (!response.headersSent) {
-              response.status(500).json({ error: 'Stream error occurred' });
-            } else {
+            if (response.headersSent) {
               response.destroy();
+            } else {
+              response.status(500).json({ error: 'Stream error occurred' });
             }
             abortController.abort();
           });

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -656,7 +656,7 @@ export async function createRouter(
           const nodeStream = Readable.fromWeb(fetchResponse.body as any);
 
           // Handle stream errors (RHIDP-13064)
-          nodeStream.on('error', error => {
+          nodeStream.on('error', (error: Error) => {
             logger.error(
               `Upstream stream error while processing query: ${error}`,
             );
@@ -666,7 +666,7 @@ export async function createRouter(
           });
 
           // Handle client disconnection (RHIDP-13064)
-          response.on('error', error => {
+          response.on('error', (error: Error) => {
             logger.warn(`Client disconnected while processing query: ${error}`);
             nodeStream.destroy();
           });


### PR DESCRIPTION
## Summary
Attach error handlers to streaming responses to prevent unhandled error events from crashing the Node.js process when the LCS connection drops mid-stream.

Addresses security vulnerability identified in Red Hat Product Security threat model (dated Mar 15, 2026).

## Changes
- Add error handler to nodeStream in POST `/v1/query` endpoint (router.ts)
- Add error handler to response object to detect client disconnections
- Add error handlers to both source and transform streams in notebooks query endpoint (`/v1/sessions/:sessionId/query`)
- Ensure streams are properly destroyed on error to prevent hanging connections

## Affected Endpoints
- `/v1/query` endpoint (Lightspeed router)
- `/v1/sessions/:sessionId/query` endpoint (Notebooks router)

## Checklist

- [ ] A changeset describing the change and affected packages
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

**Testing note:** Verified with manual tests simulating LCS stream failures and client disconnections. Error handlers work correctly and prevent process crashes. Existing unit tests verify the happy path.