### PR TITLE
chore(x2a): add missing changeset for PR #3436

### DIFF
--- a/workspaces/x2a/.changeset/wide-phones-prove.md
+++ b/workspaces/x2a/.changeset/wide-phones-prove.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+Add gitignore detection logging in x2a job script cleanup


### PR DESCRIPTION
  ## Summary
  Adds the changeset that was requested in
  https://github.com/redhat-developer/rhdh-plugins/pull/3436#pullrequestreview , but was missed before
  the PR was merged.

  ## Changes
  - Adds changeset for `@red-hat-developer-hub/backstage-plugin-x2a-backend` at patch level