### PR TITLE
chore(deps): [orchestrator][release-1.10] bump undici to 7.28.0 or higher

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-backend-module-loki/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-backend-module-loki/package.json
@@ -42,7 +42,7 @@
     "@red-hat-developer-hub/backstage-plugin-orchestrator-common": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-orchestrator-node": "workspace:^",
     "luxon": "^3.7.2",
-    "undici": "^7.24.0"
+    "undici": "7.28.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.1",

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -13275,7 +13275,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-orchestrator-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-orchestrator-node": "workspace:^"
     luxon: "npm:^3.7.2"
-    undici: "npm:^7.24.0"
+    undici: "npm:7.28.0"
   languageName: unknown
   linkType: soft
 
@@ -38726,10 +38726,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.24.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+"undici@npm:7.28.0, undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It bumps undici to 7.28.0 or higher to fix CVE-2026-12151,CVE-2026-9697,CVE-2026-6734