### PR TITLE
fix(orchestrator): remove retrigger menu for aborted workflow runs

### DIFF
--- a/workspaces/orchestrator/.changeset/orchestrator-aborted-run-menu-revert.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-aborted-run-menu-revert.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Remove the retrigger dropdown menu for aborted workflow runs.

--- a/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report-alpha.api.md
@@ -364,7 +364,6 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.buttons.runAgain': string;
     readonly 'workflow.buttons.entireWorkflow': string;
     readonly 'workflow.buttons.fromFailurePoint': string;
-    readonly 'workflow.buttons.fromAbortedPoint': string;
     readonly 'workflow.buttons.runFailedAgain': string;
     readonly 'messages.noDataAvailable': string;
     readonly 'messages.noVariablesFound': string;
@@ -381,7 +380,6 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'tooltips.workflowDown': string;
     readonly 'tooltips.suspended': string;
     readonly 'tooltips.userNotAuthorizedAbort': string;
-    readonly 'tooltips.retriggerNotSupportedForAborted': string;
     readonly 'reviewStep.hiddenFieldsNote': string;
     readonly 'reviewStep.showHiddenParameters': string;
     readonly 'permissions.accessDenied': string;

--- a/workspaces/orchestrator/plugins/orchestrator/report.api.md
+++ b/workspaces/orchestrator/plugins/orchestrator/report.api.md
@@ -180,7 +180,6 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'workflow.buttons.runAgain': string;
     readonly 'workflow.buttons.entireWorkflow': string;
     readonly 'workflow.buttons.fromFailurePoint': string;
-    readonly 'workflow.buttons.fromAbortedPoint': string;
     readonly 'workflow.buttons.runFailedAgain': string;
     readonly 'messages.noDataAvailable': string;
     readonly 'messages.noVariablesFound': string;
@@ -197,7 +196,6 @@ export const orchestratorTranslationRef: TranslationRef<
     readonly 'tooltips.workflowDown': string;
     readonly 'tooltips.suspended': string;
     readonly 'tooltips.userNotAuthorizedAbort': string;
-    readonly 'tooltips.retriggerNotSupportedForAborted': string;
     readonly 'reviewStep.hiddenFieldsNote': string;
     readonly 'reviewStep.showHiddenParameters': string;
     readonly 'permissions.accessDenied': string;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
@@ -34,7 +34,6 @@ import { JsonObject } from '@backstage/types';
 import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
 import Close from '@mui/icons-material/Close';
 import Error from '@mui/icons-material/Error';
-import ReplayOutlined from '@mui/icons-material/ReplayOutlined';
 import Start from '@mui/icons-material/Start';
 import SwipeRightAltOutlined from '@mui/icons-material/SwipeRightAltOutlined';
 import Alert from '@mui/material/Alert';
@@ -424,12 +423,7 @@ export const WorkflowInstancePage = () => {
   const handleOptionClick = (option: 'retrigger' | 'rerun') => {
     handleCloseMenu();
     if (option === 'rerun') handleRerun();
-    else if (
-      option === 'retrigger' &&
-      value?.state !== ProcessInstanceStatusDTO.Aborted
-    ) {
-      handleRetrigger();
-    }
+    else if (option === 'retrigger') handleRetrigger();
   };
 
   const combinedError: Error | undefined = error || inputSchemaError;
@@ -471,27 +465,7 @@ export const WorkflowInstancePage = () => {
     return <ResponseErrorPanel error={combinedError} />;
   };
 
-  const showRerunMenu =
-    value?.state === ProcessInstanceStatusDTO.Error ||
-    value?.state === ProcessInstanceStatusDTO.Aborted;
-
-  const fromRecoveryPointLabel =
-    value?.state === ProcessInstanceStatusDTO.Aborted
-      ? t('workflow.buttons.fromAbortedPoint')
-      : t('workflow.buttons.fromFailurePoint');
-
-  const fromRecoveryPointIcon =
-    value?.state === ProcessInstanceStatusDTO.Aborted ? (
-      <ReplayOutlined />
-    ) : (
-      <SwipeRightAltOutlined />
-    );
-
-  const isAbortedRun = value?.state === ProcessInstanceStatusDTO.Aborted;
-  const retriggerFromPointDisabled = isAbortedRun || !inputSchema;
-  const retriggerFromPointTooltip = isAbortedRun
-    ? t('tooltips.retriggerNotSupportedForAborted')
-    : '';
+  const showRerunMenu = value?.state === ProcessInstanceStatusDTO.Error;
 
   return (
     <BaseOrchestratorPage
@@ -583,20 +557,13 @@ export const WorkflowInstancePage = () => {
                     <Start />
                     {t('workflow.buttons.entireWorkflow')}
                   </MenuItem>
-                  <Tooltip
-                    title={retriggerFromPointTooltip}
-                    disableHoverListener={!retriggerFromPointTooltip}
+                  <MenuItem
+                    onClick={() => handleOptionClick('retrigger')}
+                    disabled={!inputSchema}
                   >
-                    <Box component="span" sx={{ display: 'inline-flex' }}>
-                      <MenuItem
-                        onClick={() => handleOptionClick('retrigger')}
-                        disabled={retriggerFromPointDisabled}
-                      >
-                        {fromRecoveryPointIcon}
-                        {fromRecoveryPointLabel}
-                      </MenuItem>
-                    </Box>
-                  </Tooltip>
+                    <SwipeRightAltOutlined />
+                    {t('workflow.buttons.fromFailurePoint')}
+                  </MenuItem>
                 </Menu>
               </Grid>
             </Grid>

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -184,12 +184,9 @@ const orchestratorTranslationDe = createTranslationMessages({
       'Benutzer nicht berechtigt, den Workflow abzubrechen',
     'tooltips.userNotAuthorizedExecute':
       'Benutzer nicht berechtigt, Workflow auszuführen',
-    'tooltips.retriggerNotSupportedForAborted':
-      'Erneutes Auslösen vom Abbruchpunkt wird nicht unterstützt. Verwenden Sie „Gesamter Workflow“, um einen neuen Lauf mit denselben Eingaben zu starten.',
     'tooltips.workflowDown':
       'Der Workflow ist momentan nicht verfügbar oder befindet sich in einem Fehlerzustand.',
     'workflow.buttons.entireWorkflow': 'Gesamter Workflow',
-    'workflow.buttons.fromAbortedPoint': 'Vom Abbruchpunkt',
     'workflow.buttons.fromFailurePoint': 'Vom Versagenspunkt',
     'workflow.buttons.run': 'Laufen',
     'workflow.buttons.runAgain': 'Lauf erneut',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -188,12 +188,9 @@ const orchestratorTranslationEs = createTranslationMessages({
       'Usuario no autorizado para cancelar el flujo de trabajo',
     'tooltips.userNotAuthorizedExecute':
       'Usuario no autorizado para ejecutar el flujo de trabajo',
-    'tooltips.retriggerNotSupportedForAborted':
-      'No se admite la reactivación desde el punto de cancelación. Use Flujo de trabajo completo para iniciar una nueva ejecución con las mismas entradas.',
     'tooltips.workflowDown':
       'El flujo de trabajo está actualmente inactivo o en estado de error',
     'workflow.buttons.entireWorkflow': 'Flujo de trabajo completo',
-    'workflow.buttons.fromAbortedPoint': 'Desde el punto de cancelación',
     'workflow.buttons.fromFailurePoint': 'Desde el punto de fallo',
     'workflow.buttons.run': 'Ejecutar',
     'workflow.buttons.runAgain': 'Ejecutar nuevamente',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -187,12 +187,9 @@ const orchestratorTranslationFr = createTranslationMessages({
       "L'utilisateur n'est pas autorisé à interrompre le flux de travail.",
     'tooltips.userNotAuthorizedExecute':
       "L'utilisateur n'est pas autorisé à exécuter le flux de travail.",
-    'tooltips.retriggerNotSupportedForAborted':
-      "Le redéclenchement à partir du point d'interruption n'est pas pris en charge. Utilisez Flux de travail entier pour démarrer une nouvelle exécution avec les mêmes entrées.",
     'tooltips.workflowDown':
       "Le flux de travail est actuellement indisponible ou en état d'erreur.",
     'workflow.buttons.entireWorkflow': 'Flux de travail entier',
-    'workflow.buttons.fromAbortedPoint': "À partir du point d'interruption",
     'workflow.buttons.fromFailurePoint': 'À partir du point de défaillance',
     'workflow.buttons.run': 'Exécuter',
     'workflow.buttons.runAgain': 'Exécuter à nouveau',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -187,12 +187,9 @@ const orchestratorTranslationIt = createTranslationMessages({
       'utente non autorizzato a interrompere il flusso di lavoro',
     'tooltips.userNotAuthorizedExecute':
       'utente non autorizzato a eseguire il flusso di lavoro',
-    'tooltips.retriggerNotSupportedForAborted':
-      'Il riavvio dal punto di interruzione non è supportato. Usa Intero flusso di lavoro per avviare una nuova esecuzione con gli stessi input.',
     'tooltips.workflowDown':
       'Il flusso di lavoro è attualmente inattivo o in stato di errore',
     'workflow.buttons.entireWorkflow': 'Intero flusso di lavoro',
-    'workflow.buttons.fromAbortedPoint': 'Dal punto di interruzione',
     'workflow.buttons.fromFailurePoint': 'Dal punto di fallimento',
     'workflow.buttons.run': 'Esegui',
     'workflow.buttons.runAgain': 'Esegui di nuovo',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ja.ts
@@ -183,11 +183,8 @@ const orchestratorTranslationJa = createTranslationMessages({
       'ユーザーにワークフローの中止権限がありません',
     'tooltips.userNotAuthorizedExecute':
       'ユーザーにワークフローの実行権限がありません',
-    'tooltips.retriggerNotSupportedForAborted':
-      '中止箇所からの再トリガーはサポートされていません。同じ入力で新しい実行を開始するには、ワークフロー全体を使用してください。',
     'tooltips.workflowDown': 'ワークフローは現在停止しているかエラー状態です',
     'workflow.buttons.entireWorkflow': 'ワークフロー全体',
-    'workflow.buttons.fromAbortedPoint': '中止箇所から',
     'workflow.buttons.fromFailurePoint': '失敗箇所から',
     'workflow.buttons.run': '実行',
     'workflow.buttons.runAgain': '再実行',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -140,7 +140,6 @@ export const orchestratorMessages = {
       running: 'Running...',
       entireWorkflow: 'Entire workflow',
       fromFailurePoint: 'From failure point',
-      fromAbortedPoint: 'From aborted point',
       runFailedAgain: 'Run failed again',
     },
   },
@@ -201,8 +200,6 @@ export const orchestratorMessages = {
     workflowDown: 'Workflow is currently down or in an error state',
     userNotAuthorizedAbort: 'user not authorized to abort workflow',
     userNotAuthorizedExecute: 'user not authorized to execute workflow',
-    retriggerNotSupportedForAborted:
-      'Retrigger from the abort point is not supported. Use Entire workflow to start a new run with the same inputs.',
   },
   messages: {
     noDataAvailable: 'No data available',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Story - https://redhat.atlassian.net/browse/RHIDP-15284

Slack thread - https://redhat-internal.slack.com/archives/C059YMMB664/p1782919030608299 

## Summary

- Remove the retrigger dropdown menu for aborted workflow runs on the execution page
- Aborted runs now show a single **Run again** action that starts a new run with the same inputs (entire workflow only)
- Keep the dropdown for **failed** runs with **Entire workflow** and **From failure point** options

<img width="1466" height="921" alt="Screenshot 2026-07-06 at 1 02 28 PM" src="https://github.com/user-attachments/assets/35fd1a7a-d982-4faf-bac0-4e2cd8c46ecc" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
