### PR TITLE
test(orchestrator): add frontend hook and status coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ site
 
 # Cursor IDE configuration files
 .cursorrules
+
+# Local git worktrees
+.worktrees/

--- a/workspaces/orchestrator/.changeset/tame-dragons-begin.md
+++ b/workspaces/orchestrator/.changeset/tame-dragons-begin.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Add frontend unit test coverage for orchestrator hooks and status components, and harden the status indicator fallback for unknown states.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/MissingSchemaNotice.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/MissingSchemaNotice.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import MissingSchemaNotice from './MissingSchemaNotice';
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock(
+  '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react',
+  () => ({
+    SubmitButton: ({
+      children,
+      handleClick,
+      submitting,
+    }: {
+      children: ReactNode;
+      handleClick: () => void;
+      submitting?: boolean;
+    }) => (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={submitting ?? false}
+        data-testid="submit-button"
+      >
+        {children}
+      </button>
+    ),
+  }),
+);
+
+describe('MissingSchemaNotice', () => {
+  it('renders the missing schema guidance and run button', () => {
+    render(
+      <MissingSchemaNotice
+        isExecuting={false}
+        handleExecute={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(
+      screen.getByText('messages.missingJsonSchema.title'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/messages\.missingJsonSchema\.message/),
+    ).toBeInTheDocument();
+    expect(screen.getByText('dataInputSchema')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'common.run' }),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes handleExecute with empty payload when run is clicked', () => {
+    const handleExecute = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <MissingSchemaNotice isExecuting={false} handleExecute={handleExecute} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.run' }));
+    expect(handleExecute).toHaveBeenCalledWith({});
+  });
+
+  it('renders and invokes execute-as-event button when configured', () => {
+    const handleExecuteAsEvent = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <MissingSchemaNotice
+        isExecuting={false}
+        handleExecute={jest.fn().mockResolvedValue(undefined)}
+        handleExecuteAsEvent={handleExecuteAsEvent}
+        executeAsEventLabel="Run as event"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run as event' }));
+    expect(handleExecuteAsEvent).toHaveBeenCalledWith({});
+  });
+
+  it('does not render execute-as-event button when label is missing', () => {
+    render(
+      <MissingSchemaNotice
+        isExecuting={false}
+        handleExecute={jest.fn().mockResolvedValue(undefined)}
+        handleExecuteAsEvent={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Run as event' })).toBeNull();
+  });
+
+  it('disables action buttons while execution is in progress', () => {
+    render(
+      <MissingSchemaNotice
+        isExecuting
+        handleExecute={jest.fn().mockResolvedValue(undefined)}
+        handleExecuteAsEvent={jest.fn().mockResolvedValue(undefined)}
+        executeAsEventLabel="Run as event"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'common.run' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Run as event' })).toBeDisabled();
+  });
+
+  it('re-enables action buttons when execution completes', () => {
+    const { rerender } = render(
+      <MissingSchemaNotice
+        isExecuting
+        handleExecute={jest.fn().mockResolvedValue(undefined)}
+        handleExecuteAsEvent={jest.fn().mockResolvedValue(undefined)}
+        executeAsEventLabel="Run as event"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'common.run' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Run as event' })).toBeDisabled();
+
+    rerender(
+      <MissingSchemaNotice
+        isExecuting={false}
+        handleExecute={jest.fn().mockResolvedValue(undefined)}
+        handleExecuteAsEvent={jest.fn().mockResolvedValue(undefined)}
+        executeAsEventLabel="Run as event"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'common.run' }),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Run as event' }),
+    ).not.toBeDisabled();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowInstanceStatusIndicator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowInstanceStatusIndicator.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { ProcessInstanceStatusDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { VALUE_UNAVAILABLE } from '../../constants';
+import { useWorkflowInstanceStateColors } from '../../hooks/useWorkflowInstanceStatusColors';
+import { WorkflowInstanceStatusIndicator } from './WorkflowInstanceStatusIndicator';
+
+jest.mock('@backstage/core-components', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'table.status.running': 'Running',
+        'table.status.completed': 'Completed',
+        'tooltips.suspended': 'Suspended',
+        'table.status.aborted': 'Aborted',
+        'table.status.failed': 'Failed',
+        'table.status.pending': 'Pending',
+      })[key] ?? key,
+  }),
+}));
+
+jest.mock('../../hooks/useWorkflowInstanceStatusColors', () => ({
+  useWorkflowInstanceStateColors: jest.fn(() => 'status-icon'),
+}));
+
+describe('WorkflowInstanceStatusIndicator', () => {
+  it('renders unavailable value when status is missing', () => {
+    render(<WorkflowInstanceStatusIndicator />);
+
+    expect(screen.getByText(VALUE_UNAVAILABLE)).toBeInTheDocument();
+  });
+
+  it('renders completed status text without link when instanceLink is not provided', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Completed}
+      />,
+    );
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Completed' })).toBeNull();
+  });
+
+  it('renders status title as a link when instanceLink is provided', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Error}
+        instanceLink="/orchestrator/instances/1"
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Failed' });
+    expect(link).toHaveAttribute('href', '/orchestrator/instances/1');
+  });
+
+  it('renders pending title for pending status', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Pending}
+      />,
+    );
+
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('renders running title for active status', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Active}
+      />,
+    );
+
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('renders suspended title for suspended status', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Suspended}
+      />,
+    );
+
+    expect(screen.getByText('Suspended')).toBeInTheDocument();
+  });
+
+  it('aborted title for aborted status', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Aborted}
+      />,
+    );
+
+    expect(screen.getByText('Aborted')).toBeInTheDocument();
+  });
+
+  it('renders unavailable for unknown status', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={'UnknownStatus' as ProcessInstanceStatusDTO}
+      />,
+    );
+
+    expect(screen.getByText(VALUE_UNAVAILABLE)).toBeInTheDocument();
+  });
+
+  it('calls useWorkflowInstanceStateColors with correct status', () => {
+    render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Completed}
+      />,
+    );
+
+    expect(useWorkflowInstanceStateColors).toHaveBeenCalledWith(
+      ProcessInstanceStatusDTO.Completed,
+    );
+  });
+
+  it('applies color class to the rendered icon element', () => {
+    const { container } = render(
+      <WorkflowInstanceStatusIndicator
+        status={ProcessInstanceStatusDTO.Completed}
+      />,
+    );
+
+    expect(useWorkflowInstanceStateColors).toHaveBeenCalledWith(
+      ProcessInstanceStatusDTO.Completed,
+    );
+    expect(container.querySelector('svg.status-icon')).toBeInTheDocument();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowInstanceStatusIndicator.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowInstanceStatusIndicator.tsx
@@ -80,8 +80,7 @@ export const WorkflowInstanceStatusIndicator = ({
       title = t('table.status.pending');
       break;
     default:
-      icon = VALUE_UNAVAILABLE;
-      break;
+      return <>{VALUE_UNAVAILABLE}</>;
   }
 
   return (

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowStatus.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowStatus.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+
+import { AVAILABLE, UNAVAILABLE } from '../../constants';
+import { WorkflowStatus } from './WorkflowStatus';
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'workflow.status.available': 'Available',
+        'workflow.status.unavailable': 'Unavailable',
+        'tooltips.workflowDown': 'Workflow down',
+      })[key] ?? key,
+  }),
+}));
+
+describe('WorkflowStatus', () => {
+  it('renders available status for AVAILABLE string', () => {
+    render(<WorkflowStatus availability={AVAILABLE} />);
+
+    expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+
+  it('renders available status for true boolean', () => {
+    render(<WorkflowStatus availability />);
+
+    expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+
+  it('renders unavailable status for false boolean', () => {
+    render(<WorkflowStatus availability={false} />);
+
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+  });
+
+  it('renders raw value for unsupported availability content', () => {
+    render(<WorkflowStatus availability="Unknown" />);
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('renders unavailable status for UNAVAILABLE string', () => {
+    render(<WorkflowStatus availability={UNAVAILABLE} />);
+
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useKafkaEnabled.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useKafkaEnabled.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useKafkaEnabled } from './useKafkaEnabled';
+
+const mockUseApi = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  configApiRef: {},
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+describe('useKafkaEnabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when kafka config exists', () => {
+    const configApi = {
+      getOptionalConfig: jest.fn().mockReturnValue({}),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useKafkaEnabled());
+
+    expect(result.current).toBe(true);
+    expect(configApi.getOptionalConfig).toHaveBeenCalledWith(
+      'orchestrator.kafka',
+    );
+  });
+
+  it('returns false when kafka config is missing', () => {
+    const configApi = {
+      getOptionalConfig: jest.fn().mockReturnValue(undefined),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useKafkaEnabled());
+
+    expect(result.current).toBe(false);
+    expect(configApi.getOptionalConfig).toHaveBeenCalledWith(
+      'orchestrator.kafka',
+    );
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useLanguage.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useLanguage.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useLanguage } from './useLanguage';
+
+const mockUseApi = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('@backstage/core-plugin-api/alpha', () => ({
+  appLanguageApiRef: {},
+}));
+
+describe('useLanguage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the language code from app language api', () => {
+    mockUseApi.mockReturnValue({
+      getLanguage: jest.fn().mockReturnValue({ language: 'ja' }),
+    });
+
+    const { result } = renderHook(() => useLanguage());
+
+    expect(result.current).toBe('ja');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useLogsEnabled.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useLogsEnabled.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useLogsEnabled } from './useLogsEnabled';
+
+const mockUseApi = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  configApiRef: {},
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+describe('useLogsEnabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when workflow log provider config exists', () => {
+    const configApi = {
+      getOptionalConfig: jest.fn().mockReturnValue({}),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useLogsEnabled());
+
+    expect(result.current).toBe(true);
+    expect(configApi.getOptionalConfig).toHaveBeenCalledWith(
+      'orchestrator.workflowLogProvider',
+    );
+  });
+
+  it('returns false when workflow log provider config is missing', () => {
+    const configApi = {
+      getOptionalConfig: jest.fn().mockReturnValue(undefined),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useLogsEnabled());
+
+    expect(result.current).toBe(false);
+    expect(configApi.getOptionalConfig).toHaveBeenCalledWith(
+      'orchestrator.workflowLogProvider',
+    );
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/usePermissionArray.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/usePermissionArray.test.tsx
@@ -16,13 +16,15 @@
 
 import { ReactNode } from 'react';
 
-import {
-  AuthorizeResult,
-  Permission,
-} from '@backstage/plugin-permission-common';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 import { renderHook, waitFor } from '@testing-library/react';
 import { SWRConfig } from 'swr';
+
+import {
+  orchestratorWorkflowPermission,
+  orchestratorWorkflowUsePermission,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
 
 import {
   usePermissionArray,
@@ -40,9 +42,9 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 const permissions = [
-  { name: 'orchestrator.workflow.read' },
-  { name: 'orchestrator.workflow.execute' },
-] as Permission[];
+  orchestratorWorkflowPermission,
+  orchestratorWorkflowUsePermission,
+];
 
 describe('usePermissionArray', () => {
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/usePermissionArray.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/usePermissionArray.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+import {
+  AuthorizeResult,
+  Permission,
+} from '@backstage/plugin-permission-common';
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+
+import {
+  usePermissionArray,
+  usePermissionArrayDecision,
+} from './usePermissionArray';
+
+const mockUseApi = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('@backstage/plugin-permission-react', () => ({
+  permissionApiRef: {},
+}));
+
+const permissions = [
+  { name: 'orchestrator.workflow.read' },
+  { name: 'orchestrator.workflow.execute' },
+] as Permission[];
+
+describe('usePermissionArray', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns loading state before authorization resolves', () => {
+    const authorize = jest.fn().mockReturnValue(new Promise(() => {}));
+    mockUseApi.mockReturnValue({ authorize });
+
+    const { result } = renderHook(() => usePermissionArray(permissions), {
+      wrapper,
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.allowed).toEqual([false, false]);
+  });
+
+  it('returns allowed flags based on authorization responses', async () => {
+    const authorize = jest
+      .fn()
+      .mockResolvedValueOnce({ result: AuthorizeResult.ALLOW })
+      .mockResolvedValueOnce({ result: AuthorizeResult.DENY });
+    mockUseApi.mockReturnValue({ authorize });
+
+    const { result } = renderHook(() => usePermissionArray(permissions), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.allowed).toEqual([true, false]);
+    expect(result.current.error).toBeUndefined();
+    expect(authorize).toHaveBeenNthCalledWith(1, {
+      permission: permissions[0],
+    });
+    expect(authorize).toHaveBeenNthCalledWith(2, {
+      permission: permissions[1],
+    });
+  });
+
+  it('returns error state when authorization request fails', async () => {
+    const error = new Error('permission backend unavailable');
+    const authorize = jest.fn().mockRejectedValue(error);
+    mockUseApi.mockReturnValue({ authorize });
+
+    const { result } = renderHook(() => usePermissionArray(permissions), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe(error);
+    expect(result.current.allowed).toEqual([false, false]);
+  });
+});
+
+describe('usePermissionArrayDecision', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns allowed=true when at least one permission is allowed', async () => {
+    const authorize = jest
+      .fn()
+      .mockResolvedValueOnce({ result: AuthorizeResult.DENY })
+      .mockResolvedValueOnce({ result: AuthorizeResult.ALLOW });
+    mockUseApi.mockReturnValue({ authorize });
+
+    const { result } = renderHook(
+      () => usePermissionArrayDecision(permissions),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.allowed).toBe(true);
+  });
+
+  it('returns allowed=false when no permission is allowed', async () => {
+    const authorize = jest
+      .fn()
+      .mockResolvedValueOnce({ result: AuthorizeResult.DENY })
+      .mockResolvedValueOnce({ result: AuthorizeResult.CONDITIONAL });
+    mockUseApi.mockReturnValue({ authorize });
+
+    const { result } = renderHook(
+      () => usePermissionArrayDecision(permissions),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.allowed).toBe(false);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useTranslation.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useTranslation.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { orchestratorTranslationRef } from '../translations';
+import { useTranslation } from './useTranslation';
+
+const mockUseTranslationRef = jest.fn();
+
+jest.mock('@backstage/core-plugin-api/alpha', () => ({
+  useTranslationRef: (...args: unknown[]) => mockUseTranslationRef(...args),
+}));
+
+jest.mock('../translations', () => ({
+  orchestratorTranslationRef: { id: 'plugin.orchestrator.test' },
+}));
+
+describe('useTranslation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates to useTranslationRef with orchestrator translation ref', () => {
+    const translator = { t: jest.fn() };
+    mockUseTranslationRef.mockReturnValue(translator);
+
+    const { result } = renderHook(() => useTranslation());
+
+    expect(mockUseTranslationRef).toHaveBeenCalledWith(
+      orchestratorTranslationRef,
+    );
+    expect(result.current).toBe(translator);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useWorkflowInstanceCardHeightMode.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useWorkflowInstanceCardHeightMode.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useWorkflowInstanceCardHeightMode } from './useWorkflowInstanceCardHeightMode';
+
+const mockUseApi = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  configApiRef: {},
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+describe('useWorkflowInstanceCardHeightMode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns fixed when config is missing', () => {
+    const configApi = {
+      getOptionalString: jest.fn().mockReturnValue(undefined),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useWorkflowInstanceCardHeightMode());
+
+    expect(result.current).toBe('fixed');
+  });
+
+  it('returns content when config value is content', () => {
+    const configApi = {
+      getOptionalString: jest.fn().mockReturnValue('content'),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useWorkflowInstanceCardHeightMode());
+
+    expect(result.current).toBe('content');
+  });
+
+  it('returns fixed and warns when config value is invalid', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const configApi = {
+      getOptionalString: jest.fn().mockReturnValue('stretch'),
+    };
+    mockUseApi.mockReturnValue(configApi);
+
+    const { result } = renderHook(() => useWorkflowInstanceCardHeightMode());
+
+    expect(result.current).toBe('fixed');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Unknown cardHeightMode "stretch", falling back to "fixed"',
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/hooks/useWorkflowInstanceStatusColors.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/hooks/useWorkflowInstanceStatusColors.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { ProcessInstanceStatusDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { useWorkflowInstanceStateColors } from './useWorkflowInstanceStatusColors';
+
+jest.mock('tss-react/mui', () => ({
+  makeStyles: () => () => () => ({
+    classes: {
+      [ProcessInstanceStatusDTO.Active]: 'active-class',
+      [ProcessInstanceStatusDTO.Completed]: 'completed-class',
+      [ProcessInstanceStatusDTO.Suspended]: 'suspended-class',
+      [ProcessInstanceStatusDTO.Aborted]: 'aborted-class',
+      [ProcessInstanceStatusDTO.Error]: 'error-class',
+      [ProcessInstanceStatusDTO.Pending]: 'pending-class',
+    },
+  }),
+}));
+
+describe('useWorkflowInstanceStateColors', () => {
+  it('returns undefined for undefined status', () => {
+    const { result } = renderHook(() => useWorkflowInstanceStateColors());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the class mapped to a completed status', () => {
+    const { result } = renderHook(() =>
+      useWorkflowInstanceStateColors(ProcessInstanceStatusDTO.Completed),
+    );
+
+    expect(result.current).toBe('completed-class');
+  });
+
+  it('returns the class mapped to an error status', () => {
+    const { result } = renderHook(() =>
+      useWorkflowInstanceStateColors(ProcessInstanceStatusDTO.Error),
+    );
+
+    expect(result.current).toBe('error-class');
+  });
+});


### PR DESCRIPTION
Add targeted frontend unit tests for orchestrator frontend plugin to increase coverage and catch issues earlier.
Harden the status indicator fallback for unknown states so the covered behavior matches runtime behavior.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
