### PR TITLE
chore(fullsend): add version stamps for diff-based upgrades

### DIFF
--- a/.fullsend/customized/agents/code.md
+++ b/.fullsend/customized/agents/code.md
@@ -1,4 +1,6 @@
 ---
+# forked-from: fullsend v0.17.0 scaffold (adds monorepo-workspace-routing)
+# last-synced: 2026-06-16
 name: code
 description: >-
   Implementation specialist for GitHub issues. Reads triaged issues, implements

--- a/.fullsend/customized/harness/code.yaml
+++ b/.fullsend/customized/harness/code.yaml
@@ -1,3 +1,5 @@
+# forked-from: fullsend v0.17.0 scaffold
+# last-synced: 2026-06-16
 # harness/code.yaml — code agent with pre/post script pipeline.
 #
 # Flow: pre_script → sandbox (agent) → post_script


### PR DESCRIPTION
## Summary

- Adds `forked-from` / `last-synced` version stamps to customized scaffold files (code agent + harness)
- Path fixes (`/tmp/workspace/` → `/sandbox/workspace/`) were already applied on main — this PR only adds version stamps

## Context

Part of the fullsend v0.15 → v0.17 upgrade tracked in rhdh-fullsend#11. The version stamps enable future upgrades to generate a targeted diff:

```bash
git diff v0.17.0..v0.18.0 -- internal/scaffold/fullsend-repo/harness/code.yaml
```

## Test plan

- [x] Version stamps are YAML comments — no functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)