### PR TITLE
fix(fullsend): add safe-retry skill to prevent fix agent retry loops

### DIFF
--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -17,6 +17,7 @@
 #   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
 #   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
 #   - skills: adds monorepo-workspace-routing for workspace navigation
+#   - skills: adds safe-retry to guard against infinite retry loops
 #   - policy: custom fix policy with yarn registry + pnpm binary allowlist
 agent: agents/fix.md
 doc: docs/agents/fix.md
@@ -54,6 +55,7 @@ host_files:
 skills:
   - skills/fix-review
   - skills/monorepo-workspace-routing
+  - skills/safe-retry
 
 runner_env:
   PUSH_TOKEN: "${PUSH_TOKEN}"

--- a/.fullsend/customized/skills/safe-retry/SKILL.md
+++ b/.fullsend/customized/skills/safe-retry/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: safe-retry
+description: >-
+  Guards against infinite retry loops when the agent introduces syntax or
+  parse errors during edits. Requires diagnosis before retrying any failing
+  command and enforces hard stop thresholds.
+---
+
+# Safe Retry
+
+When a test, build, or lint command fails after you edited code, the error
+is most likely YOUR fault — not a pre-existing issue or a flaky test. Before
+retrying any failing command, you MUST follow the diagnosis steps below.
+
+**This skill overrides any instinct to "just retry."**
+
+## Diagnosis before retry
+
+After every test/build/lint failure:
+
+1. **Read the full error output.** Identify the failing file and line number.
+2. **Check if the failing file is one you edited.** If yes, the error is
+   self-inflicted. Fix the file first — do not retry the command.
+3. **Classify the error.** Syntax errors, parse errors, unexpected token
+   errors, and import/export resolution errors are almost always caused by
+   incomplete edits (e.g., renaming a symbol in one place but not updating
+   its import, or breaking a multi-line statement).
+
+## Hard rules
+
+- **Never retry the same command without changing code first.** If a command
+  failed, running it again without edits will produce the same failure. This
+  includes variations like `yarn test`, `yarn backstage-cli package test`,
+  and `yarn backstage-cli package test --no-cache` — these are the same
+  command with different flags, not different fixes.
+- **After 2 consecutive test failures, STOP and diagnose.** Re-read every
+  file you edited. Diff your changes against the original. Look for broken
+  imports, unclosed brackets, missing commas, and partial renames. Fix the
+  root cause before running tests again.
+- **After 3 total test failures across the entire run, produce structured
+  output with `tests_passed: false` and stop.** Do not commit broken code.
+  The post-script will report the failure and a human can intervene.
+
+## Common self-inflicted errors
+
+| Error pattern                                   | Likely cause                                       | Fix                                                 |
+| ----------------------------------------------- | -------------------------------------------------- | --------------------------------------------------- |
+| `SyntaxError: Unexpected token`                 | Incomplete edit broke the AST                      | Read the file around the error line; fix the syntax |
+| `Unexpected token, expected "from"`             | Broke an `import` statement (e.g., partial rename) | Check all `import`/`export` lines in the file       |
+| `Module '"./foo"' has no exported member 'Bar'` | Renamed an export but didn't update imports        | Find all files importing `Bar` and update them      |
+| `Cannot find module './foo'`                    | Renamed or moved a file but didn't update imports  | Grep for the old path and fix references            |
+| `TypeError: X is not a function`                | Changed a function signature or export             | Check callers                                       |


### PR DESCRIPTION
Add a new safe-retry skill that guards against infinite retry loops when the fix agent introduces syntax or parse errors during edits. The skill requires error diagnosis before retrying any failing command and enforces hard stop thresholds (3 total failures → stop with tests_passed: false).

Wire the skill into the fix harness alongside fix-review and monorepo-workspace-routing.

addresses non-productive looping like we saw the agent fall into with https://github.com/redhat-developer/rhdh-plugins/actions/runs/27780243879 for #3442 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [n/a] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [/] Added or Updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
