### PR TITLE
feat(fullsend): auto-rebase PR branch before fix agent runs

### DIFF
--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -12,6 +12,7 @@
 #   post_script      : push commit, post summary comment on PR
 #
 # Customizations over upstream fix.yaml:
+#   - pre_script: wraps upstream pre-fix.sh with auto-rebase onto target branch
 #   - image: rhdh custom image with yarn/corepack pre-installed
 #   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
 #   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
@@ -23,7 +24,7 @@ model: opus
 image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 policy: policies/fix.yaml
 
-pre_script: scripts/pre-fix.sh
+pre_script: scripts/pre-fix-rebase.sh
 
 validation_loop:
   script: scripts/validate-output-schema.sh

--- a/.fullsend/customized/scripts/pre-fix-rebase.sh
+++ b/.fullsend/customized/scripts/pre-fix-rebase.sh
@@ -20,7 +20,7 @@ CURRENT_HEAD="$(git rev-parse HEAD)"
 TARGET_HEAD="$(git rev-parse "origin/${TARGET_BRANCH}")"
 MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}")"
 
-if [ "${MERGE_BASE}" = "${TARGET_HEAD}" ]; then
+if [[ "${MERGE_BASE}" == "${TARGET_HEAD}" ]]; then
   echo "Branch is already up-to-date with origin/${TARGET_BRANCH}. Skipping rebase."
   exit 0
 fi
@@ -30,8 +30,8 @@ echo "Branch is ${BEHIND_COUNT} commit(s) behind origin/${TARGET_BRANCH}. Rebasi
 
 if ! git rebase "origin/${TARGET_BRANCH}" 2>&1; then
   git rebase --abort 2>/dev/null || true
-  echo "::error::Rebase onto origin/${TARGET_BRANCH} failed with conflicts."
-  echo "::error::Please rebase manually and re-trigger /fs-fix."
+  echo "::error::Rebase onto origin/${TARGET_BRANCH} failed with conflicts." >&2
+  echo "::error::Please rebase manually and re-trigger /fs-fix." >&2
   exit 1
 fi
 

--- a/.fullsend/customized/scripts/pre-fix-rebase.sh
+++ b/.fullsend/customized/scripts/pre-fix-rebase.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pre-script wrapper: upstream validation + auto-rebase onto target branch.
+#
+# Runs the upstream pre-fix.sh (input checks, iteration cap), then rebases
+# the PR branch onto origin/${TARGET_BRANCH} so the agent always works on
+# a current base. Force-pushes the rebased branch while the token is fresh.
+#
+# Required env (from runner_env in fix.yaml):
+#   REPO_DIR, TARGET_BRANCH, PUSH_TOKEN, REPO_FULL_NAME
+set -euo pipefail
+
+# 1. Run upstream validation (input checks, iteration cap)
+bash scripts/pre-fix.sh
+
+# 2. Rebase PR branch onto target branch
+cd "${REPO_DIR}"
+git fetch origin "${TARGET_BRANCH}"
+
+CURRENT_HEAD="$(git rev-parse HEAD)"
+TARGET_HEAD="$(git rev-parse "origin/${TARGET_BRANCH}")"
+MERGE_BASE="$(git merge-base HEAD "origin/${TARGET_BRANCH}")"
+
+if [ "${MERGE_BASE}" = "${TARGET_HEAD}" ]; then
+  echo "Branch is already up-to-date with origin/${TARGET_BRANCH}. Skipping rebase."
+  exit 0
+fi
+
+BEHIND_COUNT="$(git rev-list --count HEAD.."origin/${TARGET_BRANCH}")"
+echo "Branch is ${BEHIND_COUNT} commit(s) behind origin/${TARGET_BRANCH}. Rebasing..."
+
+if ! git rebase "origin/${TARGET_BRANCH}" 2>&1; then
+  git rebase --abort 2>/dev/null || true
+  echo "::error::Rebase onto origin/${TARGET_BRANCH} failed with conflicts."
+  echo "::error::Please rebase manually and re-trigger /fs-fix."
+  exit 1
+fi
+
+NEW_HEAD="$(git rev-parse HEAD)"
+echo "Rebase succeeded: ${CURRENT_HEAD:0:7} → ${NEW_HEAD:0:7}"
+
+# 3. Force-push the rebased branch (token is fresh here)
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+git remote set-url origin \
+  "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_FULL_NAME}.git"
+echo "Force-pushing rebased branch ${BRANCH}..."
+git push --force-with-lease origin "${BRANCH}" 2>&1
+echo "Rebase push complete."


### PR DESCRIPTION
## Summary

- Adds `pre-fix-rebase.sh` — a wrapper script that calls upstream `pre-fix.sh` validation, then rebases the PR branch onto `origin/${TARGET_BRANCH}` and force-pushes (`--force-with-lease`) while the GitHub App token is fresh
- Updates `fix.yaml` harness to use the new wrapper as `pre_script`
- No-op when the branch is already up-to-date; fails fast with actionable error messages on rebase conflicts

**Motivation**: Stale branches cause non-fast-forward push failures or token expiry during long agent runs (observed on PR #3402). Humans asking the agent to "rebase" wastes sandbox compute and often fails because the token expires mid-run.

## Test plan

- [ ] Find a PR where the branch is behind main
- [ ] Trigger `/fs-fix` with a simple instruction
- [ ] Check workflow logs for "Rebasing..." and "Rebase push complete" messages
- [ ] Verify the agent runs on the rebased branch and post-script push succeeds
- [ ] Test on a branch already up-to-date — should see "Skipping rebase"

🤖 Generated with [Claude Code](https://claude.com/claude-code)