### PR TITLE
chore(quickstart): changing the lightspeed name to LA should be a minor release

### DIFF
--- a/workspaces/quickstart/.changeset/bright-doors-wave.md
+++ b/workspaces/quickstart/.changeset/bright-doors-wave.md
@@ -1,5 +1,5 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-quickstart': patch
+'@red-hat-developer-hub/backstage-plugin-quickstart': minor
 ---
 
 Rebrand Lightspeed quickstart steps to Intelligent Assistant: replace custom SVG icon with PatternFly RhUiAiChatbotIcon, update all English and localized i18n strings, and add test coverage for the Lightspeed icon.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

opinated: The quickstart workspace is still at Backstage 1.49.2 which allow us easily to backport changes.

But this rename we don't want ship (by accident) to RHDH 1.10. So, also if this is "just a small rename" I prefer that we bump the minor version to ensure we have the chance to ship quickstart 1.9.x for RHDH 1.10 and quickstart 1.10 or above to the upcoming version of RHDH.

Related to #3432 which says currently:

# Releases

## @red-hat-developer-hub/backstage-plugin-quickstart@1.9.8

### Patch Changes

-   8479da8: Rebrand Lightspeed quickstart steps to Intelligent Assistant: replace custom SVG icon with PatternFly RhUiAiChatbotIcon, update all English and localized i18n strings, and add test coverage for the Lightspeed icon.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
