### PR TITLE
ci: add nightly CI workflow that runs all workspaces

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,0 +1,195 @@
+name: CI Nightly
+
+on:
+  # Run every night at 00:00 UTC
+  schedule:
+    - cron: '0 0 * * *'
+  # Allow manual runs, optionally scoped to a subset of workspaces
+  workflow_dispatch:
+    inputs:
+      workspaces:
+        description: 'Optional JSON string array of workspaces to run, e.g. ["global-header","theme"]. When empty all workspaces run.'
+        required: false
+        type: string
+
+jobs:
+  list-workspaces:
+    name: List workspaces
+    runs-on: ubuntu-latest
+    outputs:
+      workspaces: ${{ steps.list-workspaces.outputs.workspaces }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+
+      - name: List workspaces
+        id: list-workspaces
+        run: node ./scripts/ci/list-all-workspaces.js
+        env:
+          WORKSPACES: ${{ inputs.workspaces }}
+
+  ci:
+    name: Workspace ${{ matrix.workspace }}, CI step for node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    needs: list-workspaces
+    strategy:
+      matrix:
+        workspace: ${{ fromJSON(needs.list-workspaces.outputs.workspaces) }}
+        node-version: [22, 24]
+      fail-fast: false
+    defaults:
+      run:
+        working-directory: ./workspaces/${{ matrix.workspace }}
+
+    env:
+      CI: true
+      NODE_OPTIONS: --max-old-space-size=8192
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+
+      - name: yarn install
+        run: yarn install --immutable
+
+      - name: check for missing repo fixes
+        run: yarn fix --check
+
+      - name: validate config
+        if: ${{ hashFiles(format('workspaces/{0}/app-config.yaml', matrix.workspace)) != '' }}
+        run: yarn backstage-cli config:check --lax
+
+      - name: type checking and declarations
+        run: yarn tsc:full
+
+      - name: prettier
+        run: yarn prettier:check
+
+      - name: read knip-reports flag from bcp.json
+        id: bcp
+        run: |
+          echo "Checking for bcp.json in workspace: workspaces/${{ matrix.workspace }}"
+          if [ -f bcp.json ]; then
+            echo "Reading knip-reports flag..."
+            KNIP_REPORTS=$(jq -r '.["knip-reports"]' bcp.json)
+            echo "knip-reports value: $KNIP_REPORTS"
+            echo "knip_reports=$KNIP_REPORTS" >> $GITHUB_OUTPUT
+          else
+            echo "bcp.json not found. Defaulting knip_reports to false."
+            echo "knip_reports=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: check knip reports
+        if: ${{ steps.bcp.outputs.knip_reports == 'true' }}
+        run: yarn build:knip-reports --ci
+
+      - name: check api reports and generate API reference
+        run: yarn build:api-reports:only --ci
+
+      - name: build all packages
+        run: yarn backstage-cli repo build --all
+
+      - name: lint
+        run: yarn backstage-cli repo lint --since origin/main
+
+      - name: publish check
+        run: yarn backstage-cli repo fix --check --publish
+
+      - name: Install jest-junit reporter
+        run: |
+          npm install jest-junit@17.0.0 --ignore-scripts --prefix ${{ runner.temp }}/jest-junit
+          mkdir -p ${{ runner.temp }}/test-results/${{ matrix.workspace }}
+
+      - name: Test changed packages
+        id: tests
+        env:
+          JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results/${{ matrix.workspace }}
+          JEST_JUNIT_CLASSNAME: '{filepath}'
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: 'true'
+        run: yarn test:all --maxWorkers=3 --reporters=default --reporters=${{ runner.temp }}/jest-junit/node_modules/jest-junit
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          flags: ${{ matrix.workspace }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          flags: ${{ matrix.workspace }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ runner.temp }}/test-results/${{ matrix.workspace }}
+          fail_ci_if_error: false
+
+      - name: install playwright
+        if: ${{ hashFiles(format('workspaces/{0}/playwright.config.ts', matrix.workspace)) != '' }}
+        run: yarn playwright install --with-deps chromium chrome
+
+      - name: run playwright tests
+        if: ${{ hashFiles(format('workspaces/{0}/playwright.config.ts', matrix.workspace)) != '' }}
+        run: yarn playwright test
+
+      - name: ensure clean working directory
+        run: |
+          if files=$(git ls-files --exclude-standard --others --modified) && [[ -z "$files" ]]; then
+            exit 0
+          else
+            echo ""
+            echo "Working directory has been modified:"
+            echo ""
+            git status --short
+            echo ""
+            exit 1
+          fi
+
+  verify:
+    name: Workspace ${{ matrix.workspace }}, Verify step
+    runs-on: ubuntu-latest
+    needs: list-workspaces
+    strategy:
+      matrix:
+        workspace: ${{ fromJSON(needs.list-workspaces.outputs.workspaces) }}
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+      - name: Install root dependencies
+        run: yarn install --immutable
+      - name: Verify lockfile duplicates
+        run: node scripts/ci/verify-lockfile-duplicates.js workspaces/${{ matrix.workspace }}/yarn.lock
+      - name: Verify changesets
+        run: node scripts/ci/verify-changesets.js ${{ matrix.workspace }}
+
+  result:
+    if: ${{ always() }}
+    name: check all required jobs
+    runs-on: ubuntu-latest
+    needs: [ci, verify]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}

--- a/scripts/ci/list-all-workspaces.js
+++ b/scripts/ci/list-all-workspaces.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import path from 'path';
+import { EOL } from 'os';
+
+/**
+ * Lists the workspaces that should run in the nightly CI workflow.
+ *
+ * When the WORKSPACES environment variable is set it is parsed as a JSON
+ * string array and used as an explicit allow list. Otherwise every workspace
+ * that contains a package.json is returned.
+ */
+function parseRequestedWorkspaces() {
+  const raw = process.env.WORKSPACES?.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse WORKSPACES as JSON: ${error.message}. Expected a JSON string array, e.g. ["global-header","theme"].`,
+    );
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every(item => typeof item === 'string')
+  ) {
+    throw new Error(
+      `WORKSPACES must be a JSON array of strings, e.g. ["global-header","theme"], but received: ${raw}`,
+    );
+  }
+
+  return parsed;
+}
+
+function listAllWorkspaces(workspacesDir) {
+  return fs
+    .readdirSync(workspacesDir, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name)
+    .filter(name =>
+      fs.existsSync(path.join(workspacesDir, name, 'package.json')),
+    )
+    .sort();
+}
+
+function main() {
+  if (!process.env.GITHUB_OUTPUT) {
+    throw new Error('GITHUB_OUTPUT environment variable not set');
+  }
+
+  const workspacesDir = path.resolve('workspaces');
+  const allWorkspaces = listAllWorkspaces(workspacesDir);
+
+  const requested = parseRequestedWorkspaces();
+
+  let workspaces;
+  if (requested) {
+    const unknown = requested.filter(name => !allWorkspaces.includes(name));
+    if (unknown.length > 0) {
+      throw new Error(
+        `The following requested workspaces do not exist: ${unknown.join(
+          ', ',
+        )}. Available workspaces: ${allWorkspaces.join(', ')}`,
+      );
+    }
+    workspaces = requested;
+  } else {
+    workspaces = allWorkspaces;
+  }
+
+  console.log('workspaces to run:', workspaces);
+
+  fs.appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `workspaces=${JSON.stringify(workspaces)}${EOL}`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a scheduled nightly workflow that runs the full CI suite across all workspaces with Node 22 and 24, plus a helper script to list workspaces with optional filtering via workflow_dispatch input.

Tested this in my fork.

### With one workspace defined

You can run specific tests for the main branch from the GitHub UI:

<img width="2193" height="788" alt="image" src="https://github.com/user-attachments/assets/8a87dafe-93d3-49b0-9b43-92b4450bec3c" />

Running job when one workspace is passed

<img width="2193" height="788" alt="image" src="https://github.com/user-attachments/assets/febd0a85-9116-4b07-a591-5a56f470ad27" />

Finished

<img width="2193" height="777" alt="image" src="https://github.com/user-attachments/assets/7cf2a4f3-b6bf-45ad-80b9-4f37af6d7e4e" />


### No workspace passed

Running job when no workspace is passed:

<img width="2193" height="1164" alt="image" src="https://github.com/user-attachments/assets/9fa62a75-bf9e-43c5-864c-97c9cc501ac3" />

Finished with errors:

<img width="2193" height="1481" alt="image" src="https://github.com/user-attachments/assets/dc753fe2-4bc1-414e-be06-c7059b404d04" />
