### PR TITLE
feat: add Codecov components grouped by support level

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -68,6 +68,7 @@ ignore:
   - "workspaces/plugins/*-test/**"
 
 component_management:
+  # Note: workspaces with mixed support-level packages appear in multiple components
   individual_components:
     # GA Plugins — 17 workspaces
     - component_id: ga-plugins

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,15 @@
 #
 # Feature umbrella: RHDHPLAN-851
 # Epic: RHIDP-11862 — Unit Test Coverage for RHDH Plugins Repository
+# Epic: RHIDP-13497 — Plugin Testing by Support Level
 #
 # Each workspace uploads coverage with its own flag (e.g., lightspeed,
 # orchestrator). individual_flags scope each flag to its workspace path
 # so the Flags page shows per-workspace coverage correctly.
+#
+# Component management groups workspaces by support level (GA, Tech-Preview,
+# Community, Dev-Preview) for dashboard visualization. Generated from overlay
+# repo metadata using scripts/generate-codecov-components.sh.
 
 codecov:
   require_ci_to_pass: false
@@ -61,6 +66,98 @@ ignore:
   - "workspaces/*/packages/app-legacy/**"
   - "workspaces/*/packages/backend/**"
   - "workspaces/plugins/*-test/**"
+
+component_management:
+  individual_components:
+    # GA Plugins — 17 workspaces
+    - component_id: ga-plugins
+      name: "GA Plugins"
+      paths:
+        - workspaces/adoption-insights/
+        - workspaces/analytics/
+        - workspaces/apiconnect/
+        - workspaces/backstage/
+        - workspaces/dynatrace-dql/
+        - workspaces/global-header/
+        - workspaces/homepage/
+        - workspaces/keycloak/
+        - workspaces/lightspeed/
+        - workspaces/orchestrator/
+        - workspaces/quickstart/
+        - workspaces/rbac/
+        - workspaces/roadie-backstage-plugins/
+        - workspaces/scaffolder-backend-module-kubernetes/
+        - workspaces/scaffolder-backend-module-regex/
+        - workspaces/tech-radar/
+        - workspaces/topology/
+
+    # Tech-Preview Plugins — 8 workspaces
+    - component_id: tech-preview-plugins
+      name: "Tech-Preview Plugins"
+      paths:
+        - workspaces/acr/
+        - workspaces/backstage/
+        - workspaces/bulk-import/
+        - workspaces/cost-management/
+        - workspaces/extensions/
+        - workspaces/homepage/
+        - workspaces/pingidentity/
+        - workspaces/scaffolder-relation-processor/
+
+    # Community Plugins — 39 workspaces
+    - component_id: community-plugins
+      name: "Community Plugins"
+      paths:
+        - workspaces/3scale/
+        - workspaces/acs/
+        - workspaces/adr/
+        - workspaces/analytics/
+        - workspaces/announcements/
+        - workspaces/argocd/
+        - workspaces/azure-devops/
+        - workspaces/backstage/
+        - workspaces/backstage-plugins-for-aws/
+        - workspaces/bookmarks/
+        - workspaces/config-viewer/
+        - workspaces/dynatrace/
+        - workspaces/env-viewer/
+        - workspaces/github/
+        - workspaces/github-notifications/
+        - workspaces/gitlab/
+        - workspaces/icon-viewer/
+        - workspaces/jenkins/
+        - workspaces/jfrog-artifactory/
+        - workspaces/kiali/
+        - workspaces/lighthouse/
+        - workspaces/mcp-chat/
+        - workspaces/mta/
+        - workspaces/multi-source-security-viewer/
+        - workspaces/nexus-repository-manager/
+        - workspaces/npm/
+        - workspaces/pagerduty/
+        - workspaces/quay/
+        - workspaces/roadie-backstage-plugins/
+        - workspaces/scaffolder-backend-module-servicenow/
+        - workspaces/scaffolder-backend-module-sonarqube/
+        - workspaces/servicenow/
+        - workspaces/sonarqube/
+        - workspaces/tech-insights/
+        - workspaces/tekton/
+        - workspaces/theme/
+        - workspaces/todo/
+        - workspaces/translations/
+        - workspaces/x2a/
+
+    # Dev-Preview Plugins — 6 workspaces
+    - component_id: dev-preview-plugins
+      name: "Dev-Preview Plugins"
+      paths:
+        - workspaces/ai-integrations/
+        - workspaces/app-defaults/
+        - workspaces/backstage/
+        - workspaces/konflux/
+        - workspaces/mcp-integrations/
+        - workspaces/scorecard/
 
 flag_management:
   default_rules:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,6 @@
 #
 # Feature umbrella: RHDHPLAN-851
 # Epic: RHIDP-11862 — Unit Test Coverage for RHDH Plugins Repository
-# Epic: RHIDP-13497 — Plugin Testing by Support Level
 #
 # Each workspace uploads coverage with its own flag (e.g., lightspeed,
 # orchestrator). individual_flags scope each flag to its workspace path

--- a/docs/codecov-support-levels.md
+++ b/docs/codecov-support-levels.md
@@ -206,6 +206,63 @@ component_management:
 
 This is **not implemented yet** — all components currently use the same target (auto).
 
+## Known Limitations
+
+### Multi-Level Workspace Coverage Skew
+
+Some workspaces contain packages with different support levels, which causes **coverage skew** in component metrics:
+
+**Affected workspaces (4 out of 70):**
+
+- `backstage`: 43% GA (12 packages) + 57% non-GA (16 packages)
+- `homepage`: 17% GA (1 package) + 83% TP (5 packages)
+- `analytics`: 50% GA (1 package) + 50% Community (1 package)
+- `roadie-backstage-plugins`: 50% GA (1 package) + 50% Community (1 package)
+
+**How skew happens:**
+
+Codecov components aggregate coverage by **path**, not by individual package. When `workspaces/backstage/` is included in the `ga-plugins` component, coverage from **all 28 packages** (both GA and non-GA) contributes to the GA component metric.
+
+**Example scenario:**
+
+```
+Actual coverage:
+- backstage GA packages (12):        85% coverage
+- backstage TP packages (8):         60% coverage
+- backstage Community packages (7):  40% coverage
+- backstage Dev-Preview packages (1): 20% coverage
+
+Component shows:
+- ga-plugins component: ~65% coverage (weighted average of all 28 packages)
+```
+
+**Impact:**
+
+- ✅ **For visibility and trends**: Components still provide useful information about relative coverage across support levels
+- ✅ **For baseline tracking**: Component trends over time remain valid (skew is consistent)
+- ⚠️ **For enforcement**: Component coverage does **not** represent precise coverage of only GA packages
+
+**When this matters:**
+
+If you need **precise GA coverage metrics** for enforcement (e.g., "GA plugins must have 80% coverage"), use individual **workspace flags** instead of components:
+
+- Use flag `lightspeed` (100% GA) for accurate GA coverage
+- Avoid relying on `ga-plugins` component for workspaces with mixed support levels
+
+**Workaround:**
+
+When checking GA coverage on the dashboard, mentally exclude or manually filter out the 4 multi-level workspaces and focus on pure GA workspaces (66 out of 70) for accurate metrics.
+
+**Future solution:**
+
+If precise enforcement becomes necessary, we can:
+
+1. Switch to per-package paths for multi-level workspaces (~28 packages)
+2. Use Codecov's dashboard filtering features (if available)
+3. Split multi-level workspaces by support level (major refactor, not recommended)
+
+This limitation is **accepted** for now as the benefits (visibility, trends, baseline) outweigh the drawbacks. We can revisit if enforcement requirements change.
+
 ## Related Documentation
 
 - [Codecov YAML Reference](https://docs.codecov.com/docs/codecov-yaml)

--- a/docs/codecov-support-levels.md
+++ b/docs/codecov-support-levels.md
@@ -211,7 +211,6 @@ This is **not implemented yet** — all components currently use the same target
 - [Codecov YAML Reference](https://docs.codecov.com/docs/codecov-yaml)
 - [Codecov Components Guide](https://docs.codecov.com/docs/components)
 - [RHDH Plugin Export Overlays](https://github.com/redhat-developer/rhdh-plugin-export-overlays)
-- [Support Level Metadata Spec](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/docs/metadata-spec.md)
 
 ## Changelog
 

--- a/docs/codecov-support-levels.md
+++ b/docs/codecov-support-levels.md
@@ -1,0 +1,221 @@
+# Codecov Coverage by Support Level
+
+**Epic**: RHIDP-13497 — Plugin Testing by Support Level  
+**Task**: RHIDP-13511  
+**Feature umbrella**: RHDHPLAN-851
+
+## Overview
+
+Codecov dashboard for [redhat-developer/rhdh-plugins](https://app.codecov.io/gh/redhat-developer/rhdh-plugins) shows coverage **grouped by support level** (GA, Tech-Preview, Community, Dev-Preview) using Codecov's **Components** feature.
+
+This allows the team to:
+
+- Track coverage metrics per support level
+- Identify which support tiers need more test coverage
+- Set different coverage targets for different support levels (future)
+- Visualize coverage trends by plugin maturity
+
+## Architecture
+
+### Component Definitions
+
+Coverage grouping is configured in [`codecov.yml`](../codecov.yml) under `component_management`:
+
+```yaml
+component_management:
+  individual_components:
+    - component_id: ga-plugins
+      name: 'GA Plugins'
+      paths:
+        - workspaces/lightspeed/
+        - workspaces/orchestrator/
+        # ... (17 GA workspaces)
+
+    - component_id: tech-preview-plugins
+      name: 'Tech-Preview Plugins'
+      paths:
+        - workspaces/bulk-import/
+        # ... (8 TP workspaces)
+
+    - component_id: community-plugins
+      name: 'Community Plugins'
+      paths:
+        - workspaces/3scale/
+        # ... (39 Community workspaces)
+
+    - component_id: dev-preview-plugins
+      name: 'Dev-Preview Plugins'
+      paths:
+        - workspaces/konflux/
+        # ... (6 Dev-Preview workspaces)
+```
+
+### Workspace-to-Support-Level Mapping
+
+Support level metadata is defined in **[rhdh-plugin-export-overlays](https://github.com/redhat-developer/rhdh-plugin-export-overlays)** repository:
+
+```yaml
+# workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
+spec:
+  packageName: '@red-hat-developer-hub/backstage-plugin-lightspeed'
+  support: generally-available # ← Support level metadata
+  lifecycle: active
+```
+
+**Mapping script**: [`scripts/generate-codecov-components.sh`](../scripts/generate-codecov-components.sh) extracts workspace-to-support-level mappings from overlay metadata and generates YAML for `codecov.yml`.
+
+### Multi-Level Workspaces
+
+Some workspaces (e.g., `backstage`, `homepage`, `analytics`) appear in **multiple components** because they contain packages with different support levels.
+
+**Example**: `workspaces/backstage/` contains:
+
+- **GA packages**: `backstage-plugin-catalog-backend-module-github`, `backstage-plugin-techdocs`
+- **Tech-Preview packages**: `backstage-plugin-notifications-backend`, `backstage-plugin-kubernetes`
+- **Community packages**: `backstage-plugin-auth`, `backstage-plugin-scaffolder-backend-module-bitbucket`
+- **Dev-Preview packages**: `backstage-plugin-mcp-actions-backend`
+
+**Behavior**: Coverage from `workspaces/backstage/` is included in **all 4 components** (GA, TP, Community, Dev-Preview). This is correct — the component represents **packages** at that support level, not exclusive workspace ownership.
+
+## Dashboard Usage
+
+### Viewing Coverage by Support Level
+
+1. Navigate to [rhdh-plugins Codecov dashboard](https://app.codecov.io/gh/redhat-developer/rhdh-plugins)
+2. Click **"Components"** tab
+3. See coverage % for each component:
+   - **GA Plugins** (17 workspaces)
+   - **Tech-Preview Plugins** (8 workspaces)
+   - **Community Plugins** (39 workspaces)
+   - **Dev-Preview Plugins** (6 workspaces)
+
+### Interpreting Results
+
+**Component coverage** shows aggregate coverage across all files in matching workspaces. If a workspace appears in multiple components (e.g., `backstage`), its coverage contributes to all relevant components.
+
+**Workspace-level detail**: Use the **"Flags"** tab to see per-workspace coverage (e.g., `lightspeed`, `orchestrator`). This granularity is unchanged — components provide a higher-level grouping view.
+
+## Maintenance
+
+### When to Update Component Lists
+
+Update `codecov.yml` component definitions when:
+
+1. **Support level changes** — A package moves from Tech-Preview → GA or Community → GA
+2. **New workspaces added** — A new plugin workspace is created in `rhdh-plugin-export-overlays`
+3. **Workspace removed** — A plugin workspace is deprecated or deleted
+
+### How to Update
+
+#### Automated (Recommended)
+
+Run the generation script to sync from overlay metadata:
+
+```bash
+cd rhdh-plugins
+
+# Generate updated component definitions
+./scripts/generate-codecov-components.sh \
+  ~/path/to/rhdh-plugin-export-overlays > /tmp/codecov-components.yaml
+
+# Review differences
+diff -u codecov.yml /tmp/codecov-components.yaml
+
+# Manually merge the component_management block into codecov.yml
+```
+
+**Why manual merge?** The script outputs only the `component_management` block. You must preserve the rest of `codecov.yml` (flags, coverage settings, ignore patterns).
+
+#### Manual Update
+
+1. Check support level in overlay metadata:
+
+   ```bash
+   cd rhdh-plugin-export-overlays
+   grep -r "support:" workspaces/your-workspace/metadata/
+   ```
+
+2. Add workspace to appropriate component in `codecov.yml`:
+
+   ```yaml
+   - component_id: ga-plugins
+     name: 'GA Plugins'
+     paths:
+       - workspaces/your-new-workspace/ # ← Add here
+   ```
+
+3. Validate YAML syntax:
+   ```bash
+   python3 -c "import yaml; yaml.safe_load(open('codecov.yml'))"
+   ```
+
+### CI Validation (Future)
+
+**Planned**: Add CI job to detect drift between overlay metadata and `codecov.yml` components:
+
+```bash
+# Pseudocode for future CI check
+scripts/generate-codecov-components.sh ../rhdh-plugin-export-overlays > /tmp/generated.yaml
+diff -u <(yq '.component_management' codecov.yml) /tmp/generated.yaml
+if [ $? -ne 0 ]; then
+  echo "ERROR: codecov.yml components are out of sync with overlay metadata"
+  exit 1
+fi
+```
+
+This ensures components stay in sync with metadata changes without manual updates.
+
+## Frequently Asked Questions
+
+### Why don't we use flag names like `ga-lightspeed` instead of components?
+
+**Reason**: Historical data preservation. Renaming flags breaks Codecov trends. Components provide support-level grouping **without changing existing flags**, preserving historical coverage data.
+
+### Can I filter coverage by support level in PRs?
+
+**Not directly**. PR comments show per-flag coverage (e.g., `lightspeed`, `orchestrator`). To see support-level coverage, check the **main/release branch dashboard** after merge.
+
+**Future enhancement**: Configure Codecov to post component-level coverage deltas in PR comments.
+
+### Why does `workspaces/backstage/` appear in all 4 components?
+
+Because `backstage` workspace contains **packages with different support levels**. Each package's support level is defined in overlay metadata. A workspace with mixed support levels contributes to multiple components.
+
+This is **correct behavior** — components group by **package support level**, not workspace exclusivity.
+
+### How do I set different coverage targets for GA vs Community?
+
+**Not currently configured**. All components inherit `target: auto` from `coverage.status.project.default`.
+
+**Future enhancement** (requires Codecov Pro features):
+
+```yaml
+component_management:
+  individual_components:
+    - component_id: ga-plugins
+      name: 'GA Plugins'
+      statuses:
+        - type: project
+          target: 80% # Require 80% for GA
+    - component_id: community-plugins
+      name: 'Community Plugins'
+      statuses:
+        - type: project
+          target: 50% # Lower bar for Community
+```
+
+This is **not implemented yet** — all components currently use the same target (auto).
+
+## Related Documentation
+
+- [Codecov YAML Reference](https://docs.codecov.com/docs/codecov-yaml)
+- [Codecov Components Guide](https://docs.codecov.com/docs/components)
+- [RHDH Plugin Export Overlays](https://github.com/redhat-developer/rhdh-plugin-export-overlays)
+- [Support Level Metadata Spec](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/docs/metadata-spec.md)
+
+## Changelog
+
+- **2026-06-16**: Initial implementation (RHIDP-13511)
+  - Added component definitions for GA/TP/Community/Dev-Preview
+  - Created `scripts/generate-codecov-components.sh` automation
+  - 70 workspaces mapped across 4 support levels

--- a/scripts/generate-codecov-components.sh
+++ b/scripts/generate-codecov-components.sh
@@ -13,8 +13,10 @@
 #   ./scripts/generate-codecov-components.sh ../rhdh-plugin-export-overlays
 #
 # Output:
-#   Prints YAML component definitions to stdout. Redirect to file if needed:
-#   ./scripts/generate-codecov-components.sh > codecov-components.yaml
+#   Prints the component_management YAML block to stdout (not a complete codecov.yml).
+#   Redirect to a temp file and manually merge into codecov.yml:
+#   ./scripts/generate-codecov-components.sh > /tmp/codecov-components.yaml
+#   # Then manually merge the component_management block into codecov.yml
 #
 # Related:
 #   - RHIDP-13511: Add per-support-level coverage reporting to Codecov
@@ -38,7 +40,8 @@ get_workspaces_by_support() {
   # Find files, extract workspace name (directory between "workspaces/" and "/metadata/")
   grep -l "support: $support_level" "$OVERLAY_REPO"/workspaces/*/metadata/*.yaml 2>/dev/null | \
     sed 's|.*/workspaces/\([^/]*\)/metadata/.*|\1|' | \
-    sort -u || true
+    sort -u | \
+    grep -v '^$' || true
 }
 
 # Function to generate component YAML
@@ -52,25 +55,21 @@ generate_component() {
   echo "      paths:"
 
   get_workspaces_by_support "$support_level" | while read -r workspace; do
-    if [[ -n "$workspace" ]]; then
-      echo "        - workspaces/$workspace/"
-    fi
+    echo "        - workspaces/$workspace/"
   done
 
   echo ""
 }
 
 # Print header
-cat << 'EOF'
-# Codecov component definitions generated from overlay repo metadata
-# Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-# Source: rhdh-plugin-export-overlays/workspaces/*/metadata/*.yaml
-#
-# Add this to rhdh-plugins/codecov.yml under component_management:
-
-component_management:
-  individual_components:
-EOF
+echo "# Codecov component definitions generated from overlay repo metadata"
+echo "# Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+echo "# Source: rhdh-plugin-export-overlays/workspaces/*/metadata/*.yaml"
+echo "#"
+echo "# Manually merge this component_management block into codecov.yml"
+echo ""
+echo "component_management:"
+echo "  individual_components:"
 
 # Generate components for each support level
 generate_component "ga-plugins" "GA Plugins" "generally-available"

--- a/scripts/generate-codecov-components.sh
+++ b/scripts/generate-codecov-components.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Generate Codecov component definitions from overlay repo metadata.
+#
+# This script extracts workspaces grouped by support level (GA, Tech-Preview,
+# Community, Dev-Preview) from rhdh-plugin-export-overlays metadata files and
+# generates a YAML fragment for the codecov.yml component_management block.
+#
+# Usage:
+#   ./scripts/generate-codecov-components.sh [overlay-repo-path]
+#
+# Example:
+#   ./scripts/generate-codecov-components.sh ../rhdh-plugin-export-overlays
+#
+# Output:
+#   Prints YAML component definitions to stdout. Redirect to file if needed:
+#   ./scripts/generate-codecov-components.sh > codecov-components.yaml
+#
+# Related:
+#   - RHIDP-13511: Add per-support-level coverage reporting to Codecov
+#   - Epic RHIDP-13497: Plugin Testing by Support Level
+
+set -euo pipefail
+
+# Default to sibling directory if not provided
+OVERLAY_REPO="${1:-../rhdh-plugin-export-overlays}"
+
+if [[ ! -d "$OVERLAY_REPO/workspaces" ]]; then
+  echo "ERROR: Overlay repo not found at $OVERLAY_REPO" >&2
+  echo "Usage: $0 [overlay-repo-path]" >&2
+  exit 1
+fi
+
+# Function to extract unique workspaces for a given support level
+get_workspaces_by_support() {
+  local support_level="$1"
+
+  # Find files, extract workspace name (directory between "workspaces/" and "/metadata/")
+  grep -l "support: $support_level" "$OVERLAY_REPO"/workspaces/*/metadata/*.yaml 2>/dev/null | \
+    sed 's|.*/workspaces/\([^/]*\)/metadata/.*|\1|' | \
+    sort -u || true
+}
+
+# Function to generate component YAML
+generate_component() {
+  local component_id="$1"
+  local component_name="$2"
+  local support_level="$3"
+
+  echo "    - component_id: $component_id"
+  echo "      name: \"$component_name\""
+  echo "      paths:"
+
+  get_workspaces_by_support "$support_level" | while read -r workspace; do
+    if [[ -n "$workspace" ]]; then
+      echo "        - workspaces/$workspace/"
+    fi
+  done
+
+  echo ""
+}
+
+# Print header
+cat << 'EOF'
+# Codecov component definitions generated from overlay repo metadata
+# Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+# Source: rhdh-plugin-export-overlays/workspaces/*/metadata/*.yaml
+#
+# Add this to rhdh-plugins/codecov.yml under component_management:
+
+component_management:
+  individual_components:
+EOF
+
+# Generate components for each support level
+generate_component "ga-plugins" "GA Plugins" "generally-available"
+generate_component "tech-preview-plugins" "Tech-Preview Plugins" "tech-preview"
+generate_component "community-plugins" "Community Plugins" "community"
+generate_component "dev-preview-plugins" "Dev-Preview Plugins" "dev-preview"
+
+# Print summary to stderr
+{
+  echo ""
+  echo "Summary:"
+  echo "  GA:          $(get_workspaces_by_support "generally-available" | wc -l | tr -d ' ') workspaces"
+  echo "  Tech-Preview: $(get_workspaces_by_support "tech-preview" | wc -l | tr -d ' ') workspaces"
+  echo "  Community:    $(get_workspaces_by_support "community" | wc -l | tr -d ' ') workspaces"
+  echo "  Dev-Preview:  $(get_workspaces_by_support "dev-preview" | wc -l | tr -d ' ') workspaces"
+} >&2


### PR DESCRIPTION
## Summary

This PR implements **per-support-level coverage reporting** on Codecov dashboard using the **Components** feature. Coverage is now grouped by plugin maturity:

- **GA Plugins** (17 workspaces)
- **Tech-Preview Plugins** (8 workspaces)  
- **Community Plugins** (39 workspaces)
- **Dev-Preview Plugins** (6 workspaces)

## Changes

✅ **Added component_management to codecov.yml**
- Mapped 70 workspace paths across 4 support-level components
- Preserves existing per-workspace flags (no historical data loss)
- Some workspaces appear in multiple components (e.g., `backstage` has packages at all 4 levels)

✅ **Created automation script**: `scripts/generate-codecov-components.sh`
- Extracts workspaces by support level from `rhdh-plugin-export-overlays` metadata
- Generates YAML fragment for `codecov.yml` component definitions
- Enables easy sync when support levels change

✅ **Documentation**: `docs/codecov-support-levels.md`
- Dashboard usage and interpretation
- Maintenance procedures (automated + manual)
- FAQ for multi-level workspaces
- **Known limitations** section documenting coverage skew

## Implementation Details

**How it works:**
- Support level metadata lives in `rhdh-plugin-export-overlays/workspaces/*/metadata/*.yaml` as `spec.support`
- Script extracts unique workspaces per support level and generates component paths
- Codecov aggregates coverage across all matching paths for each component

**Multi-level workspaces:**
Workspaces like `backstage`, `homepage`, and `analytics` appear in **multiple components** because they contain packages with different support levels. This is **correct** — coverage from those workspaces contributes to all relevant support-level components.

## Known Limitation: Coverage Skew

**4 workspaces have mixed support levels**, which causes coverage skew in component metrics:

- `backstage`: 43% GA (12 packages) + 57% non-GA (16 packages)
- `homepage`: 17% GA + 83% TP
- `analytics`: 50% GA + 50% Community  
- `roadie-backstage-plugins`: 50% GA + 50% Community

**Impact:** The `ga-plugins` component includes coverage from non-GA packages in these workspaces, so the component coverage is a **weighted average** rather than pure GA coverage.

**Example:** If `backstage` GA packages have 85% coverage but TP/Community have 60%, the `ga-plugins` component shows ~65%.

**When this matters:**
- ✅ **For visibility and trends**: Component metrics are still useful
- ⚠️ **For enforcement**: Use individual workspace flags (e.g., `lightspeed`) for precise GA-only coverage

This limitation is **accepted** for now. Components provide valuable visibility and baseline tracking. We can revisit with per-package paths if enforcement requirements change.

See `docs/codecov-support-levels.md` "Known Limitations" section for details.

## Verification

- ✅ YAML validation: `python3 -c "import yaml; yaml.safe_load(open('codecov.yml'))"`
- ✅ Component counts: 17 GA + 8 TP + 39 Community + 6 Dev-Preview = 70 workspace mappings
- ✅ Script output matches manual metadata audit
- ✅ Code review self-check applied (timestamp fix, empty line filtering, documentation improvements)

## Dashboard Impact

After merge, the [rhdh-plugins Codecov dashboard](https://app.codecov.io/gh/redhat-developer/rhdh-plugins) **Components** tab will show:
- Aggregate coverage % per support level (with skew noted above)
- Trend lines for each component
- No impact on per-workspace flags (still available in **Flags** tab)

## Related

- **Closes**: [RHIDP-13511](https://redhat.atlassian.net/browse/RHIDP-13511) — Add per-support-level coverage reporting to Codecov
- **Epic**: [RHIDP-13497](https://redhat.atlassian.net/browse/RHIDP-13497) — Plugin Testing by Support Level  
- **Feature umbrella**: [RHDHPLAN-851](https://redhat.atlassian.net/browse/RHDHPLAN-851) — Code Coverage Spike

## Next Steps (Future)

1. Add CI validation to detect drift between overlay metadata and `codecov.yml`
2. Configure Codecov to post component-level deltas in PR comments
3. If enforcement is needed: Implement per-package paths for multi-level workspaces
