### PR TITLE
chore(boost): add issue #3597 to staged-issues.md

### DIFF
--- a/workspaces/boost/staged-issues.md
+++ b/workspaces/boost/staged-issues.md
@@ -473,6 +473,10 @@ From `openspec/changes/platform-operations-deployment/tasks.md` section 3:
 
 ## boost-skills-routes — Skills marketplace route improvements and runtime config (issue 16 after 15)
 
+https://github.com/redhat-developer/rhdh-plugins/issues/3597
+
+https://github.com/redhat-developer/rhdh-plugins/issues/3597
+
 **Labels:** `ready-to-code`
 **Depends on:** Issue 15 (#3311)
 


### PR DESCRIPTION
## Summary
- Add GitHub issue URL for issue 16 (#3597) to `workspaces/boost/staged-issues.md`

Issue 16 covers skills marketplace route improvements deferred from #3311 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)