### PR TITLE
[Orchestrator] Show unavailable workflow details and disable run actions

### DIFF
--- a/workspaces/orchestrator/.changeset/orchestrator-unavailable-workflow-ui.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-unavailable-workflow-ui.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Show unavailable workflow error details in tooltips and disable run actions when a workflow is not available.

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -337,6 +337,11 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.ofTotal': string;
     readonly 'workflow.statsSuccess': string;
     readonly 'workflow.statsFailed': string;
+    readonly 'workflow.unavailable.title': string;
+    readonly 'workflow.unavailable.runTooltip': string;
+    readonly 'workflow.unavailable.requestFailed': string;
+    readonly 'workflow.unavailable.statusCodeLine': string;
+    readonly 'workflow.unavailable.statusTextLine': string;
     readonly 'workflow.fields.description': string;
     readonly 'workflow.fields.version': string;
     readonly 'workflow.fields.workflowId': string;

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -153,6 +153,11 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.ofTotal': string;
     readonly 'workflow.statsSuccess': string;
     readonly 'workflow.statsFailed': string;
+    readonly 'workflow.unavailable.title': string;
+    readonly 'workflow.unavailable.runTooltip': string;
+    readonly 'workflow.unavailable.requestFailed': string;
+    readonly 'workflow.unavailable.statusCodeLine': string;
+    readonly 'workflow.unavailable.statusTextLine': string;
     readonly 'workflow.fields.description': string;
     readonly 'workflow.fields.version': string;
     readonly 'workflow.fields.workflowId': string;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTable.tsx
@@ -44,6 +44,7 @@ import {
 import {
   DEFAULT_TABLE_PAGE_SIZE,
   ENFORCING_UNIQUE_WORKFLOW_IDS_DOC_URL,
+  UNAVAILABLE,
   VALUE_UNAVAILABLE,
 } from '../../constants';
 import WorkflowOverviewFormatter, {
@@ -180,8 +181,13 @@ export const WorkflowsTable = ({
     const actionItems: TableProps<FormattedWorkflowOverview>['actions'] = [
       rowData => ({
         icon: () => <PlayArrow />,
-        tooltip: t('table.actions.run'),
-        disabled: !canExecuteWorkflow(rowData.id),
+        tooltip:
+          rowData.availability === UNAVAILABLE
+            ? t('workflow.unavailable.runTooltip')
+            : t('table.actions.run'),
+        disabled:
+          !canExecuteWorkflow(rowData.id) ||
+          rowData.availability === UNAVAILABLE,
         onClick: () => handleExecute(rowData),
       }),
     ];
@@ -257,7 +263,10 @@ export const WorkflowsTable = ({
         title: t('table.headers.workflowStatus'),
         field: 'availability',
         render: rowData => (
-          <WorkflowStatus availability={rowData.availability} />
+          <WorkflowStatus
+            availability={rowData.availability}
+            availabilityDetails={rowData.availabilityDetails}
+          />
         ),
       },
       {

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/RunButton.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/RunButton.tsx
@@ -73,8 +73,8 @@ export const RunButton = ({
   let tooltipText = '';
   if (!canRun) {
     tooltipText = t('workflow.messages.userNotAuthorizedExecute');
-  } else if (!isAvailable) {
-    tooltipText = t('workflow.messages.workflowDown');
+  } else if (isAvailable === false) {
+    tooltipText = t('workflow.unavailable.runTooltip');
   }
 
   return (
@@ -91,7 +91,7 @@ export const RunButton = ({
               variant="contained"
               color="primary"
               onClick={handleExecute}
-              disabled={!canRun}
+              disabled={!canRun || isAvailable === false}
             >
               {t('workflow.buttons.run')}
             </Button>

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/WorkflowDetailsCard.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowPage/WorkflowDetailsCard.tsx
@@ -126,6 +126,7 @@ const WorkflowDefinitionDetailsCard = ({
         <b>
           <WorkflowStatus
             availability={formattedWorkflowOverview?.availability}
+            availabilityDetails={workflowOverview?.availability}
           />
         </b>
       )}

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowStatus.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowStatus.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC } from 'react';
+import { FC, ReactElement } from 'react';
 
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
@@ -22,8 +22,12 @@ import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
 import { makeStyles } from 'tss-react/mui';
 
+import { WorkflowOverviewDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
 import { AVAILABLE, UNAVAILABLE } from '../../constants';
 import { useTranslation } from '../../hooks/useTranslation';
+import { hasWorkflowAvailabilityDetails } from '../../utils/workflowAvailability';
+import { WorkflowUnavailableTooltip } from './WorkflowUnavailableTooltip';
 
 const useStyles = makeStyles()(theme => ({
   warning: {
@@ -36,11 +40,13 @@ const useStyles = makeStyles()(theme => ({
 
 export interface WorkflowStatusProps {
   availability: string | undefined | boolean;
+  availabilityDetails?: WorkflowOverviewDTO['availability'];
   compact?: boolean;
 }
 
 export const WorkflowStatus: FC<WorkflowStatusProps> = ({
   availability,
+  availabilityDetails,
   compact = false,
 }) => {
   const { t } = useTranslation();
@@ -54,18 +60,25 @@ export const WorkflowStatus: FC<WorkflowStatusProps> = ({
         &nbsp; {t('workflow.status.available')}
       </Box>
     );
-  } else if (availability === UNAVAILABLE || availability === false) {
-    return (
-      <Tooltip title={t('tooltips.workflowDown')}>
-        <Box display="flex" alignItems="center">
-          <WarningAmberOutlined
-            className={classes.warning}
-            {...iconSizeProps}
-          />
-          &nbsp; {t('workflow.status.unavailable')}
-        </Box>
-      </Tooltip>
+  }
+
+  if (availability === UNAVAILABLE || availability === false) {
+    const statusLabel = (
+      <Box display="flex" alignItems="center">
+        <WarningAmberOutlined className={classes.warning} {...iconSizeProps} />
+        &nbsp; {t('workflow.status.unavailable')}
+      </Box>
     );
+
+    if (hasWorkflowAvailabilityDetails(availabilityDetails)) {
+      return (
+        <WorkflowUnavailableTooltip availability={availabilityDetails}>
+          {statusLabel as ReactElement}
+        </WorkflowUnavailableTooltip>
+      );
+    }
+
+    return <Tooltip title={t('tooltips.workflowDown')}>{statusLabel}</Tooltip>;
   }
 
   return <>{availability}</>;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowUnavailableTooltip.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowUnavailableTooltip.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement } from 'react';
+
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import Box from '@mui/material/Box';
+import MuiLink from '@mui/material/Link';
+import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+
+import { WorkflowOverviewDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { BUILD_WORKFLOWS_DOC_URL } from '../../constants';
+import { useTranslation } from '../../hooks/useTranslation';
+import { translateMessage } from '../Trans';
+
+type WorkflowAvailabilityDetails = NonNullable<
+  WorkflowOverviewDTO['availability']
+>;
+
+type WorkflowUnavailableTooltipProps = {
+  availability: WorkflowAvailabilityDetails;
+  children: ReactElement;
+};
+
+const TOOLTIP_MAX_WIDTH = 359;
+
+export const WorkflowUnavailableTooltip = ({
+  availability,
+  children,
+}: WorkflowUnavailableTooltipProps) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  const title = (
+    <Box
+      sx={{
+        maxWidth: TOOLTIP_MAX_WIDTH,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0.5,
+      }}
+    >
+      <Typography variant="subtitle2" fontWeight={700} color="text.primary">
+        {t('workflow.unavailable.title')}
+      </Typography>
+      <Typography
+        variant="body2"
+        color="text.primary"
+        sx={{ wordBreak: 'break-word' }}
+      >
+        {translateMessage(t, 'workflow.unavailable.requestFailed', {
+          url: availability.urlToFetch ?? '',
+        })}
+      </Typography>
+      <Typography variant="body2" color="text.primary">
+        {translateMessage(t, 'workflow.unavailable.statusCodeLine', {
+          statusCode: availability.statusCode ?? '',
+        })}
+      </Typography>
+      <Typography variant="body2" color="text.primary">
+        {translateMessage(t, 'workflow.unavailable.statusTextLine', {
+          reason: availability.reason ?? '',
+        })}
+      </Typography>
+      <MuiLink
+        href={BUILD_WORKFLOWS_DOC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        color="primary"
+        underline="always"
+        variant="body2"
+        sx={{ display: 'inline-flex', alignItems: 'center', mt: 1 }}
+      >
+        {t('emptyState.workflows.viewDocumentation')}
+        <OpenInNewIcon
+          sx={{ ml: 0.5, fontSize: '1em', verticalAlign: 'text-bottom' }}
+          aria-hidden
+        />
+      </MuiLink>
+    </Box>
+  );
+
+  return (
+    <Tooltip
+      title={title}
+      placement="right"
+      arrow
+      slotProps={{
+        popper: {
+          modifiers: [
+            {
+              name: 'offset',
+              options: { offset: [0, -4] },
+            },
+          ],
+        },
+        tooltip: {
+          sx: {
+            bgcolor: 'background.paper',
+            color: 'text.primary',
+            boxShadow: theme.shadows[4],
+            borderRadius: `${theme.shape.borderRadius * 1.5}px`,
+            maxWidth: TOOLTIP_MAX_WIDTH,
+            p: 2,
+          },
+        },
+        arrow: {
+          sx: {
+            color: 'background.paper',
+            '&::before': {
+              bgcolor: 'background.paper',
+              boxShadow: theme.shadows[2],
+            },
+          },
+        },
+      }}
+    >
+      <Box component="span" sx={{ display: 'inline-flex', cursor: 'default' }}>
+        {children}
+      </Box>
+    </Tooltip>
+  );
+};

--- a/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
@@ -35,6 +35,7 @@ export interface FormattedWorkflowOverview {
   readonly description: string;
   readonly format: WorkflowFormatDTO;
   readonly availability?: string;
+  readonly availabilityDetails?: WorkflowOverviewDTO['availability'];
   readonly runsLastMonth: string;
   readonly successRatio?: number;
   readonly successRatioDisplay: string;
@@ -90,6 +91,7 @@ const WorkflowOverviewFormatter: DataFormatter<
       description: data.description ?? VALUE_UNAVAILABLE,
       format: data.format,
       availability: formatIsAvailable(data.isAvailable),
+      availabilityDetails: data.availability,
       runsLastMonth: formatRunsLastMonth(data.workflowRunStats?.runsLastMonth),
       successRatio: data.workflowRunStats?.successRatio,
       successRatioDisplay: formatSuccessRatioDisplay(

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -238,6 +238,12 @@ const orchestratorTranslationDe = createTranslationMessages({
     'workflow.progress': 'Workflow-Fortschritt',
     'workflow.status.available': 'Verfügbar',
     'workflow.status.unavailable': 'Nicht verfügbar',
+    'workflow.unavailable.title': 'Workflow nicht verfügbar',
+    'workflow.unavailable.runTooltip': 'Workflow nicht verfügbar',
+    'workflow.unavailable.requestFailed':
+      'HTTP-GET-Anfrage an {{url}} ist fehlgeschlagen.',
+    'workflow.unavailable.statusCodeLine': 'Statuscode: {{statusCode}}',
+    'workflow.unavailable.statusTextLine': 'Statustext: {{reason}}',
     'samlSso.title': 'GitHub SAML SSO-Sitzung abgelaufen',
     'samlSso.reauthorizeButton': 'SSO erneut autorisieren',
     'samlSso.body':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -241,6 +241,12 @@ const orchestratorTranslationEs = createTranslationMessages({
     'workflow.progress': 'Progreso del flujo de trabajo',
     'workflow.status.available': 'Disponible',
     'workflow.status.unavailable': 'No disponible',
+    'workflow.unavailable.title': 'Flujo de trabajo no disponible',
+    'workflow.unavailable.runTooltip': 'Flujo de trabajo no disponible',
+    'workflow.unavailable.requestFailed':
+      'La solicitud HTTP GET a {{url}} falló.',
+    'workflow.unavailable.statusCodeLine': 'Código de estado: {{statusCode}}',
+    'workflow.unavailable.statusTextLine': 'Texto de estado: {{reason}}',
     'samlSso.title': 'Sesión de GitHub SAML SSO expirada',
     'samlSso.reauthorizeButton': 'Reautorizar SSO',
     'samlSso.body':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -239,6 +239,13 @@ const orchestratorTranslationFr = createTranslationMessages({
       "Le flux de travail est actuellement interrompu ou en état d'erreur. Son exécution maintenant peut échouer ou produire des résultats inattendus.",
     'workflow.progress': 'Avancement du flux de travail',
     'workflow.status.available': 'Disponible',
+    'workflow.status.unavailable': 'Indisponible',
+    'workflow.unavailable.title': 'Flux de travail indisponible',
+    'workflow.unavailable.runTooltip': 'Flux de travail indisponible',
+    'workflow.unavailable.requestFailed':
+      'La requête HTTP GET vers {{url}} a échoué.',
+    'workflow.unavailable.statusCodeLine': 'Code de statut : {{statusCode}}',
+    'workflow.unavailable.statusTextLine': 'Texte de statut : {{reason}}',
     'samlSso.title': 'Session GitHub SAML SSO expirée',
     'samlSso.reauthorizeButton': 'Réautoriser SSO',
     'samlSso.body':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -240,6 +240,12 @@ const orchestratorTranslationIt = createTranslationMessages({
     'workflow.progress': 'Avanzamento del flusso di lavoro',
     'workflow.status.available': 'Disponibile',
     'workflow.status.unavailable': 'Non disponibile',
+    'workflow.unavailable.title': 'Flusso di lavoro non disponibile',
+    'workflow.unavailable.runTooltip': 'Flusso di lavoro non disponibile',
+    'workflow.unavailable.requestFailed':
+      'Richiesta HTTP GET a {{url}} non riuscita.',
+    'workflow.unavailable.statusCodeLine': 'Codice di stato: {{statusCode}}',
+    'workflow.unavailable.statusTextLine': 'Testo di stato: {{reason}}',
     'samlSso.title': 'Sessione GitHub SAML SSO scaduta',
     'samlSso.reauthorizeButton': 'Riautorizza SSO',
     'samlSso.body':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
@@ -235,6 +235,12 @@ const orchestratorTranslationJa = createTranslationMessages({
     'workflow.progress': 'ワークフロー進捗',
     'workflow.status.available': '利用可能',
     'workflow.status.unavailable': '利用不可',
+    'workflow.unavailable.title': '利用できないワークフロー',
+    'workflow.unavailable.runTooltip': '利用できないワークフロー',
+    'workflow.unavailable.requestFailed':
+      'HTTP GET リクエスト {{url}} は失敗しました。',
+    'workflow.unavailable.statusCodeLine': 'ステータスコード: {{statusCode}}',
+    'workflow.unavailable.statusTextLine': 'ステータステキスト: {{reason}}',
     'samlSso.title': 'GitHub SAML SSO セッションの有効期限切れ',
     'samlSso.reauthorizeButton': 'SSO を再認証',
     'samlSso.body':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -98,6 +98,13 @@ export const orchestratorMessages = {
       available: 'Available',
       unavailable: 'Unavailable',
     },
+    unavailable: {
+      title: 'Unavailable workflow',
+      runTooltip: 'Unavailable workflow',
+      requestFailed: 'HTTP GET request to {{url}} failed.',
+      statusCodeLine: 'Status Code: {{statusCode}}',
+      statusTextLine: 'Status Text: {{reason}}',
+    },
     fields: {
       entity: 'Entity',
       workflow: 'Workflow',

--- a/workspaces/orchestrator/plugins/orchestrator/src/utils/workflowAvailability.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/utils/workflowAvailability.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkflowOverviewDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+export const isWorkflowUnavailable = (isAvailable?: boolean): boolean =>
+  isAvailable === false;
+
+export const hasWorkflowAvailabilityDetails = (
+  availability?: WorkflowOverviewDTO['availability'],
+): availability is NonNullable<WorkflowOverviewDTO['availability']> =>
+  Boolean(availability && availability.isAvailable === false);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Story : https://redhat.atlassian.net/browse/RHIDP-15089

## Summary

Improves UX when a workflow backend is unreachable (`isAvailable === false`).
- **Rich tooltip** on **Unavailable** status (workflows table + workflow detail) showing HTTP error details: request URL, status code, status text, and a documentation link
- **Disable Run** in the workflows table row actions and on the workflow detail page when unavailable
- **Run action tooltip** shows "Unavailable workflow" instead of "Run" when disabled for availability

## Out of scope
Create page scaffolder **CHOOSE** button is not disabled for unavailable workflows — stock `TemplateCard` has no supported `disabled` API. Tracked separately as an upstream scaffolder request.

Created upstream issue for this - https://github.com/backstage/backstage/issues/34750

## Screenshots

<img width="1470" height="709" alt="Screenshot 2026-06-30 at 11 55 13 AM" src="https://github.com/user-attachments/assets/8141cb2c-0fbb-4167-b004-74428fe22a37" />
<img width="1468" height="791" alt="Screenshot 2026-06-30 at 11 55 29 AM" src="https://github.com/user-attachments/assets/450f5f96-47ae-4add-bc8a-53f5b9fa2b44" />

### How to test

- Local dev environment running (`yarn dev` in orchestrator workspace)
- SonataFlow container running (port 8899)

#### Simulate an unavailable workflow

1. Stop or break one workflow in dev mode, e.g. temporarily remove:
   `packages/backend/.devModeTemp/repository/workflows/ansible-job-template.sw.yaml`
2. Restart the SonataFlow container:
   `docker restart <sonataflow-container-id>`
3. Wait for the backend to report ping failure for that workflow

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
