### PR TITLE
feat(mcp-integrations): add missing attributes annotations to MCP tools

### DIFF
--- a/workspaces/mcp-integrations/.changeset/mcp-tool-attribute-annotations.md
+++ b/workspaces/mcp-integrations/.changeset/mcp-tool-attribute-annotations.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scaffolder-mcp-extras': patch
+'@red-hat-developer-hub/backstage-plugin-software-catalog-mcp-extras': patch
+'@red-hat-developer-hub/backstage-plugin-techdocs-mcp-extras': patch
+---
+
+Add missing MCP tool attribute annotations (`readOnly`, `destructive`, `idempotent`) to `fetch-template-metadata`, `query-catalog-entities`, and `analyze-techdocs-coverage` tools.

--- a/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createFetchTemplateMetadataAction.ts
+++ b/workspaces/mcp-integrations/plugins/scaffolder-mcp-extras/src/actions/createFetchTemplateMetadataAction.ts
@@ -29,6 +29,11 @@ export const createFetchTemplateMetadataAction = ({
   actionsRegistry.register({
     name: 'fetch-template-metadata',
     title: 'Fetch Software Template Metadata',
+    attributes: {
+      destructive: false,
+      readOnly: true,
+      idempotent: true,
+    },
     description: `Search and retrieve Software Template metadata from the Backstage catalog.
 
 This tool retrieves Backstage Software Templates with their configuration details including parameters and steps. 

--- a/workspaces/mcp-integrations/plugins/software-catalog-mcp-extras/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/workspaces/mcp-integrations/plugins/software-catalog-mcp-extras/src/actions/createQueryCatalogEntitiesAction.ts
@@ -30,6 +30,11 @@ export const createQueryCatalogEntitiesAction = ({
   actionsRegistry.register({
     name: 'query-catalog-entities',
     title: 'Fetch Catalog Entities',
+    attributes: {
+      destructive: false,
+      readOnly: true,
+      idempotent: true,
+    },
     description: `Search and retrieve catalog entities from the Backstage server.
 
 List all Backstage entities such as Components, Systems, Resources, APIs, Locations, Users, and Groups. 

--- a/workspaces/mcp-integrations/plugins/techdocs-mcp-extras/src/actions/createAnalyzeTechDocsCoverageAction.ts
+++ b/workspaces/mcp-integrations/plugins/techdocs-mcp-extras/src/actions/createAnalyzeTechDocsCoverageAction.ts
@@ -37,6 +37,11 @@ export const createAnalyzeTechDocsCoverageAction = ({
   actionsRegistry.register({
     name: 'analyze-techdocs-coverage',
     title: 'Analyze TechDocs Coverage',
+    attributes: {
+      destructive: false,
+      readOnly: true,
+      idempotent: true,
+    },
     description: `Analyze documentation coverage across Backstage entities to understand what percentage of entities have TechDocs available.
 
       It calculates the percentage of entities that have TechDocs configured, helping identify documentation gaps and improve overall documentation coverage.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add the missing \`attributes\` block (\`readOnly\`, \`destructive\`, \`idempotent\`) to three MCP tools in the \`mcp-integrations\` workspace that were previously unannotated:

- \`fetch-template-metadata\` (scaffolder-mcp-extras) — reads catalog, no side effects
- \`query-catalog-entities\` (software-catalog-mcp-extras) — reads catalog entities, no side effects
- \`analyze-techdocs-coverage\` (techdocs-mcp-extras) — reads catalog + TechDocs metadata, no side effects

All three are set to \`{ readOnly: true, destructive: false, idempotent: true }\`, consistent with the other read-only tools in the workspace.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)