### PR TITLE
fix(orchestrator): clear validation errors when user edits a form field

### DIFF
--- a/workspaces/orchestrator/.changeset/clear-validation-errors-on-edit.md
+++ b/workspaces/orchestrator/.changeset/clear-validation-errors-on-edit.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Clear async validation errors when the user edits a workflow form field after clicking Next. Only the changed field's error is removed; other field errors remain until that field is edited or the step is validated again. Also handle empty or non-JSON validation responses without breaking the form.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -33,6 +33,10 @@ import {
 } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 
 import { useTranslation } from '../hooks/useTranslation';
+import {
+  clearExtraErrorAtPath,
+  rjsfIdToFieldPath,
+} from '../utils/clearExtraErrorAtPath';
 import { getActiveStepKey } from '../utils/getSortedStepEntries';
 import { useStepperContext } from '../utils/StepperContext';
 import { toRootExtraErrors } from '../utils/toRootExtraErrors';
@@ -130,10 +134,14 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
 
   const onChange = (
     e: IChangeEvent<JsonObject, JSONSchema7, OrchestratorFormContextProps>,
+    id?: string,
   ) => {
+    const fieldPath = rjsfIdToFieldPath(id);
+    setExtraErrors(prev => clearExtraErrorAtPath(prev, fieldPath));
+    setValidationError(undefined);
     setFormData(e.formData || {});
     if (decoratorProps.onChange) {
-      decoratorProps.onChange(e);
+      decoratorProps.onChange(e, id);
     }
   };
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
@@ -64,8 +64,8 @@ const StepperObjectField = ({
                 schema={{ ...subSchema, title: '' }} // the title is in the step
                 uiSchema={uiSchema?.[key] || {}}
                 formData={(formData?.[key] as JsonObject) || {}}
-                onChange={data => {
-                  onChange({ ...formData, [key]: data });
+                onChange={(data, newErrorSchema, id) => {
+                  onChange({ ...formData, [key]: data }, newErrorSchema, id);
                 }}
                 idSchema={idSchema[key] as IdSchema<JsonObject>}
                 registry={{

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/clearExtraErrorAtPath.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/clearExtraErrorAtPath.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import { ERRORS_KEY, ErrorSchema } from '@rjsf/utils';
+
+import {
+  clearExtraErrorAtPath,
+  rjsfIdToFieldPath,
+} from './clearExtraErrorAtPath';
+
+describe('clearExtraErrorAtPath', () => {
+  const extraErrors = {
+    'managed-app-ci': {
+      xParams: {
+        fossaTeamName: { [ERRORS_KEY]: ['required'] },
+        sonarProjectKey: { [ERRORS_KEY]: ['required'] },
+      },
+    },
+  } as ErrorSchema<JsonObject>;
+
+  it('preserves all errors when fieldPath is undefined', () => {
+    expect(clearExtraErrorAtPath(extraErrors, undefined)).toBe(extraErrors);
+  });
+
+  it('clears only the targeted field', () => {
+    expect(
+      clearExtraErrorAtPath(
+        extraErrors,
+        'managed-app-ci.xParams.fossaTeamName',
+      ),
+    ).toEqual({
+      'managed-app-ci': {
+        xParams: {
+          sonarProjectKey: { [ERRORS_KEY]: ['required'] },
+        },
+      },
+    });
+  });
+
+  it('maps rjsf ids with hyphens to dotted paths', () => {
+    expect(rjsfIdToFieldPath('root_managed-app-ci_xParams_fossaTeamName')).toBe(
+      'managed-app-ci.xParams.fossaTeamName',
+    );
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/clearExtraErrorAtPath.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/clearExtraErrorAtPath.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import { ERRORS_KEY, ErrorSchema } from '@rjsf/utils';
+import cloneDeep from 'lodash/cloneDeep';
+import unset from 'lodash/unset';
+
+/**
+ * Maps an RJSF field id (e.g. `root_stepOne_xParams_name`) to a dotted form
+ * path used in extraErrors (e.g. `stepOne.xParams.name`).
+ */
+export function rjsfIdToFieldPath(id?: string): string | undefined {
+  if (!id || id === 'root') {
+    return undefined;
+  }
+
+  const withoutRoot = id.startsWith('root_') ? id.slice('root_'.length) : id;
+  if (!withoutRoot) {
+    return undefined;
+  }
+
+  return withoutRoot.replace(/_/g, '.');
+}
+
+function pruneEmptyErrorBranches(
+  node: ErrorSchema<JsonObject> | undefined,
+): ErrorSchema<JsonObject> | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+
+  if (Array.isArray((node as JsonObject)[ERRORS_KEY])) {
+    return node;
+  }
+
+  const pruned: ErrorSchema<JsonObject> = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === ERRORS_KEY) {
+      continue;
+    }
+    const child = pruneEmptyErrorBranches(value as ErrorSchema<JsonObject>);
+    if (child !== undefined) {
+      pruned[key] = child;
+    }
+  }
+
+  return Object.keys(pruned).length > 0 ? pruned : undefined;
+}
+
+/**
+ * Removes async validation errors for a single field. When `fieldPath` is
+ * omitted, existing errors are preserved (nested step onChange often has no id).
+ */
+export function clearExtraErrorAtPath(
+  extraErrors: ErrorSchema<JsonObject> | undefined,
+  fieldPath: string | undefined,
+): ErrorSchema<JsonObject> | undefined {
+  if (!extraErrors) {
+    return undefined;
+  }
+
+  if (!fieldPath) {
+    return extraErrors;
+  }
+
+  const next = cloneDeep(extraErrors);
+  unset(next, fieldPath);
+  return pruneEmptyErrorBranches(next);
+}

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/clearExtraErrorAtPath.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/clearExtraErrorAtPath.ts
@@ -23,6 +23,11 @@ import unset from 'lodash/unset';
 /**
  * Maps an RJSF field id (e.g. `root_stepOne_xParams_name`) to a dotted form
  * path used in extraErrors (e.g. `stepOne.xParams.name`).
+ *
+ * Assumes schema property names do not contain underscores. RJSF encodes nested
+ * paths in ids using the configured id separator (default `_`), so an
+ * underscore inside a field name would be indistinguishable from a path segment
+ * and cannot be mapped back reliably.
  */
 export function rjsfIdToFieldPath(id?: string): string | undefined {
   if (!id || id === 'root') {

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/parseValidationErrorBody.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/parseValidationErrorBody.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseValidationErrorBody } from './parseValidationErrorBody';
+
+const mockResponse = (
+  overrides: Partial<Response> & {
+    text?: () => Promise<string>;
+    json?: () => Promise<unknown>;
+  },
+): Response => overrides as Response;
+
+describe('parseValidationErrorBody', () => {
+  it('parses JSON from response.text()', async () => {
+    const response = mockResponse({
+      text: async () => JSON.stringify({ issues: ['field is required'] }),
+    });
+
+    await expect(parseValidationErrorBody(response)).resolves.toEqual({
+      issues: ['field is required'],
+    });
+  });
+
+  it('returns undefined when response.text() is empty', async () => {
+    const response = mockResponse({
+      text: async () => '',
+    });
+
+    await expect(parseValidationErrorBody(response)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when response.text() is not valid JSON', async () => {
+    const response = mockResponse({
+      text: async () => 'not-json',
+    });
+
+    await expect(parseValidationErrorBody(response)).resolves.toBeUndefined();
+  });
+
+  it('falls back to response.json() when text is unavailable', async () => {
+    const response = mockResponse({
+      json: async () => ({ issues: ['from json()'] }),
+    });
+
+    await expect(parseValidationErrorBody(response)).resolves.toEqual({
+      issues: ['from json()'],
+    });
+  });
+
+  it('returns undefined when response.json() throws', async () => {
+    const response = mockResponse({
+      json: async () => {
+        throw new Error('Unexpected end of JSON input');
+      },
+    });
+
+    await expect(parseValidationErrorBody(response)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when neither text nor json is available', async () => {
+    const response = mockResponse({});
+
+    await expect(parseValidationErrorBody(response)).resolves.toBeUndefined();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/parseValidationErrorBody.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/parseValidationErrorBody.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+export const parseValidationErrorBody = async (
+  response: Response,
+): Promise<JsonObject | undefined> => {
+  try {
+    if (typeof response.text === 'function') {
+      const text = await response.text();
+      if (!text) {
+        return undefined;
+      }
+      return JSON.parse(text) as JsonObject;
+    }
+    if (typeof response.json === 'function') {
+      return (await response.json()) as JsonObject;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
@@ -27,6 +27,26 @@ import { evaluateTemplateString } from './evaluateTemplate';
 import { getRequestInit } from './useRequestInit';
 import { safeSet } from './safeSet';
 
+const parseValidationErrorBody = async (
+  response: Response,
+): Promise<JsonObject | undefined> => {
+  try {
+    if (typeof response.text === 'function') {
+      const text = await response.text();
+      if (!text) {
+        return undefined;
+      }
+      return JSON.parse(text) as JsonObject;
+    }
+    if (typeof response.json === 'function') {
+      return (await response.json()) as JsonObject;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
 // Walks through the uiSchema and calls the "callback" for every field which is backed by the dynamic ui:widget.
 // The callback is provided with the uiSchema path, content of the uiSchema part and the corresponding entered formData value.
 const walkThrough: (
@@ -115,7 +135,13 @@ export const useGetExtraErrors = () => {
               evaluatedRequestInit,
             );
             if (response.status !== 200) {
-              const data = (await response.json()) as JsonObject;
+              const data = await parseValidationErrorBody(response);
+              if (!data || Object.keys(data).length === 0) {
+                safeSet(errors, path, {
+                  [ERRORS_KEY]: `Validation request failed with status ${response.status}`,
+                });
+                return;
+              }
 
               Object.keys(data).forEach(key => {
                 // @ts-ignore

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
@@ -25,27 +25,8 @@ import { ERRORS_KEY, ErrorSchema } from '@rjsf/utils';
 import { useTemplateUnitEvaluator } from './useTemplateUnitEvaluator';
 import { evaluateTemplateString } from './evaluateTemplate';
 import { getRequestInit } from './useRequestInit';
+import { parseValidationErrorBody } from './parseValidationErrorBody';
 import { safeSet } from './safeSet';
-
-const parseValidationErrorBody = async (
-  response: Response,
-): Promise<JsonObject | undefined> => {
-  try {
-    if (typeof response.text === 'function') {
-      const text = await response.text();
-      if (!text) {
-        return undefined;
-      }
-      return JSON.parse(text) as JsonObject;
-    }
-    if (typeof response.json === 'function') {
-      return (await response.json()) as JsonObject;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
-};
 
 // Walks through the uiSchema and calls the "callback" for every field which is backed by the dynamic ui:widget.
 // The callback is provided with the uiSchema path, content of the uiSchema part and the corresponding entered formData value.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3381

### Summary

- Clear async validation errors when the user edits a workflow form field after clicking **Next** (field-level and top-level error list).
- Only the edited field’s error is removed; errors on other invalid fields stay until those fields are edited or **Next** is run again.


https://github.com/user-attachments/assets/94895315-3aa1-4710-8e22-f89f7165341a

------------------

For testing, create the below `workspaces/orchestrator/packages/backend/src/devMockValidationModule.ts` file add in `workspaces/orchestrator/packages/backend/src/index.ts` 

`backend.add(import('./devMockValidationModule'));
`

```
import {
  coreServices,
  createBackendModule,
} from '@backstage/backend-plugin-api';
import express, { Request, Response } from 'express';

const isBlank = (value: unknown): boolean =>
  value === undefined ||
  value === null ||
  (typeof value === 'string' && value.trim() === '');

/**
 * Local-dev mock validation APIs for devModeTemp workflows (e.g. managed-app-ci
 * stale-error reproduction). Mounted at /api/orchestrator/dev/mock-validate.
 */
export default createBackendModule({
  pluginId: 'orchestrator',
  moduleId: 'dev-mock-validation',
  register(env) {
    env.registerInit({
      deps: { httpRouter: coreServices.httpRouter },
      async init({ httpRouter }) {
        const router = express.Router();
        router.use(express.json());

        router.post('/dev/mock-validate/field', (req: Request, res: Response) => {
          const { value, fieldLabel, requiredMessage } = req.body ?? {};
          if (isBlank(value)) {
            const label = fieldLabel ?? 'field';
            const message =
              requiredMessage ??
              `The property '${label}' in solution 'managed-app-ci' is a blank string and allowNullOrEmpty is false. Please provide a value.`;
            return res.status(422).json({
              issues: [message],
            });
          }
          return res.status(200).json({ ok: true });
        });

        router.post(
          '/dev/mock-validate/openshift-pair',
          (req: Request, res: Response) => {
            const { namespace, cluster } = req.body ?? {};
            const issues: string[] = [];
            if (isBlank(namespace)) {
              issues.push(
                'OpenShift namespace and cluster must both be provided.',
              );
            }
            if (isBlank(cluster)) {
              issues.push(
                'OpenShift namespace and cluster must both be provided.',
              );
            }
            if (issues.length > 0) {
              return res.status(422).json({ issues });
            }
            return res.status(200).json({ ok: true });
          },
        );

        httpRouter.use(router);
        httpRouter.addAuthPolicy({
          path: '/dev/mock-validate',
          allow: 'unauthenticated',
        });
      },
    });
  },
});
```

------------------

Workflow to test 

```
id: test-managed-app-ci-validation
version: '1.0'
specVersion: '0.8'
name: Test Managed App CI Validation
description: |
  Local dev workflow mimicking customer managed-app-ci validation.
  Uses /api/orchestrator/dev/mock-validate to return 422 for blank fields.
  Reproduces stale validation errors after Next — clear field, click Next, then type.
dataInputSchema: 'schemas/test-managed-app-ci-validation.input-schema.json'
start: InjectState
states:
  - name: InjectState
    type: inject
    data:
      message: Hello from test-managed-app-ci-validation
    end: true
```

```
{
  "$id": "classpath:/schemas/test-managed-app-ci-validation.input-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Test Managed App CI Validation",
  "description": "Mimics customer managed-app-ci xParams fields for local validation error testing",
  "type": "object",
  "ui:order": ["managed-app-ci"],
  "properties": {
    "managed-app-ci": {
      "title": "Managed App CI",
      "type": "object",
      "properties": {
        "xParams": {
          "type": "object",
          "title": "Managed App CI Parameters",
          "properties": {
            "containerRegistryNamespace": {
              "title": "Container Registry Namespace",
              "description": "The organization in the container registry where images are pushed.",
              "type": "string",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:method": "POST",
                "validate:url": "$${{backend.baseUrl}}/api/orchestrator/dev/mock-validate/field",
                "validate:body": {
                  "value": "$${{current.managed-app-ci.xParams.containerRegistryNamespace}}",
                  "fieldLabel": "containerRegistryNamespace"
                }
              }
            },
            "fossaTeamName": {
              "title": "Fossa Team Name",
              "type": "string",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:method": "POST",
                "validate:url": "$${{backend.baseUrl}}/api/orchestrator/dev/mock-validate/field",
                "validate:body": {
                  "value": "$${{current.managed-app-ci.xParams.fossaTeamName}}",
                  "fieldLabel": "fossaTeamName",
                  "requiredMessage": "Fossa Team Name is required when scaffolding a sample app."
                }
              }
            },
            "fossaSaUsername": {
              "title": "Fossa Service Account Username",
              "type": "string",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:method": "POST",
                "validate:url": "$${{backend.baseUrl}}/api/orchestrator/dev/mock-validate/field",
                "validate:body": {
                  "value": "$${{current.managed-app-ci.xParams.fossaSaUsername}}",
                  "fieldLabel": "fossaSaUsername",
                  "requiredMessage": "Fossa Service Account Username is required."
                }
              }
            },
            "sonarProjectKey": {
              "title": "Sonar Project Key",
              "type": "string",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:method": "POST",
                "validate:url": "$${{backend.baseUrl}}/api/orchestrator/dev/mock-validate/field",
                "validate:body": {
                  "value": "$${{current.managed-app-ci.xParams.sonarProjectKey}}",
                  "fieldLabel": "sonarProjectKey",
                  "requiredMessage": "Sonar Project Key is required when scaffolding a sample app."
                }
              }
            },
            "openshiftCluster": {
              "title": "OpenShift Cluster",
              "description": "Pair-validated with namespace (both required on Next).",
              "type": "string",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:method": "POST",
                "validate:url": "$${{backend.baseUrl}}/api/orchestrator/dev/mock-validate/openshift-pair",
                "validate:body": {
                  "namespace": "$${{current.managed-app-ci.xParams.openshiftNamespace}}",
                  "cluster": "$${{current.managed-app-ci.xParams.openshiftCluster}}"
                }
              }
            },
            "openshiftNamespace": {
              "title": "OpenShift Namespace",
              "description": "Pair-validated with cluster (both required on Next).",
              "type": "string",
              "default": "",
              "ui:widget": "ActiveTextInput",
              "ui:props": {
                "validate:method": "POST",
                "validate:url": "$${{backend.baseUrl}}/api/orchestrator/dev/mock-validate/openshift-pair",
                "validate:body": {
                  "namespace": "$${{current.managed-app-ci.xParams.openshiftNamespace}}",
                  "cluster": "$${{current.managed-app-ci.xParams.openshiftCluster}}"
                }
              }
            }
          }
        }
      }
    }
  }
}
```



-------------------


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
