### PR TITLE
fix(homepage): fix missing translations for homepage card widgets

### DIFF
--- a/workspaces/homepage/e2e-tests/homepageCustomizable.test.ts
+++ b/workspaces/homepage/e2e-tests/homepageCustomizable.test.ts
@@ -80,7 +80,7 @@ test.describe.serial('Dynamic Home Page Customization', () => {
   });
 
   test('Verify Add Widget Button Adds Cards', async () => {
-    await homePageCustomization.addWidget('Onboarding');
+    await homePageCustomization.addWidget('Red Hat Developer Hub - Onboarding');
     await expect(
       sharedPage.getByText(/Good (morning|afternoon|evening)/),
     ).toBeVisible();

--- a/workspaces/homepage/e2e-tests/pages/homePageCustomization.ts
+++ b/workspaces/homepage/e2e-tests/pages/homePageCustomization.ts
@@ -232,7 +232,7 @@ export class HomePageCustomization {
     await this.page.waitForTimeout(1000); // Wait for dialog to open
 
     // Select the specific widget type from the dialog
-    await this.page.getByRole('button', { name: title }).click();
+    await this.page.getByRole('button', { name: title, exact: true }).click();
     await this.page.waitForTimeout(1000);
   }
 

--- a/workspaces/homepage/plugins/homepage/report-alpha.api.md
+++ b/workspaces/homepage/plugins/homepage/report-alpha.api.md
@@ -20,6 +20,7 @@ export const homepageTranslationRef: TranslationRef<
     readonly 'header.welcome': string;
     readonly 'header.welcomePersonalized': string;
     readonly 'search.placeholder': string;
+    readonly 'search.clearButton': string;
     readonly 'homePage.empty': string;
     readonly 'quickAccess.title': string;
     readonly 'quickAccess.error': string;
@@ -28,7 +29,9 @@ export const homepageTranslationRef: TranslationRef<
     readonly 'featuredDocs.learnMore': string;
     readonly 'starredEntities.title': string;
     readonly 'recentlyVisited.title': string;
+    readonly 'recentlyVisited.description': string;
     readonly 'topVisited.title': string;
+    readonly 'topVisited.description': string;
     readonly 'templates.title': string;
     readonly 'templates.error': string;
     readonly 'templates.empty': string;
@@ -57,9 +60,9 @@ export const homepageTranslationRef: TranslationRef<
     readonly 'entities.close': string;
     readonly 'entities.empty': string;
     readonly 'entities.fetchError': string;
+    readonly 'entities.description': string;
     readonly 'entities.emptyDescription': string;
     readonly 'entities.register': string;
-    readonly 'entities.description': string;
     readonly 'entities.browseTheCatalog': string;
   }
 >;

--- a/workspaces/homepage/plugins/homepage/src/alpha/alpha.test.ts
+++ b/workspaces/homepage/plugins/homepage/src/alpha/alpha.test.ts
@@ -25,6 +25,7 @@ import {
   searchBarWidget,
   featuredDocsCardWidget,
   catalogStarredWidget,
+  disableRandomJoke,
   disableToolkit,
   RecentlyVisitedWidget,
   TopVisitedWidget,
@@ -76,6 +77,7 @@ describe('Dynamic Home Page plugin Alpha (NFS)', () => {
       expect(featuredDocsCardWidget).toBeDefined();
       expect(catalogStarredWidget).toBeDefined();
       expect(disableToolkit).toBeDefined();
+      expect(disableRandomJoke).toBeDefined();
       expect(RecentlyVisitedWidget).toBeDefined();
       expect(TopVisitedWidget).toBeDefined();
     });

--- a/workspaces/homepage/plugins/homepage/src/alpha/extensions/homePageCards.tsx
+++ b/workspaces/homepage/plugins/homepage/src/alpha/extensions/homePageCards.tsx
@@ -17,8 +17,19 @@
 import { HomePageWidgetBlueprint } from '@backstage/plugin-home-react/alpha';
 import homePlugin from '@backstage/plugin-home/alpha';
 import { compatWrapper } from '@backstage/core-compat-api';
-import { homepageMessages } from '../../translations/ref';
 import { createTranslatedCardRenderer } from '../../utils/translatedCardRenderer';
+
+/**
+ * NFS homepage widgets.
+ *
+ * i18n follows the upstream `@backstage/plugin-home` model:
+ * - Blueprint `params.title` / `description` are English catalog labels.
+ *   `AddWidgetDialog` renders them as-is (no `t()`).
+ * - On-card headers are translated at render time via
+ *   {@link createTranslatedCardRenderer} or Content hooks such as
+ *   `useHomePageCardTitle`.
+ * - In-widget copy uses `homepageTranslationRef` through `useTranslation`.
+ */
 
 const defaultCardLayout = {
   width: {
@@ -59,7 +70,8 @@ export const entitySectionWidget = HomePageWidgetBlueprint.make({
   name: 'rhdh-entity-section',
   params: {
     name: 'Red Hat Developer Hub - Software Catalog',
-    title: homepageMessages.entities.title,
+    description:
+      'Browse the Systems, Components, Resources, and APIs that are available in your organization.',
     layout: defaultCardLayout,
     components: () =>
       import('../../components/EntitySection/EntitySection').then(m => ({
@@ -77,7 +89,6 @@ export const templateSectionWidget = HomePageWidgetBlueprint.make({
   name: 'rhdh-template-section',
   params: {
     name: 'Red Hat Developer Hub - Explore templates',
-    title: homepageMessages.templates.title,
     layout: defaultCardLayout,
     components: () =>
       import('../../components/TemplateSection/TemplateSection').then(m => ({
@@ -95,7 +106,7 @@ export const quickAccessCardWidget = HomePageWidgetBlueprint.make({
   name: 'quick-access-card',
   params: {
     name: 'Quick Access Card',
-    title: homepageMessages.quickAccess.title,
+    title: 'Quick Access',
     layout: defaultCardLayout,
     components: () =>
       import('../../components/QuickAccessCard').then(m => ({
@@ -151,7 +162,7 @@ export const featuredDocsCardWidget = HomePageWidgetBlueprint.make({
   name: 'featured-docs-card',
   params: {
     name: 'Featured docs',
-    title: homepageMessages.featuredDocs.title,
+    title: 'Featured Docs',
     layout: defaultCardLayout,
     components: () =>
       import('../../components/FeaturedDocsCard').then(m => ({
@@ -169,8 +180,8 @@ export const catalogStarredWidget = homePlugin
   .getExtension('home-page-widget:home/starred-entities')
   .override({
     params: {
-      name: 'CatalogStarred',
-      title: homepageMessages.starredEntities.title,
+      name: 'Catalog starred',
+      title: 'Starred Catalog Entities',
       components: () =>
         import('../../components/legacy/TranslatedUpstreamHomePageCards').then(
           m => ({
@@ -192,6 +203,16 @@ export const disableToolkit = homePlugin
   });
 
 /**
+ * Disables the upstream demo random-joke widget.
+ * @alpha
+ */
+export const disableRandomJoke = homePlugin
+  .getExtension('home-page-widget:home/random-joke')
+  .override({
+    disabled: true,
+  });
+
+/**
  * NFS widget: RecentlyVisited (migrated from mountPoint home.page/cards).
  * @alpha
  */
@@ -200,7 +221,8 @@ export const RecentlyVisitedWidget = HomePageWidgetBlueprint.make({
   params: {
     layout: defaultCardLayout,
     name: 'Recently visited',
-    title: homepageMessages.recentlyVisited.title,
+    title: 'Recently Visited',
+    description: 'Quick access to recently viewed entities and pages',
     components: () =>
       import('../../components/legacy/TranslatedUpstreamHomePageCards').then(
         m => ({
@@ -220,7 +242,8 @@ export const TopVisitedWidget = HomePageWidgetBlueprint.make({
   params: {
     layout: defaultCardLayout,
     name: 'Top visited',
-    title: homepageMessages.topVisited.title,
+    title: 'Top Visited',
+    description: 'Your most frequently accessed entities and services',
     components: () =>
       import('../../components/legacy/TranslatedUpstreamHomePageCards').then(
         m => ({

--- a/workspaces/homepage/plugins/homepage/src/alpha/index.ts
+++ b/workspaces/homepage/plugins/homepage/src/alpha/index.ts
@@ -18,6 +18,7 @@ import { TranslationBlueprint } from '@backstage/plugin-app-react';
 import { createFrontendModule } from '@backstage/frontend-plugin-api';
 import {
   catalogStarredWidget,
+  disableRandomJoke,
   disableToolkit,
   entitySectionWidget,
   featuredDocsCardWidget,
@@ -58,6 +59,7 @@ export const homePageModule = createFrontendModule({
     RecentlyVisitedWidget,
     catalogStarredWidget,
     disableToolkit,
+    disableRandomJoke,
   ],
 });
 

--- a/workspaces/homepage/plugins/homepage/src/components/QuickAccessCard.tsx
+++ b/workspaces/homepage/plugins/homepage/src/components/QuickAccessCard.tsx
@@ -88,5 +88,3 @@ export const QuickAccessCardContent = ({
 
   return content;
 };
-
-export { QuickAccessCard } from './legacy/QuickAccessCardLegacy';

--- a/workspaces/homepage/plugins/homepage/src/components/SearchBar.tsx
+++ b/workspaces/homepage/plugins/homepage/src/components/SearchBar.tsx
@@ -19,6 +19,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { SearchBarBase } from '@backstage/plugin-search-react';
 
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
 import { styled } from '@mui/material/styles';
 
 import { useTranslation } from '../hooks/useTranslation';
@@ -39,6 +41,11 @@ const StyledSearchBar = styled(SearchBarBase)(({ theme }) => ({
   },
   '& .MuiOutlinedInput-notchedOutline, & fieldset': {
     border: 'none',
+  },
+  '& .MuiInputAdornment-positionEnd .MuiButton-root': {
+    color: theme.palette.text.primary,
+    fontWeight: theme.typography.fontWeightRegular,
+    textTransform: 'none',
   },
 }));
 
@@ -71,6 +78,12 @@ export const SearchBar = ({ path, queryParam }: SearchBarProps) => {
     navigate(`${url.pathname}${search ? '?' : ''}${search}`);
   }, [navigate, path, queryParam]);
 
+  const handleClear = useCallback(() => {
+    setValue('');
+  }, []);
+
+  const clearLabel = t('search.clearButton');
+
   return (
     <StyledSearchBar
       placeholder={t('search.placeholder')}
@@ -79,6 +92,24 @@ export const SearchBar = ({ path, queryParam }: SearchBarProps) => {
       onSubmit={handleSubmit}
       margin="none"
       inputProps={{ ref }}
+      clearButton={false}
+      endAdornment={
+        <InputAdornment position="end">
+          <Button
+            aria-label={clearLabel}
+            color="inherit"
+            size="small"
+            onClick={handleClear}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                event.stopPropagation();
+              }
+            }}
+          >
+            {clearLabel}
+          </Button>
+        </InputAdornment>
+      }
     />
   );
 };

--- a/workspaces/homepage/plugins/homepage/src/plugin.ts
+++ b/workspaces/homepage/plugins/homepage/src/plugin.ts
@@ -166,7 +166,9 @@ export const QuickAccessCard: ComponentType<QuickAccessCardProps> =
       name: 'QuickAccessCard',
       component: {
         lazy: () =>
-          import('./components/QuickAccessCard').then(m => m.QuickAccessCard),
+          import('./components/legacy/QuickAccessCardLegacy').then(
+            m => m.QuickAccessCard,
+          ),
       },
     }),
   );

--- a/workspaces/homepage/plugins/homepage/src/translations/de.ts
+++ b/workspaces/homepage/plugins/homepage/src/translations/de.ts
@@ -29,6 +29,7 @@ const homepageTranslationDe = createTranslationMessages({
     'header.local': 'Lokal',
     'homePage.empty': 'Keine Homepage-Karten konfiguriert oder gefunden.',
     'search.placeholder': 'Suchen',
+    'search.clearButton': 'Löschen',
     'quickAccess.title': 'Schnellzugriff',
     'quickAccess.fetchError': 'Daten konnten nicht abgerufen werden.',
     'quickAccess.error': 'Unbekannter Fehler',
@@ -36,7 +37,11 @@ const homepageTranslationDe = createTranslationMessages({
     'featuredDocs.learnMore': ' Mehr erfahren',
     'starredEntities.title': 'Markierte Katalogentitäten',
     'recentlyVisited.title': 'Zuletzt besucht',
+    'recentlyVisited.description':
+      'Schnellzugriff auf kürzlich angesehene Entitäten und Seiten',
     'topVisited.title': 'Am häufigsten besucht',
+    'topVisited.description':
+      'Ihre am häufigsten aufgerufenen Entitäten und Services',
     'templates.title': 'Vorlagen erkunden',
     'templates.fetchError': 'Daten konnten nicht abgerufen werden.',
     'templates.error': 'Unbekannter Fehler',

--- a/workspaces/homepage/plugins/homepage/src/translations/es.ts
+++ b/workspaces/homepage/plugins/homepage/src/translations/es.ts
@@ -30,6 +30,7 @@ const homepageTranslationEs = createTranslationMessages({
     'homePage.empty':
       'No se configuraron o encontraron tarjetas de página de inicio (puntos de montaje).',
     'search.placeholder': 'Buscar',
+    'search.clearButton': 'Borrar',
     'quickAccess.title': 'Acceso rápido',
     'quickAccess.fetchError': 'No se pudieron obtener los datos.',
     'quickAccess.error': 'Error desconocido',
@@ -37,7 +38,11 @@ const homepageTranslationEs = createTranslationMessages({
     'featuredDocs.learnMore': ' Saber más',
     'starredEntities.title': 'Entidades del catálogo marcadas',
     'recentlyVisited.title': 'Visitados recientemente',
+    'recentlyVisited.description':
+      'Acceso rápido a entidades y páginas vistas recientemente',
     'topVisited.title': 'Más visitados',
+    'topVisited.description':
+      'Tus entidades y servicios a los que accedes con más frecuencia',
     'templates.title': 'Explorar plantillas',
     'templates.fetchError': 'No se pudieron obtener los datos.',
     'templates.error': 'Error desconocido',

--- a/workspaces/homepage/plugins/homepage/src/translations/fr.ts
+++ b/workspaces/homepage/plugins/homepage/src/translations/fr.ts
@@ -29,6 +29,7 @@ const homepageTranslationFr = createTranslationMessages({
     'header.local': 'Locale',
     'homePage.empty': "Aucune carte de page d'accueil configurée ou trouvée.",
     'search.placeholder': 'Recherche',
+    'search.clearButton': 'Effacer',
     'quickAccess.title': 'Accès rapide',
     'quickAccess.fetchError': 'Impossible de récupérer les données.',
     'quickAccess.error': 'Erreur inconnue',
@@ -36,7 +37,11 @@ const homepageTranslationFr = createTranslationMessages({
     'featuredDocs.learnMore': ' En savoir plus',
     'starredEntities.title': 'Entités du catalogue favoris',
     'recentlyVisited.title': 'Récemment visités',
+    'recentlyVisited.description':
+      'Accès rapide aux entités et pages consultées récemment',
     'topVisited.title': 'Les plus visités',
+    'topVisited.description':
+      'Vos entités et services les plus fréquemment consultés',
     'templates.title': 'Explorer les modèles',
     'templates.fetchError': 'Impossible de récupérer les données.',
     'templates.error': 'Erreur inconnue',

--- a/workspaces/homepage/plugins/homepage/src/translations/it.ts
+++ b/workspaces/homepage/plugins/homepage/src/translations/it.ts
@@ -29,6 +29,7 @@ const homepageTranslationIt = createTranslationMessages({
     'header.local': 'Locale',
     'homePage.empty': 'Nessuna scheda home page configurata o trovata.',
     'search.placeholder': 'Ricerca',
+    'search.clearButton': 'Cancella',
     'quickAccess.title': 'Accesso rapido',
     'quickAccess.fetchError': 'Impossibile recuperare i dati.',
     'quickAccess.error': 'Errore sconosciuto',
@@ -36,7 +37,11 @@ const homepageTranslationIt = createTranslationMessages({
     'featuredDocs.learnMore': ' Per saperne di più',
     'starredEntities.title': 'Entità del catalogo preferite',
     'recentlyVisited.title': 'Visitati di recente',
+    'recentlyVisited.description':
+      'Accesso rapido a entità e pagine visualizzate di recente',
     'topVisited.title': 'I più visitati',
+    'topVisited.description':
+      'Le entità e i servizi a cui accedi più di frequente',
     'templates.title': 'Esplora i modelli',
     'templates.fetchError': 'Impossibile recuperare i dati.',
     'templates.error': 'Errore sconosciuto',

--- a/workspaces/homepage/plugins/homepage/src/translations/ja.ts
+++ b/workspaces/homepage/plugins/homepage/src/translations/ja.ts
@@ -29,6 +29,7 @@ const homepageTranslationJa = createTranslationMessages({
     'header.local': 'ローカル',
     'homePage.empty': 'ホームページカード が設定されていないか見つかりません。',
     'search.placeholder': '検索',
+    'search.clearButton': 'クリア',
     'quickAccess.title': 'クイックアクセス',
     'quickAccess.fetchError': 'データを取得できませんでした。',
     'quickAccess.error': '不明なエラー',
@@ -36,7 +37,10 @@ const homepageTranslationJa = createTranslationMessages({
     'featuredDocs.learnMore': ' 詳細',
     'starredEntities.title': 'スター付きカタログエンティティ',
     'recentlyVisited.title': '最近の訪問',
+    'recentlyVisited.description':
+      '最近表示したエンティティやページへのクイックアクセス',
     'topVisited.title': 'よく訪問される項目',
+    'topVisited.description': '最も頻繁にアクセスするエンティティとサービス',
     'templates.title': 'テンプレートの探索',
     'templates.fetchError': 'データを取得できませんでした。',
     'templates.error': '不明なエラー',

--- a/workspaces/homepage/plugins/homepage/src/translations/ref.ts
+++ b/workspaces/homepage/plugins/homepage/src/translations/ref.ts
@@ -33,6 +33,7 @@ export const homepageMessages = {
   },
   search: {
     placeholder: 'Search',
+    clearButton: 'Clear',
   },
   quickAccess: {
     title: 'Quick Access',
@@ -44,13 +45,15 @@ export const homepageMessages = {
     learnMore: ' Learn more',
   },
   starredEntities: {
-    title: 'Starred catalog entities',
+    title: 'Starred Catalog Entities',
   },
   recentlyVisited: {
     title: 'Recently Visited',
+    description: 'Quick access to recently viewed entities and pages',
   },
   topVisited: {
     title: 'Top Visited',
+    description: 'Your most frequently accessed entities and services',
   },
   templates: {
     title: 'Explore Templates',

--- a/workspaces/homepage/plugins/homepage/src/utils/translatedCardRenderer.tsx
+++ b/workspaces/homepage/plugins/homepage/src/utils/translatedCardRenderer.tsx
@@ -29,8 +29,12 @@ const QuickAccessInfoCard = styled(InfoCard)({
 });
 
 /**
- * Creates a home page card Renderer that resolves the title via the plugin
- * translation system at render time (for NFS HomePageWidgetBlueprint widgets).
+ * Creates a home page card Renderer that resolves the on-card title via
+ * `homepageTranslationRef` at render time.
+ *
+ * Blueprint `params.title` stays English for the Add-widget catalog
+ * (`AddWidgetDialog` does not translate widget titles). This Renderer is
+ * the NFS equivalent of translating inside Content.
  */
 export function createTranslatedCardRenderer(
   titleKey: string,

--- a/workspaces/homepage/plugins/homepage/src/utils/useHomePageCardTitle.ts
+++ b/workspaces/homepage/plugins/homepage/src/utils/useHomePageCardTitle.ts
@@ -17,11 +17,25 @@
 import { useTranslation } from '../hooks/useTranslation';
 import { getTranslatedTextWithFallback } from '../translations/utils';
 
+/**
+ * Optional title overrides. Prefer `titleKey` (translation key) when provided;
+ * `title` is English fallback only (e.g. blueprint catalog string).
+ *
+ * Used by Content components so on-card headers translate at render time,
+ * while blueprint `params.title` remains English for AddWidgetDialog.
+ */
 export interface TranslatableCardTitleProps {
   title?: string;
   titleKey?: string;
 }
 
+/**
+ * Resolves the on-card title from `homepageTranslationRef`.
+ *
+ * @param defaultTitleKey - Plugin message key for this widget's title
+ * @param props - Optional `titleKey` override (legacy mount points) and
+ *   English `title` fallback from the blueprint
+ */
 export function useHomePageCardTitle(
   defaultTitleKey: string,
   props: TranslatableCardTitleProps,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://redhat.atlassian.net/browse/RHDHBUGS-3271

**Solution description:**
- Aligned RHDH homepage widgets with the upstream `@backstage/plugin-home` i18n model
- Blueprint params.title / description / name are plain English catalog strings not pre-translated message keys.
- On-card titles are translated at render time via:
    - createTranslatedCardRenderer (NFS card headers)
    - useHomePageCardTitle (Content hooks where needed)
- Disabled upstream demo random-joke widget; small API/test/report touch-ups.



https://github.com/user-attachments/assets/ef191e9d-4107-4ec6-9a1d-189518f281f8





#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
