### PR TITLE
fix(orchestrator): show run stats on entity catalog workflow overview

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-entity-workflow-run-stats.md
+++ b/workspaces/orchestrator/.changeset/fix-entity-workflow-run-stats.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+Fix workflow run stats on entity catalog workflow overview by querying instances with workflow definition ids and optional target entity filter.

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/Helper.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/Helper.ts
@@ -104,9 +104,19 @@ export function groupByProcessIdAndVersion(instances: ProcessInstance[]) {
   }, {});
 }
 
+export type WorkflowRunStatsResult = {
+  processIdVersion: string;
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  successRatio: number;
+  runsLastMonth: number;
+  averageTimeToComplete: number;
+};
+
 export function getWorkflowRunStats(
   groupedData: Record<string, ProcessInstance[]>,
-) {
+): WorkflowRunStatsResult[] {
   return Object.entries(groupedData).map(([processIdVersion, items]) => {
     const averageTimeToComplete =
       items.reduce((acc, item) => {

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.test.ts
@@ -17,6 +17,7 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 import {
+  Filter,
   ProcessInstance,
   ProcessInstanceState,
   WorkflowInfo,
@@ -876,6 +877,66 @@ describe('SonataFlowService', () => {
 
       expect(result).toHaveLength(1);
       expect(result?.[0].workflowId).toBe('workflow-a');
+    });
+
+    it('queries instance stats by workflow definition id for entity overview', async () => {
+      const helloWorldSource = JSON.stringify({
+        id: 'hello-world',
+        specVersion: '0.8',
+        name: 'Hello World Workflow',
+        version: '1.0',
+        start: 'startState',
+        states: [{ name: 'startState', type: 'inject', end: true }],
+      });
+      const workflowInfos: WorkflowInfo[] = [
+        { id: 'hello-world', source: helloWorldSource },
+      ];
+      const overviewFilter: Filter = {
+        field: 'id',
+        operator: 'IN',
+        value: ['hello-world'],
+      };
+      const targetEntity = 'component:default/my-component';
+
+      dataIndexServiceMock.fetchWorkflowInfos = jest
+        .fn()
+        .mockResolvedValue(workflowInfos);
+      dataIndexServiceMock.fetchInstances = jest.fn().mockResolvedValue([
+        createProcessInstance({
+          id: 'instance-1',
+          processId: 'hello-world',
+          version: '1.0',
+          state: ProcessInstanceState.Completed,
+          start: WITHIN_30_DAYS,
+        }),
+      ]);
+      dataIndexServiceMock.fetchInstancesByDefinitionId = jest
+        .fn()
+        .mockResolvedValue([]);
+
+      const result = await sonataFlowService.fetchWorkflowOverviews({
+        filter: overviewFilter,
+        targetEntity,
+      });
+
+      expect(dataIndexServiceMock.fetchInstances).toHaveBeenCalledWith({
+        definitionIds: ['hello-world'],
+        filter: {
+          field: 'variables',
+          nested: {
+            operator: 'EQ',
+            field: 'targetEntity',
+            value: targetEntity,
+          },
+        },
+      });
+      expect(result?.[0].workflowRunStats).toMatchObject({
+        successRatio: 1,
+        runsLastMonth: 1,
+        successCount: 1,
+        errorCount: 0,
+        totalCount: 1,
+      });
     });
   });
 

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -118,11 +118,24 @@ export class SonataFlowService {
       return [];
     }
 
-    // Can reuse the instances to get the stats
+    const statsDefinitionIds = workflowInfos.map(info => info.id);
+    const instancesFilter: Filter | undefined = targetEntity
+      ? {
+          field: 'variables',
+          nested: {
+            operator: 'EQ',
+            field: 'targetEntity',
+            value: targetEntity,
+          },
+        }
+      : undefined;
+
+    // Fetch instances by workflow definition id. Do not reuse the overview
+    // filter here: entity overview passes `id IN [workflowIds]`, which applies
+    // to definitions but would match instance ids when querying instances.
     const instances = await this.dataIndexService.fetchInstances({
-      definitionIds,
-      pagination,
-      filter,
+      definitionIds: statsDefinitionIds,
+      filter: instancesFilter,
     });
 
     // This will have all the workflows, so we need to group by workflow id


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Story: https://redhat.atlassian.net/browse/RHIDP-14987 

### Summary
- Fixes entity catalog **Workflows** tab showing `---` for **Runs (last month)** and **Success ratio**
- When building overview stats, query process instances by **workflow definition id** instead of reusing the overview `id IN [workflowIds]` filter (that filter applies to definitions, but matches instance UUIDs when used on instances)
- For entity overview requests, scope instance stats to the requesting **targetEntity**
- Export `WorkflowRunStatsResult` from `getWorkflowRunStats` so `averageTimeToComplete` is included in the return type

<img width="668" height="477" alt="Screenshot 2026-06-22 at 2 40 49 PM" src="https://github.com/user-attachments/assets/aaa10150-91c4-46f0-bb35-e6dea0f055cb" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
