### PR TITLE
docs(orchestrator): update Changelog to include 1.10 backport versions

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-backend/CHANGELOG.md
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/CHANGELOG.md
@@ -16,6 +16,12 @@
   - @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.7.0
   - @red-hat-developer-hub/backstage-plugin-orchestrator-node@1.3.0
 
+## 8.9.5
+
+### Patch Changes
+
+- 06ac2d0: Fix an issue where filtering workflow runs by status or date could show an error instead of results.
+
 ## 8.9.4
 
 ### Patch Changes

--- a/workspaces/orchestrator/plugins/orchestrator-form-api/CHANGELOG.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-api/CHANGELOG.md
@@ -13,6 +13,12 @@
 - Updated dependencies [bd80b86]
   - @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.7.0
 
+## 2.7.4
+
+### Patch Changes
+
+- 06ac2d0: detect GitHub SAML SSO session expiry and prompt users to re-authorize
+
 ## 2.7.3
 
 ### Patch Changes

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/CHANGELOG.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/CHANGELOG.md
@@ -18,6 +18,16 @@
   - @red-hat-developer-hub/backstage-plugin-orchestrator-form-api@2.8.0
   - @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.7.0
 
+## 2.8.5
+
+### Patch Changes
+
+- 06ac2d0: Hide wizard steps when conditional `ui:hidden` rules evaluate to true, and add `isNotEmptyList`/`notContains` operators for conditional hidden expressions.
+- 06ac2d0: Remove unnecessary gaps from conditionally hidden form fields.
+- 06ac2d0: detect GitHub SAML SSO session expiry and prompt users to re-authorize
+- Updated dependencies [06ac2d0]
+  - @red-hat-developer-hub/backstage-plugin-orchestrator-form-api@2.7.4
+
 ## 2.8.4
 
 ### Patch Changes

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/CHANGELOG.md
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/CHANGELOG.md
@@ -20,6 +20,17 @@
   - @red-hat-developer-hub/backstage-plugin-orchestrator-form-api@2.8.0
   - @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.7.0
 
+## 1.10.8
+
+### Patch Changes
+
+- 06ac2d0: detect GitHub SAML SSO session expiry and prompt users to re-authorize
+- Updated dependencies [06ac2d0]
+- Updated dependencies [06ac2d0]
+- Updated dependencies [06ac2d0]
+  - @red-hat-developer-hub/backstage-plugin-orchestrator-form-react@2.8.5
+  - @red-hat-developer-hub/backstage-plugin-orchestrator-form-api@2.7.4
+
 ## 1.10.7
 
 ### Patch Changes

--- a/workspaces/orchestrator/plugins/orchestrator/CHANGELOG.md
+++ b/workspaces/orchestrator/plugins/orchestrator/CHANGELOG.md
@@ -20,6 +20,17 @@
   - @red-hat-developer-hub/backstage-plugin-orchestrator-form-api@2.8.0
   - @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.7.0
 
+## 5.7.13
+
+### Patch Changes
+
+- 06ac2d0: detect GitHub SAML SSO session expiry and prompt users to re-authorize
+- Updated dependencies [06ac2d0]
+- Updated dependencies [06ac2d0]
+- Updated dependencies [06ac2d0]
+  - @red-hat-developer-hub/backstage-plugin-orchestrator-form-react@2.8.5
+  - @red-hat-developer-hub/backstage-plugin-orchestrator-form-api@2.7.4
+
 ## 5.7.12
 
 ### Patch Changes


### PR DESCRIPTION
## Hey, I just made a Pull Request!


This PR is to update the changelog in orchestrator plugins to include the 1.10 backported patch version information.

