### PR TITLE
chore(app-defaults): keep app-auth at 0.0.x for now

### DIFF
--- a/workspaces/app-defaults/.changeset/tough-carpets-smell.md
+++ b/workspaces/app-defaults/.changeset/tough-carpets-smell.md
@@ -1,5 +1,5 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-app-auth': minor
+'@red-hat-developer-hub/backstage-plugin-app-auth': patch
 ---
 
 Make signInPage config optional and derive signInPage cards from configs defined under auth.providers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

opinated: app-auth iss 0.0.3, make a flag should be fine to go to 0.0.4 for now.

We can use 0.0.x until we like to bump it because we get closer to a release

Rel to #3452

# Releases

## @red-hat-developer-hub/backstage-plugin-app-auth@0.1.0

### Minor Changes

-   d7f7899: Make signInPage config optional and derive signInPage cards from configs defined under auth.providers

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
