### PR TITLE
chore(release): cherry-pick fix for is_version_pr typo on workspace/bulk-import

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -34,7 +34,7 @@ jobs:
               if [[ "$PR_TITLE" == Version*Packages* \
               && "$USER_LOGIN" == "rhdh-bot" ]] \
               && [[ "$HEAD_REF" == maintenance-changesets-release/* ]] \
-              && [[ "PR_MERGED" == "true" ]]; then
+              && [[ "$PR_MERGED" == "true" ]]; then
                 echo "is_version_pr=true" >> $GITHUB_OUTPUT
               else
                 echo "is_version_pr=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

The `workspace/bulk-import` branch has its own copy of `release_workspace_version.yml` that was last updated by [#2150](https://github.com/redhat-developer/rhdh-plugins/pull/2150) (Jan 28, 2026). The typo fix [#2468](https://github.com/redhat-developer/rhdh-plugins/pull/2468) — which adds the missing `$` in `"PR_MERGED"` vs `"$PR_MERGED"` — was merged to `main` on Mar 5, 2026, but was never cherry-picked to `workspace/bulk-import`.

Without this fix, `is_version_pr` always evaluates to `false`, so the release/publish job is skipped entirely. When I created and merged the Version Packages PR [#3568](https://github.com/redhat-developer/rhdh-plugins/pull/3568) targeting `workspace/bulk-import`, the workflow picked up the buggy version of the file from that branch. It ran the wrong job (`changesets-pr` instead of `release`) and [errored out](https://github.com/redhat-developer/rhdh-plugins/actions/runs/28112730420/job/83244145099) because the `maintenance-changesets-release/bulk-import` branch already existed.

This PR cherry-picks commit `a8cd84b` from `main` onto `workspace/bulk-import` to fix the issue. Once merged, we need to:
1. Delete the stale `maintenance-changesets-release/bulk-import` remote branch
2. Re-trigger the Version Packages flow to publish `7.0.2` to npm




<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
