### PR TITLE
chore(deps): bump fast-uri to 3.1.2 or higher

### DIFF
--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -24336,9 +24336,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.0.3
-  resolution: "fast-uri@npm:3.0.3"
-  checksum: 10c0/4b2c5ce681a062425eae4f15cdc8fc151fd310b2f69b1f96680677820a8b49c3cd6e80661a406e19d50f0c40a3f8bffdd458791baf66f4a879d80be28e10a320
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It fixes https://redhat.atlassian.net/browse/RHDHBUGS-3314