### PR TITLE
fix(fullsend): add required role field to harness files for v0.19.0

### DIFF
--- a/.fullsend/customized/harness/code.yaml
+++ b/.fullsend/customized/harness/code.yaml
@@ -15,6 +15,7 @@
 #   - policy: custom code policy with repo.yarnpkg.com for corepack downloads
 #   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
 #   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
+role: coder
 agent: agents/code.md
 doc: docs/agents/code.md
 model: opus

--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -18,6 +18,7 @@
 #   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
 #   - skills: adds rhdh-workspace for workspace navigation + test scoping
 #   - policy: custom fix policy with yarn registry + pnpm binary allowlist
+role: fix
 agent: agents/fix.md
 doc: docs/agents/fix.md
 model: opus


### PR DESCRIPTION
## Summary
- fullsend v0.19.0 now requires a `role` field in harness YAML files
- Adds `role: coder` to `code.yaml` and `role: fix` to `fix.yaml`
- Fixes coder agent failure: `Error: loading harness: invalid harness: role field is required` ([workflow run](https://github.com/redhat-developer/rhdh-plugins/actions/runs/28110640203))

## Test plan
- [ ] Verify `/fs-code` on an issue triggers the coder agent without harness load errors
- [ ] Verify `/fs-fix` on a PR triggers the fix agent without harness load errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)