### PR TITLE
Bugfix - Notebooks 404 passthrough error resolved

### DIFF
--- a/workspaces/lightspeed/.changeset/fuzzy-peaches-shake.md
+++ b/workspaces/lightspeed/.changeset/fuzzy-peaches-shake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': minor
+---
+
+bugfix - Notebooks routes 404 passthrough error resolved

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
@@ -51,17 +51,6 @@ export const lightspeedPlugin = createBackendPlugin({
       }) {
         await migrate(database);
 
-        http.use(
-          await createRouter({
-            config,
-            logger,
-            database,
-            httpAuth,
-            userInfo,
-            permissions,
-          }),
-        );
-
         const aiNotebooksEnabled =
           config.getOptionalBoolean('lightspeed.notebooks.enabled') ?? false;
 
@@ -97,6 +86,17 @@ export const lightspeedPlugin = createBackendPlugin({
             });
           }
         }
+
+        http.use(
+          await createRouter({
+            config,
+            logger,
+            database,
+            httpAuth,
+            userInfo,
+            permissions,
+          }),
+        );
 
         // Configure authentication policies
         http.addAuthPolicy({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Due to 
`  router.use((_request, response) => {
    response.status(404).json({ error: 'Requested path is not available' });
  });`
Notebooks routes have been filtered to be 404. Resolved this by changing route registration order.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
