### PR TITLE
fix(orchestrator): remove incorrect aria-label on Run again button

### DIFF
--- a/workspaces/orchestrator/.changeset/orchestrator-run-again-aria-label.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-run-again-aria-label.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix incorrect aria-label on Run again and Abort buttons when the user is authorized to execute the workflow.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, type ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAsync } from 'react-use';
 
@@ -123,6 +123,15 @@ const useStyles = makeStyles()(theme => ({
     },
   },
 }));
+
+const withPermissionTooltip = (tooltipText: string, node: ReactElement) =>
+  tooltipText ? (
+    <Tooltip title={tooltipText}>
+      <span>{node}</span>
+    </Tooltip>
+  ) : (
+    node
+  );
 
 export type AbortConfirmationDialogActionsProps = {
   handleSubmit: () => void;
@@ -493,6 +502,13 @@ export const WorkflowInstancePage = () => {
     ? t('tooltips.retriggerNotSupportedForAborted')
     : '';
 
+  const abortTooltipText = permittedToUse.allowed
+    ? ''
+    : t('tooltips.userNotAuthorizedAbort');
+  const runAgainTooltipText = permittedToUse.allowed
+    ? ''
+    : t('tooltips.userNotAuthorizedExecute');
+
   return (
     <BaseOrchestratorPage
       title={instanceId ?? ''}
@@ -522,11 +538,9 @@ export const WorkflowInstancePage = () => {
             </InfoDialog>
             <Grid container item justifyContent="flex-end" spacing={1}>
               <Grid item>
-                {canAbort && (
-                  <Tooltip
-                    title={t('tooltips.userNotAuthorizedAbort')}
-                    disableHoverListener={permittedToUse.allowed}
-                  >
+                {canAbort &&
+                  withPermissionTooltip(
+                    abortTooltipText,
                     <Button
                       variant="outlined"
                       color="primary"
@@ -534,15 +548,12 @@ export const WorkflowInstancePage = () => {
                       onClick={toggleAbortConfirmationDialog}
                     >
                       {t('run.abort.button')}
-                    </Button>
-                  </Tooltip>
-                )}
+                    </Button>,
+                  )}
               </Grid>
               <Grid item>
-                <Tooltip
-                  title={t('tooltips.userNotAuthorizedExecute')}
-                  disableHoverListener={permittedToUse.allowed}
-                >
+                {withPermissionTooltip(
+                  runAgainTooltipText,
                   <Button
                     ref={anchorRef}
                     variant="contained"
@@ -562,8 +573,8 @@ export const WorkflowInstancePage = () => {
                     ) : (
                       t('workflow.buttons.runAgain')
                     )}
-                  </Button>
-                </Tooltip>
+                  </Button>,
+                )}
 
                 <Menu
                   anchorEl={anchorRef.current}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3400

## Summary

- Fix misleading accessibility labels on the workflow instance page **Abort** and **Run again** buttons
- Only wrap buttons in a permission `Tooltip` when the user is **not** authorized to execute/abort
- When authorized, buttons render without a tooltip so MUI does not set `aria-label="user not authorized to execute workflow"` on enabled buttons

<img width="1020" height="580" alt="image" src="https://github.com/user-attachments/assets/c6adaf19-7e7f-47f2-8145-efb026d6ac1a" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
