### PR TITLE
test(orchestrator): add backend plugin unit test coverage

### DIFF
--- a/workspaces/orchestrator/.changeset/rhidp-9858-backend-tests.md
+++ b/workspaces/orchestrator/.changeset/rhidp-9858-backend-tests.md
@@ -1,5 +1,0 @@
----
-'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
----
-
-Added unit test coverage for orchestrator backend plugin services and helpers.

--- a/workspaces/orchestrator/.changeset/rhidp-9858-backend-tests.md
+++ b/workspaces/orchestrator/.changeset/rhidp-9858-backend-tests.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-backend': patch
+---
+
+Added unit test coverage for orchestrator backend plugin services and helpers.

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/errorBuilder.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/errorBuilder.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ErrorBuilder,
+  NO_CLIENT_PROVIDED,
+  NO_DATA_INDEX_URL,
+  NO_LOG_STORAGE_URL,
+  SWF_BACKEND_NOT_INITED,
+} from './errorBuilder';
+
+describe('ErrorBuilder', () => {
+  describe('NewBackendError', () => {
+    it('should create an Error with custom name and message', () => {
+      const errorName = 'CUSTOM_ERROR';
+      const errorMessage = 'This is a custom error message';
+
+      const error = ErrorBuilder.NewBackendError(errorName, errorMessage);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe(errorName);
+      expect(error.message).toBe(errorMessage);
+    });
+
+    it('should create an Error with empty message', () => {
+      const errorName = 'EMPTY_MESSAGE_ERROR';
+      const errorMessage = '';
+
+      const error = ErrorBuilder.NewBackendError(errorName, errorMessage);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe(errorName);
+      expect(error.message).toBe('');
+    });
+  });
+
+  describe('GET_NO_LOG_STORAGE_URL_ERR', () => {
+    it('should return an error with NO_LOG_STORAGE_URL name', () => {
+      const error = ErrorBuilder.GET_NO_LOG_STORAGE_URL_ERR();
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe(NO_LOG_STORAGE_URL);
+      expect(error.message).toBe('No log storage url specified or found');
+    });
+  });
+
+  describe('GET_NO_DATA_INDEX_URL_ERR', () => {
+    it('should return an error with NO_DATA_INDEX_URL name', () => {
+      const error = ErrorBuilder.GET_NO_DATA_INDEX_URL_ERR();
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe(NO_DATA_INDEX_URL);
+      expect(error.message).toBe('No data index url specified or found');
+    });
+  });
+
+  describe('GET_NO_CLIENT_PROVIDED_ERR', () => {
+    it('should return an error with NO_CLIENT_PROVIDED name', () => {
+      const error = ErrorBuilder.GET_NO_CLIENT_PROVIDED_ERR();
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe(NO_CLIENT_PROVIDED);
+      expect(error.message).toBe('No or null graphql client');
+    });
+  });
+
+  describe('GET_SWF_BACKEND_NOT_INITED', () => {
+    it('should return an error with SWF_BACKEND_NOT_INITED name', () => {
+      const error = ErrorBuilder.GET_SWF_BACKEND_NOT_INITED();
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe(SWF_BACKEND_NOT_INITED);
+      expect(error.message).toBe(
+        'The SonataFlow backend is not initialized, call initialize() method before trying to get the workflows.',
+      );
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/providers/WorkflowLogsProvidersRegistry.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/providers/WorkflowLogsProvidersRegistry.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConflictError, NotFoundError } from '@backstage/errors';
+
+import { WorkflowLogsProvidersRegistry } from './WorkflowLogsProvidersRegistry';
+
+describe('WorkflowLogsProvidersRegistry', () => {
+  let registry: WorkflowLogsProvidersRegistry;
+
+  beforeEach(() => {
+    registry = new WorkflowLogsProvidersRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a provider successfully', () => {
+      const mockProvider = {
+        getProviderId: () => 'test-provider',
+        getWorkflowLogs: jest.fn(),
+      };
+
+      registry.register(mockProvider as any);
+
+      expect(registry.getProvider('test-provider')).toBe(mockProvider);
+    });
+
+    it('should allow multiple providers with different IDs', () => {
+      const provider1 = {
+        getProviderId: () => 'provider-1',
+        getWorkflowLogs: jest.fn(),
+      };
+      const provider2 = {
+        getProviderId: () => 'provider-2',
+        getWorkflowLogs: jest.fn(),
+      };
+
+      registry.register(provider1 as any);
+      registry.register(provider2 as any);
+
+      expect(registry.getProvider('provider-1')).toBe(provider1);
+      expect(registry.getProvider('provider-2')).toBe(provider2);
+    });
+
+    it('should throw ConflictError when registering provider with duplicate ID', () => {
+      const provider1 = {
+        getProviderId: () => 'test-provider',
+        getWorkflowLogs: jest.fn(),
+      };
+      const provider2 = {
+        getProviderId: () => 'test-provider',
+        getWorkflowLogs: jest.fn(),
+      };
+
+      registry.register(provider1 as any);
+
+      expect(() => registry.register(provider2 as any)).toThrow(ConflictError);
+      expect(() => registry.register(provider2 as any)).toThrow(
+        'Workflow Log Provider with ID test-provider has already been registered',
+      );
+    });
+  });
+
+  describe('getProvider', () => {
+    it('should throw NotFoundError for non-existent provider', () => {
+      expect(() => registry.getProvider('non-existent')).toThrow(NotFoundError);
+      expect(() => registry.getProvider('non-existent')).toThrow(
+        "Workflow Log Provider with ID 'non-existent' is not registered",
+      );
+    });
+
+    it('should return the correct provider by ID', () => {
+      const mockProvider = {
+        getProviderId: () => 'loki-provider',
+        getWorkflowLogs: jest.fn(),
+      };
+
+      registry.register(mockProvider as any);
+
+      expect(registry.getProvider('loki-provider')).toBe(mockProvider);
+    });
+
+    it('should be case-sensitive when getting providers', () => {
+      const mockProvider = {
+        getProviderId: () => 'TestProvider',
+        getWorkflowLogs: jest.fn(),
+      };
+
+      registry.register(mockProvider as any);
+
+      expect(registry.getProvider('TestProvider')).toBe(mockProvider);
+      expect(() => registry.getProvider('testprovider')).toThrow(NotFoundError);
+    });
+  });
+
+  describe('listProviders', () => {
+    it('should return empty array when no providers are registered', () => {
+      expect(registry.listProviders()).toEqual([]);
+    });
+
+    it('should return all registered providers', () => {
+      const provider1 = {
+        getProviderId: () => 'provider-1',
+        getWorkflowLogs: jest.fn(),
+      };
+      const provider2 = {
+        getProviderId: () => 'provider-2',
+        getWorkflowLogs: jest.fn(),
+      };
+      const provider3 = {
+        getProviderId: () => 'provider-3',
+        getWorkflowLogs: jest.fn(),
+      };
+
+      registry.register(provider1 as any);
+      registry.register(provider2 as any);
+      registry.register(provider3 as any);
+
+      const providers = registry.listProviders();
+      expect(providers).toHaveLength(3);
+      expect(providers).toContain(provider1);
+      expect(providers).toContain(provider2);
+      expect(providers).toContain(provider3);
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DataInputSchemaService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DataInputSchemaService.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WORKFLOW_DATA_KEY } from './constants';
+import { DataInputSchemaService } from './DataInputSchemaService';
+
+describe('DataInputSchemaService', () => {
+  let service: DataInputSchemaService;
+
+  beforeEach(() => {
+    service = new DataInputSchemaService();
+  });
+
+  describe('extractWorkflowData', () => {
+    it('should extract workflow data when WORKFLOW_DATA_KEY is present', () => {
+      const workflowData = {
+        name: 'Test Workflow',
+        version: '1.0.0',
+        parameters: { param1: 'value1' },
+      };
+      const variables = {
+        [WORKFLOW_DATA_KEY]: workflowData,
+        otherKey: 'other value',
+      };
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toEqual(workflowData);
+    });
+
+    it('should return undefined when WORKFLOW_DATA_KEY is not present', () => {
+      const variables = {
+        someKey: 'some value',
+        anotherKey: 'another value',
+      };
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when variables is undefined', () => {
+      const result = service.extractWorkflowData(undefined);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when variables is an empty object', () => {
+      const variables = {};
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should extract workflow data when it is an empty object', () => {
+      const variables = {
+        [WORKFLOW_DATA_KEY]: {},
+      };
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toEqual({});
+    });
+
+    it('should extract workflow data when it contains nested objects', () => {
+      const workflowData = {
+        level1: {
+          level2: {
+            level3: 'deep value',
+          },
+        },
+        array: [1, 2, 3],
+      };
+      const variables = {
+        [WORKFLOW_DATA_KEY]: workflowData,
+      };
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toEqual(workflowData);
+    });
+
+    it('should extract workflow data when it is null', () => {
+      const variables = {
+        [WORKFLOW_DATA_KEY]: null,
+      };
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toBeNull();
+    });
+
+    it('should extract workflow data when it contains arrays', () => {
+      const workflowData = ['item1', 'item2', 'item3'];
+      const variables = {
+        [WORKFLOW_DATA_KEY]: workflowData,
+      };
+
+      const result = service.extractWorkflowData(variables);
+
+      expect(result).toEqual(workflowData);
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DevModeService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DevModeService.test.ts
@@ -1,0 +1,481 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import type { Config } from '@backstage/config';
+
+import {
+  DEFAULT_SONATAFLOW_BASE_URL,
+  DEFAULT_SONATAFLOW_CONTAINER_IMAGE,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
+import { DevModeService } from './DevModeService';
+
+jest.mock('child_process');
+jest.mock('fs-extra');
+jest.mock('./GitService');
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+const flushPromises = () => new Promise(resolve => process.nextTick(resolve));
+
+describe('DevModeService', () => {
+  let mockLogger: jest.Mocked<LoggerService>;
+  let mockConfig: jest.Mocked<Config>;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalFetch = global.fetch;
+
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    mockConfig = {
+      getOptionalString: jest.fn(),
+      getOptionalNumber: jest.fn(),
+      getOptionalConfigArray: jest.fn().mockReturnValue([]),
+      getOptionalConfig: jest.fn(),
+      has: jest.fn(),
+      keys: jest.fn(),
+      get: jest.fn(),
+      getBoolean: jest.fn(),
+      getNumber: jest.fn(),
+      getString: jest.fn(),
+      getStringArray: jest.fn(),
+      getConfig: jest.fn(),
+      getConfigArray: jest.fn(),
+      getOptionalBoolean: jest.fn(),
+      getOptionalStringArray: jest.fn(),
+    } as unknown as jest.Mocked<Config>;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('constructor and devModeUrl', () => {
+    it('should construct with default values when config is empty', () => {
+      mockConfig.getOptionalString.mockReturnValue(undefined);
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+
+      expect(service.devModeUrl).toBe(DEFAULT_SONATAFLOW_BASE_URL);
+    });
+
+    it('should construct devModeUrl without port when port is not configured', () => {
+      const customHost = 'http://custom-host';
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl') return customHost;
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+
+      expect(service.devModeUrl).toBe(customHost);
+    });
+
+    it('should construct devModeUrl with port when port is configured', () => {
+      const customHost = 'http://custom-host';
+      const customPort = 8080;
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl') return customHost;
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(customPort);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+
+      expect(service.devModeUrl).toBe(`${customHost}:${customPort}`);
+    });
+
+    it('should use default container image when not configured', () => {
+      mockConfig.getOptionalString.mockReturnValue(undefined);
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+
+      expect(service).toBeDefined();
+      expect(mockConfig.getOptionalString).toHaveBeenCalledWith(
+        'orchestrator.sonataFlowService.container',
+      );
+    });
+  });
+
+  describe('launchDevMode', () => {
+    it('should return true when SonataFlow is already running', async () => {
+      mockConfig.getOptionalString.mockReturnValue(undefined);
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+      });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const result = await service.launchDevMode();
+
+      expect(result).toBe(true);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('SonataFlow is up and running'),
+      );
+    });
+  });
+
+  describe('loadDevWorkflows', () => {
+    it('should skip loading when no repo URL configured', async () => {
+      mockConfig.getOptionalString.mockReturnValue(undefined);
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      await service.loadDevWorkflows();
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('No Git repository or path configured'),
+      );
+    });
+
+    it('should skip loading when no resource path configured', async () => {
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (
+          key ===
+          'orchestrator.sonataFlowService.workflowsSource.gitRepositoryUrl'
+        )
+          return 'https://github.com/test/repo.git';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      await service.loadDevWorkflows();
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('No Git repository or path configured'),
+      );
+    });
+  });
+
+  describe('extractConnectionConfig', () => {
+    it('should extract all configuration values correctly', () => {
+      const customHost = 'http://custom-host';
+      const customPort = 8080;
+      const customImage = 'custom-image:latest';
+      const customPath = '/custom/path';
+      const customPersistencePath = '/custom/persistence';
+      const customRepoUrl = 'https://github.com/test/repo.git';
+      const customToken = 'test-token';
+      const customNotificationsUrl = 'http://notifications';
+      const customRuntime = 'podman';
+
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl') return customHost;
+        if (key === 'orchestrator.sonataFlowService.container')
+          return customImage;
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return customPath;
+        if (key === 'orchestrator.sonataFlowService.persistence.path')
+          return customPersistencePath;
+        if (
+          key ===
+          'orchestrator.sonataFlowService.workflowsSource.gitRepositoryUrl'
+        )
+          return customRepoUrl;
+        if (key === 'orchestrator.sonataFlowService.notificationsBearerToken')
+          return customToken;
+        if (key === 'orchestrator.sonataFlowService.notificationsUrl')
+          return customNotificationsUrl;
+        if (key === 'orchestrator.sonataFlowService.runtime')
+          return customRuntime;
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(customPort);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+
+      expect(service.devModeUrl).toBe(`${customHost}:${customPort}`);
+      expect(mockConfig.getOptionalString).toHaveBeenCalledWith(
+        'orchestrator.sonataFlowService.baseUrl',
+      );
+      expect(mockConfig.getOptionalString).toHaveBeenCalledWith(
+        'orchestrator.sonataFlowService.container',
+      );
+      expect(mockConfig.getOptionalString).toHaveBeenCalledWith(
+        'orchestrator.sonataFlowService.workflowsSource.localPath',
+      );
+      expect(mockConfig.getOptionalString).toHaveBeenCalledWith(
+        'orchestrator.sonataFlowService.persistence.path',
+      );
+    });
+
+    it('should use default values when config is not provided', () => {
+      mockConfig.getOptionalString.mockReturnValue(undefined);
+      mockConfig.getOptionalNumber.mockReturnValue(undefined);
+
+      const service = new DevModeService(mockConfig, mockLogger);
+
+      expect(service.devModeUrl).toBe(DEFAULT_SONATAFLOW_BASE_URL);
+      expect(mockConfig.getOptionalString).toHaveBeenCalledWith(
+        'orchestrator.sonataFlowService.container',
+      );
+    });
+  });
+
+  describe('command generation with different configurations', () => {
+    it('should include persistence volume when configured', async () => {
+      const persistencePath = '/test/persistence';
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.persistence.path')
+          return persistencePath;
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Persistence is enabled'),
+      );
+
+      await launchPromise;
+    });
+
+    it('should not include persistence volume when not configured', async () => {
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      await service.launchDevMode();
+
+      await flushPromises();
+
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('Persistence is enabled'),
+      );
+    });
+
+    it('should use correct container runtime arguments for docker', async () => {
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.container')
+          return DEFAULT_SONATAFLOW_CONTAINER_IMAGE;
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'docker',
+        expect.arrayContaining([
+          'run',
+          '--name',
+          'backstage-internal-sonataflow',
+          '--add-host',
+          'host.docker.internal:host-gateway',
+        ]),
+        expect.objectContaining({
+          shell: false,
+        }),
+      );
+
+      await launchPromise;
+    });
+
+    it('should use correct container runtime arguments for podman', async () => {
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.container')
+          return DEFAULT_SONATAFLOW_CONTAINER_IMAGE;
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'podman';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'podman',
+        expect.arrayContaining([
+          'run',
+          '--name',
+          'backstage-internal-sonataflow',
+          '--replace',
+        ]),
+        expect.any(Object),
+      );
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).not.toContain('--add-host');
+
+      await launchPromise;
+    });
+
+    it('should include all required environment variables', async () => {
+      const port = 9090;
+      const token = 'test-bearer-token';
+      const notificationsUrl = 'http://notifications-service';
+
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.notificationsBearerToken')
+          return token;
+        if (key === 'orchestrator.sonataFlowService.notificationsUrl')
+          return notificationsUrl;
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(port);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+
+      expect(spawnArgs).toContain('-e');
+
+      const envVarString = spawnArgs.join(' ');
+      expect(envVarString).toContain(`QUARKUS_HTTP_PORT=${port}`);
+      expect(envVarString).toContain(
+        `KOGITO_SERVICE_URL=http://localhost:${port}`,
+      );
+      expect(envVarString).toContain(`NOTIFICATIONS_BEARER_TOKEN=${token}`);
+      expect(envVarString).toContain(
+        `BACKSTAGE_NOTIFICATIONS_URL=${notificationsUrl}`,
+      );
+      expect(envVarString).toContain(
+        'KOGITO.CODEGEN.PROCESS.FAILONERROR=false',
+      );
+
+      await launchPromise;
+    });
+
+    it('should mount volumes correctly', async () => {
+      const workflowsPath = '/test/workflows';
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return workflowsPath;
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const volumeFlag = spawnArgs.indexOf('-v');
+
+      expect(volumeFlag).toBeGreaterThan(-1);
+      expect(spawnArgs[volumeFlag + 1]).toMatch(new RegExp(`${workflowsPath}`));
+
+      await launchPromise;
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/GitService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/GitService.test.ts
@@ -174,7 +174,7 @@ describe('GitService', () => {
       mockGit.checkout.mockResolvedValue(undefined);
       mockGit.add.mockResolvedValue(undefined);
       mockGit.commit.mockResolvedValue('commit-sha');
-      mockGit.push.mockResolvedValue(undefined);
+      mockGit.push.mockResolvedValue({} as any);
 
       const service = new GitService(mockLogger, mockConfig);
       const dir = '/tmp/test-repo';
@@ -248,7 +248,7 @@ describe('GitService', () => {
 
       mockGit.fetch.mockResolvedValue(undefined);
       mockGit.checkout.mockResolvedValue(undefined);
-      mockGit.merge.mockResolvedValue(undefined);
+      mockGit.merge.mockResolvedValue({} as any);
 
       const service = new GitService(mockLogger, mockConfig);
       const localPath = '/tmp/test-repo';

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/GitService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/GitService.test.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import type { Config } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
+
+import { GitService } from './GitService';
+import { Git } from './GitWrapper';
+
+jest.mock('@backstage/integration');
+jest.mock('./GitWrapper');
+
+const flushPromises = () => new Promise(resolve => process.nextTick(resolve));
+
+describe('GitService', () => {
+  let mockLogger: jest.Mocked<LoggerService>;
+  let mockConfig: jest.Mocked<Config>;
+  let mockGit: jest.Mocked<Git>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    mockConfig = {} as jest.Mocked<Config>;
+
+    mockGit = {
+      clone: jest.fn(),
+      checkout: jest.fn(),
+      fetch: jest.fn(),
+      add: jest.fn(),
+      commit: jest.fn(),
+      push: jest.fn(),
+      merge: jest.fn(),
+    } as unknown as jest.Mocked<Git>;
+
+    (Git.fromAuth as jest.Mock).mockReturnValue(mockGit);
+  });
+
+  describe('constructor', () => {
+    it('should initialize with GitHub token when available', () => {
+      const mockToken = 'test-github-token';
+      const mockGithubIntegration = {
+        config: { token: mockToken },
+      };
+
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([mockGithubIntegration]),
+        },
+      });
+
+      const service = new GitService(mockLogger, mockConfig);
+
+      expect(service).toBeDefined();
+      expect(Git.fromAuth).toHaveBeenCalledWith({
+        username: 'x-access-token',
+        password: mockToken,
+      });
+    });
+
+    it('should initialize without authentication when no token available', () => {
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([]),
+        },
+      });
+
+      const service = new GitService(mockLogger, mockConfig);
+
+      expect(service).toBeDefined();
+      expect(Git.fromAuth).toHaveBeenCalledWith({
+        username: 'x-access-token',
+        password: undefined,
+      });
+    });
+  });
+
+  describe('clone', () => {
+    it('should clone repository and checkout main branch', async () => {
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([]),
+        },
+      });
+
+      mockGit.clone.mockResolvedValue(undefined);
+      mockGit.checkout.mockResolvedValue(undefined);
+
+      const service = new GitService(mockLogger, mockConfig);
+      const repoURL = 'https://github.com/test/repo.git';
+      const localPath = '/tmp/test-repo';
+
+      await service.clone(repoURL, localPath);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        `cloning repo ${repoURL} into ${localPath}`,
+      );
+      expect(mockGit.clone).toHaveBeenCalledWith({
+        url: repoURL,
+        dir: localPath,
+        depth: 1,
+      });
+      expect(mockGit.checkout).toHaveBeenCalledWith({
+        dir: localPath,
+        ref: 'main',
+      });
+    });
+
+    it('should handle clone errors', async () => {
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([]),
+        },
+      });
+
+      const cloneError = new Error('Clone failed');
+      mockGit.clone.mockRejectedValue(cloneError);
+
+      const service = new GitService(mockLogger, mockConfig);
+
+      await expect(
+        service.clone('https://github.com/test/repo.git', '/tmp/test-repo'),
+      ).rejects.toThrow('Clone failed');
+    });
+  });
+
+  describe('push', () => {
+    it('should warn and return early when not authenticated', async () => {
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([]),
+        },
+      });
+
+      const service = new GitService(mockLogger, mockConfig);
+      await service.push('/tmp/test-repo', 'Test commit');
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Git integration is required to be configured for push, with the token or credentials',
+      );
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should execute full push workflow when authenticated', async () => {
+      const mockToken = 'test-token';
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([{ config: { token: mockToken } }]),
+        },
+      });
+
+      mockGit.fetch.mockResolvedValue(undefined);
+      mockGit.checkout.mockResolvedValue(undefined);
+      mockGit.add.mockResolvedValue(undefined);
+      mockGit.commit.mockResolvedValue('commit-sha');
+      mockGit.push.mockResolvedValue(undefined);
+
+      const service = new GitService(mockLogger, mockConfig);
+      const dir = '/tmp/test-repo';
+      const message = 'Test commit message';
+
+      await service.push(dir, message);
+      await flushPromises();
+
+      expect(mockGit.fetch).toHaveBeenCalledWith({
+        remote: 'origin',
+        dir,
+      });
+      expect(mockGit.checkout).toHaveBeenCalledWith({
+        dir,
+        ref: 'main',
+      });
+      expect(mockGit.add).toHaveBeenCalledWith({
+        dir,
+        filepath: '.',
+      });
+      expect(mockGit.commit).toHaveBeenCalledWith({
+        dir,
+        message,
+        author: {
+          name: 'backstage-orchestrator',
+          email: 'orchestrator@backstage.io',
+        },
+        committer: {
+          name: 'backstage-orchestrator',
+          email: 'orchestrator@backstage.io',
+        },
+      });
+      expect(mockGit.push).toHaveBeenCalledWith({
+        dir,
+        remote: 'origin',
+        remoteRef: 'main',
+        force: true,
+      });
+    });
+
+    it('should handle push errors gracefully', async () => {
+      const mockToken = 'test-token';
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([{ config: { token: mockToken } }]),
+        },
+      });
+
+      const pushError = new Error('Push failed');
+      mockGit.fetch.mockResolvedValue(undefined);
+      mockGit.checkout.mockResolvedValue(undefined);
+      mockGit.add.mockResolvedValue(undefined);
+      mockGit.commit.mockResolvedValue('commit-sha');
+      mockGit.push.mockRejectedValue(pushError);
+
+      const service = new GitService(mockLogger, mockConfig);
+      await service.push('/tmp/test-repo', 'Test commit');
+      await flushPromises();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(pushError);
+    });
+  });
+
+  describe('pull', () => {
+    it('should execute full pull workflow', async () => {
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([]),
+        },
+      });
+
+      mockGit.fetch.mockResolvedValue(undefined);
+      mockGit.checkout.mockResolvedValue(undefined);
+      mockGit.merge.mockResolvedValue(undefined);
+
+      const service = new GitService(mockLogger, mockConfig);
+      const localPath = '/tmp/test-repo';
+
+      await service.pull(localPath);
+      await flushPromises();
+
+      expect(mockGit.fetch).toHaveBeenCalledWith({
+        remote: 'origin',
+        dir: localPath,
+      });
+      expect(mockGit.checkout).toHaveBeenCalledWith({
+        dir: localPath,
+        ref: 'main',
+      });
+      expect(mockGit.merge).toHaveBeenCalledWith({
+        dir: localPath,
+        ours: 'main',
+        theirs: 'origin/main',
+        author: {
+          name: 'backstage-orchestrator',
+          email: 'orchestrator@backstage.io',
+        },
+        committer: {
+          name: 'backstage-orchestrator',
+          email: 'orchestrator@backstage.io',
+        },
+      });
+    });
+
+    it('should handle pull errors gracefully', async () => {
+      (ScmIntegrations.fromConfig as jest.Mock).mockReturnValue({
+        github: {
+          list: jest.fn().mockReturnValue([]),
+        },
+      });
+
+      const pullError = new Error('Pull failed');
+      mockGit.fetch.mockResolvedValue(undefined);
+      mockGit.checkout.mockResolvedValue(undefined);
+      mockGit.merge.mockRejectedValue(pullError);
+
+      const service = new GitService(mockLogger, mockConfig);
+      await service.pull('/tmp/test-repo');
+      await flushPromises();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(pullError);
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/GitWrapper/git.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/GitWrapper/git.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Git } from './git';
+
+jest.mock('isomorphic-git');
+jest.mock('fs-extra');
+
+describe('Git', () => {
+  describe('fromAuth with StaticAuthOptions', () => {
+    it('should create Git instance with username and password', () => {
+      const git = Git.fromAuth({
+        username: 'test-user',
+        password: 'test-password',
+      });
+
+      expect(git).toBeInstanceOf(Git);
+    });
+
+    it('should create Git instance with token', () => {
+      const git = Git.fromAuth({
+        token: 'test-token',
+      });
+
+      expect(git).toBeInstanceOf(Git);
+    });
+
+    it('should create Git instance with username, password and token', () => {
+      const git = Git.fromAuth({
+        username: 'test-user',
+        password: 'test-password',
+        token: 'test-token',
+      });
+
+      expect(git).toBeInstanceOf(Git);
+    });
+
+    it('should create Git instance with no credentials', () => {
+      const git = Git.fromAuth({});
+
+      expect(git).toBeInstanceOf(Git);
+    });
+
+    it('should create Git instance with logger', () => {
+      const mockLogger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      };
+
+      const git = Git.fromAuth({
+        username: 'test-user',
+        password: 'test-password',
+        logger: mockLogger as any,
+      });
+
+      expect(git).toBeInstanceOf(Git);
+    });
+  });
+
+  describe('fromAuth with AuthCallbackOptions', () => {
+    it('should create Git instance with auth callback', () => {
+      const mockCallback = jest.fn();
+      const git = Git.fromAuth({
+        onAuth: mockCallback,
+      });
+
+      expect(git).toBeInstanceOf(Git);
+    });
+
+    it('should create Git instance with auth callback and logger', () => {
+      const mockCallback = jest.fn();
+      const mockLogger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      };
+
+      const git = Git.fromAuth({
+        onAuth: mockCallback,
+        logger: mockLogger as any,
+      });
+
+      expect(git).toBeInstanceOf(Git);
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/WorkflowCacheService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/WorkflowCacheService.test.ts
@@ -67,6 +67,9 @@ describe('WorkflowCacheService', () => {
       });
       mockSonataFlowService.pingWorkflowService.mockResolvedValue({
         isAvailable: true,
+        statusCode: 200,
+        urlToFetch: 'http://service',
+        reason: '',
       });
 
       const mockScheduler = {
@@ -96,8 +99,18 @@ describe('WorkflowCacheService', () => {
         'workflow-2': 'http://service2',
       });
       mockSonataFlowService.pingWorkflowService
-        .mockResolvedValueOnce({ isAvailable: true })
-        .mockResolvedValueOnce({ isAvailable: false });
+        .mockResolvedValueOnce({
+          isAvailable: true,
+          statusCode: 200,
+          urlToFetch: 'http://service',
+          reason: '',
+        })
+        .mockResolvedValueOnce({
+          isAvailable: false,
+          statusCode: 500,
+          urlToFetch: 'http://service',
+          reason: 'not available',
+        });
 
       const mockScheduler = {
         scheduleTask: jest.fn(({ fn }) => {
@@ -129,6 +142,9 @@ describe('WorkflowCacheService', () => {
       });
       mockSonataFlowService.pingWorkflowService.mockResolvedValue({
         isAvailable: true,
+        statusCode: 200,
+        urlToFetch: 'http://service',
+        reason: '',
       });
 
       const mockScheduler = {
@@ -147,6 +163,9 @@ describe('WorkflowCacheService', () => {
       mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({});
       mockSonataFlowService.pingWorkflowService.mockResolvedValue({
         isAvailable: true,
+        statusCode: 200,
+        urlToFetch: 'http://service',
+        reason: '',
       });
 
       const mockScheduler = {
@@ -214,6 +233,9 @@ describe('WorkflowCacheService', () => {
       });
       mockSonataFlowService.pingWorkflowService.mockResolvedValue({
         isAvailable: true,
+        statusCode: 200,
+        urlToFetch: 'http://service',
+        reason: '',
       });
 
       const mockScheduler = {
@@ -244,6 +266,9 @@ describe('WorkflowCacheService', () => {
         });
       mockSonataFlowService.pingWorkflowService.mockResolvedValue({
         isAvailable: true,
+        statusCode: 200,
+        urlToFetch: 'http://service',
+        reason: '',
       });
 
       let taskFn: () => Promise<void>;
@@ -269,6 +294,9 @@ describe('WorkflowCacheService', () => {
       });
       mockSonataFlowService.pingWorkflowService.mockResolvedValue({
         isAvailable: false,
+        statusCode: 500,
+        urlToFetch: 'http://service',
+        reason: 'not available',
       });
 
       const mockScheduler = {

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/WorkflowCacheService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/WorkflowCacheService.test.ts
@@ -1,0 +1,331 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  LoggerService,
+  SchedulerService,
+} from '@backstage/backend-plugin-api';
+
+import type { DataIndexService } from './DataIndexService';
+import type { SonataFlowService } from './SonataFlowService';
+import { WorkflowCacheService } from './WorkflowCacheService';
+
+const flushPromises = () => new Promise(resolve => process.nextTick(resolve));
+
+describe('WorkflowCacheService', () => {
+  let mockLogger: jest.Mocked<LoggerService>;
+  let mockDataIndexService: jest.Mocked<DataIndexService>;
+  let mockSonataFlowService: jest.Mocked<SonataFlowService>;
+  let service: WorkflowCacheService;
+
+  beforeEach(() => {
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    mockDataIndexService = {
+      fetchWorkflowServiceUrls: jest.fn(),
+    } as unknown as jest.Mocked<DataIndexService>;
+
+    mockSonataFlowService = {
+      pingWorkflowService: jest.fn(),
+    } as unknown as jest.Mocked<SonataFlowService>;
+
+    service = new WorkflowCacheService(
+      mockLogger,
+      mockDataIndexService,
+      mockSonataFlowService,
+    );
+  });
+
+  describe('definitionIds getter', () => {
+    it('should return empty array initially', () => {
+      expect(service.definitionIds).toEqual([]);
+    });
+
+    it('should return cached definition IDs as array', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({
+        'workflow-1': 'http://service1',
+        'workflow-2': 'http://service2',
+      });
+      mockSonataFlowService.pingWorkflowService.mockResolvedValue({
+        isAvailable: true,
+      });
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      const ids = service.definitionIds;
+      expect(ids).toContain('workflow-1');
+      expect(ids).toContain('workflow-2');
+      expect(ids).toHaveLength(2);
+    });
+  });
+
+  describe('unavailableDefinitionIds getter', () => {
+    it('should return empty array initially', () => {
+      expect(service.unavailableDefinitionIds).toEqual([]);
+    });
+
+    it('should return unavailable workflow IDs as array', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({
+        'workflow-1': 'http://service1',
+        'workflow-2': 'http://service2',
+      });
+      mockSonataFlowService.pingWorkflowService
+        .mockResolvedValueOnce({ isAvailable: true })
+        .mockResolvedValueOnce({ isAvailable: false });
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      const unavailableIds = service.unavailableDefinitionIds;
+      expect(unavailableIds).toContain('workflow-2');
+      expect(unavailableIds).toHaveLength(1);
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('should return false when definitionId is undefined', () => {
+      expect(service.isAvailable(undefined)).toBe(false);
+    });
+
+    it('should return false when definitionId is not in cache', () => {
+      expect(service.isAvailable('non-existent-workflow')).toBe(false);
+    });
+
+    it('should return true when definitionId is in cache', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({
+        'workflow-1': 'http://service1',
+      });
+      mockSonataFlowService.pingWorkflowService.mockResolvedValue({
+        isAvailable: true,
+      });
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      expect(service.isAvailable('workflow-1')).toBe(true);
+    });
+
+    it('should throw error when cache handler is "throw" and workflow not available', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({});
+      mockSonataFlowService.pingWorkflowService.mockResolvedValue({
+        isAvailable: true,
+      });
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      expect(() => service.isAvailable('missing-workflow', 'throw')).toThrow(
+        'Workflow service "missing-workflow" not available at the moment',
+      );
+    });
+
+    it('should not throw when cache handler is "skip" and workflow not available', () => {
+      expect(() =>
+        service.isAvailable('missing-workflow', 'skip'),
+      ).not.toThrow();
+      expect(service.isAvailable('missing-workflow', 'skip')).toBe(false);
+    });
+  });
+
+  describe('schedule', () => {
+    it('should schedule task with default frequency and timeout', () => {
+      const mockScheduler = {
+        scheduleTask: jest.fn(),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+
+      expect(mockScheduler.scheduleTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'task__Orchestrator__WorkflowCacheService',
+          frequency: { seconds: 5 },
+          timeout: { minutes: 10 },
+          fn: expect.any(Function),
+        }),
+      );
+    });
+
+    it('should schedule task with custom frequency and timeout', () => {
+      const mockScheduler = {
+        scheduleTask: jest.fn(),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({
+        scheduler: mockScheduler,
+        frequencyInSeconds: 30,
+        timeoutInMinutes: 5,
+      });
+
+      expect(mockScheduler.scheduleTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          frequency: { seconds: 30 },
+          timeout: { minutes: 5 },
+        }),
+      );
+    });
+
+    it('should handle task execution and update cache', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({
+        'workflow-1': 'http://service1',
+      });
+      mockSonataFlowService.pingWorkflowService.mockResolvedValue({
+        isAvailable: true,
+      });
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      expect(mockDataIndexService.fetchWorkflowServiceUrls).toHaveBeenCalled();
+      expect(mockSonataFlowService.pingWorkflowService).toHaveBeenCalledWith({
+        definitionId: 'workflow-1',
+        serviceUrl: 'http://service1',
+      });
+      expect(service.definitionIds).toContain('workflow-1');
+    });
+
+    it('should remove workflows no longer in data index', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls
+        .mockResolvedValueOnce({
+          'workflow-1': 'http://service1',
+          'workflow-2': 'http://service2',
+        })
+        .mockResolvedValueOnce({
+          'workflow-1': 'http://service1',
+        });
+      mockSonataFlowService.pingWorkflowService.mockResolvedValue({
+        isAvailable: true,
+      });
+
+      let taskFn: () => Promise<void>;
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          taskFn = fn;
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await taskFn!();
+      await flushPromises();
+      await taskFn!();
+      await flushPromises();
+
+      expect(service.definitionIds).toContain('workflow-1');
+      expect(service.definitionIds).not.toContain('workflow-2');
+    });
+
+    it('should move workflow to unavailable cache when ping fails', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({
+        'workflow-1': 'http://service1',
+      });
+      mockSonataFlowService.pingWorkflowService.mockResolvedValue({
+        isAvailable: false,
+      });
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      expect(service.unavailableDefinitionIds).toContain('workflow-1');
+      expect(service.definitionIds).not.toContain('workflow-1');
+    });
+
+    it('should handle ping service throwing error', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockResolvedValue({
+        'workflow-1': 'http://service1',
+      });
+      mockSonataFlowService.pingWorkflowService.mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Ping workflow workflow-1 service threw error'),
+      );
+      expect(service.unavailableDefinitionIds).toContain('workflow-1');
+    });
+
+    it('should handle fetchWorkflowServiceUrls throwing error', async () => {
+      mockDataIndexService.fetchWorkflowServiceUrls.mockRejectedValue(
+        new Error('Data index error'),
+      );
+
+      const mockScheduler = {
+        scheduleTask: jest.fn(({ fn }) => {
+          fn();
+        }),
+      } as unknown as jest.Mocked<SchedulerService>;
+
+      service.schedule({ scheduler: mockScheduler });
+      await flushPromises();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Error running task__Orchestrator__WorkflowCacheService',
+        ),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Add unit tests for the orchestrator-backend plugin covering:
- ErrorBuilder helper (error factory methods)
- DataInputSchemaService (workflow data extraction)
- DevModeService (config, launch, command generation)
- WorkflowCacheService (scheduling, availability, cache ops)
- GitService (clone, push, pull operations)
- WorkflowLogsProvidersRegistry (register, get, list)
- Git wrapper (factory methods)

Resolves: RHIDP-9858

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes