### PR TITLE
fix(orchestrator): prevent card overlap when workflow instance cardHeightMode is content

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-workflow-instance-content-layout.md
+++ b/workspaces/orchestrator/.changeset/fix-workflow-instance-content-layout.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix workflow instance page layout overlap when `cardHeightMode` is set to `content`.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInputs.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInputs.tsx
@@ -23,8 +23,26 @@ import {
   StructuredMetadataTable,
 } from '@backstage/core-components';
 
+import { makeStyles } from 'tss-react/mui';
+
 import { useTranslation } from '../../hooks/useTranslation';
 import { formatMetadataForDisplay } from '../../utils/formatMetadataForDisplay';
+
+const useStyles = makeStyles()(() => ({
+  metadataTable: {
+    minWidth: 0,
+    maxWidth: '100%',
+    overflowX: 'auto',
+    '& table': {
+      tableLayout: 'fixed',
+      width: '100%',
+    },
+    '& td': {
+      wordBreak: 'break-word',
+      whiteSpace: 'normal',
+    },
+  },
+}));
 
 export const WorkflowInputs: FC<{
   className: string;
@@ -34,6 +52,7 @@ export const WorkflowInputs: FC<{
   cardClassName: string;
 }> = ({ className, value, loading, responseError, cardClassName }) => {
   const { t } = useTranslation();
+  const { classes } = useStyles();
   const inputs = value?.data;
   const displayInputs = useMemo(
     () => (inputs ? formatMetadataForDisplay(inputs) : inputs),
@@ -58,7 +77,9 @@ export const WorkflowInputs: FC<{
       )}
 
       {!loading && !responseError && displayInputs && (
-        <StructuredMetadataTable dense metadata={displayInputs} />
+        <div className={classes.metadataTable}>
+          <StructuredMetadataTable dense metadata={displayInputs} />
+        </div>
       )}
     </InfoCard>
   );

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePageContent.tsx
@@ -21,6 +21,7 @@ import { Content, InfoCard, Link } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { usePermission } from '@backstage/plugin-permission-react';
 
+import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { DateTime } from 'luxon';
@@ -80,7 +81,7 @@ export const mapProcessInstanceToDetails = (
   };
 };
 
-const useStyles = makeStyles()(() => ({
+const useStyles = makeStyles()(theme => ({
   topRowCard: {
     height: '24rem',
   },
@@ -95,6 +96,31 @@ const useStyles = makeStyles()(() => ({
   recommendedLabel: { margin: '0 0.25rem' },
   cardClassName: {
     overflow: 'auto',
+  },
+  contentModeCard: {
+    width: '100%',
+    maxWidth: '100%',
+    minWidth: 0,
+  },
+  contentCardOverflow: {
+    minWidth: 0,
+    maxWidth: '100%',
+    overflowX: 'auto',
+    wordBreak: 'break-word',
+  },
+  contentModeLayout: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+    gap: theme.spacing(2),
+    width: '100%',
+    alignItems: 'start',
+  },
+  contentModeColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    minWidth: 0,
+    maxWidth: '100%',
   },
   titleContainer: {
     display: 'flex',
@@ -116,7 +142,12 @@ export const WorkflowInstancePageContent: React.FC<{
   const isFixedHeightMode = cardHeightMode !== 'content';
   const topRowClassName = isFixedHeightMode ? classes.topRowCard : '';
   const bottomRowClassName = isFixedHeightMode ? classes.bottomRowCard : '';
-  const cardOverflowClassName = isFixedHeightMode ? classes.cardClassName : '';
+  const cardOverflowClassName = isFixedHeightMode
+    ? classes.cardClassName
+    : classes.contentCardOverflow;
+  const contentModeCardClassName = isFixedHeightMode
+    ? ''
+    : classes.contentModeCard;
 
   const details = useMemo(
     () => mapProcessInstanceToDetails(instance, t),
@@ -186,7 +217,7 @@ export const WorkflowInstancePageContent: React.FC<{
         </div>
       }
       divider={false}
-      className={topRowClassName}
+      className={`${topRowClassName} ${contentModeCardClassName}`.trim()}
       cardClassName={cardOverflowClassName}
     >
       <WorkflowRunDetails details={details} />
@@ -195,7 +226,7 @@ export const WorkflowInstancePageContent: React.FC<{
 
   const resultCard = (
     <WorkflowResult
-      className={topRowClassName}
+      className={`${topRowClassName} ${contentModeCardClassName}`.trim()}
       cardClassName={cardOverflowClassName}
       instance={instance}
     />
@@ -203,7 +234,7 @@ export const WorkflowInstancePageContent: React.FC<{
 
   const inputsCard = (
     <WorkflowInputs
-      className={bottomRowClassName}
+      className={`${bottomRowClassName} ${contentModeCardClassName}`.trim()}
       cardClassName={cardOverflowClassName}
       value={value}
       loading={loading}
@@ -215,7 +246,7 @@ export const WorkflowInstancePageContent: React.FC<{
     <InfoCard
       title={t('workflow.progress')}
       divider={false}
-      className={bottomRowClassName}
+      className={`${bottomRowClassName} ${contentModeCardClassName}`.trim()}
       cardClassName={cardOverflowClassName}
     >
       <WorkflowProgress
@@ -236,34 +267,32 @@ export const WorkflowInstancePageContent: React.FC<{
       <Grid container spacing={2}>
         {isFixedHeightMode ? (
           <>
-            <Grid item xs={6}>
+            <Grid item xs={6} zeroMinWidth>
               {detailsCard}
             </Grid>
-            <Grid item xs={6}>
+            <Grid item xs={6} zeroMinWidth>
               {resultCard}
             </Grid>
-            <Grid item xs={6}>
+            <Grid item xs={6} zeroMinWidth>
               {inputsCard}
             </Grid>
-            <Grid item xs={6}>
+            <Grid item xs={6} zeroMinWidth>
               {progressCard}
             </Grid>
           </>
         ) : (
-          <>
-            <Grid item xs={6}>
-              <Grid container spacing={2} direction="column">
-                <Grid item>{detailsCard}</Grid>
-                <Grid item>{inputsCard}</Grid>
-              </Grid>
-            </Grid>
-            <Grid item xs={6}>
-              <Grid container spacing={2} direction="column">
-                <Grid item>{resultCard}</Grid>
-                <Grid item>{progressCard}</Grid>
-              </Grid>
-            </Grid>
-          </>
+          <Grid item xs={12}>
+            <Box className={classes.contentModeLayout}>
+              <Box className={classes.contentModeColumn}>
+                {detailsCard}
+                {inputsCard}
+              </Box>
+              <Box className={classes.contentModeColumn}>
+                {resultCard}
+                {progressCard}
+              </Box>
+            </Box>
+          </Grid>
         )}
       </Grid>
     </Content>

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -69,6 +69,8 @@ const useStyles = makeStyles()(theme => ({
     flexDirection: 'column',
     gap: theme.spacing(2),
     width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
   },
   outputGrid: {
     '& h2': {
@@ -80,6 +82,17 @@ const useStyles = makeStyles()(theme => ({
     padding: '0px',
   },
   values: {
+    minWidth: 0,
+    maxWidth: '100%',
+    overflowX: 'auto',
+    '& table': {
+      tableLayout: 'fixed',
+      width: '100%',
+    },
+    '& td': {
+      wordBreak: 'break-word',
+      whiteSpace: 'normal',
+    },
     '& tr > td': {
       paddingLeft: '0px',
     },

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowRunDetails.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowRunDetails.tsx
@@ -75,7 +75,12 @@ export const WorkflowRunDetails: FC<WorkflowDetailsCardProps> = ({
   const workflowPageLink = useRouteRef(workflowRouteRef);
 
   return (
-    <Grid container alignContent="flex-start" spacing="1rem">
+    <Grid
+      container
+      alignContent="flex-start"
+      spacing="1rem"
+      sx={{ minWidth: 0 }}
+    >
       <Grid item md={7} key="Workflow">
         <AboutField label={t('workflow.fields.workflow')}>
           <Link to={workflowPageLink({ workflowId: details.workflowId })}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3429

## Summary
- Fixes layout overlap on the workflow run page when `orchestrator.workflowInstancePage.cardHeightMode` is set to `content`
- Replaces the nested MUI Grid layout with a CSS Grid two-column layout using `minmax(0, 1fr)` so left and right columns stay within their boundaries
- Constrains metadata tables in Results and Inputs cards so long values wrap or scroll instead of bleeding into adjacent cards
Fixes customer-reported regression after #2386 where Details/Inputs content overlapped the Results and Workflow progress cards.

-------------------

### Screen recordings

#### RHDH


https://github.com/user-attachments/assets/89bb70c6-a45c-455c-9e7c-5f09ed5b3c61


https://github.com/user-attachments/assets/b5ae2404-e60a-4ab8-9116-06bf0bb2f169

-------------------

#### rhdh-plugins


https://github.com/user-attachments/assets/d22fea69-9455-4f97-adbd-54557725b64d


https://github.com/user-attachments/assets/6150767e-df25-4865-ad9b-c5b91fa64a25


-------------------





## How to test

### Setup

1. In `app-config.yaml` (or `app-config.local.yaml`), set:
   ```yaml
   orchestrator:
     workflowInstancePage:
       cardHeightMode: content
2. Restart the backend so the config is picked up.

Test cases
1. Content mode — no overlap (primary fix)
Open a workflow run with nested inputs and/or long result content (e.g. Test Nested Review, GCP Kubernetes-style composite run, or any run with long URLs/image digests).
Confirm the page shows two clean columns:
Left: Details, then Inputs (stacked)
Right: Results, then Workflow progress (stacked)
No cards overlap or bleed into each other

2. Fixed mode — no regression
Set cardHeightMode: fixed (or remove the config; default is fixed).
Open the same workflow run.
Confirm the original 2×2 grid layout still works with fixed card heights and internal scrolling.

3. Long content stress test
With cardHeightMode: content, use a run that has:
Lengthy “What to do next” markdown in Results
Long container image digests or nested input objects
Confirm Results card grows vertically as needed without breaking column alignment.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
