### PR TITLE
fix(fullsend): set git identity before rebase in pre-fix-rebase.sh

### DIFF
--- a/.fullsend/customized/scripts/pre-fix-rebase.sh
+++ b/.fullsend/customized/scripts/pre-fix-rebase.sh
@@ -14,6 +14,8 @@ bash scripts/pre-fix.sh
 
 # 2. Rebase PR branch onto target branch
 cd "${REPO_DIR}"
+git config user.name "fullsend-ai-coder[bot]"
+git config user.email "fullsend-ai-coder[bot]@users.noreply.github.com"
 git fetch origin "${TARGET_BRANCH}"
 
 CURRENT_HEAD="$(git rev-parse HEAD)"
@@ -30,7 +32,7 @@ echo "Branch is ${BEHIND_COUNT} commit(s) behind origin/${TARGET_BRANCH}. Rebasi
 
 if ! git rebase "origin/${TARGET_BRANCH}" 2>&1; then
   git rebase --abort 2>/dev/null || true
-  echo "::error::Rebase onto origin/${TARGET_BRANCH} failed with conflicts." >&2
+  echo "::error::Rebase onto origin/${TARGET_BRANCH} failed (check log above for cause)." >&2
   echo "::error::Please rebase manually and re-trigger /fs-fix." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Sets `git config user.name/email` before rebase — CI runners lack git identity, causing `fatal: empty ident name`
- Fixes misleading "failed with conflicts" error message to "failed (check log above for cause)"
- Root cause of the rebase failure on PR #3431

## Test plan
- [ ] Re-trigger `/fs-fix` on a PR that is behind `origin/main` — rebase should succeed and force-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)