### PR TITLE
feat(adoption-insights): expose Alpha module for dynamic plugin translations

### DIFF
--- a/workspaces/adoption-insights/.changeset/expose-alpha-translations.md
+++ b/workspaces/adoption-insights/.changeset/expose-alpha-translations.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Expose the Alpha Scalprum module and `adoptionInsightsTranslations` for dynamic plugins, and register `translationResources` in `app-config.dynamic.yaml` for loading translations from the Alpha bundle.

--- a/workspaces/adoption-insights/plugins/adoption-insights/app-config.dynamic.yaml
+++ b/workspaces/adoption-insights/plugins/adoption-insights/app-config.dynamic.yaml
@@ -1,6 +1,10 @@
 dynamicPlugins:
   frontend:
     red-hat-developer-hub.backstage-plugin-adoption-insights:
+      translationResources:
+        - importName: adoptionInsightsTranslations
+          module: Alpha
+          ref: adoptionInsightsTranslationRef
       appIcons:
         - name: adoptionInsightsIcon
           importName: AdoptionInsightsIcon

--- a/workspaces/adoption-insights/plugins/adoption-insights/package.json
+++ b/workspaces/adoption-insights/plugins/adoption-insights/package.json
@@ -91,6 +91,14 @@
   },
   "files": [
     "app-config.dynamic.yaml",
-    "dist"
-  ]
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "red-hat-developer-hub.backstage-plugin-adoption-insights",
+    "exposedModules": {
+      "PluginRoot": "./src/index.ts",
+      "Alpha": "./src/alpha.tsx"
+    }
+  }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Summary
- Expose the `Alpha` Scalprum module in the adoption-insights plugin `package.json` so translation exports are available in dynamic plugin bundles.
- Register `translationResources` in `app-config.dynamic.yaml` to load `adoptionInsightsTranslations` from the Alpha module.

<img width="1715" height="1022" alt="Screenshot 2026-06-18 at 4 15 42 PM" src="https://github.com/user-attachments/assets/2e76d476-6353-46cc-9a35-26da5598a819" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
