### PR TITLE
feat(lightspeed): rename config namespace to intelligent-assistant and update rbac policy name

### DIFF
--- a/workspaces/lightspeed/.changeset/clever-foxes-dance.md
+++ b/workspaces/lightspeed/.changeset/clever-foxes-dance.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': minor
+'@red-hat-developer-hub/backstage-plugin-lightspeed-common': minor
+---
+
+Rename config namespace from `lightspeed` to `intelligent-assistant` and update permission names to use the `intelligent-assistant.*` prefix.

--- a/workspaces/lightspeed/.changeset/clever-foxes-dance.md
+++ b/workspaces/lightspeed/.changeset/clever-foxes-dance.md
@@ -1,7 +1,7 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
-'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': minor
-'@red-hat-developer-hub/backstage-plugin-lightspeed-common': minor
+'@red-hat-developer-hub/backstage-plugin-lightspeed': major
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': major
+'@red-hat-developer-hub/backstage-plugin-lightspeed-common': major
 ---
 
-Rename config namespace from `lightspeed` to `intelligent-assistant` and update permission names to use the `intelligent-assistant.*` prefix.
+BREAKING CHANGE: The configuration namespace has been renamed from `lightspeed` to `intelligent-assistant`. Update your `app-config.yaml` to replace `lightspeed:` with `intelligent-assistant:`. RBAC permission policy names have also been renamed (e.g., `lightspeed.chat.read` → `intelligent-assistant.chat.read`). Update your `rbac-policy.csv` accordingly. See the migration guide in the lightspeed-backend plugin's README for full details.

--- a/workspaces/lightspeed/app-config.yaml
+++ b/workspaces/lightspeed/app-config.yaml
@@ -17,7 +17,7 @@ organization:
   name: Red Hat
 
 # Disable AI Notebooks feature by default
-lightspeed:
+intelligent-assistant:
   notebooks:
     enabled: ${NOTEBOOKS_ENABLED:-false}
     queryDefaults:

--- a/workspaces/lightspeed/packages/app/package.json
+++ b/workspaces/lightspeed/packages/app/package.json
@@ -19,6 +19,7 @@
     "lint": "backstage-cli package lint"
   },
   "dependencies": {
+    "@backstage-community/plugin-rbac": "^1.51.0",
     "@backstage/cli": "^0.36.0",
     "@backstage/core-compat-api": "^0.5.6",
     "@backstage/core-components": "^0.18.8",

--- a/workspaces/lightspeed/packages/app/src/modules/nav/Sidebar.tsx
+++ b/workspaces/lightspeed/packages/app/src/modules/nav/Sidebar.tsx
@@ -46,6 +46,7 @@ export const SidebarContent = NavContentBlueprint.make({
           </SidebarGroup>
           <SidebarSpace />
           <SidebarDivider />
+          {nav.take('page:rbac')}
           {nav.take('page:user-settings')}
         </Sidebar>
       );

--- a/workspaces/lightspeed/plugins/lightspeed-backend/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/README.md
@@ -25,6 +25,32 @@ backend.add(
 backend.start();
 ```
 
+### Migration from `lightspeed` to `intelligent-assistant`
+
+If you are upgrading from a previous version, the configuration namespace and RBAC permission names have changed:
+
+**Configuration** — rename the top-level key in `app-config.yaml`:
+
+| Before        | After                    |
+| ------------- | ------------------------ |
+| `lightspeed:` | `intelligent-assistant:` |
+
+All nested keys (`servicePort`, `systemPrompt`, `prompts`, `mcpServers`, `notebooks`, etc.) remain the same.
+
+**RBAC policies** — update permission names in your `rbac-policy.csv`:
+
+| Before                     | After                                 |
+| -------------------------- | ------------------------------------- |
+| `lightspeed.chat.read`     | `intelligent-assistant.chat.read`     |
+| `lightspeed.chat.create`   | `intelligent-assistant.chat.create`   |
+| `lightspeed.chat.delete`   | `intelligent-assistant.chat.delete`   |
+| `lightspeed.chat.update`   | `intelligent-assistant.chat.update`   |
+| `lightspeed.notebooks.use` | `intelligent-assistant.notebooks.use` |
+| `lightspeed.mcp.read`      | `intelligent-assistant.mcp.read`      |
+| `lightspeed.mcp.manage`    | `intelligent-assistant.mcp.manage`    |
+
+> **Warning**: The old `lightspeed:` config key and `lightspeed.*` permission names are no longer recognized. Existing deployments that do not update will silently lose functionality.
+
 ### Plugin Configurations
 
 Add the following lightspeed configurations into your `app-config.yaml` file:
@@ -33,6 +59,9 @@ Add the following lightspeed configurations into your `app-config.yaml` file:
 intelligent-assistant:
   servicePort: <portNumber> # Optional - Change the LS service port number. Defaults to 8080.
   systemPrompt: <system prompt> # Optional - Override the default system prompt.
+  prompts: # Optional - Custom prompts displayed to users in the chat UI
+    - title: <prompt_title>
+      message: <prompt_message>
   mcpServers: # Optional - one or more MCP servers
     - name: <mcp server name> # must match the name configured in LCS
       token: ${MCP_TOKEN}

--- a/workspaces/lightspeed/plugins/lightspeed-backend/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/README.md
@@ -30,7 +30,7 @@ backend.start();
 Add the following lightspeed configurations into your `app-config.yaml` file:
 
 ```yaml
-lightspeed:
+intelligent-assistant:
   servicePort: <portNumber> # Optional - Change the LS service port number. Defaults to 8080.
   systemPrompt: <system prompt> # Optional - Override the default system prompt.
   mcpServers: # Optional - one or more MCP servers
@@ -63,9 +63,17 @@ The Lightspeed Backend plugin has support for the permission framework.
 - When [RBAC permission](https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend#installation) framework is enabled, for non-admin users to access lightspeed backend API, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file named `rbac-policy.csv`:
 
 ```CSV
-p, role:default/team_a, lightspeed.chat.read, read, allow
-p, role:default/team_a, lightspeed.chat.create, create, allow
-p, role:default/team_a, lightspeed.chat.delete, delete, allow
+p, role:default/team_a, intelligent-assistant.chat.read, read, allow
+p, role:default/team_a, intelligent-assistant.chat.create, create, allow
+p, role:default/team_a, intelligent-assistant.chat.delete, delete, allow
+p, role:default/team_a, intelligent-assistant.chat.update, update, allow
+
+# Required for Notebooks feature (if enabled)
+p, role:default/team_a, intelligent-assistant.notebooks.use, update, allow
+
+# Required for MCP server management (if configured)
+p, role:default/team_a, intelligent-assistant.mcp.read, read, allow
+p, role:default/team_a, intelligent-assistant.mcp.manage, update, allow
 
 g, user:default/<your-user-name>, role:default/team_a
 
@@ -101,7 +109,7 @@ For Llama Stack setup and configuration, refer to the [Llama Stack documentation
 To enable Notebooks, add the following configuration to your `app-config.yaml`:
 
 ```yaml
-lightspeed:
+intelligent-assistant:
   servicePort: 8080 # Optional: Lightspeed Core service port (default: 8080)
 
   notebooks:
@@ -125,7 +133,7 @@ lightspeed:
 
 **Core Settings**:
 
-- **`lightspeed.servicePort`** _(optional)_: Port where Lightspeed Core service is running (default: `8080`). The backend connects to Lightspeed Core at `http://{DEFAULT_LIGHTSPEED_SERVICE_HOST}:{servicePort}` to proxy vector store operations. The host is defined by the `DEFAULT_LIGHTSPEED_SERVICE_HOST` constant in the source.
+- **`intelligent-assistant.servicePort`** _(optional)_: Port where Lightspeed Core service is running (default: `8080`). The backend connects to Lightspeed Core at `http://{DEFAULT_LIGHTSPEED_SERVICE_HOST}:{servicePort}` to proxy vector store operations. The host is defined by the `DEFAULT_LIGHTSPEED_SERVICE_HOST` constant in the source.
 
 **Notebooks Settings**:
 
@@ -177,7 +185,7 @@ When enabled, Notebooks exposes the following REST API endpoints:
 **Notes**:
 
 - All endpoints require authentication (user context is automatically provided by Backstage)
-- All `/v1/*` endpoints require the `lightspeed.notebooks.use` permission
+- All `/v1/*` endpoints require the `intelligent-assistant.notebooks.use` permission
 - Document endpoints verify session ownership before allowing operations
 - `documentId` in paths is the document title (URL-encoded for special characters)
 
@@ -186,9 +194,9 @@ When enabled, Notebooks exposes the following REST API endpoints:
 When RBAC is enabled, users need the following permission to use Notebooks:
 
 ```CSV
-p, role:default/team_a, lightspeed.notebooks.use, update, allow
+p, role:default/team_a, intelligent-assistant.notebooks.use, update, allow
 
 g, user:default/<your-user-name>, role:default/team_a
 ```
 
-Add this to your `rbac-policy.csv` file along with the existing lightspeed permissions.
+Add this to your `rbac-policy.csv` file along with the existing intelligent-assistant permissions.

--- a/workspaces/lightspeed/plugins/lightspeed-backend/app-config.yaml
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/app-config.yaml
@@ -1,5 +1,5 @@
 # OPTIONAL: Backend-only configurations
-#lightspeed:
+#intelligent-assistant:
 #  servicePort: 8080 # OPTIONAL: Port for lightspeed-core service (default: 8080)
 #  systemPrompt: <custom_system_prompt> # OPTIONAL: Override default RHDH system prompt
 #

--- a/workspaces/lightspeed/plugins/lightspeed-backend/config.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/config.d.ts
@@ -16,10 +16,10 @@
 
 export interface Config {
   /**
-   * Configuration required for using lightspeed
+   * Configuration required for using intelligent-assistant
    * @visibility frontend
    */
-  lightspeed?: {
+  'intelligent-assistant'?: {
     /**
      * configure the port number for the lightspeed service.
      * @visibility backend

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
@@ -52,20 +52,22 @@ export const lightspeedPlugin = createBackendPlugin({
         await migrate(database);
 
         const aiNotebooksEnabled =
-          config.getOptionalBoolean('lightspeed.notebooks.enabled') ?? false;
+          config.getOptionalBoolean(
+            'intelligent-assistant.notebooks.enabled',
+          ) ?? false;
 
         if (aiNotebooksEnabled) {
           const queryModel = config.getOptionalString(
-            'lightspeed.notebooks.queryDefaults.model',
+            'intelligent-assistant.notebooks.queryDefaults.model',
           );
           const queryProvider = config.getOptionalString(
-            'lightspeed.notebooks.queryDefaults.provider_id',
+            'intelligent-assistant.notebooks.queryDefaults.provider_id',
           );
 
           if (!queryModel || !queryProvider) {
             logger.warn(
               'AI Notebooks feature is enabled but required configuration is missing. ' +
-                'Please configure lightspeed.notebooks.queryDefaults.model and lightspeed.notebooks.queryDefaults.provider_id. ' +
+                'Please configure intelligent-assistant.notebooks.queryDefaults.model and intelligent-assistant.notebooks.queryDefaults.provider_id. ' +
                 'Notebooks will not be available until these are set.',
             );
           } else {

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/plugin.ts
@@ -51,6 +51,14 @@ export const lightspeedPlugin = createBackendPlugin({
       }) {
         await migrate(database);
 
+        if (config.has('lightspeed')) {
+          logger.warn(
+            'DEPRECATED: The "lightspeed" configuration key has been renamed to "intelligent-assistant". ' +
+              'Please update your app-config.yaml. The old "lightspeed" key is no longer read. ' +
+              'Migration guide: https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md#migration-from-lightspeed-to-intelligent-assistant',
+          );
+        }
+
         const aiNotebooksEnabled =
           config.getOptionalBoolean(
             'intelligent-assistant.notebooks.enabled',

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/mcp-server.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/mcp-server.test.ts
@@ -38,7 +38,7 @@ import { lightspeedPlugin } from '../plugin';
 const mockUserId = 'user:default/user1';
 
 const BASE_CONFIG = {
-  lightspeed: {
+  'intelligent-assistant': {
     servers: [
       {
         id: 'test-server',
@@ -52,8 +52,8 @@ const BASE_CONFIG = {
 // URLs are not in app-config — they come from LCS (GET /v1/mcp-servers).
 // The LCS mock in lcsHandlers returns URLs for 'static-mcp' and 'no-token-server'.
 const MCP_CONFIG = {
-  lightspeed: {
-    ...BASE_CONFIG.lightspeed,
+  'intelligent-assistant': {
+    ...BASE_CONFIG['intelligent-assistant'],
     mcpServers: [
       {
         name: 'static-mcp',
@@ -64,8 +64,8 @@ const MCP_CONFIG = {
 };
 
 const MCP_CONFIG_MULTI = {
-  lightspeed: {
-    ...BASE_CONFIG.lightspeed,
+  'intelligent-assistant': {
+    ...BASE_CONFIG['intelligent-assistant'],
     mcpServers: [
       {
         name: 'static-mcp',
@@ -84,8 +84,8 @@ const MCP_CONFIG_ENCRYPTED = {
       keys: [{ secret: 'EXAMPLE-key-EXAMPLE-key-EXAMPLE!' }], // notsecret
     },
   },
-  lightspeed: {
-    ...BASE_CONFIG.lightspeed,
+  'intelligent-assistant': {
+    ...BASE_CONFIG['intelligent-assistant'],
     mcpServers: [
       {
         name: 'static-mcp',

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/documents/documentService.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/documents/documentService.test.ts
@@ -51,7 +51,7 @@ describe('DocumentService', () => {
     resetMockStorage();
     const config = mockServices.rootConfig({
       data: {
-        lightspeed: {
+        'intelligent-assistant': {
           notebooks: {
             sessionDefaults: {
               provider_id: 'test-notebooks',

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/documents/documentService.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/documents/documentService.ts
@@ -50,8 +50,9 @@ export class DocumentService {
 
     // Chunking strategy configuration
     const chunkingType =
-      config?.getOptionalString('lightspeed.notebooks.chunkingStrategy.type') ||
-      DEFAULT_CHUNKING_STRATEGY_TYPE;
+      config?.getOptionalString(
+        'intelligent-assistant.notebooks.chunkingStrategy.type',
+      ) || DEFAULT_CHUNKING_STRATEGY_TYPE;
 
     if (chunkingType === 'static') {
       this.chunkingStrategy = {
@@ -59,11 +60,11 @@ export class DocumentService {
         static: {
           max_chunk_size_tokens:
             config?.getOptionalNumber(
-              'lightspeed.notebooks.chunkingStrategy.maxChunkSizeTokens',
+              'intelligent-assistant.notebooks.chunkingStrategy.maxChunkSizeTokens',
             ) || DEFAULT_MAX_CHUNK_SIZE_TOKENS,
           chunk_overlap_tokens:
             config?.getOptionalNumber(
-              'lightspeed.notebooks.chunkingStrategy.chunkOverlapTokens',
+              'intelligent-assistant.notebooks.chunkingStrategy.chunkOverlapTokens',
             ) || DEFAULT_CHUNK_OVERLAP_TOKENS,
         },
       };

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouter.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouter.test.ts
@@ -59,7 +59,7 @@ describe('Notebooks Router', () => {
     const logger = mockServices.logger.mock();
     const config = mockServices.rootConfig({
       data: {
-        lightspeed: {
+        'intelligent-assistant': {
           servicePort: 7007,
           notebooks: {
             enabled: true,
@@ -342,7 +342,7 @@ describe('Notebooks Router', () => {
       const logger = mockServices.logger.mock();
       const config = mockServices.rootConfig({
         data: {
-          lightspeed: {
+          'intelligent-assistant': {
             servicePort: 7007,
             notebooks: {
               enabled: true,

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/notebooks/notebooksRouters.ts
@@ -72,14 +72,14 @@ export async function createNotebooksRouter(
   notebooksRouter.use(express.json());
 
   const lightSpeedPort =
-    config.getOptionalNumber('lightspeed.servicePort') ??
+    config.getOptionalNumber('intelligent-assistant.servicePort') ??
     DEFAULT_LIGHTSPEED_SERVICE_PORT;
   const lightspeedBaseUrl = `http://${DEFAULT_LIGHTSPEED_SERVICE_HOST}:${lightSpeedPort}`;
   const queryModel = config.getString(
-    'lightspeed.notebooks.queryDefaults.model',
+    'intelligent-assistant.notebooks.queryDefaults.model',
   );
   const queryProvider = config.getString(
-    'lightspeed.notebooks.queryDefaults.provider_id',
+    'intelligent-assistant.notebooks.queryDefaults.provider_id',
   );
   const systemPrompt = NOTEBOOKS_SYSTEM_PROMPT;
 

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.test.ts
@@ -42,7 +42,7 @@ const mockModel = 'test-model';
 const mockToken = 'dummy-token';
 
 const BASE_CONFIG = {
-  lightspeed: {
+  'intelligent-assistant': {
     servers: [
       {
         id: 'test-server',
@@ -634,8 +634,8 @@ describe('lightspeed router tests', () => {
       );
 
       const backendServer = await startBackendServer({
-        lightspeed: {
-          ...BASE_CONFIG.lightspeed,
+        'intelligent-assistant': {
+          ...BASE_CONFIG['intelligent-assistant'],
           mcpServers: [
             { name: 'mcp-server-1', token: 'token-1' },
             { name: 'mcp-server-2', token: 'token-2' },
@@ -740,8 +740,8 @@ describe('lightspeed router tests', () => {
       );
 
       const backendServer = await startBackendServer({
-        lightspeed: {
-          ...BASE_CONFIG.lightspeed,
+        'intelligent-assistant': {
+          ...BASE_CONFIG['intelligent-assistant'],
           mcpServers: [{ name: 'single-mcp-server', token: 'single-token' }],
         },
       });

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -109,9 +109,11 @@ export async function createRouter(
   router.use(express.json());
 
   const port =
-    config.getOptionalNumber('lightspeed.servicePort') ??
+    config.getOptionalNumber('intelligent-assistant.servicePort') ??
     DEFAULT_LIGHTSPEED_SERVICE_PORT;
-  const system_prompt = config.getOptionalString('lightspeed.systemPrompt');
+  const system_prompt = config.getOptionalString(
+    'intelligent-assistant.systemPrompt',
+  );
   const lightspeedCoreBaseUrl = `http://${DEFAULT_LIGHTSPEED_SERVICE_HOST}:${port}`;
 
   const apiProxy = createProxyMiddleware({
@@ -138,7 +140,7 @@ export async function createRouter(
   // Only name is required; token is optional (users can provide their own via the UI).
   // URLs come from LCS (GET /v1/mcp-servers), not from app-config.
   const mcpServersConfig = config.getOptionalConfigArray(
-    'lightspeed.mcpServers',
+    'intelligent-assistant.mcpServers',
   );
   const staticServers: StaticMcpServer[] = [];
   if (mcpServersConfig) {
@@ -305,7 +307,7 @@ export async function createRouter(
         const server = staticServers.find(s => s.name === name);
         if (!server) {
           res.status(404).json({
-            error: `MCP server '${name}' is not configured — it must be defined in the Lightspeed Stack config and listed under lightspeed.mcpServers in app-config`,
+            error: `MCP server '${name}' is not configured — it must be defined in the Lightspeed Stack config and listed under intelligent-assistant.mcpServers in app-config`,
           });
           return;
         }
@@ -370,7 +372,7 @@ export async function createRouter(
         const server = staticServers.find(s => s.name === name);
         if (!server) {
           res.status(404).json({
-            error: `MCP server '${name}' is not configured — it must be defined in the Lightspeed Stack config and listed under lightspeed.mcpServers in app-config`,
+            error: `MCP server '${name}' is not configured — it must be defined in the Lightspeed Stack config and listed under intelligent-assistant.mcpServers in app-config`,
           });
           return;
         }

--- a/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-common/src/permissions.ts
@@ -20,7 +20,7 @@ import { createPermission } from '@backstage/plugin-permission-common';
  * @public
  */
 export const lightspeedChatReadPermission = createPermission({
-  name: 'lightspeed.chat.read',
+  name: 'intelligent-assistant.chat.read',
   attributes: {
     action: 'read',
   },
@@ -30,7 +30,7 @@ export const lightspeedChatReadPermission = createPermission({
  * @public
  */
 export const lightspeedChatCreatePermission = createPermission({
-  name: 'lightspeed.chat.create',
+  name: 'intelligent-assistant.chat.create',
   attributes: {
     action: 'create',
   },
@@ -40,7 +40,7 @@ export const lightspeedChatCreatePermission = createPermission({
  * @public
  */
 export const lightspeedChatDeletePermission = createPermission({
-  name: 'lightspeed.chat.delete',
+  name: 'intelligent-assistant.chat.delete',
   attributes: {
     action: 'delete',
   },
@@ -50,7 +50,7 @@ export const lightspeedChatDeletePermission = createPermission({
  * @public
  */
 export const lightspeedChatUpdatePermission = createPermission({
-  name: 'lightspeed.chat.update',
+  name: 'intelligent-assistant.chat.update',
   attributes: {
     action: 'update',
   },
@@ -60,7 +60,7 @@ export const lightspeedChatUpdatePermission = createPermission({
  * @public
  */
 export const lightspeedMcpReadPermission = createPermission({
-  name: 'lightspeed.mcp.read',
+  name: 'intelligent-assistant.mcp.read',
   attributes: {
     action: 'read',
   },
@@ -70,7 +70,7 @@ export const lightspeedMcpReadPermission = createPermission({
  * @public
  */
 export const lightspeedMcpManagePermission = createPermission({
-  name: 'lightspeed.mcp.manage',
+  name: 'intelligent-assistant.mcp.manage',
   attributes: {
     action: 'update',
   },
@@ -80,7 +80,7 @@ export const lightspeedMcpManagePermission = createPermission({
  * @public
  */
 export const lightspeedNotebooksUsePermission = createPermission({
-  name: 'lightspeed.notebooks.use',
+  name: 'intelligent-assistant.notebooks.use',
   attributes: {
     action: 'update',
   },

--- a/workspaces/lightspeed/plugins/lightspeed/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed/README.md
@@ -6,6 +6,12 @@ The Intelligent Assistant for RHDH provides a natural language interface within 
 
 ## For administrators
 
+### Migration from `lightspeed` to `intelligent-assistant`
+
+If you are upgrading from a previous version, the configuration namespace and RBAC permission names have changed. See the [backend plugin migration guide](../lightspeed-backend/README.md#migration-from-lightspeed-to-intelligent-assistant) for the full list of renamed config keys and permission policies.
+
+> **Warning**: The old `lightspeed:` config key and `lightspeed.*` permission names are no longer recognized. Existing deployments that do not update will silently lose functionality.
+
 ### Prerequisites
 
 - Follow the lightspeed backend plugin [README](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/lightspeed/plugins/lightspeed-backend/README.md) to integrate lightspeed backend in your Backstage instance.

--- a/workspaces/lightspeed/plugins/lightspeed/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed/README.md
@@ -19,13 +19,17 @@ The Lightspeed plugin has support for the permission framework.
 - When [RBAC permission](https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend#installation) framework is enabled, for non-admin users to access lightspeed UI, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file named `rbac-policy.csv`:
 
 ```CSV
-p, role:default/team_a, lightspeed.chat.read, read, allow
-p, role:default/team_a, lightspeed.chat.create, create, allow
-p, role:default/team_a, lightspeed.chat.delete, delete, allow
-p, role:default/team_a, lightspeed.chat.update, update, allow
+p, role:default/team_a, intelligent-assistant.chat.read, read, allow
+p, role:default/team_a, intelligent-assistant.chat.create, create, allow
+p, role:default/team_a, intelligent-assistant.chat.delete, delete, allow
+p, role:default/team_a, intelligent-assistant.chat.update, update, allow
 
 # Required for Notebooks feature (if enabled)
-p, role:default/team_a, lightspeed.notebooks.use, update, allow
+p, role:default/team_a, intelligent-assistant.notebooks.use, update, allow
+
+# Required for MCP server management (if configured)
+p, role:default/team_a, intelligent-assistant.mcp.read, read, allow
+p, role:default/team_a, intelligent-assistant.mcp.manage, update, allow
 
 g, user:default/<your-user-name>, role:default/team_a
 
@@ -162,7 +166,7 @@ global:
     - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:next__0.6.1!red-hat-developer-hub-backstage-plugin-lightspeed
       disabled: false
       pluginConfig:
-        lightspeed:
+        intelligent-assistant:
           # OPTIONAL: Custom users prompts displayed to users
           # If not provided, the plugin uses built-in default prompts
           prompts:

--- a/workspaces/lightspeed/plugins/lightspeed/config.d.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/config.d.ts
@@ -16,10 +16,10 @@
 
 export interface Config {
   /**
-   * Configuration required for using lightspeed
+   * Configuration required for using intelligent-assistant
    * @visibility frontend
    */
-  lightspeed?: {
+  'intelligent-assistant'?: {
     prompts?: Array</**
      * @visibility frontend
      */

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -630,7 +630,8 @@ export const LightspeedChat = ({
   const navigate = useNavigate();
   const configApi = useApi(configApiRef);
   const notebooksEnabled =
-    configApi.getOptionalBoolean('lightspeed.notebooks.enabled') ?? false;
+    configApi.getOptionalBoolean('intelligent-assistant.notebooks.enabled') ??
+    false;
   const notebooksRouteMatch = useMatch(`${LIGHTSPEED_PATH}/notebooks`);
   const notebookViewRouteMatch = useMatch(
     `${LIGHTSPEED_PATH}/notebooks/:notebookId`,
@@ -2175,7 +2176,7 @@ export const LightspeedChat = ({
           !hasNotebooksAccess && (
             <PermissionRequiredState
               subject={t('permission.subject.notebooks')}
-              permissions={['lightspeed.notebooks.use']}
+              permissions={['intelligent-assistant.notebooks.use']}
               action={
                 <Button
                   variant="outlined"

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
@@ -165,7 +165,10 @@ const LightspeedChatContainerInner = () => {
     return (
       <PermissionRequiredState
         subject={t('permission.subject.plugin')}
-        permissions={['lightspeed.chat.read', 'lightspeed.chat.create']}
+        permissions={[
+          'intelligent-assistant.chat.read',
+          'intelligent-assistant.chat.create',
+        ]}
         action={
           <Button
             variant="outlined"

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/Router.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/Router.tsx
@@ -33,7 +33,8 @@ import { LightspeedPage } from './LightspeedPage';
 export const Router = () => {
   const configApi = useApi(configApiRef);
   const notebooksEnabled =
-    configApi.getOptionalBoolean('lightspeed.notebooks.enabled') ?? false;
+    configApi.getOptionalBoolean('intelligent-assistant.notebooks.enabled') ??
+    false;
 
   return (
     <StylesProvider generateClassName={generateClassName}>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/LightspeedChat.test.tsx
@@ -157,7 +157,7 @@ const mockUseLightspeedDrawerContext =
 
 const configAPi = mockApis.config({
   data: {
-    lightspeed: {
+    'intelligent-assistant': {
       notebooks: {
         enabled: true,
         queryDefaults: {
@@ -873,7 +873,7 @@ describe('LightspeedChat', () => {
   describe('notebooks permission denied', () => {
     beforeEach(() => {
       mockUsePermission.mockImplementation((args: any) => {
-        if (args.permission.name === 'lightspeed.notebooks.use') {
+        if (args.permission.name === 'intelligent-assistant.notebooks.use') {
           return { loading: false, allowed: false };
         }
         return { loading: false, allowed: true };

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/Trans.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/Trans.test.tsx
@@ -134,10 +134,14 @@ describe('Trans Component', () => {
     it('should handle permission description formatting', () => {
       render(
         <Trans
-          message="To view intelligent assistant plugin, contact your administrator to give the <b>lightspeed.chat.read</b> and <b>lightspeed.chat.create</b> permissions."
+          message="To view intelligent assistant plugin, contact your administrator to give the <b>intelligent-assistant.chat.read</b> and <b>intelligent-assistant.chat.create</b> permissions."
           components={{
-            '<b>lightspeed.chat.read</b>': <b>lightspeed.chat.read</b>,
-            '<b>lightspeed.chat.create</b>': <b>lightspeed.chat.create</b>,
+            '<b>intelligent-assistant.chat.read</b>': (
+              <b>intelligent-assistant.chat.read</b>
+            ),
+            '<b>intelligent-assistant.chat.create</b>': (
+              <b>intelligent-assistant.chat.create</b>
+            ),
           }}
         />,
       );
@@ -146,12 +150,20 @@ describe('Trans Component', () => {
       expect(
         screen.getByText(/To view intelligent assistant plugin/),
       ).toBeInTheDocument();
-      expect(screen.getByText('lightspeed.chat.read')).toBeInTheDocument();
-      expect(screen.getByText('lightspeed.chat.create')).toBeInTheDocument();
+      expect(
+        screen.getByText('intelligent-assistant.chat.read'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('intelligent-assistant.chat.create'),
+      ).toBeInTheDocument();
 
       // Check that permission names are bold
-      expect(screen.getByText('lightspeed.chat.read').tagName).toBe('B');
-      expect(screen.getByText('lightspeed.chat.create').tagName).toBe('B');
+      expect(screen.getByText('intelligent-assistant.chat.read').tagName).toBe(
+        'B',
+      );
+      expect(
+        screen.getByText('intelligent-assistant.chat.create').tagName,
+      ).toBe('B');
     });
   });
 

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/notebooks/NotebookView.tsx
@@ -302,8 +302,9 @@ export const NotebookView = ({
 
   // Use notebook-specific model from config instead of chat's selected model
   const notebookModel =
-    configApi.getOptionalString('lightspeed.notebooks.queryDefaults.model') ||
-    '';
+    configApi.getOptionalString(
+      'intelligent-assistant.notebooks.queryDefaults.model',
+    ) || '';
 
   const [conversationId, setConversationId] = useState(
     metadata?.conversation_id ?? TEMP_CONVERSATION_ID,

--- a/workspaces/lightspeed/plugins/lightspeed/src/hooks/useWelcomePrompts.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/hooks/useWelcomePrompts.ts
@@ -50,7 +50,7 @@ export const useWelcomePrompts = (): SamplePrompts => {
       : translatePrompts([...DEFAULT_SAMPLE_PROMPTS, ...RHDH_SAMPLE_PROMPTS]);
 
     const userConfiguredPrompts: SamplePrompts = (
-      configApi?.getOptionalConfigArray('lightspeed.prompts') ?? []
+      configApi?.getOptionalConfigArray('intelligent-assistant.prompts') ?? []
     ).map(config => ({
       title: config.getString('title') ?? '',
       message: config.getString('message') ?? '',

--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -16288,6 +16288,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
+    "@backstage-community/plugin-rbac": "npm:^1.51.0"
     "@backstage/cli": "npm:^0.36.0"
     "@backstage/core-compat-api": "npm:^0.5.6"
     "@backstage/core-components": "npm:^0.18.8"


### PR DESCRIPTION
## Description
Rename the configuration namespace from `lightspeed` to `intelligent-assistant` across all backend, frontend, and common plugins. Update RBAC permission policy names to use the `intelligent-assistant.*` prefix. 

## Fixed
- https://redhat.atlassian.net/browse/RHIDP-14476

## UI after change

### configuration namespace from `lightspeed` to `intelligent-assistant`

https://github.com/user-attachments/assets/4c00c6e8-7732-4dac-b45e-084da6ef5746

### Update RBAC permission policy names to use the `intelligent-assistant.*` prefix. 

https://github.com/user-attachments/assets/f7f17a01-481f-4570-9eca-95f5b97aab5d



https://github.com/user-attachments/assets/623ad6cd-b001-485d-b1e8-920b8b4303fc

### Depreciation warning

<img width="1512" height="982" alt="S_ 2026-06-23 at 5 30 48 AM" src="https://github.com/user-attachments/assets/2c50f1dd-5de5-448f-82cd-a4eee1ace146" />


## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)


