### PR TITLE
plugin(lightspeed-notebooks): de-duplicate documents and fix document deletion

### DIFF
--- a/workspaces/lightspeed/.changeset/khaki-tomatoes-help.md
+++ b/workspaces/lightspeed/.changeset/khaki-tomatoes-help.md
@@ -1,0 +1,10 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Backport: Fix document upload gating and conversation deletion in notebooks
+
+This backports fixes from commits f7d96f8, e49fc2c, and d5199d6 on main to the 1.10 release line:
+
+- Prevent additional document uploads while another document is still being processed, avoiding race conditions in the notebook vector store
+- Fix document deletion to use the proper conversations API abstraction instead of direct internal base URL access

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/constant.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/constant.ts
@@ -26,7 +26,7 @@ export const DEFAULT_LIGHTSPEED_SERVICE_HOST = '127.0.0.1'; // Lightspeed core s
 export const DEFAULT_LIGHTSPEED_SERVICE_PORT = 8080; // Lightspeed service port
 export const DEFAULT_MAX_FILE_SIZE_MB = 20 * 1024 * 1024; // 20MB
 export const NOTEBOOKS_SYSTEM_PROMPT = `
-You are a helpful, analytical Senior Research Analyst assistant. Your primary objective is to synthesize cross-document information to answer user queries with 100% fidelity to the provided documents.
+You are a helpful, analytical Research Analyst assistant. Your primary objective is to synthesize cross-document information to answer user queries with 100% fidelity to the provided documents.
 
 ### QUERY TYPES - IMPORTANT
 * **Meta Queries ONLY:** ONLY when the user asks specifically about YOU as an assistant (e.g., "who are you", "what can you do", "hello"), respond naturally without requiring documents.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/VectorStoresOperator.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/VectorStoresOperator.ts
@@ -487,4 +487,40 @@ export class VectorStoresOperator {
       return response.json();
     },
   };
+
+  /**
+   * Conversations API
+   */
+  conversations = {
+    /**
+     * Delete a conversation
+     * DELETE /v2/conversations/{conversation_id}
+     */
+    delete: async (conversationId: string, userId: string): Promise<void> => {
+      this.logger.debug(
+        `VectorStoresOperator: Deleting conversation ${conversationId}`,
+      );
+
+      const response = await fetch(
+        `${this.baseURL}/v2/conversations/${encodeURIComponent(conversationId)}?user_id=${encodeURIComponent(userId)}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        this.logger.warn(
+          `Failed to delete conversation ${conversationId}: HTTP ${response.status}`,
+        );
+        throw new Error(
+          `Failed to delete conversation: HTTP ${response.status}`,
+        );
+      }
+
+      this.logger.info(`Deleted conversation ${conversationId}`);
+    },
+  };
 }

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -482,6 +482,7 @@ export async function createNotebooksRouter(
         input: query,
         instructions: systemPrompt,
         tools: [{ type: 'file_search', vector_store_ids: [sessionId] }],
+        tool_choice: 'required',
         model: `${queryProvider}/${queryModel}`,
         stream: true,
         temperature: 0.35,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/sessions/sessionService.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/sessions/sessionService.ts
@@ -184,32 +184,55 @@ export class SessionService {
    * @throws NotAllowedError if user does not own the session
    */
   async deleteSession(sessionId: string, userId: string): Promise<void> {
-    // Verify ownership before deletion
-    await this.readSession(sessionId, userId);
+    // Verify ownership before deletion and get session details
+    const session = await this.readSession(sessionId, userId);
+    const conversationId = session.metadata?.conversation_id;
 
-    // Delete all underlying files from Files API to prevent orphans
+    // Delete associated conversation if it exists
+    if (conversationId) {
+      try {
+        await this.client.conversations.delete(conversationId, userId);
+        this.logger.info(
+          `Deleted conversation ${conversationId} for session ${sessionId}`,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to delete conversation ${conversationId}: ${error}`,
+        );
+      }
+    }
+
+    // Delete all vector store files (same pattern as documentService.deleteDocument)
     try {
       const filesResponse =
         await this.client.vectorStores.files.list(sessionId);
-      const fileIds = filesResponse.data?.map((f: any) => f.file_id) || [];
+      const files = filesResponse.data || [];
+
+      this.logger.info(
+        `Deleting ${files.length} vector store files for session ${sessionId}`,
+      );
 
       await Promise.all(
-        fileIds.map(async (fileId: string) => {
+        files.map(async (file: any) => {
           try {
-            await this.client.files.delete(fileId);
-            this.logger.info(`Deleted file ${fileId} from Files API`);
+            await this.client.vectorStores.files.delete(sessionId, file.id);
+            this.logger.info(
+              `Deleted vector store file ${file.id} (${file.attributes?.title || 'untitled'})`,
+            );
           } catch (error) {
-            this.logger.warn(`Failed to delete file ${fileId}: ${error}`);
+            this.logger.warn(
+              `Failed to delete vector store file ${file.id}: ${error}`,
+            );
           }
         }),
       );
     } catch (error) {
       this.logger.warn(
-        `Failed to clean up files for session ${sessionId}: ${error}`,
+        `Failed to clean up vector store files for session ${sessionId}: ${error}`,
       );
     }
 
-    // Delete the vector store (cascade deletes vector store files)
+    // Delete the vector store itself
     await this.client.vectorStores.delete(sessionId);
     this.logger.info(`Session ${sessionId} deleted`);
   }

--- a/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report-alpha.api.md
@@ -241,6 +241,7 @@ export const lightspeedTranslationRef: TranslationRef<
     readonly 'notebook.view.sidebar.resize': string;
     readonly 'notebook.view.documents.uploading': string;
     readonly 'notebook.view.documents.maxReached': string;
+    readonly 'notebook.view.documents.uploadsInProgress': string;
     readonly 'notebook.upload.failed': string;
     readonly 'notebook.upload.modal.title': string;
     readonly 'notebook.upload.modal.dragDropTitle': string;

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -694,9 +694,8 @@ export const LightspeedChat = ({
     [],
   );
   const createNotebookMutation = useCreateNotebook();
-  const { data: notebookDocuments = [] } = useNotebookDocuments(
-    activeNotebook?.session_id,
-  );
+  const { data: notebookDocuments = [], isFetching: isDocumentsFetching } =
+    useNotebookDocuments(activeNotebook?.session_id);
   const [conversationId, setConversationId] = useState<string>('');
   const [requestId, setRequestId] = useState<string>('');
   const [newChatCreated, setNewChatCreated] = useState<boolean>(false);
@@ -2085,6 +2084,7 @@ export const LightspeedChat = ({
               sessionId={activeNotebook.session_id}
               notebookName={activeNotebook.name}
               documents={notebookDocuments}
+              isDocumentsFetching={isDocumentsFetching}
               metadata={activeNotebook.metadata}
               topicSummary={
                 conversations.find(

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/AddDocumentModal.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/AddDocumentModal.tsx
@@ -113,6 +113,7 @@ type AddDocumentModalProps = {
   onClose: () => void;
   sessionId: string;
   existingDocumentNames: string[];
+  hasUploadsInProgress?: boolean;
   onFilesUploading?: (files: File[]) => void;
   onUploadStarted?: (info: { fileName: string; documentId: string }) => void;
   onUploadFailed?: (fileName: string) => void;
@@ -126,6 +127,7 @@ export const AddDocumentModal = ({
   onClose,
   sessionId,
   existingDocumentNames,
+  hasUploadsInProgress,
   onFilesUploading,
   onUploadStarted,
   onUploadFailed,
@@ -261,6 +263,12 @@ export const AddDocumentModal = ({
           </Alert>
         )}
 
+        {hasUploadsInProgress && (
+          <Alert severity="info" className={classes.errorAlert}>
+            {t('notebook.view.documents.uploadsInProgress')}
+          </Alert>
+        )}
+
         {remainingSlots > 0 && (
           <MultipleFileUpload
             className={classes.dropzone}
@@ -320,7 +328,7 @@ export const AddDocumentModal = ({
           className={classes.addButton}
           variant="contained"
           color="primary"
-          disabled={selectedFiles.length === 0}
+          disabled={selectedFiles.length === 0 || hasUploadsInProgress}
         >
           {(t as Function)('notebook.upload.modal.addButton', {
             count: selectedFiles.length,

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DocumentSidebar.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/DocumentSidebar.tsx
@@ -129,6 +129,7 @@ type DocumentSidebarProps = {
   completedFileNames?: Set<string>;
   deletingDocumentIds?: Set<string>;
   collapsed: boolean;
+  hasUploadsInProgress?: boolean;
   onToggleCollapse: () => void;
   onAddDocument: () => void;
   onDeleteDocument?: (documentId: string) => void;
@@ -141,6 +142,7 @@ export const DocumentSidebar = ({
   completedFileNames,
   deletingDocumentIds,
   collapsed,
+  hasUploadsInProgress,
   onToggleCollapse,
   onAddDocument,
   onDeleteDocument,
@@ -158,7 +160,8 @@ export const DocumentSidebar = ({
     name => !uploadedNames.has(name),
   );
   const totalCount = documents.length + activePending.length;
-  const isAddDisabled = totalCount >= NOTEBOOK_MAX_FILES;
+  const isAddDisabled =
+    totalCount >= NOTEBOOK_MAX_FILES || hasUploadsInProgress;
 
   return (
     <div className={classes.sidebar}>
@@ -184,10 +187,14 @@ export const DocumentSidebar = ({
         </Typography>
         {isAddDisabled ? (
           <Tooltip
-            content={t('notebook.view.documents.maxReached')}
+            content={
+              hasUploadsInProgress
+                ? t('notebook.view.documents.uploadsInProgress')
+                : t('notebook.view.documents.maxReached')
+            }
             position="top"
           >
-            <span>
+            <Typography component="div">
               <Button
                 variant="link"
                 className={classes.addButton}
@@ -196,7 +203,7 @@ export const DocumentSidebar = ({
               >
                 {t('notebook.view.documents.add')}
               </Button>
-            </span>
+            </Typography>
           </Tooltip>
         ) : (
           <Button

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
@@ -270,6 +270,7 @@ type NotebookViewProps = {
   sessionId: string;
   notebookName?: string;
   documents?: SessionDocument[];
+  isDocumentsFetching?: boolean;
   metadata?: NotebookSessionMetadata;
   topicSummary?: string;
   userName?: string;
@@ -283,6 +284,7 @@ export const NotebookView = ({
   sessionId,
   notebookName = UNTITLED_NOTEBOOK_NAME,
   documents = [],
+  isDocumentsFetching = false,
   metadata,
   topicSummary,
   userName,
@@ -548,7 +550,9 @@ export const NotebookView = ({
 
   const hasDocuments = documents.length > 0 || uploadingFileNames.length > 0;
   const totalDocumentCount = documents.length + uploadingFileNames.length;
-  const isAddDisabled = totalDocumentCount >= NOTEBOOK_MAX_FILES;
+  const hasUploadsInProgress = pendingUploads.length > 0 || isDocumentsFetching;
+  const isAddDisabled =
+    totalDocumentCount >= NOTEBOOK_MAX_FILES || hasUploadsInProgress;
 
   const panelContent = (
     <DrawerPanelContent
@@ -565,6 +569,7 @@ export const NotebookView = ({
         completedFileNames={completedFileNames}
         deletingDocumentIds={deletingDocumentIds}
         collapsed={sidebarCollapsed}
+        hasUploadsInProgress={hasUploadsInProgress}
         onToggleCollapse={() => setSidebarCollapsed(prev => !prev)}
         onAddDocument={handleOpenUploadModal}
         onDeleteDocument={handleDeleteDocument}
@@ -694,11 +699,13 @@ export const NotebookView = ({
                     </Button>
                   </Tooltip>
                   <Tooltip
-                    content={
-                      isAddDisabled
-                        ? t('notebook.view.documents.maxReached')
-                        : t('notebook.view.documents.add')
-                    }
+                    content={(() => {
+                      if (hasUploadsInProgress)
+                        return t('notebook.view.documents.uploadsInProgress');
+                      if (isAddDisabled)
+                        return t('notebook.view.documents.maxReached');
+                      return t('notebook.view.documents.add');
+                    })()}
                     position="right"
                   >
                     <Typography component="span">
@@ -778,6 +785,7 @@ export const NotebookView = ({
         onClose={handleCloseUploadModal}
         sessionId={sessionId}
         existingDocumentNames={documents.map(d => d.title)}
+        hasUploadsInProgress={hasUploadsInProgress}
         onFilesUploading={handleFilesUploading}
         onUploadStarted={handleUploadStarted}
         onUploadFailed={handleUploadFailed}

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -76,6 +76,8 @@ export const lightspeedMessages = {
   'notebook.view.documents.uploading': 'Uploading document',
   'notebook.view.documents.maxReached':
     'Maximum 10 documents are allowed. Delete a document to upload a new document.',
+  'notebook.view.documents.uploadsInProgress':
+    'Please wait for current uploads to complete before adding more documents.',
   'notebook.upload.failed': '"{{fileName}}" upload failed.',
 
   // Notebook upload modal


### PR DESCRIPTION
* documents verified before adding another one in notebooks



# Conflicts:
#	workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts

* adding changeset



* Update API reports for new translation key

Add notebook.view.documents.uploadsInProgress to lightspeed translation API



* address comments



* fix document deletion



* fix: restore SSE end event, fix upload gating, and refactor conversation deletion

- Restore legacy 'end' event emission in notebooksRouters SSE transform
- Extract citations from file_search tool calls for referenced_documents
- Fix DocumentSidebar to respect hasUploadsInProgress when disabling Add button
- Add conversations API to VectorStoresOperator for proper abstraction
- Update SessionService to use conversations.delete instead of internal baseURL access



* fix(lightspeed): update changeset from minor to patch

* fix(lightspeed): update changeset description for backport

---------

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
