### PR TITLE
chore(fullsend): complete v0.17 upgrade — dispatch ref + version stamps

### DIFF
--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -1,6 +1,8 @@
+# forked-from: fullsend v0.17.0 scaffold
+# last-synced: 2026-06-16
 # harness/fix.yaml — fix agent with yarn sandbox workaround.
 #
-# Based on upstream fix.yaml (baseline 2025-06-05). The fix agent handles
+# Based on upstream fix.yaml. The fix agent handles
 # automated fixes triggered by /fs-fix commands on issues or PRs.
 #
 # Flow: pre_script → sandbox (agent) → validation_loop → post_script

--- a/.fullsend/customized/policies/code.yaml
+++ b/.fullsend/customized/policies/code.yaml
@@ -3,7 +3,9 @@ version: 1
 
 # Sandbox policy for the code agent.
 #
-# Based on upstream code policy (baseline 2025-06-05) with additions:
+# forked-from: fullsend v0.17.0 scaffold
+# last-synced: 2026-06-16
+# Based on upstream code policy with additions:
 #   - repo.yarnpkg.com endpoint in package_registries (corepack downloads
 #     yarn binary from repo.yarnpkg.com, not registry.yarnpkg.com)
 #   - corepack binary in package_registries

--- a/.fullsend/customized/policies/fix.yaml
+++ b/.fullsend/customized/policies/fix.yaml
@@ -3,7 +3,9 @@ version: 1
 
 # Sandbox policy for the fix agent.
 #
-# Based on the upstream fix policy (baseline 2025-06-05) with additions:
+# forked-from: fullsend v0.17.0 scaffold
+# last-synced: 2026-06-16
+# Based on upstream fix policy with additions:
 #   - repo.yarnpkg.com endpoint in package_registries (corepack downloads
 #     yarn binary from repo.yarnpkg.com, not registry.yarnpkg.com)
 #   - pnpm binary in package_registries (present in sandbox image)

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -55,6 +55,7 @@ jobs:
       install_mode: per-repo
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      fullsend_ai_ref: v0
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}


### PR DESCRIPTION
## Summary

Completes the fullsend v0.15 → v0.17 scaffold sync for rhdh-plugins:

- Adds `fullsend_ai_ref: v0` input to dispatch workflow (new in v0.17 template)
- Adds `forked-from` / `last-synced` version stamps to all remaining customized files:
  - `harness/fix.yaml`
  - `policies/code.yaml`
  - `policies/fix.yaml`

Combined with the already-merged PRs (#3421 for code agent/harness stamps, plus paths already fixed on main), this covers all customized scaffold files.

## Context

Part of fullsend v0.15 → v0.17 upgrade tracked in rhdh-fullsend#11.

The version stamps enable future upgrades to diff only what changed upstream:
```bash
git diff v0.17.0..v0.18.0 -- internal/scaffold/fullsend-repo/harness/fix.yaml
```

Closes #3423

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/fullsend.yaml` | `fullsend_ai_ref: v0` input |
| `.fullsend/customized/harness/fix.yaml` | version stamp |
| `.fullsend/customized/policies/code.yaml` | version stamp |
| `.fullsend/customized/policies/fix.yaml` | version stamp |

## Test plan

- [x] All changes are comments or workflow inputs — no functional change
- [x] Verified all customized files against upstream v0.17 scaffold — no missing fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)