### PR TITLE
fix(Orchestrator): Fix boolean workflow inputs showing emoji on instance page

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-boolean-input-display.md
+++ b/workspaces/orchestrator/.changeset/fix-boolean-input-display.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix boolean workflow inputs and outputs displaying as emoji checkmarks on the workflow instance page; show `true` and `false` instead.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInputs.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInputs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 import {
   InfoCard,
@@ -24,6 +24,7 @@ import {
 } from '@backstage/core-components';
 
 import { useTranslation } from '../../hooks/useTranslation';
+import { formatMetadataForDisplay } from '../../utils/formatMetadataForDisplay';
 
 export const WorkflowInputs: FC<{
   className: string;
@@ -34,6 +35,10 @@ export const WorkflowInputs: FC<{
 }> = ({ className, value, loading, responseError, cardClassName }) => {
   const { t } = useTranslation();
   const inputs = value?.data;
+  const displayInputs = useMemo(
+    () => (inputs ? formatMetadataForDisplay(inputs) : inputs),
+    [inputs],
+  );
   return (
     <InfoCard
       title={t('run.inputs')}
@@ -52,8 +57,8 @@ export const WorkflowInputs: FC<{
         <ResponseErrorPanel error={responseError} />
       )}
 
-      {!loading && !responseError && inputs && (
-        <StructuredMetadataTable dense metadata={inputs} />
+      {!loading && !responseError && displayInputs && (
+        <StructuredMetadataTable dense metadata={displayInputs} />
       )}
     </InfoCard>
   );

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -53,6 +53,7 @@ import {
   extractSsoReauthorizeUrl,
   isSamlSsoError,
 } from '../../utils/ErrorUtils';
+import { formatMetadataForDisplay } from '../../utils/formatMetadataForDisplay';
 import { buildUrl } from '../../utils/UrlUtils';
 import { Trans } from '../Trans';
 import { SamlSsoExpiredDialog } from '../ui/SamlSsoExpiredDialog';
@@ -400,7 +401,10 @@ const WorkflowOutputs = ({
                 />
               ))}
             {Object.keys(valuesAsObject).length > 0 && (
-              <StructuredMetadataTable dense metadata={valuesAsObject} />
+              <StructuredMetadataTable
+                dense
+                metadata={formatMetadataForDisplay(valuesAsObject)}
+              />
             )}
           </AboutField>
         </Grid>

--- a/workspaces/orchestrator/plugins/orchestrator/src/utils/formatMetadataForDisplay.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/utils/formatMetadataForDisplay.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatMetadataForDisplay } from './formatMetadataForDisplay';
+
+describe('formatMetadataForDisplay', () => {
+  it('converts top-level booleans to strings', () => {
+    expect(
+      formatMetadataForDisplay({ enabled: true, disabled: false }),
+    ).toEqual({ enabled: 'true', disabled: 'false' });
+  });
+
+  it('converts nested booleans to strings', () => {
+    expect(
+      formatMetadataForDisplay({
+        options: { notify: true, archive: false },
+        flags: [true, false],
+      }),
+    ).toEqual({
+      options: { notify: 'true', archive: 'false' },
+      flags: ['true', 'false'],
+    });
+  });
+
+  it('leaves non-boolean values unchanged', () => {
+    expect(
+      formatMetadataForDisplay({
+        name: 'workflow',
+        count: 3,
+        tags: ['a', 'b'],
+      }),
+    ).toEqual({
+      name: 'workflow',
+      count: 3,
+      tags: ['a', 'b'],
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/utils/formatMetadataForDisplay.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/utils/formatMetadataForDisplay.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Converts boolean values to strings so StructuredMetadataTable shows "true"/"false"
+ * instead of emoji checkmarks.
+ */
+export function formatMetadataForDisplay<T>(value: T): T {
+  if (typeof value === 'boolean') {
+    return String(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map(formatMetadataForDisplay) as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        formatMetadataForDisplay(nestedValue),
+      ]),
+    ) as T;
+  }
+  return value;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3394

## Summary
- Boolean workflow inputs on the workflow instance page were rendered as ✅/❌ by Backstage's `StructuredMetadataTable`, which was confusing for users expecting literal `true`/`false` values.
- Added `formatMetadataForDisplay` to recursively convert boolean values to strings before passing metadata to `StructuredMetadataTable`.
- Applied the formatter on the workflow instance **Inputs** card and **Results** values section for consistency.


https://github.com/user-attachments/assets/fb8835e0-2727-409a-b0c8-80f5cac2783e



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
