### PR TITLE
fix(lightspeed): stop hardcoding vector_store_ids to product docs only

### DIFF
--- a/workspaces/lightspeed/.changeset/fix-byok-vector-store-ids.md
+++ b/workspaces/lightspeed/.changeset/fix-byok-vector-store-ids.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
+---
+
+Removed hardcoded vector_store_ids override to enable BYOK RAG sources

--- a/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
+++ b/workspaces/lightspeed/plugins/lightspeed-backend/src/service/router.ts
@@ -134,8 +134,6 @@ export async function createRouter(
     lightspeedCoreBaseUrl,
     logger,
   );
-  let lightspeed_vector_store_id: string = '';
-
   // Parse admin-configured MCP servers from app-config.
   // Only name is required; token is optional (users can provide their own via the UI).
   // URLs come from LCS (GET /v1/mcp-servers), not from app-config.
@@ -600,19 +598,6 @@ export async function createRouter(
         const { userEntityRef } = getIdentity(request);
 
         logger.info(`/v1/query receives call from user: ${userEntityRef}`);
-
-        // get the vector store id for the rhdh-product-docs vector store
-        if (lightspeed_vector_store_id === '') {
-          const vectorStores = await vectorStoresOperator.vectorStores.list();
-          lightspeed_vector_store_id =
-            vectorStores.data.find((v: any) =>
-              v.name.startsWith('rhdh-product-docs'),
-            )?.id || '';
-        }
-
-        if (lightspeed_vector_store_id !== '') {
-          request.body.vector_store_ids = [lightspeed_vector_store_id];
-        }
 
         const userQueryParam = `user_id=${encodeURIComponent(userEntityRef)}`;
         request.body.media_type = 'application/json'; // set media_type to receive start and end event


### PR DESCRIPTION

# Summary
The backend plugin was explicitly setting `vector_store_ids` to only the `rhdh-product-docs` vector store, which prevented BYOK RAG sources configured in `rag.inline` from being queried via inline RAG.

By removing this override, the lightspeed-stack uses its own `rag.inline` config to determine which stores to query, enabling multi-source RAG.

## Context
When BYOK knowledge sources are configured in `lightspeed-stack.yaml`, the `_fetch_byok_rag()` function in lightspeed-stack filters the request's `vector_store_ids` against `rag.inline`. Since the plugin was only sending the product docs store ID, BYOK stores were always filtered out and inline RAG was silently skipped.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)