### PR TITLE
fix(lightspeed): disable model selector during active chat session

### DIFF
--- a/workspaces/lightspeed/.changeset/quiet-lions-rest.md
+++ b/workspaces/lightspeed/.changeset/quiet-lions-rest.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Disable model selector during active chat session to prevent unintended new conversation creation when switching models

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightSpeedChat.tsx
@@ -1805,7 +1805,7 @@ export const LightspeedChat = ({
                 onNewChat();
                 handleSelectedModel(item);
               }}
-              disabled={isSendButtonDisabled}
+              disabled={isSendButtonDisabled || messages.length > 0}
             />
           }
           forceMultilineLayout
@@ -1977,7 +1977,9 @@ export const LightspeedChat = ({
             }}
             models={models}
             isPinningChatsEnabled={isPinningChatsEnabled}
-            isModelSelectorDisabled={isSendButtonDisabled}
+            isModelSelectorDisabled={
+              isSendButtonDisabled || messages.length > 0
+            }
             hideModelSelector
             showChatTabOptions={!showNotebooksPanel}
             setDisplayMode={setDisplayModeFromHeader}

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/MessageBarModelSelector.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/MessageBarModelSelector.tsx
@@ -23,6 +23,7 @@ import {
   DropdownList,
   MenuToggle,
   MenuToggleElement,
+  Tooltip,
 } from '@patternfly/react-core';
 import { AngleDownIcon } from '@patternfly/react-icons';
 
@@ -77,20 +78,32 @@ export const MessageBarModelSelector = ({
   const selectedModelLabel =
     models.find(m => m.value === selectedModel)?.label ?? selectedModel;
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={() => setIsOpen(!isOpen)}
-      isExpanded={isOpen}
-      isDisabled={disabled}
-      variant="plain"
-      className={classes.selectorToggle}
-      aria-label={t('aria.chatbotSelector')}
-    >
-      {selectedModelLabel}
-      <AngleDownIcon />
-    </MenuToggle>
-  );
+  const toggle = (toggleRef: Ref<MenuToggleElement>) => {
+    const menuToggle = (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={() => setIsOpen(!isOpen)}
+        isExpanded={isOpen}
+        isDisabled={disabled}
+        variant="plain"
+        className={classes.selectorToggle}
+        aria-label={t('aria.chatbotSelector')}
+      >
+        {selectedModelLabel}
+        <AngleDownIcon />
+      </MenuToggle>
+    );
+
+    if (disabled) {
+      return (
+        <Tooltip content={t('modelSelector.disabled.tooltip')}>
+          <span>{menuToggle}</span>
+        </Tooltip>
+      );
+    }
+
+    return menuToggle;
+  };
 
   return (
     <Dropdown

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/MessageBarModelSelector.test.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/__tests__/MessageBarModelSelector.test.tsx
@@ -235,4 +235,28 @@ describe('MessageBarModelSelector', () => {
 
     expect(screen.getByText('granite-3.3')).toBeInTheDocument();
   });
+
+  it('should show tooltip when disabled', async () => {
+    render(
+      <MessageBarModelSelector
+        selectedModel="granite-3.3"
+        models={mockModels}
+        onSelect={mockOnSelect}
+        disabled
+      />,
+    );
+
+    const toggleButton = screen.getByRole('button', {
+      name: 'Chatbot selector',
+    });
+    await userEvent.hover(toggleButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Each chat session supports only one model. To switch models, open a new chat.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/de.ts
@@ -171,6 +171,8 @@ const lightspeedTranslationDe = createTranslationMessages({
       'Administratoranmeldedaten werden verwendet. Geben Sie einen persönlichen Token ein, um ihn für Ihr Konto zu überschreiben.',
     'menu.newConversation': 'Neuer Chat',
     'message.options.label': 'Optionen',
+    'modelSelector.disabled.tooltip':
+      'Jede Chat-Sitzung unterstützt nur ein Modell. Um das Modell zu wechseln, starten Sie einen neuen Chat.',
     'modal.cancel': 'Abbrechen',
     'modal.close': 'Schließen',
     'modal.edit': 'Bearbeiten',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/es.ts
@@ -167,6 +167,8 @@ const lightspeedTranslationEs = createTranslationMessages({
       'Se están usando credenciales proporcionadas por el administrador. Introduce un token personal para reemplazarlas en tu cuenta.',
     'menu.newConversation': 'Nuevo chat',
     'message.options.label': 'Opciones',
+    'modelSelector.disabled.tooltip':
+      'Cada sesión de chat solo admite un modelo. Para cambiar de modelo, abre un nuevo chat.',
     'modal.cancel': 'Cancelar',
     'modal.close': 'Cerrar',
     'modal.edit': 'Modificar',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/fr.ts
@@ -171,6 +171,8 @@ const lightspeedTranslationFr = createTranslationMessages({
       'Les identifiants fournis par l’administrateur sont utilisés. Saisissez un jeton personnel pour les remplacer pour votre compte.',
     'menu.newConversation': 'Nouvelle Conversation',
     'message.options.label': 'Options',
+    'modelSelector.disabled.tooltip':
+      "Chaque session de chat ne prend en charge qu'un seul modèle. Pour changer de modèle, ouvrez un nouveau chat.",
     'modal.cancel': 'Annuler',
     'modal.close': 'Fermer',
     'modal.edit': 'Modifier',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/it.ts
@@ -169,6 +169,8 @@ const lightspeedTranslationIt = createTranslationMessages({
       "Sono in uso le credenziali fornite dall'amministratore. Inserisci un token personale per sovrascriverle per il tuo account.",
     'menu.newConversation': 'Nuova chat',
     'message.options.label': 'Opzioni',
+    'modelSelector.disabled.tooltip':
+      'Ogni sessione di chat supporta un solo modello. Per cambiare modello, apri una nuova chat.',
     'modal.cancel': 'Cancella',
     'modal.close': 'Chiudi',
     'modal.edit': 'Modifica',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ja.ts
@@ -166,6 +166,8 @@ const lightspeedTranslationJa = createTranslationMessages({
       '管理者が提供した認証情報を使用しています。アカウント用に上書きするには個人トークンを入力してください。',
     'menu.newConversation': '新しいチャット',
     'message.options.label': 'オプション',
+    'modelSelector.disabled.tooltip':
+      '各チャットセッションは1つのモデルのみをサポートしています。モデルを切り替えるには、新しいチャットを開いてください。',
     'modal.cancel': 'キャンセル',
     'modal.close': '閉じる',
     'modal.edit': '編集',

--- a/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/translations/ref.ts
@@ -217,6 +217,10 @@ export const lightspeedMessages = {
   'chatbox.fileUpload.infoText':
     'Supported file types are: .txt, .yaml, and .json. The maximum file size is 25 MB.',
 
+  // Model selector
+  'modelSelector.disabled.tooltip':
+    'Each chat session supports only one model. To switch models, open a new chat.',
+
   // Accessibility and ARIA labels
   'aria.chatbotSelector': 'Chatbot selector',
   'aria.important': 'Important',


### PR DESCRIPTION
## Description

Disables the model selector once a chat session is active (has messages) to prevent the user from inadvertently creating a new conversation by switching models mid-session. When disabled, hovering the selector shows a localized tooltip explaining: "Each chat session supports only one model. To switch models, open a new chat."

**Root cause:** The `MessageBarModelSelector`'s `disabled` prop was only set to `isSendButtonDisabled` (true only during streaming). Once streaming completed, the selector became clickable again. The `onSelect` handler always called `onNewChat()`, which created a new conversation instead of keeping the user in the current session.

## Fixed
- [RHDHBUGS-3313](https://redhat.atlassian.net/browse/RHDHBUGS-3313) — Lightspeed: Switching model in an active conversation incorrectly opens a new chat

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

Made with [Cursor](https://cursor.com)