### PR TITLE
chore(fullsend): bump fix agent timeout from 25m to 90m

### DIFF
--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -69,4 +69,4 @@ runner_env:
   FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/fix-result.schema.json
   FULLSEND_OUTPUT_FILE: fix-result.json
 
-timeout_minutes: 25
+timeout_minutes: 90


### PR DESCRIPTION
## Summary
- Bumps `timeout_minutes` in `.fullsend/customized/harness/fix.yaml` from 25 to 90
- The 25-minute limit is too tight for this monorepo — yarn install, test suites, tsc, and API report generation consume most of the budget before the agent reaches the actual fix work
- Observed in [run 27699916006](https://github.com/redhat-developer/rhdh-plugins/actions/runs/27699916006) on PR #3402: agent completed successfully but was killed at exactly 25m0s

## Test plan
- [ ] Next `/fs-fix` invocation should have 90 minutes available
- [ ] Verify the timeout value is picked up by checking the workflow run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)