### PR TITLE
feat(homepage): change homepage plugin id to allow installation home and homepage together

### DIFF
--- a/workspaces/homepage/.changeset/shiny-suns-sniff.md
+++ b/workspaces/homepage/.changeset/shiny-suns-sniff.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-homepage': minor
+---
+
+Change plugin id to homepage

--- a/workspaces/homepage/plugins/homepage/dev/index.tsx
+++ b/workspaces/homepage/plugins/homepage/dev/index.tsx
@@ -19,6 +19,7 @@
  */
 
 import '@backstage/cli/asset-types';
+// eslint-disable-next-line @backstage/no-ui-css-imports-in-non-frontend
 import '@backstage/ui/css/styles.css';
 import ReactDOM from 'react-dom/client';
 import { createApp } from '@backstage/frontend-defaults';
@@ -61,7 +62,7 @@ import {
 import { searchApiRef } from '@backstage/plugin-search-react';
 
 const homepageApiMocksModule = createFrontendModule({
-  pluginId: 'home',
+  pluginId: 'home', // upstream home!
   extensions: [
     ApiBlueprint.make({
       name: 'quickaccess',

--- a/workspaces/homepage/plugins/homepage/package.json
+++ b/workspaces/homepage/plugins/homepage/package.json
@@ -71,6 +71,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1 || ^17.0.0 || ^18.2.0",
+    "react-dom": "*",
     "react-router-dom": "6.30.4"
   },
   "devDependencies": {

--- a/workspaces/homepage/plugins/homepage/src/alpha/index.ts
+++ b/workspaces/homepage/plugins/homepage/src/alpha/index.ts
@@ -43,7 +43,7 @@ import { defaultWidgetsApi, quickAccessApi } from './extensions/apis';
  * @alpha
  */
 export const homePageModule = createFrontendModule({
-  pluginId: 'home',
+  pluginId: 'home', // upstream home!
   extensions: [
     homePageLayoutExtension,
     onboardingSectionWidget,

--- a/workspaces/homepage/plugins/homepage/src/plugin.ts
+++ b/workspaces/homepage/plugins/homepage/src/plugin.ts
@@ -78,7 +78,7 @@ export type {
  * @public
  */
 export const dynamicHomePagePlugin = createPlugin({
-  id: 'dynamic-home-page',
+  id: 'homepage',
   routes: {
     root: rootRouteRef,
   },

--- a/workspaces/homepage/yarn.lock
+++ b/workspaces/homepage/yarn.lock
@@ -9765,6 +9765,7 @@ __metadata:
     react-use: "npm:17.6.1"
   peerDependencies:
     react: 16.13.1 || ^17.0.0 || ^18.2.0
+    react-dom: "*"
     react-router-dom: 6.30.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Change the different plugin ids for the homepage to homepage, so that its possible to install the upstream home and our homepage plugin side by side.

Part of https://redhat.atlassian.net/browse/RHIDP-14515

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
