### PR TITLE
test(orchestrator): add scaffolder backend module test coverage

### DIFF
--- a/workspaces/orchestrator/.changeset/rhidp-9861-tests.md
+++ b/workspaces/orchestrator/.changeset/rhidp-9861-tests.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator': patch
+---
+
+Added unit test coverage for orchestrator scaffolder actions and fixed token fallback logic.

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { JsonObject } from '@backstage/types';
+
+import { createGetWorkflowParamsAction } from './getWorkflowParams';
+import { getOrchestratorApi, getRequestConfigOption } from './utils';
+
+jest.mock('axios', () => ({
+  isAxiosError: (error: { isAxiosError?: boolean }) =>
+    Boolean(error?.isAxiosError),
+}));
+
+jest.mock('./utils', () => ({
+  getOrchestratorApi: jest.fn(),
+  getRequestConfigOption: jest.fn(),
+}));
+
+const mockedGetOrchestratorApi = jest.mocked(getOrchestratorApi);
+const mockedGetRequestConfigOption = jest.mocked(getRequestConfigOption);
+
+describe('createGetWorkflowParamsAction', () => {
+  const discoveryService = {} as any;
+  const authService = {} as any;
+  const reqConfigOption = {
+    headers: {
+      Authorization: 'Bearer token',
+    },
+  };
+  const mockApi = {
+    getWorkflowOverviewById: jest.fn(),
+    getWorkflowInputSchemaById: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetOrchestratorApi.mockResolvedValue(mockApi as any);
+    mockedGetRequestConfigOption.mockResolvedValue(reqConfigOption as any);
+  });
+
+  it('throws when workflow_id is missing', async () => {
+    const action = createGetWorkflowParamsAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {},
+    });
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Missing workflow_id required input parameter.',
+    );
+    expect(mockedGetOrchestratorApi).not.toHaveBeenCalled();
+  });
+
+  it('outputs fallback title, empty description, and indented parameters yaml', async () => {
+    const workflowId = 'greeting';
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        greeting: {
+          type: 'string',
+        },
+      },
+    } satisfies JsonObject;
+
+    mockApi.getWorkflowOverviewById.mockResolvedValue({
+      data: {
+        name: '',
+      },
+    });
+    mockApi.getWorkflowInputSchemaById.mockResolvedValue({
+      data: {
+        inputSchema,
+      },
+    });
+
+    const action = createGetWorkflowParamsAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: workflowId,
+        indent: 4,
+      },
+    });
+
+    await action.handler(ctx);
+
+    expect(mockApi.getWorkflowOverviewById).toHaveBeenCalledWith(
+      workflowId,
+      reqConfigOption,
+    );
+    expect(mockApi.getWorkflowInputSchemaById).toHaveBeenCalledWith(
+      workflowId,
+      undefined,
+      reqConfigOption,
+    );
+    expect(ctx.output).toHaveBeenCalledWith('title', workflowId);
+    expect(ctx.output).toHaveBeenCalledWith('description', '');
+
+    const parametersOutput = (ctx.output as jest.Mock).mock.calls.find(
+      ([key]) => key === 'parameters',
+    )?.[1];
+    expect(parametersOutput).toContain('greeting:');
+    expect(parametersOutput.startsWith('\n    -')).toBe(true);
+  });
+
+  it('outputs empty parameters when the schema does not define properties', async () => {
+    mockApi.getWorkflowOverviewById.mockResolvedValue({
+      data: {
+        name: 'Greeting workflow',
+        description: 'Collect greeting details',
+      },
+    });
+    mockApi.getWorkflowInputSchemaById.mockResolvedValue({
+      data: {
+        inputSchema: {},
+      },
+    });
+
+    const action = createGetWorkflowParamsAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+      },
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('title', 'Greeting workflow');
+    expect(ctx.output).toHaveBeenCalledWith(
+      'description',
+      'Collect greeting details',
+    );
+    expect(ctx.output).toHaveBeenCalledWith('parameters', '{}');
+  });
+
+  it('throws when the workflow is not found', async () => {
+    mockApi.getWorkflowOverviewById.mockResolvedValue({
+      data: undefined,
+    });
+
+    const action = createGetWorkflowParamsAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'missing-workflow',
+      },
+    });
+
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Can not find workflow missing-workflow',
+    );
+  });
+
+  it('maps axios-shaped errors to orchestrator error details', async () => {
+    mockApi.getWorkflowOverviewById.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        data: {
+          error: {
+            message: 'Workflow service unavailable',
+            name: 'UpstreamWorkflowError',
+          },
+        },
+      },
+    });
+
+    const action = createGetWorkflowParamsAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+      },
+    });
+
+    await expect(action.handler(ctx)).rejects.toMatchObject({
+      message: 'Workflow service unavailable',
+      name: 'UpstreamWorkflowError',
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { JsonObject } from '@backstage/types';
 
@@ -25,6 +26,7 @@ jest.mock('axios', () => ({
 }));
 
 jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
   getOrchestratorApi: jest.fn(),
   getRequestConfigOption: jest.fn(),
 }));

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.ts
@@ -18,22 +18,9 @@ import { DiscoveryApi } from '@backstage/plugin-permission-common';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
 
-import { isAxiosError } from 'axios';
 import { dump } from 'js-yaml';
 
-import { getOrchestratorApi, getRequestConfigOption } from './utils';
-
-const getError = (err: unknown): Error => {
-  if (
-    isAxiosError<{ error: { message: string; name: string } }>(err) &&
-    err.response?.data?.error?.message
-  ) {
-    const error = new Error(err.response?.data?.error?.message);
-    error.name = err.response?.data?.error?.name || 'Error';
-    return error;
-  }
-  return err as Error;
-};
+import { getError, getOrchestratorApi, getRequestConfigOption } from './utils';
 
 const indentString = (str: string, indent: number) =>
   indent ? str.replace(/^/gm, ' '.repeat(indent)) : str;

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 
 import { createRunWorkflowAction } from './runWorkflow';
@@ -24,6 +25,7 @@ jest.mock('axios', () => ({
 }));
 
 jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
   getOrchestratorApi: jest.fn(),
   getRequestConfigOption: jest.fn(),
 }));
@@ -92,7 +94,6 @@ describe('createRunWorkflowAction', () => {
       templateInfo: {
         entityRef: 'component:default/sample-service',
       },
-      isDryRun: true,
       logger: {
         ...createMockActionContext().logger,
         info: loggerInfo,

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+
+import { createRunWorkflowAction } from './runWorkflow';
+import { getOrchestratorApi, getRequestConfigOption } from './utils';
+
+jest.mock('axios', () => ({
+  isAxiosError: (error: { isAxiosError?: boolean }) =>
+    Boolean(error?.isAxiosError),
+}));
+
+jest.mock('./utils', () => ({
+  getOrchestratorApi: jest.fn(),
+  getRequestConfigOption: jest.fn(),
+}));
+
+const mockedGetOrchestratorApi = jest.mocked(getOrchestratorApi);
+const mockedGetRequestConfigOption = jest.mocked(getRequestConfigOption);
+
+describe('createRunWorkflowAction', () => {
+  const discoveryService = {} as any;
+  const authService = {} as any;
+  const reqConfigOption = {
+    headers: {
+      Authorization: 'Bearer token',
+    },
+  };
+  const mockApi = {
+    executeWorkflow: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetOrchestratorApi.mockResolvedValue(mockApi as any);
+    mockedGetRequestConfigOption.mockResolvedValue(reqConfigOption as any);
+  });
+
+  it('throws when the template entity is missing', async () => {
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+        parameters: {},
+      },
+    });
+
+    await expect(action.handler(ctx)).rejects.toThrow('No template entity');
+    expect(mockedGetOrchestratorApi).not.toHaveBeenCalled();
+  });
+
+  it('throws when workflow_id is missing', async () => {
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        parameters: {},
+      },
+      templateInfo: {
+        entityRef: 'component:default/sample-service',
+      },
+    });
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      "Missing required 'workflow_id' input. Ensure that the step invoking the 'orchestrator:workflow:run' action includes an explicit 'workflow_id' field in its input.",
+    );
+    expect(mockedGetOrchestratorApi).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits dry runs before creating the orchestrator client', async () => {
+    const loggerInfo = jest.fn();
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+        parameters: {
+          greeting: 'hello',
+        },
+      },
+      templateInfo: {
+        entityRef: 'component:default/sample-service',
+      },
+      isDryRun: true,
+      logger: {
+        ...createMockActionContext().logger,
+        info: loggerInfo,
+      },
+    });
+    (ctx as typeof ctx & { isDryRun: boolean }).isDryRun = true;
+
+    await action.handler(ctx);
+
+    expect(loggerInfo).toHaveBeenCalledWith('Dry run complete');
+    expect(mockedGetOrchestratorApi).not.toHaveBeenCalled();
+    expect(mockedGetRequestConfigOption).not.toHaveBeenCalled();
+    expect(mockApi.executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('executes the workflow and outputs the instance url derived from the template entity', async () => {
+    mockApi.executeWorkflow.mockResolvedValue({
+      data: {
+        id: 'instance-123',
+      },
+    });
+
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+        parameters: {
+          greeting: 'hello',
+        },
+      },
+      templateInfo: {
+        entityRef: 'component:default/sample-service',
+      },
+    });
+
+    await action.handler(ctx);
+
+    expect(mockApi.executeWorkflow).toHaveBeenCalledWith(
+      'greeting',
+      {
+        inputData: {
+          greeting: 'hello',
+        },
+        targetEntity: 'component:default/sample-service',
+      },
+      reqConfigOption,
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'instanceUrl',
+      '/orchestrator/entity/default/component/sample-service/greeting/instance-123',
+    );
+  });
+
+  it('uses an explicit target entity when provided', async () => {
+    mockApi.executeWorkflow.mockResolvedValue({
+      data: {
+        id: 'instance-456',
+      },
+    });
+
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+        target_entity: 'resource:prod/database',
+        parameters: {
+          greeting: 'hello',
+        },
+      },
+      templateInfo: {
+        entityRef: 'component:default/sample-service',
+      },
+    });
+
+    await action.handler(ctx);
+
+    expect(mockApi.executeWorkflow).toHaveBeenCalledWith(
+      'greeting',
+      expect.objectContaining({
+        targetEntity: 'resource:prod/database',
+      }),
+      reqConfigOption,
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'instanceUrl',
+      '/orchestrator/entity/prod/resource/database/greeting/instance-456',
+    );
+  });
+
+  it('maps axios-shaped execution errors', async () => {
+    mockApi.executeWorkflow.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        data: {
+          error: {
+            message: 'Workflow start failed',
+            name: 'WorkflowExecutionError',
+          },
+        },
+      },
+    });
+
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+        parameters: {},
+      },
+      templateInfo: {
+        entityRef: 'component:default/sample-service',
+      },
+    });
+
+    await expect(action.handler(ctx)).rejects.toMatchObject({
+      message: 'Workflow start failed',
+      name: 'WorkflowExecutionError',
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.ts
@@ -17,21 +17,7 @@ import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryApi } from '@backstage/plugin-permission-common';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 
-import { isAxiosError } from 'axios';
-
-import { getOrchestratorApi, getRequestConfigOption } from './utils';
-
-const getError = (err: unknown): Error => {
-  if (
-    isAxiosError<{ error: { message: string; name: string } }>(err) &&
-    err.response?.data?.error?.message
-  ) {
-    const error = new Error(err.response?.data?.error?.message);
-    error.name = err.response?.data?.error?.name || 'Error';
-    return error;
-  }
-  return err as Error;
-};
+import { getError, getOrchestratorApi, getRequestConfigOption } from './utils';
 
 export function createRunWorkflowAction(
   discoveryService: DiscoveryApi,

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.ts
@@ -73,14 +73,14 @@ export function createRunWorkflowAction(
         );
       }
 
-      const api = await getOrchestratorApi(discoveryService);
-      const reqConfigOption = await getRequestConfigOption(authService, ctx);
-
       // If this is a dry run, log and return
       if (ctx.isDryRun) {
         ctx.logger.info(`Dry run complete`);
         return;
       }
+
+      const api = await getOrchestratorApi(discoveryService);
+      const reqConfigOption = await getRequestConfigOption(authService, ctx);
 
       try {
         const { data } = await api.executeWorkflow(

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/utils.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/utils.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AuthService } from '@backstage/backend-plugin-api';
+import { DiscoveryApi } from '@backstage/plugin-permission-common';
+
+import axios from 'axios';
+
+import {
+  Configuration,
+  DefaultApi,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { getError, getOrchestratorApi, getRequestConfigOption } from './utils';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(),
+  },
+  isAxiosError: (error: { isAxiosError?: boolean }) =>
+    Boolean(error?.isAxiosError),
+}));
+
+jest.mock(
+  '@red-hat-developer-hub/backstage-plugin-orchestrator-common',
+  () => ({
+    Configuration: jest.fn(),
+    DefaultApi: jest.fn(),
+  }),
+);
+
+const mockedAxios = jest.mocked(axios);
+const MockedConfiguration = jest.mocked(Configuration);
+const MockedDefaultApi = jest.mocked(DefaultApi);
+
+describe('utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getError', () => {
+    it('maps axios errors with orchestrator payloads to Error instances', () => {
+      const error = getError({
+        isAxiosError: true,
+        response: {
+          data: {
+            error: {
+              message: 'Workflow execution failed',
+              name: 'WorkflowError',
+            },
+          },
+        },
+      });
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Workflow execution failed');
+      expect(error.name).toBe('WorkflowError');
+    });
+
+    it('returns generic errors unchanged', () => {
+      const original = new Error('plain error');
+
+      expect(getError(original)).toBe(original);
+    });
+  });
+
+  describe('getOrchestratorApi', () => {
+    it('builds the orchestrator client from discovery base url', async () => {
+      const discoveryService = {
+        getBaseUrl: jest
+          .fn()
+          .mockResolvedValue('http://orchestrator.example.com'),
+      } as unknown as jest.Mocked<DiscoveryApi>;
+      const axiosInstance = { request: jest.fn() };
+      const apiInstance = { executeWorkflow: jest.fn() };
+
+      mockedAxios.create.mockReturnValue(axiosInstance as never);
+      MockedConfiguration.mockImplementation(() => ({}) as never);
+      MockedDefaultApi.mockImplementation(() => apiInstance as never);
+
+      const api = await getOrchestratorApi(discoveryService);
+
+      expect(discoveryService.getBaseUrl).toHaveBeenCalledWith('orchestrator');
+      expect(MockedConfiguration).toHaveBeenCalledWith({});
+      expect(mockedAxios.create).toHaveBeenCalledWith({
+        baseURL: 'http://orchestrator.example.com',
+      });
+      expect(MockedDefaultApi).toHaveBeenCalledWith(
+        expect.anything(),
+        'http://orchestrator.example.com',
+        axiosInstance,
+      );
+      expect(api).toBe(apiInstance);
+    });
+  });
+
+  describe('getRequestConfigOption', () => {
+    it('uses the plugin request token when auth service returns one', async () => {
+      const credentials = { principal: 'user:default/alice' };
+      const ctx = {
+        getInitiatorCredentials: jest.fn().mockResolvedValue(credentials),
+        secrets: {
+          backstageToken: 'fallback-token',
+        },
+      };
+      const authService = {
+        getPluginRequestToken: jest.fn().mockResolvedValue({
+          token: 'plugin-request-token',
+        }),
+      } as unknown as jest.Mocked<AuthService>;
+
+      const config = await getRequestConfigOption(authService, ctx);
+
+      expect(ctx.getInitiatorCredentials).toHaveBeenCalledTimes(1);
+      expect(authService.getPluginRequestToken).toHaveBeenCalledWith({
+        onBehalfOf: credentials,
+        targetPluginId: 'orchestrator',
+      });
+      expect(config).toEqual({
+        headers: {
+          Authorization: 'Bearer plugin-request-token',
+        },
+      });
+    });
+
+    it('falls back to the backstage secret when the auth service does not return a token', async () => {
+      const ctx = {
+        getInitiatorCredentials: jest.fn().mockResolvedValue({
+          principal: 'user:default/bob',
+        }),
+        secrets: {
+          backstageToken: 'fallback-token',
+        },
+      };
+      const authService = {
+        getPluginRequestToken: jest.fn().mockResolvedValue({
+          token: undefined,
+        }),
+      } as unknown as jest.Mocked<AuthService>;
+
+      const config = await getRequestConfigOption(authService, ctx);
+
+      expect(config).toEqual({
+        headers: {
+          Authorization: 'Bearer fallback-token',
+        },
+      });
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/utils.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/utils.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryApi } from '@backstage/plugin-permission-common';
 
@@ -87,9 +88,9 @@ describe('utils', () => {
       const axiosInstance = { request: jest.fn() };
       const apiInstance = { executeWorkflow: jest.fn() };
 
-      mockedAxios.create.mockReturnValue(axiosInstance as never);
-      MockedConfiguration.mockImplementation(() => ({}) as never);
-      MockedDefaultApi.mockImplementation(() => apiInstance as never);
+      mockedAxios.create.mockReturnValue(axiosInstance as any);
+      MockedConfiguration.mockImplementation(() => ({}) as any);
+      MockedDefaultApi.mockImplementation(() => apiInstance as any);
 
       const api = await getOrchestratorApi(discoveryService);
 
@@ -149,6 +150,28 @@ describe('utils', () => {
         getPluginRequestToken: jest.fn().mockResolvedValue({
           token: undefined,
         }),
+      } as unknown as jest.Mocked<AuthService>;
+
+      const config = await getRequestConfigOption(authService, ctx);
+
+      expect(config).toEqual({
+        headers: {
+          Authorization: 'Bearer fallback-token',
+        },
+      });
+    });
+
+    it('falls back to the backstage secret when the auth service returns undefined', async () => {
+      const ctx = {
+        getInitiatorCredentials: jest.fn().mockResolvedValue({
+          principal: 'user:default/bob',
+        }),
+        secrets: {
+          backstageToken: 'fallback-token',
+        },
+      };
+      const authService = {
+        getPluginRequestToken: jest.fn().mockResolvedValue(undefined),
       } as unknown as jest.Mocked<AuthService>;
 
       const config = await getRequestConfigOption(authService, ctx);

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/utils.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/utils.ts
@@ -52,10 +52,11 @@ export const getRequestConfigOption = async (
   authService: AuthService,
   ctx: any,
 ) => {
-  const { token } = (await authService.getPluginRequestToken({
+  const tokenResponse = await authService.getPluginRequestToken({
     onBehalfOf: await ctx.getInitiatorCredentials(),
     targetPluginId: 'orchestrator',
-  })) ?? { token: ctx.secrets?.backstageToken };
+  });
+  const token = tokenResponse?.token ?? ctx.secrets?.backstageToken;
 
   const reqConfigOption: AxiosRequestConfig = {
     headers: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Unit test coverage for scaffolder-backend-module-orchestrator
- Adds unit tests for utils, getWorkflowParams, and runWorkflow actions. 
- Fixes undefined token fallback in utils and dry-run early return in runWorkflow.

Closes: https://redhat.atlassian.net/browse/RHIDP-9861
