### PR TITLE
fix(orchestrator): register permission backend and fix RBAC workflows list

### DIFF
--- a/workspaces/orchestrator/.changeset/orchestrator-rbac-workflows-list.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-rbac-workflows-list.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix the workflows list when RBAC restricts read access to specific workflows.

--- a/workspaces/orchestrator/packages/backend/src/index.ts
+++ b/workspaces/orchestrator/packages/backend/src/index.ts
@@ -40,6 +40,10 @@ backend.add(
 // See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors
 backend.add(import('@backstage/plugin-catalog-backend-module-logs'));
 
+// permission plugin (required when permission.enabled is true — see homepage/scorecard workspaces)
+backend.add(import('@backstage/plugin-permission-backend'));
+backend.add(import('@backstage-community/plugin-rbac-backend'));
+
 // search plugin
 backend.add(import('@backstage/plugin-search-backend'));
 
@@ -50,9 +54,6 @@ backend.add(import('@backstage/plugin-search-backend-module-pg'));
 // search collators
 backend.add(import('@backstage/plugin-search-backend-module-catalog'));
 backend.add(import('@backstage/plugin-search-backend-module-techdocs'));
-
-// permission plugin
-backend.add(import('@backstage-community/plugin-rbac-backend'));
 
 // orchestrator
 backend.add(

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.tsx
@@ -28,7 +28,6 @@ import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
 import {
   isEntityScopedWorkflowOverviews,
   useAllWorkflowOverviews,
-  useWorkflowOverviews,
   WorkflowOverviewsState,
 } from '../../hooks/useWorkflowsCount';
 import { filterWorkflowOverviewsBySearch } from '../../utils/filterWorkflowOverviews';
@@ -128,11 +127,6 @@ const WorkflowsTabContentWithFetch = ({
     workflowsArray,
     targetEntity,
   });
-  const paginatedWorkflows = useWorkflowOverviews({
-    workflowsArray,
-    targetEntity,
-    ...(isEntityScoped || isSearching ? {} : { page, pageSize }),
-  });
 
   useEffect(() => {
     setPage(0);
@@ -154,11 +148,9 @@ const WorkflowsTabContentWithFetch = ({
       return slicePaginatedPage(filteredOverviews, page, pageSize);
     }
 
-    const rows = paginatedWorkflows.overviews ?? [];
-    if (rows.length > pageSize) {
-      return rows.slice(0, pageSize);
-    }
-    return rows;
+    // Server-side pagination runs before RBAC filtering; paginate the
+    // authorized list client-side so allowed workflows are not dropped.
+    return slicePaginatedPage(allWorkflows.overviews ?? [], page, pageSize);
   }, [
     allWorkflows.overviews,
     filteredOverviews,
@@ -166,8 +158,9 @@ const WorkflowsTabContentWithFetch = ({
     isSearching,
     page,
     pageSize,
-    paginatedWorkflows.overviews,
   ]);
+
+  const authorizedCount = allWorkflows.overviews?.length ?? 0;
 
   const totalCount = isSearching
     ? filteredOverviews.length
@@ -175,23 +168,17 @@ const WorkflowsTabContentWithFetch = ({
 
   const hasNextPage = isSearching
     ? (page + 1) * pageSize < filteredOverviews.length
-    : Boolean(paginatedWorkflows.hasNextPage);
+    : (page + 1) * pageSize < authorizedCount;
 
   const isPaginated =
     isEntityScoped || isSearching
       ? filteredOverviews.length > pageSize || page > 0
-      : Boolean(paginatedWorkflows.isPaginated);
+      : authorizedCount > pageSize || page > 0;
 
-  const loading =
-    allWorkflows.loading || (!isSearching && paginatedWorkflows.loading);
-  const tableLoading =
-    isSearching || isEntityScoped
-      ? allWorkflows.tableLoading
-      : allWorkflows.tableLoading || paginatedWorkflows.tableLoading;
-  const error = allWorkflows.error ?? paginatedWorkflows.error;
-  const isReady =
-    allWorkflows.isReady &&
-    (isSearching || isEntityScoped || paginatedWorkflows.isReady);
+  const loading = allWorkflows.loading;
+  const tableLoading = allWorkflows.tableLoading;
+  const error = allWorkflows.error;
+  const isReady = allWorkflows.isReady;
 
   return (
     <WorkflowsTabContentView


### PR DESCRIPTION
## Hey, I just made a Pull Request!


#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3443

## Summary
- Register `@backstage/plugin-permission-backend` alongside `@backstage-community/plugin-rbac-backend` in the orchestrator workspace backend (aligned with homepage, scorecard, lightspeed).
- Fix the workflows tab showing an empty table when RBAC limits users to per-workflow read permissions.
## Problem
When `permission.enabled: true` with RBAC:
1. **Permission plugin failed to start** — the workspace backend only registered `rbac-backend`, not `permission-backend`. This caused `/api/permission/authorize` to return **503** and broke orchestrator permission checks.
2. **Empty workflows table** — the tab could show **Workflows (N)** while the table displayed **“No workflows added yet”**. The table used server-side pagination before RBAC filtering, so allowed workflows (e.g. `wait-or-error`) on later alphabetical pages were dropped from page 0.
## Solution
- Add `permission-backend` registration in `packages/backend/src/index.ts`.
- Paginate the RBAC-filtered workflow overview client-side in `WorkflowsTabContent.tsx` instead of using a separate server-paginated request.
## Steps to reproduce (before fix)
1. Enable RBAC in `app-config.yaml`:
   ```yaml
   permission:
     enabled: true
     rbac:
       policies-csv-file: ../../docs/rbac-policy.csv
       pluginsWithPermission: [orchestrator]
2. Start the orchestrator workspace (yarn dev).
3. Log in as guest (user:development/guest).
4. Open Orchestrator → Workflows.

### Before:

Permission API may return 503 (if permission-backend is missing).
Tab shows Workflows (1) but table is empty.

### After:

Permission plugin starts; authorize calls return 200.
Guest sees allowed workflows (e.g. wait-or-error) in the table.

### Test plan

-  Enable RBAC locally; confirm permission plugin starts without 503
-  As guest, verify allowed workflows appear in the Workflows table
-  As workflowAdmin, verify all workflows still load
-  Search and pagination on the workflows tab still work
-  With RBAC disabled, workflows list behaves as before

### Video


https://github.com/user-attachments/assets/0fe867fa-8bdd-4076-bc84-6ca4919bd33c



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
