### PR TITLE
fix(theme): hover color of myGroup submenu items

### DIFF
--- a/workspaces/theme/.changeset/fix-sidebar-selected-overrides.md
+++ b/workspaces/theme/.changeset/fix-sidebar-selected-overrides.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+fix(theme): use MUI theme overrides for sidebar selected states instead of class name selectors
+
+Replaced `class*=` CSS selectors with proper `styleOverrides.selected` on `BackstageSidebarItem` and `BackstageSidebarSubmenuItem`. The previous `class*=` approach failed in production where JSS minifies class names.

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -630,9 +630,9 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         drawer: {
           gap: '0.25rem',
-          borderRight: `0.5rem solid ${sidebarBackgroundColor}`,
           paddingBottom: '1.5rem',
           backgroundColor: sidebarBackgroundColor,
+          alignItems: 'stretch',
           '& hr': {
             backgroundColor: general.sidebarDividerColor,
           },
@@ -652,7 +652,7 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         root: {
           borderRadius: '6px',
-          width: 'calc(100% - 0.5rem) !important',
+          width: 'calc(100% - 1rem) !important',
           marginLeft: '0.5rem !important',
           textDecorationLine: 'none',
           '&:hover, &:focus-visible': {

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -34,6 +34,7 @@ export type Components = UnifiedThemeOptions['components'] & {
   BackstageHeaderTabs?: Component;
   BackstageSidebar?: Component;
   BackstageSidebarItem?: Component;
+  BackstageSidebarSubmenuItem?: Component;
   BackstagePage?: Component;
   BackstageContent?: Component;
   BackstageContentHeader?: Component;
@@ -644,16 +645,6 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
                 color: 'inherit !important',
               },
             },
-          '& [class*="BackstageSidebarItem-selected-"][class*="BackstageSidebarItem-root-"]':
-            {
-              backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,
-              color: `${navigationSelectedColor} !important`,
-            },
-
-          '& [class*="BackstageSidebarSubmenuItem-selected-"]': {
-            background: `${sidebarItemInteractionBackgroundColor} !important`,
-            color: `${navigationSelectedColor} !important`,
-          },
         },
       },
     };
@@ -674,8 +665,16 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           },
         },
         selected: {
-          backgroundColor: sidebarItemInteractionBackgroundColor,
-          color: navigationSelectedColor,
+          backgroundColor: `${sidebarItemInteractionBackgroundColor} !important`,
+          color: `${navigationSelectedColor} !important`,
+        },
+      },
+    };
+    components.BackstageSidebarSubmenuItem = {
+      styleOverrides: {
+        selected: {
+          background: `${sidebarItemInteractionBackgroundColor} !important`,
+          color: `${navigationSelectedColor} !important`,
         },
       },
     };


### PR DESCRIPTION
 ## Summary

  Replace class*= CSS attribute selectors with MUI styleOverrides.selected for
  BackstageSidebarItem and BackstageSidebarSubmenuItem.

  ### Problem
  The class*="BackstageSidebarItem-selected-" selectors relied on CSS class name substrings. In
  production, JSS can minify class names (e.g., jss4-123), breaking the match and losing selected
  styles in the cluster.

  ###Fix
  - Use styleOverrides.selected which merges at the JS level inside makeStyles — before class
  names are generated, so minification doesn't matter
  - Add BackstageSidebarSubmenuItem to the Components type (was missing)
  - Add !important to override hardcoded styles in the upstream components
## in cluster before changes
<img width="528" height="277" alt="Screenshot 2026-06-29 at 1 53 28 PM" src="https://github.com/user-attachments/assets/2d83aa1a-005d-491f-83e3-bf973a3eaa7b" />



## after changes locally

https://github.com/user-attachments/assets/db5965a3-d1a4-4931-b31e-c28aa810032f




- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
