### PR TITLE
ci: add reusable workflow to build dynamic plugins container images

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -1,0 +1,124 @@
+name: Build container image
+
+# Reusable workflow that builds a Red Hat Developer Hub dynamic plugins
+# container image for a single workspace using the rhdh-cli.
+# Adds a quay expiration label and pushes the image to the container registry.
+
+on:
+  workflow_call:
+    inputs:
+      workspace:
+        description: Name of the workspace to build an image for
+        required: true
+        type: string
+      tags:
+        description: >-
+          Space separated list of image tags (the part after the colon).
+          The literal `${SHORT_SHA}` placeholder is replaced with the
+          short commit sha of the checked out ref. The first tag is used to
+          build the image, additional tags are added afterwards.
+          All tags should be prefixed with the workspace name.
+        required: true
+        type: string
+      registry:
+        description: Image repository the tags are pushed to (without the tag part)
+        required: false
+        type: string
+        default: quay.io/rhdh/rhdh-plugins
+      expires_after:
+        description: >-
+          Adds a `quay.expires-after` label with this value (for example `2w`)
+          so the image is removed automatically.
+        required: true
+        type: string
+        default: ''
+      ref:
+        description: Git ref (branch, tag or sha) to checkout and build from
+        required: false
+        type: string
+        default: ''
+    secrets:
+      QUAY_USERNAME:
+        description: Username used to authenticate against quay.io when pushing
+        required: false
+      QUAY_PASSWORD:
+        description: Password or token used to authenticate against quay.io when pushing
+        required: false
+
+jobs:
+  build-container-image:
+    name: Build image for ${{ inputs.workspace }}
+    if: inputs.workspace != 'noop'
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      NODE_OPTIONS: --max-old-space-size=8192
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+
+      - name: yarn install
+        working-directory: ./workspaces/${{ inputs.workspace }}
+        run: yarn install --immutable
+
+      - name: Build dynamic plugins image
+        working-directory: ./workspaces/${{ inputs.workspace }}
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          TAGS: ${{ inputs.tags }}
+          EXPIRES_AFTER: ${{ inputs.expires_after }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the ${SHORT_SHA} placeholder in the requested tags.
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          TAGS_ONE_LINE="$(printf '%s' "${TAGS}" | tr '\n' ' ')"
+          RESOLVED_TAGS="${TAGS_ONE_LINE//\$\{SHORT_SHA\}/${SHORT_SHA}}"
+          read -ra TAG_LIST <<< "${RESOLVED_TAGS}"
+
+          if [ "${#TAG_LIST[@]}" -eq 0 ]; then
+            echo "No tags provided" >&2
+            exit 1
+          fi
+
+          PRIMARY_IMAGE="${REGISTRY}:${TAG_LIST[0]}"
+
+          echo "Building ${PRIMARY_IMAGE} with rhdh-cli"
+          npx @red-hat-developer-hub/cli@latest plugin package \
+            --tag "${PRIMARY_IMAGE}" \
+            --container-tool podman \
+            --label "quay.expires-after=${EXPIRES_AFTER}"
+
+          # Add any additional tags to the freshly built image.
+          for tag in "${TAG_LIST[@]:1}"; do
+            echo "Tagging ${REGISTRY}:${tag}"
+            podman tag "${PRIMARY_IMAGE}" "${REGISTRY}:${tag}"
+          done
+
+          # Hand the resolved tags over to the push step.
+          echo "RESOLVED_TAGS=${RESOLVED_TAGS}" >> "${GITHUB_ENV}"
+
+      - name: Push image to registry
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          podman login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
+
+          read -ra TAG_LIST <<< "${RESOLVED_TAGS}"
+          for tag in "${TAG_LIST[@]}"; do
+            [ -z "${tag}" ] && continue
+            echo "Pushing ${REGISTRY}:${tag}"
+            podman push "${REGISTRY}:${tag}"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,24 @@ jobs:
             exit 1
           fi
 
+  build-image:
+    name: Workspace ${{ matrix.workspace }}, Build container image
+    if: github.repository == 'redhat-developer/rhdh-plugins'
+    needs: find-changed-workspaces
+    strategy:
+      matrix:
+        workspace: ${{ fromJSON(needs.find-changed-workspaces.outputs.workspaces) }}
+      fail-fast: false
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      workspace: ${{ matrix.workspace }}
+      ref: ${{ github.event.pull_request.head.sha }}
+      tags: |
+        ${{ matrix.workspace }}-pr-${{ github.event.pull_request.number }}
+        ${{ matrix.workspace }}-pr-${{ github.event.pull_request.number }}-${SHORT_SHA}
+      expires_after: 2w
+    secrets: inherit
+
   verify:
     name: Workspace ${{ matrix.workspace }}, Verify step
     runs-on: ubuntu-latest
@@ -201,7 +219,7 @@ jobs:
     if: ${{ always() }}
     name: check all required jobs
     runs-on: ubuntu-latest
-    needs: [ci, verify]
+    needs: [ci, build-image, verify]
     steps:
       - run: exit 1
         if: >-

--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -162,3 +162,28 @@ jobs:
         env:
           WORKSPACE_NAME: ${{ inputs.workspace }}
           GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN}}
+
+  build-next-image:
+    name: Build "next" image for ${{ inputs.workspace }}
+    # Build the rolling "next" image for every merge into main, independent of
+    # whether the changesets resulted in a release.
+    if: inputs.branch == 'main'
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      workspace: ${{ inputs.workspace }}
+      ref: ${{ inputs.branch }}
+      tags: ${{ inputs.workspace }}-next
+      expires_after: 4w
+    secrets: inherit
+
+  build-latest-image:
+    name: Build "latest" image for ${{ inputs.workspace }}
+    # Only build the "latest" image once a release of the workspace happened.
+    needs: release
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      workspace: ${{ inputs.workspace }}
+      ref: ${{ inputs.branch }}
+      tags: ${{ inputs.workspace }}-latest
+      expires_after: 4w
+    secrets: inherit


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Introduce build-container-image.yml that uses rhdh-cli to package and push workspace images to quay.io.

Wire it into CI for a per-PR build, and the release workflow for next and latest tags.

The per-PR images has a 2w expiry, next and images a 4w expiry.

**The images are build per workspace, not separated per package. The workspace is also added as a prefix to the tag, so that we don't need a quay repo per workspace. Feedback is very welcome for this. Both is different to the overlay build process but simplifies this, because rhdh-cli just builds all packages.**

:warning: Untested, and it includes a high risk that this could break the CI or release pipelines.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
