### PR TITLE
fix(intelligent-assistant): refactored mcp config modal

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
@@ -10,6 +10,7 @@ Refactor the MCP server configure modal with PatternFly layout and improved cred
 - Hide the tools section when the server is disabled; keep status consistent while drafting an unverified personal token
 - Disable Save after a failed token validation until the input changes
 - Auto-enable the server after a successful personal token save
+- Add sortable **Name** and **Status** columns to the MCP servers table, with always-visible sort icons (gray when inactive, directional when active)
 - Bump `@patternfly/react-core` to 6.6.0 and add translations for new modal strings (de, es, fr, it, ja)
 
 The backend now exposes `hasOrgToken` on MCP server list and patch responses so the UI can distinguish organization default tokens from personal-only servers.

--- a/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
@@ -1,5 +1,15 @@
 ---
 '@red-hat-developer-hub/backstage-plugin-lightspeed': minor
+'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
 ---
 
-Enhance the MCP server configure modal with PatternFly layout, server status and tools list, aligned enabled toggle behavior, personal token save/remove flows (including disconnecting state and warnings), auto-enable on successful token validation, and unit tests.
+Refactor the MCP server configure modal with PatternFly layout and improved credential management:
+
+- Add **Use organization default token** / **Use personal token** radio selectors when an app-config default token is available, replacing the remove-personal-token flow
+- Show server status, tools list, and enabled toggle with local draft state applied on Save
+- Hide the tools section when the server is disabled; keep status consistent while drafting an unverified personal token
+- Disable Save after a failed token validation until the input changes
+- Auto-enable the server after a successful personal token save
+- Bump `@patternfly/react-core` to 6.6.0 and add translations for new modal strings (de, es, fr, it, ja)
+
+The backend now exposes `hasOrgToken` on MCP server list and patch responses so the UI can distinguish organization default tokens from personal-only servers.

--- a/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
+---
+
+Enhance the MCP server configure modal with PatternFly layout, server status and tools list, aligned enabled toggle behavior, personal token save/remove flows (including disconnecting state and warnings), auto-enable on successful token validation, and unit tests.

--- a/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
@@ -11,6 +11,7 @@ Refactor the MCP server configure modal with PatternFly layout and improved cred
 - Disable Save after a failed token validation until the input changes
 - Auto-enable the server after a successful personal token save
 - Add sortable **Name** and **Status** columns to the MCP servers table, with always-visible sort icons (gray when inactive, directional when active)
+- Keep the DCR configure modal as an information-only view (DCR explanation + Cancel) with no token or status/enabled controls
 - Bump `@patternfly/react-core` to 6.6.0 and add translations for new modal strings (de, es, fr, it, ja)
 
 The backend now exposes `hasOrgToken` on MCP server list and patch responses so the UI can distinguish organization default tokens from personal-only servers.

--- a/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
@@ -11,7 +11,8 @@ Refactor the MCP server configure modal with PatternFly layout and improved cred
 - Disable Save after a failed token validation until the input changes
 - Auto-enable the server after a successful personal token save
 - Add sortable **Name** and **Status** columns to the MCP servers table, with always-visible sort icons (gray when inactive, directional when active)
-- Keep the DCR configure modal as an information-only view (DCR explanation + Cancel) with no token or status/enabled controls
+- Keep the DCR configure modal aligned with personal-token servers (status, tools, enabled toggle, and Save/Cancel) with an additional DCR info alert and no token input
+- Show **Fetching status...** in the Status section while server tools/status are loading
 - Bump `@patternfly/react-core` to 6.6.0 and add translations for new modal strings (de, es, fr, it, ja)
 
 The backend now exposes `hasOrgToken` on MCP server list and patch responses so the UI can distinguish organization default tokens from personal-only servers.

--- a/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-configure-modal-enhancements.md
@@ -1,6 +1,6 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
-'@red-hat-developer-hub/backstage-plugin-lightspeed-backend': patch
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': minor
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': patch
 ---
 
 Refactor the MCP server configure modal with PatternFly layout and improved credential management:

--- a/workspaces/intelligent-assistant/e2e-tests/fixtures/mcpServerMocks.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/fixtures/mcpServerMocks.ts
@@ -30,6 +30,7 @@ export type McpServerMockEntry = {
   toolCount: number;
   hasToken: boolean;
   hasUserToken: boolean;
+  hasOrgToken: boolean;
 };
 
 export type McpServersListMock = {
@@ -48,6 +49,7 @@ export function mcpServer(
     toolCount: 0,
     hasToken: true,
     hasUserToken: false,
+    hasOrgToken: true,
     ...overrides,
   };
 }
@@ -94,6 +96,7 @@ export const mcpServerScenarios = {
         toolCount: 14,
         hasToken: true,
         hasUserToken: false,
+        hasOrgToken: true,
       },
       {
         name: 'test-mcp-server',
@@ -103,6 +106,7 @@ export const mcpServerScenarios = {
         toolCount: 0,
         hasToken: false,
         hasUserToken: false,
+        hasOrgToken: false,
       },
     ],
   } satisfies McpServersListMock,
@@ -142,11 +146,13 @@ export const mcpServerScenarios = {
     servers: [
       mcpServer('needs-token-a', {
         hasToken: false,
+        hasOrgToken: false,
         toolCount: 0,
         status: 'unknown',
       }),
       mcpServer('needs-token-b', {
         hasToken: false,
+        hasOrgToken: false,
         toolCount: 0,
         status: 'unknown',
       }),
@@ -162,6 +168,7 @@ export const mcpServerScenarios = {
     servers: [
       mcpServer('needs-token', {
         hasToken: false,
+        hasOrgToken: false,
         toolCount: 0,
         status: 'unknown',
       }),
@@ -183,6 +190,7 @@ export const tokenCredentialValidationScenario = {
   servers: [
     mcpServer('credential-test-mcp', {
       hasToken: false,
+      hasOrgToken: false,
       toolCount: 0,
       status: 'unknown',
       url: 'http://127.0.0.1:7777/mcp',
@@ -195,6 +203,7 @@ export const tokenCredentialNoUrlScenario = {
   servers: [
     mcpServer('no-url-mcp', {
       hasToken: false,
+      hasOrgToken: false,
       toolCount: 0,
       status: 'unknown',
     }),

--- a/workspaces/intelligent-assistant/e2e-tests/fixtures/mcpServerMocks.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/fixtures/mcpServerMocks.ts
@@ -25,6 +25,8 @@ export type McpServerMockEntry = {
   name: string;
   /** Optional — some backends send it; not shown in the MCP table name/status cells. */
   url?: string;
+  /** Optional auth mode (e.g. 'dcr' for Dynamic Client Registration servers). */
+  auth?: 'dcr';
   enabled: boolean;
   status: 'connected' | 'error' | 'unknown';
   toolCount: number;

--- a/workspaces/intelligent-assistant/e2e-tests/lightspeed.mcp.test.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/lightspeed.mcp.test.ts
@@ -18,6 +18,7 @@ import { test, expect, Page } from '@playwright/test';
 import {
   conversations,
   E2E_MCP_VALID_TOKEN,
+  mcpServer,
   mcpServerScenarios,
   tokenCredentialNoUrlScenario,
   tokenCredentialValidationScenario,
@@ -29,10 +30,15 @@ import { openLightspeed, sendMessage } from './utils/testHelper';
 import {
   openChatbot,
   selectDisplayMode,
+  type DisplayMode,
   expectBackstagePageVisible,
   verifyMcpSettingsPanel,
   openMcpSettingsPanel,
   closeMcpSettingsPanel,
+  mcpConfigureModalSaveButton,
+  mcpCredentialConfigureModal,
+  mcpEditServerButton,
+  mcpPersonalAccessTokenInput,
   mcpServerToggle,
   mcpServerRow,
   clickMcpServersStatusColumn,
@@ -45,6 +51,7 @@ import {
   mockConversations,
   mockMcpServers,
   mockQuery,
+  type MockMcpServersOptions,
 } from './utils/devMode';
 import {
   LightspeedMessages,
@@ -67,10 +74,23 @@ test.describe('Intelligent assistant MCP', () => {
   });
 
   test.describe('Chatbot MCP settings', () => {
-    async function runMcpPanelScenario(mcpList: McpServersListMock) {
+    async function openChatbotWithMcpMock(
+      mcpList: McpServersListMock = mcpServerScenarios.default,
+    ) {
       await mockMcpServers(sharedPage, mcpList);
       await openChatbot(sharedPage, translations);
+    }
+
+    async function verifyMcpPanelScenario(mcpList: McpServersListMock) {
+      await openChatbotWithMcpMock(mcpList);
       await verifyMcpSettingsPanel(sharedPage, translations, mcpList);
+    }
+
+    async function openMcpPanelWithMock(
+      mcpList: McpServersListMock = mcpServerScenarios.default,
+    ) {
+      await openChatbotWithMcpMock(mcpList);
+      await openMcpSettingsPanel(sharedPage, translations);
     }
 
     test.beforeEach(async () => {
@@ -81,216 +101,446 @@ test.describe('Intelligent assistant MCP', () => {
       await mockMcpServers(sharedPage);
     });
 
-    test('Overlay', async () => {
-      await expectBackstagePageVisible(sharedPage);
-      await openChatbot(sharedPage, translations);
-      await verifyMcpSettingsPanel(sharedPage, translations);
-    });
-
-    test('Dock to Window', async () => {
-      await openChatbot(sharedPage, translations);
-      await selectDisplayMode(sharedPage, translations, 'Dock to window');
-      await verifyMcpSettingsPanel(sharedPage, translations);
-    });
-
-    test('Fullscreen', async () => {
-      await openChatbot(sharedPage, translations);
-      await selectDisplayMode(sharedPage, translations, 'Fullscreen');
-      await verifyMcpSettingsPanel(sharedPage, translations);
-    });
-
-    test('Empty list', async () => {
-      await runMcpPanelScenario(mcpServerScenarios.empty);
-    });
-
-    test.describe('Two-row mocks', () => {
-      test('All healthy', async () => {
-        await runMcpPanelScenario(mcpServerScenarios.allHealthy);
+    test.describe('Panel rendering', () => {
+      test('renders in overlay mode', async () => {
+        await expectBackstagePageVisible(sharedPage);
+        await openChatbot(sharedPage, translations);
+        await verifyMcpSettingsPanel(sharedPage, translations);
       });
 
-      test('Failed + OK', async () => {
-        await runMcpPanelScenario(mcpServerScenarios.errorAndOk);
+      test('renders in docked mode', async () => {
+        await openChatbot(sharedPage, translations);
+        await selectDisplayMode(sharedPage, translations, 'Dock to window');
+        await verifyMcpSettingsPanel(sharedPage, translations);
       });
 
-      test('Disabled + active', async () => {
-        await runMcpPanelScenario(mcpServerScenarios.disabledAndOk);
+      test('renders in fullscreen mode', async () => {
+        await openChatbot(sharedPage, translations);
+        await selectDisplayMode(sharedPage, translations, 'Fullscreen');
+        await verifyMcpSettingsPanel(sharedPage, translations);
       });
 
-      test('Both need token', async () => {
-        await runMcpPanelScenario(mcpServerScenarios.twoTokenRequired);
+      test('renders empty state when no MCP servers are configured', async () => {
+        await verifyMcpPanelScenario(mcpServerScenarios.empty);
+      });
+
+      test.describe('scenario coverage', () => {
+        test('renders all healthy servers', async () => {
+          await verifyMcpPanelScenario(mcpServerScenarios.allHealthy);
+        });
+
+        test('renders failed and healthy servers together', async () => {
+          await verifyMcpPanelScenario(mcpServerScenarios.errorAndOk);
+        });
+
+        test('renders disabled and active servers together', async () => {
+          await verifyMcpPanelScenario(mcpServerScenarios.disabledAndOk);
+        });
+
+        test('renders token-required servers', async () => {
+          await verifyMcpPanelScenario(mcpServerScenarios.twoTokenRequired);
+        });
       });
     });
 
-    test('Sort works as expected', async () => {
-      await mockMcpServers(sharedPage, mcpServerScenarios.allHealthy);
-      await openChatbot(sharedPage, translations);
-      await openMcpSettingsPanel(sharedPage, translations);
+    test.describe('Table interactions', () => {
+      test('sorts rows by server name', async () => {
+        await openMcpPanelWithMock(mcpServerScenarios.allHealthy);
 
-      const rows = mcpServersTableBodyRows(sharedPage, translations);
-      await expect(rows.nth(0)).toContainText('alpha-mcp');
-      await expect(rows.nth(1)).toContainText('beta-mcp');
+        const rows = mcpServersTableBodyRows(sharedPage, translations);
+        await expect(rows.nth(0)).toContainText('alpha-mcp');
+        await expect(rows.nth(1)).toContainText('beta-mcp');
 
-      await clickMcpServersNameColumn(sharedPage, translations);
-      await expect(rows.nth(0)).toContainText('beta-mcp');
-      await expect(rows.nth(1)).toContainText('alpha-mcp');
+        await clickMcpServersNameColumn(sharedPage, translations);
+        await expect(rows.nth(0)).toContainText('beta-mcp');
+        await expect(rows.nth(1)).toContainText('alpha-mcp');
 
-      await closeMcpSettingsPanel(sharedPage, translations);
+        await closeMcpSettingsPanel(sharedPage, translations);
+      });
+
+      test('sorts rows by status rank and tool-count tie-breaker', async () => {
+        const statusSortScenario: McpServersListMock = {
+          servers: [
+            mcpServer('ok-many-tools', { toolCount: 5 }),
+            mcpServer('failed-server', { status: 'error', toolCount: 0 }),
+            mcpServer('token-required-server', {
+              hasToken: false,
+              hasOrgToken: false,
+              toolCount: 0,
+              status: 'unknown',
+            }),
+            mcpServer('disabled-server', { enabled: false, toolCount: 8 }),
+            mcpServer('ok-one-tool', { toolCount: 1 }),
+            mcpServer('unknown-server', { status: 'unknown', toolCount: 4 }),
+          ],
+        };
+
+        await openMcpPanelWithMock(statusSortScenario);
+
+        const rows = mcpServersTableBodyRows(sharedPage, translations);
+        await clickMcpServersStatusColumn(sharedPage, translations);
+
+        await expect(rows.nth(0)).toContainText('ok-one-tool');
+        await expect(rows.nth(1)).toContainText('ok-many-tools');
+        await expect(rows.nth(2)).toContainText('disabled-server');
+        await expect(rows.nth(3)).toContainText('unknown-server');
+        await expect(rows.nth(4)).toContainText('token-required-server');
+        await expect(rows.nth(5)).toContainText('failed-server');
+
+        await clickMcpServersStatusColumn(sharedPage, translations);
+
+        await expect(rows.nth(0)).toContainText('failed-server');
+        await expect(rows.nth(1)).toContainText('token-required-server');
+        await expect(rows.nth(2)).toContainText('unknown-server');
+        await expect(rows.nth(3)).toContainText('disabled-server');
+        await expect(rows.nth(4)).toContainText('ok-many-tools');
+        await expect(rows.nth(5)).toContainText('ok-one-tool');
+
+        await closeMcpSettingsPanel(sharedPage, translations);
+      });
+
+      test('toggles server enabled state from the table', async () => {
+        const serverName = 'mcp-integration-tools';
+        await openMcpPanelWithMock();
+
+        const row = mcpServerRow(sharedPage, serverName, translations);
+        await clickMcpServersStatusColumn(sharedPage, translations);
+        await mcpServerToggle(sharedPage, serverName, translations).click();
+        await expect(
+          row.getByText(translations['mcp.settings.status.disabled'], {
+            exact: true,
+          }),
+        ).toBeVisible();
+
+        await mcpServerToggle(sharedPage, serverName, translations).click();
+        await expect(
+          row.getByText(formatMcpToolCountStatus(translations, 14), {
+            exact: true,
+          }),
+        ).toBeVisible();
+
+        await closeMcpSettingsPanel(sharedPage, translations);
+      });
     });
 
-    test('Toggle works as expected', async () => {
-      const serverName = 'mcp-integration-tools';
-      await openChatbot(sharedPage, translations);
-      await openMcpSettingsPanel(sharedPage, translations);
-
-      const row = mcpServerRow(sharedPage, serverName, translations);
-      await clickMcpServersStatusColumn(sharedPage, translations);
-      await mcpServerToggle(sharedPage, serverName, translations).click();
-      await expect(
-        row.getByText(translations['mcp.settings.status.disabled'], {
-          exact: true,
-        }),
-      ).toBeVisible();
-
-      await mcpServerToggle(sharedPage, serverName, translations).click();
-      await expect(
-        row.getByText(formatMcpToolCountStatus(translations, 14), {
-          exact: true,
-        }),
-      ).toBeVisible();
-
-      await closeMcpSettingsPanel(sharedPage, translations);
-    });
-
-    test.describe('Configure MCP server token', () => {
+    test.describe('Configure MCP server modal', () => {
       let mcpToken: McpConfigureTokenPage;
+      const credentialServerName = 'credential-test-mcp';
+      const noUrlServerName = 'no-url-mcp';
+
+      async function openCredentialServerModal(
+        mode: DisplayMode,
+        mockOptions?: MockMcpServersOptions,
+      ) {
+        await mcpToken.gotoMcpSettings(
+          tokenCredentialValidationScenario,
+          mode,
+          mockOptions,
+        );
+        await mcpToken.seeRowStatus(
+          credentialServerName,
+          translations['mcp.settings.status.tokenRequired'],
+        );
+        await mcpToken.openEditServer(credentialServerName);
+      }
+
+      async function openNoUrlServerModal(mode: DisplayMode) {
+        await mcpToken.gotoMcpSettings(tokenCredentialNoUrlScenario, mode);
+        await mcpToken.openEditServer(noUrlServerName);
+      }
 
       test.beforeEach(() => {
         mcpToken = new McpConfigureTokenPage(sharedPage, translations);
       });
 
-      test('Valid token saves and row shows tools — Overlay', async () => {
-        await mcpToken.gotoMcpSettings(
-          tokenCredentialValidationScenario,
-          'Overlay',
-        );
+      test.describe('Token validation and persistence', () => {
+        test('saves a valid personal token from token-required state — Overlay', async () => {
+          await openCredentialServerModal('Overlay');
 
-        const serverName = 'credential-test-mcp';
-        await mcpToken.seeRowStatus(
-          serverName,
-          translations['mcp.settings.status.tokenRequired'],
-        );
+          const modal = mcpCredentialConfigureModal(sharedPage);
+          const tokenRequiredSwitch = modal.getByRole('switch', {
+            name: evaluateMessage(
+              translations['mcp.settings.toggleServerAriaLabel'],
+              credentialServerName,
+            ),
+          });
+          await expect(tokenRequiredSwitch).toBeDisabled();
 
-        await mcpToken.openEditServer(serverName);
-        await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
-        await mcpToken.save();
+          await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
+          await mcpToken.save();
 
-        await mcpToken.seeTokenHidden();
-        await mcpToken.seeRowStatus(
-          serverName,
-          formatMcpToolCountStatus(translations, 5),
-        );
+          await mcpToken.seeTokenHidden();
+          await mcpToken.seeRowStatus(
+            credentialServerName,
+            formatMcpToolCountStatus(translations, 5),
+          );
+          await mcpToken.closeMcpPanel();
+        });
 
-        await mcpToken.closeMcpPanel();
+        test('shows invalid credentials, then succeeds with a valid token — Dock to window', async () => {
+          await openCredentialServerModal('Dock to window');
+
+          await mcpToken.typeToken('bad-token');
+          await mcpToken.save();
+          await mcpToken.seeMessage(
+            translations['mcp.settings.token.invalidCredentials'],
+          );
+
+          await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
+          await mcpToken.save();
+          await mcpToken.seeTokenHidden();
+          await mcpToken.seeRowStatus(
+            credentialServerName,
+            formatMcpToolCountStatus(translations, 5),
+          );
+          await mcpToken.closeMcpPanel();
+        });
+
+        test('cancel closes modal without persisting token draft — Fullscreen', async () => {
+          await openCredentialServerModal('Fullscreen');
+
+          await mcpToken.typeToken('draft-token');
+          await mcpToken.cancel();
+
+          await mcpToken.seeModalClosed();
+          await mcpToken.seeRowStatus(
+            credentialServerName,
+            translations['mcp.settings.status.tokenRequired'],
+          );
+          await mcpToken.closeMcpPanel();
+        });
+
+        test('clear token input empties PAT and restores helper text — Fullscreen', async () => {
+          await openNoUrlServerModal('Fullscreen');
+
+          await mcpToken.typeThenClearToken('e2e-draft-personal-access-token');
+          await mcpToken.cancel();
+          await mcpToken.closeMcpPanel();
+        });
       });
 
-      test('Invalid token then valid token — Dock to window', async () => {
-        await mcpToken.gotoMcpSettings(
-          tokenCredentialValidationScenario,
-          'Dock to window',
-        );
-
-        const serverName = 'credential-test-mcp';
-        await mcpToken.openEditServer(serverName);
-
-        await mcpToken.typeToken('bad-token');
-        await mcpToken.save();
-        await mcpToken.seeMessage(
-          translations['mcp.settings.token.invalidCredentials'],
-        );
-
-        await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
-        await mcpToken.save();
-        await mcpToken.seeTokenHidden();
-        await mcpToken.seeRowStatus(
-          serverName,
-          formatMcpToolCountStatus(translations, 5),
-        );
-
-        await mcpToken.closeMcpPanel();
-      });
-
-      test('Cancel discards without saving — Fullscreen', async () => {
-        await mcpToken.gotoMcpSettings(
-          tokenCredentialValidationScenario,
-          'Fullscreen',
-        );
-
-        const serverName = 'credential-test-mcp';
-        await mcpToken.openEditServer(serverName);
-        await mcpToken.typeToken('draft-token');
-        await mcpToken.cancel();
-
-        await mcpToken.seeModalClosed();
-        await mcpToken.seeRowStatus(
-          serverName,
-          translations['mcp.settings.status.tokenRequired'],
-        );
-
-        await mcpToken.closeMcpPanel();
-      });
-
-      test('Server validation failure shows error — Overlay', async () => {
-        await mcpToken.gotoMcpSettings(
-          tokenCredentialValidationScenario,
-          'Overlay',
-          {
-            failServerValidateFor: 'credential-test-mcp',
+      test.describe('Validation errors', () => {
+        test('shows server validation failure after save — Overlay', async () => {
+          await openCredentialServerModal('Overlay', {
+            failServerValidateFor: credentialServerName,
             failServerValidateError:
               translations['mcp.settings.token.validationFailed'],
-          },
-        );
+          });
 
-        const serverName = 'credential-test-mcp';
-        await mcpToken.openEditServer(serverName);
-        await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
-        await mcpToken.save();
+          await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
+          await mcpToken.save();
+          await mcpToken.seeMessage(
+            translations['mcp.settings.token.validationFailed'],
+          );
+          await mcpToken.cancel();
+          await mcpToken.closeMcpPanel();
+        });
 
-        await mcpToken.seeMessage(
-          translations['mcp.settings.token.validationFailed'],
-        );
-        await mcpToken.cancel();
-        await mcpToken.closeMcpPanel();
+        test('shows URL-unavailable error when server URL is missing — Dock to window', async () => {
+          await openNoUrlServerModal('Dock to window');
+
+          await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
+          await mcpToken.save();
+          await mcpToken.seeMessage(
+            translations['mcp.settings.token.urlUnavailableForValidation'],
+          );
+          await mcpToken.cancel();
+          await mcpToken.closeMcpPanel();
+        });
       });
 
-      test('Missing server URL shows error — Dock to window', async () => {
-        await mcpToken.gotoMcpSettings(
-          tokenCredentialNoUrlScenario,
-          'Dock to window',
-        );
+      test.describe('Credential source modes', () => {
+        test('shows DCR-only modal content for DCR-authenticated servers — Overlay', async () => {
+          const serverName = 'mcp-integration-tools';
+          const dcrServerTools = [
+            'mcp_list_tools',
+            'mcp_create_incident',
+            'mcp_get_service_status',
+          ];
+          const dcrScenario: McpServersListMock = {
+            servers: [
+              mcpServer(serverName, {
+                url: 'http://localhost:7008/api/mcp-actions/v1',
+                auth: 'dcr',
+                hasToken: true,
+                hasUserToken: false,
+                hasOrgToken: false,
+                enabled: true,
+                status: 'connected',
+                toolCount: dcrServerTools.length,
+              }),
+            ],
+          };
 
-        const serverName = 'no-url-mcp';
-        await mcpToken.openEditServer(serverName);
-        await mcpToken.typeToken(E2E_MCP_VALID_TOKEN);
-        await mcpToken.save();
+          await mcpToken.gotoMcpSettings(dcrScenario, 'Overlay', {
+            validationToolsByServer: {
+              [serverName]: dcrServerTools,
+            },
+          });
+          await mcpEditServerButton(
+            sharedPage,
+            serverName,
+            translations,
+          ).click();
 
-        await mcpToken.seeMessage(
-          translations['mcp.settings.token.urlUnavailableForValidation'],
-        );
-        await mcpToken.cancel();
-        await mcpToken.closeMcpPanel();
-      });
+          const modal = mcpCredentialConfigureModal(sharedPage);
+          await expect(modal).toContainText(
+            translations['mcp.settings.modalDescriptionDcr'],
+          );
+          await expect(
+            modal.getByRole('button', { name: translations['common.cancel'] }),
+          ).toBeVisible();
+          await expect(
+            modal.getByRole('button', { name: translations['modal.save'] }),
+          ).toBeDisabled();
+          await expect(mcpPersonalAccessTokenInput(sharedPage)).toBeHidden();
+          for (const toolName of dcrServerTools) {
+            await expect(
+              modal.getByText(toolName, { exact: true }),
+            ).toBeVisible();
+          }
 
-      test('Clear token input empties PAT — Fullscreen', async () => {
-        await mcpToken.gotoMcpSettings(
-          tokenCredentialNoUrlScenario,
-          'Fullscreen',
-        );
+          await modal
+            .getByRole('button', {
+              name: translations['mcp.settings.closeConfigureModalAriaLabel'],
+            })
+            .click();
+          await mcpToken.closeMcpPanel();
+        });
 
-        await mcpToken.openEditServer('no-url-mcp');
-        await mcpToken.typeThenClearToken('e2e-draft-personal-access-token');
+        test('switching to organization token hides personal token input — Overlay', async () => {
+          const serverName = 'org-backed-mcp';
+          const orgServerTools = ['github.list-repos', 'github.get-repo'];
+          const organizationTokenScenario: McpServersListMock = {
+            servers: [
+              mcpServer(serverName, {
+                url: 'http://localhost:8555/mcp',
+                hasUserToken: true,
+                hasOrgToken: true,
+                hasToken: true,
+                toolCount: 2,
+                status: 'connected',
+              }),
+            ],
+          };
 
-        await mcpToken.cancel();
-        await mcpToken.closeMcpPanel();
+          await mcpToken.gotoMcpSettings(organizationTokenScenario, 'Overlay', {
+            validationToolsByServer: {
+              [serverName]: orgServerTools,
+            },
+          });
+          await mcpToken.openEditServer(serverName);
+
+          const modal = mcpCredentialConfigureModal(sharedPage);
+          const organizationTokenRadio = modal.getByRole('radio', {
+            name: translations[
+              'mcp.settings.modal.credentialMode.organization'
+            ],
+          });
+          const personalTokenRadio = modal.getByRole('radio', {
+            name: translations['mcp.settings.modal.credentialMode.personal'],
+          });
+
+          await expect(personalTokenRadio).toBeChecked();
+          for (const toolName of orgServerTools) {
+            await expect(
+              modal.getByText(toolName, { exact: true }),
+            ).toBeVisible();
+          }
+          await organizationTokenRadio.click();
+          await expect(organizationTokenRadio).toBeChecked();
+          await expect(mcpPersonalAccessTokenInput(sharedPage)).toBeHidden();
+          await expect(
+            mcpConfigureModalSaveButton(sharedPage, translations),
+          ).toBeEnabled();
+
+          await mcpToken.save();
+          await mcpToken.seeModalClosed();
+          await mcpToken.seeRowStatus(
+            serverName,
+            formatMcpToolCountStatus(translations, 2),
+          );
+          await mcpToken.closeMcpPanel();
+        });
+
+        test('removing a personal token changes status to token required — Overlay', async () => {
+          const serverName = 'personal-only-mcp';
+          const personalServerTools = ['jira.search-issues', 'jira.get-issue'];
+          const personalTokenScenario: McpServersListMock = {
+            servers: [
+              mcpServer(serverName, {
+                url: 'http://localhost:8666/mcp',
+                hasUserToken: true,
+                hasOrgToken: false,
+                hasToken: true,
+                toolCount: 2,
+                status: 'connected',
+              }),
+            ],
+          };
+
+          await mcpToken.gotoMcpSettings(personalTokenScenario, 'Overlay', {
+            validationToolsByServer: {
+              [serverName]: personalServerTools,
+            },
+          });
+          await mcpToken.seeRowStatus(
+            serverName,
+            formatMcpToolCountStatus(translations, 2),
+          );
+          await mcpToken.openEditServer(serverName);
+
+          const modal = mcpCredentialConfigureModal(sharedPage);
+          const removePersonalTokenButton = modal.getByRole('button', {
+            name: translations['mcp.settings.removePersonalToken'],
+          });
+
+          await expect(
+            modal.getByText(
+              formatMcpToolCountStatus(
+                translations,
+                personalServerTools.length,
+              ),
+              {
+                exact: true,
+              },
+            ),
+          ).toBeVisible();
+          for (const toolName of personalServerTools) {
+            await expect(
+              modal.getByText(toolName, { exact: true }),
+            ).toBeVisible();
+          }
+          await expect(removePersonalTokenButton).toBeVisible();
+          await removePersonalTokenButton.click();
+          await expect(
+            modal.getByText(
+              translations['mcp.settings.modal.tokenRemovedWarning'],
+            ),
+          ).toBeVisible();
+          await expect(
+            modal.getByText(translations['mcp.settings.status.tokenRequired'], {
+              exact: true,
+            }),
+          ).toBeVisible();
+          for (const toolName of personalServerTools) {
+            await expect(
+              modal.getByText(toolName, { exact: true }),
+            ).toBeHidden();
+          }
+          await expect(removePersonalTokenButton).toBeDisabled();
+          await expect(
+            mcpConfigureModalSaveButton(sharedPage, translations),
+          ).toBeEnabled();
+
+          await mcpToken.save();
+          await mcpToken.seeModalClosed();
+          await mcpToken.seeRowStatus(
+            serverName,
+            translations['mcp.settings.status.tokenRequired'],
+          );
+          await mcpToken.closeMcpPanel();
+        });
       });
     });
   });

--- a/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
@@ -275,7 +275,7 @@ export async function clickMcpServersStatusColumn(
   t: LightspeedMessages,
 ) {
   await mcpServersTable(page, t)
-    .getByRole('columnheader', { name: t['mcp.settings.status'] })
+    .getByRole('button', { name: t['mcp.settings.status'] })
     .click();
 }
 
@@ -332,7 +332,7 @@ export async function verifyMcpSettingsPanel(
     table.getByRole('button', { name: t['mcp.settings.name'] }),
   ).toBeVisible();
   await expect(
-    table.getByRole('columnheader', { name: t['mcp.settings.status'] }),
+    table.getByRole('button', { name: t['mcp.settings.status'] }),
   ).toBeVisible();
 
   await clickMcpServersStatusColumn(page, t);

--- a/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
@@ -247,9 +247,9 @@ export function mcpConfigureModalMessage(
   page: Page,
   exactText: string,
 ): Locator {
-  return mcpCredentialConfigureModal(page).getByText(exactText, {
-    exact: true,
-  });
+  // PatternFly HelperTextItem appends ": error status;" for error variants; validation
+  // errors may also appear in the tools section. Substring match + first() avoids both.
+  return mcpCredentialConfigureModal(page).getByText(exactText).first();
 }
 
 /**

--- a/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
@@ -206,11 +206,11 @@ export function mcpPersonalAccessTokenInput(page: Page): Locator {
   return page.locator('#mcp-pat-input');
 }
 
-/** Configure-server modal that contains the PAT field (avoids matching other dialogs). */
+/** Configure-server modal for MCP settings (works for token and DCR flows). */
 export function mcpCredentialConfigureModal(page: Page): Locator {
   return page
     .getByRole('dialog')
-    .filter({ has: page.locator('#mcp-pat-input') });
+    .filter({ has: page.locator('#mcp-configure-modal-body') });
 }
 
 /** Clear (×) control on the PAT field (`mcp.settings.token.clearAriaLabel`). */

--- a/workspaces/intelligent-assistant/e2e-tests/pages/McpConfigureTokenPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/McpConfigureTokenPage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { expect, type Locator, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import type { McpServersListMock } from '../fixtures/responses';
 import type { MockMcpServersOptions } from '../utils/devMode';
 import { mockMcpServers } from '../utils/devMode';
@@ -98,20 +98,12 @@ export class McpConfigureTokenPage {
     await closeMcpSettingsPanel(this.page, this.t);
   }
 
-  tokenField(): Locator {
-    return mcpPersonalAccessTokenInput(this.page);
-  }
-
-  async clearToken(): Promise<void> {
-    await mcpClearTokenInputButton(this.page, this.t).click();
-  }
-
   async typeThenClearToken(draft: string): Promise<void> {
-    const field = this.tokenField();
+    const field = mcpPersonalAccessTokenInput(this.page);
     await field.click();
     await field.fill(draft);
     await expect(field).toHaveValue(draft);
-    await this.clearToken();
+    await mcpClearTokenInputButton(this.page, this.t).click();
     await expect(field).toHaveValue('');
     await this.seeMessage(this.t['mcp.settings.enterToken']);
   }

--- a/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
@@ -703,10 +703,12 @@ export async function mockMcpServers(
           server.status = 'connected';
           server.toolCount = 5;
         } else {
-          server.hasToken = false;
           server.hasUserToken = false;
-          server.status = 'unknown';
-          server.toolCount = 0;
+          server.hasToken = Boolean(server.hasOrgToken);
+          if (!server.hasToken) {
+            server.status = 'unknown';
+            server.toolCount = 0;
+          }
         }
       }
       await route.fulfill({ json: { server } });

--- a/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
@@ -32,6 +32,11 @@ export type MockMcpServersOptions = {
   failServerValidateFor?: string;
   /** Shown as `validation.error` when POST validate fails for `failServerValidateFor` (use product i18n, e.g. `mcp.settings.token.validationFailed`). */
   failServerValidateError?: string;
+  /**
+   * Optional per-server tool names returned by POST `/mcp-servers/:name/validate`.
+   * This allows modal "Tools" list assertions to mirror real server names.
+   */
+  validationToolsByServer?: Record<string, string[]>;
 };
 
 let mcpMockOptions: MockMcpServersOptions = {};
@@ -655,14 +660,22 @@ export async function mockMcpServers(
       }
 
       const toolCount = server.toolCount;
+      const validationTools = mcpMockOptions.validationToolsByServer?.[name];
+      const validation: { tools?: { name: string }[]; error?: string } = {};
+      if (validationTools) {
+        validation.tools = validationTools.map(toolName => ({
+          name: toolName,
+        }));
+      }
+      if (server.status === 'error') {
+        validation.error = 'MCP validation failed';
+      }
       await route.fulfill({
         json: {
           name,
           status: server.status,
           toolCount,
-          ...(server.status === 'error'
-            ? { validation: { error: 'MCP validation failed' } }
-            : {}),
+          ...(Object.keys(validation).length > 0 ? { validation } : {}),
         },
       });
       return;

--- a/workspaces/intelligent-assistant/package.json
+++ b/workspaces/intelligent-assistant/package.json
@@ -85,7 +85,7 @@
     "@backstage/plugin-permission-react": "0.5.2",
     "@backstage/plugin-search-react": "1.11.5",
     "@backstage/plugin-techdocs-react": "1.3.12",
-    "@patternfly/react-core": "6.5.1",
+    "@patternfly/react-core": "6.6.0",
     "@protobufjs/inquire": "1.1.0",
     "@remix-run/router": "1.23.3",
     "@testing-library/react": "15.0.7",

--- a/workspaces/intelligent-assistant/packages/app/knip-report.md
+++ b/workspaces/intelligent-assistant/packages/app/knip-report.md
@@ -1,23 +1,24 @@
 # Knip report
 
-## Unused dependencies (7)
+## Unused dependencies (8)
 
-| Name                            | Location          | Severity |
-| :------------------------------ | :---------------- | :------- |
-| @backstage/plugin-user-settings | package.json:33:6 | error    |
-| @backstage/integration-react    | package.json:28:6 | error    |
-| @backstage/plugin-scaffolder    | package.json:31:6 | error    |
-| @backstage/core-compat-api      | package.json:23:6 | error    |
-| @backstage/plugin-catalog       | package.json:30:6 | error    |
-| @backstage/plugin-search        | package.json:32:6 | error    |
-| react-router                    | package.json:42:6 | error    |
+| Name                             | Location          | Severity |
+| :------------------------------- | :---------------- | :------- |
+| @backstage-community/plugin-rbac | package.json:22:6 | error    |
+| @backstage/plugin-user-settings  | package.json:35:6 | error    |
+| @backstage/integration-react     | package.json:29:6 | error    |
+| @backstage/plugin-scaffolder     | package.json:33:6 | error    |
+| @backstage/core-compat-api       | package.json:24:6 | error    |
+| @backstage/plugin-catalog        | package.json:32:6 | error    |
+| @backstage/plugin-search         | package.json:34:6 | error    |
+| react-router                     | package.json:44:6 | error    |
 
 ## Unused devDependencies (5)
 
 | Name                           | Location          | Severity |
 | :----------------------------- | :---------------- | :------- |
-| @backstage/frontend-test-utils | package.json:46:6 | error    |
-| @testing-library/user-event    | package.json:51:6 | error    |
-| @testing-library/dom           | package.json:48:6 | error    |
-| @playwright/test               | package.json:47:6 | error    |
-| cross-env                      | package.json:53:6 | error    |
+| @backstage/frontend-test-utils | package.json:48:6 | error    |
+| @testing-library/user-event    | package.json:53:6 | error    |
+| @testing-library/dom           | package.json:50:6 | error    |
+| @playwright/test               | package.json:49:6 | error    |
+| cross-env                      | package.json:55:6 | error    |

--- a/workspaces/intelligent-assistant/packages/backend/knip-report.md
+++ b/workspaces/intelligent-assistant/packages/backend/knip-report.md
@@ -1,12 +1,11 @@
 # Knip report
 
-## Unused dependencies (10)
+## Unused dependencies (9)
 
 | Name                                                         | Location          | Severity |
 | :----------------------------------------------------------- | :---------------- | :------- |
 | @backstage/plugin-permission-backend-module-allow-all-policy | package.json:37:6 | error    |
 | @backstage/plugin-search-backend-node                        | package.json:46:6 | error    |
-| @backstage/plugin-permission-backend                         | package.json:36:6 | error    |
 | @backstage/plugin-permission-common                          | package.json:38:6 | error    |
 | @backstage/plugin-permission-node                            | package.json:39:6 | error    |
 | @backstage/plugin-auth-node                                  | package.json:31:6 | error    |

--- a/workspaces/intelligent-assistant/packages/backend/src/index.ts
+++ b/workspaces/intelligent-assistant/packages/backend/src/index.ts
@@ -33,7 +33,7 @@ backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
 // Not enabled by default — adopters who need DCR must uncomment the line below,
 // add @backstage/plugin-mcp-actions-backend@0.1.12 to packages/backend/package.json
 // (pin 0.1.12; newer versions require tracing APIs not in backend-defaults@0.16),
-// and follow the DCR setup in plugins/lightspeed-backend/README.md.
+// and follow the DCR setup in plugins/intelligent-assistant-backend/README.md.
 // backend.add(import('@backstage/plugin-mcp-actions-backend'));
 
 // catalog plugin

--- a/workspaces/intelligent-assistant/packages/backend/src/index.ts
+++ b/workspaces/intelligent-assistant/packages/backend/src/index.ts
@@ -29,6 +29,13 @@ backend.add(import('@backstage/plugin-auth-backend'));
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
 // See https://backstage.io/docs/auth/guest/provider
 
+// Optional: MCP actions backend for Dynamic Client Registration (DCR).
+// Not enabled by default — adopters who need DCR must uncomment the line below,
+// add @backstage/plugin-mcp-actions-backend@0.1.12 to packages/backend/package.json
+// (pin 0.1.12; newer versions require tracing APIs not in backend-defaults@0.16),
+// and follow the DCR setup in plugins/lightspeed-backend/README.md.
+// backend.add(import('@backstage/plugin-mcp-actions-backend'));
+
 // catalog plugin
 backend.add(import('@backstage/plugin-catalog-backend'));
 backend.add(

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/README.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/README.md
@@ -254,6 +254,77 @@ settings panel:
 These endpoints power server selection and token configuration, including inline
 success/error feedback while users enter tokens.
 
+#### DCR authentication for Backstage-internal MCP servers (optional)
+
+By default, MCP servers use **static tokens** (`token` in app-config or a personal
+token in the UI). For Backstage-internal MCP servers that support OAuth, you can
+instead use **Dynamic Client Registration (DCR)**: Lightspeed mints a per-user
+Backstage plugin-request token on each request — no manual token is required.
+
+DCR is **not enabled out of the box**. Adopters must configure the Backstage
+instance, Lightspeed Core (LCS), and Lightspeed app-config as follows.
+
+**1. Backstage backend** — register the MCP actions plugin in
+`packages/backend/src/index.ts` and add the dependency (pin version **0.1.12**;
+do not use `^0.1.14` with `backend-defaults@0.16` — the plugin will fail to start):
+
+```bash
+yarn add --cwd packages/backend @backstage/plugin-mcp-actions-backend@0.1.12
+```
+
+```ts
+backend.add(import('@backstage/plugin-mcp-actions-backend'));
+```
+
+Expose catalog/scaffolder actions as MCP tools (adjust plugin IDs for your setup):
+
+```yaml
+backend:
+  actions:
+    pluginSources:
+      - catalog
+      - scaffolder
+```
+
+**2. Backstage auth** — enable experimental DCR and use the new frontend app
+(`@backstage/plugin-auth` is required for the OAuth consent flow; `yarn start`,
+not `start:legacy`):
+
+```yaml
+auth:
+  experimentalDynamicClientRegistration:
+    enabled: true
+    allowedRedirectUriPatterns:
+      - '*'
+```
+
+**3. Lightspeed app-config** — mark the MCP server as DCR (omit `token`; it is
+ignored when `auth: dcr` is set):
+
+```yaml
+intelligent-assistant:
+  mcpServers:
+    - name: test-mcp-server
+      auth: dcr
+```
+
+**4. LCS (`lightspeed-stack.yaml`)** — point the server URL at your Backstage
+MCP endpoint and use client authorization headers:
+
+```yaml
+mcp_servers:
+  - name: test-mcp-server
+    url: 'http://<backstage-host>:7007/api/mcp-actions/v1'
+    authorization_headers:
+      Authorization: client
+```
+
+**5. MCP clients (e.g. Cursor)** — connect to the same Backstage MCP URL. DCR
+handles OAuth; no static token in `mcp.json` is needed when DCR is configured.
+
+See also commented examples in the workspace `app-config.yaml` under
+`intelligent-assistant.mcpServers` and `auth.experimentalDynamicClientRegistration`.
+
 #### Permission Framework Support
 
 The Intelligent Assistant Backend plugin has support for the permission framework.

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/report.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/report.api.md
@@ -28,6 +28,7 @@ export interface McpServerResponse {
   auth?: McpServerAuth;
   // (undocumented)
   enabled: boolean;
+  hasOrgToken: boolean;
   // (undocumented)
   hasToken: boolean;
   // (undocumented)

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/mcp-server-types.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/mcp-server-types.ts
@@ -50,6 +50,8 @@ export interface McpServerResponse {
   toolCount: number;
   hasToken: boolean;
   hasUserToken: boolean;
+  /** True when app-config defines a default token for this server. */
+  hasOrgToken: boolean;
   /** Authentication mode — `'dcr'` means tokens are minted automatically. */
   auth?: McpServerAuth;
 }

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/mcp-server.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/mcp-server.test.ts
@@ -200,6 +200,7 @@ describe('MCP server management endpoints', () => {
         toolCount: 0,
         hasToken: true,
         hasUserToken: false,
+        hasOrgToken: true,
       });
     });
 
@@ -217,12 +218,30 @@ describe('MCP server management endpoints', () => {
       );
       expect(noTokenServer.hasToken).toBe(false);
       expect(noTokenServer.hasUserToken).toBe(false);
+      expect(noTokenServer.hasOrgToken).toBe(false);
 
       const withTokenServer = response.body.servers.find(
         (s: any) => s.name === 'static-mcp',
       );
       expect(withTokenServer.hasToken).toBe(true);
       expect(withTokenServer.hasUserToken).toBe(false);
+      expect(withTokenServer.hasOrgToken).toBe(true);
+    });
+
+    it('exposes hasOrgToken independently of user token', async () => {
+      const backendServer = await startBackendServer(MCP_CONFIG);
+
+      await request(backendServer)
+        .patch('/api/lightspeed/mcp-servers/static-mcp')
+        .send({ token: 'my-personal-token' });
+
+      const response = await request(backendServer).get(
+        '/api/lightspeed/mcp-servers',
+      );
+
+      expect(response.body.servers[0].hasToken).toBe(true);
+      expect(response.body.servers[0].hasUserToken).toBe(true);
+      expect(response.body.servers[0].hasOrgToken).toBe(true);
     });
 
     it('distinguishes admin token from user token via hasUserToken', async () => {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/mcp-server.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/mcp-server.test.ts
@@ -232,11 +232,11 @@ describe('MCP server management endpoints', () => {
       const backendServer = await startBackendServer(MCP_CONFIG);
 
       await request(backendServer)
-        .patch('/api/lightspeed/mcp-servers/static-mcp')
+        .patch('/api/intelligent-assistant/mcp-servers/static-mcp')
         .send({ token: 'my-personal-token' });
 
       const response = await request(backendServer).get(
-        '/api/lightspeed/mcp-servers',
+        '/api/intelligent-assistant/mcp-servers',
       );
 
       expect(response.body.servers[0].hasToken).toBe(true);

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
@@ -336,6 +336,7 @@ export async function createRouter(
             hasToken:
               server.auth === 'dcr' || !!(setting?.token || server.token),
             hasUserToken: !!setting?.token,
+            hasOrgToken: server.auth !== 'dcr' && !!server.token,
             auth: server.auth,
           };
         });
@@ -541,6 +542,7 @@ export async function createRouter(
             hasToken:
               server.auth === 'dcr' || !!(setting.token || server.token),
             hasUserToken: !!setting.token,
+            hasOrgToken: server.auth !== 'dcr' && !!server.token,
             auth: server.auth,
           },
         };

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/knip-report.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/knip-report.md
@@ -1,16 +1,1 @@
 # Knip report
-
-## Unused dependencies (2)
-
-| Name             | Location          | Severity |
-| :--------------- | :---------------- | :------- |
-| @material-ui/lab | package.json:63:6 | error    |
-| react-markdown   | package.json:78:6 | error    |
-
-## Unused devDependencies (3)
-
-| Name                    | Location          | Severity |
-| :---------------------- | :---------------- | :------- |
-| @backstage/core-app-api | package.json:87:6 | error    |
-| @emotion/is-prop-valid  | package.json:90:6 | error    |
-| msw                     | package.json:97:6 | error    |

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/package.json
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/package.json
@@ -72,7 +72,6 @@
     "@backstage/plugin-permission-react": "^0.5.2",
     "@backstage/theme": "^0.7.3",
     "@material-ui/core": "^4.9.13",
-    "@material-ui/lab": "^4.0.0-alpha.61",
     "@monaco-editor/react": "^4.7.0",
     "@mui/icons-material": "^6.1.8",
     "@mui/material": "^5.12.2",
@@ -87,7 +86,6 @@
     "@tanstack/react-query": "^5.59.15",
     "monaco-editor": "^0.55.0",
     "react-dropzone": "^14.4.0",
-    "react-markdown": "^9.0.1",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
@@ -106,7 +104,6 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@testing-library/user-event": "14.6.1",
-    "msw": "1.3.5",
     "prettier": "3.8.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
@@ -240,6 +240,15 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.configureServerTitle': string;
     readonly 'mcp.settings.closeConfigureModalAriaLabel': string;
     readonly 'mcp.settings.modalDescription': string;
+    readonly 'mcp.settings.authenticationToken': string;
+    readonly 'mcp.settings.modal.toolsHeading': string;
+    readonly 'mcp.settings.modal.loadingTools': string;
+    readonly 'mcp.settings.modal.loadingStatus': string;
+    readonly 'mcp.settings.modal.tokenRemovedWarning': string;
+    readonly 'mcp.settings.modal.noToolsAvailable': string;
+    readonly 'mcp.settings.modal.toolsLoadFailed': string;
+    readonly 'mcp.settings.modal.enabledDescription': string;
+    readonly 'mcp.settings.modal.enabledDescriptionOff': string;
     readonly 'mcp.settings.savedToken': string;
     readonly 'mcp.settings.personalAccessToken': string;
     readonly 'mcp.settings.usingAdminCredential': string;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
@@ -249,6 +249,7 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.modal.toolsLoadFailed': string;
     readonly 'mcp.settings.modal.enabledDescription': string;
     readonly 'mcp.settings.modal.enabledDescriptionOff': string;
+    readonly 'mcp.settings.modal.enabledDescriptionTokenRequired': string;
     readonly 'mcp.settings.savedToken': string;
     readonly 'mcp.settings.personalAccessToken': string;
     readonly 'mcp.settings.usingAdminCredential': string;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
@@ -241,10 +241,12 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.closeConfigureModalAriaLabel': string;
     readonly 'mcp.settings.modalDescription': string;
     readonly 'mcp.settings.authenticationToken': string;
+    readonly 'mcp.settings.modal.authenticationHeading': string;
+    readonly 'mcp.settings.modal.credentialMode.organization': string;
+    readonly 'mcp.settings.modal.credentialMode.organizationDescription': string;
+    readonly 'mcp.settings.modal.credentialMode.personal': string;
     readonly 'mcp.settings.modal.toolsHeading': string;
     readonly 'mcp.settings.modal.loadingTools': string;
-    readonly 'mcp.settings.modal.loadingStatus': string;
-    readonly 'mcp.settings.modal.tokenRemovedWarning': string;
     readonly 'mcp.settings.modal.noToolsAvailable': string;
     readonly 'mcp.settings.modal.toolsLoadFailed': string;
     readonly 'mcp.settings.modal.enabledDescription': string;
@@ -252,9 +254,7 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.modal.enabledDescriptionTokenRequired': string;
     readonly 'mcp.settings.savedToken': string;
     readonly 'mcp.settings.personalAccessToken': string;
-    readonly 'mcp.settings.usingAdminCredential': string;
     readonly 'mcp.settings.enterToken': string;
-    readonly 'mcp.settings.removePersonalToken': string;
     readonly 'mcp.settings.token.clearAriaLabel': string;
     readonly 'mcp.settings.token.validating': string;
     readonly 'mcp.settings.token.savingAndValidating': string;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
@@ -247,6 +247,7 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.modal.credentialMode.personal': string;
     readonly 'mcp.settings.modal.toolsHeading': string;
     readonly 'mcp.settings.modal.loadingTools': string;
+    readonly 'mcp.settings.modal.fetchingStatus': string;
     readonly 'mcp.settings.modal.loadingStatus': string;
     readonly 'mcp.settings.modal.tokenRemovedWarning': string;
     readonly 'mcp.settings.modal.noToolsAvailable': string;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/report-alpha.api.md
@@ -247,6 +247,8 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.modal.credentialMode.personal': string;
     readonly 'mcp.settings.modal.toolsHeading': string;
     readonly 'mcp.settings.modal.loadingTools': string;
+    readonly 'mcp.settings.modal.loadingStatus': string;
+    readonly 'mcp.settings.modal.tokenRemovedWarning': string;
     readonly 'mcp.settings.modal.noToolsAvailable': string;
     readonly 'mcp.settings.modal.toolsLoadFailed': string;
     readonly 'mcp.settings.modal.enabledDescription': string;
@@ -255,6 +257,7 @@ export const intelligentAssistantTranslationRef: TranslationRef<
     readonly 'mcp.settings.savedToken': string;
     readonly 'mcp.settings.personalAccessToken': string;
     readonly 'mcp.settings.enterToken': string;
+    readonly 'mcp.settings.removePersonalToken': string;
     readonly 'mcp.settings.token.clearAriaLabel': string;
     readonly 'mcp.settings.token.validating': string;
     readonly 'mcp.settings.token.savingAndValidating': string;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpConfigureServerModal.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpConfigureServerModal.tsx
@@ -1,0 +1,476 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles } from '@material-ui/core';
+import Typography from '@mui/material/Typography';
+import {
+  Alert,
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Radio,
+  Spinner,
+  Stack,
+  StackItem,
+  Switch,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Tooltip,
+} from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  InfoCircleIcon,
+  KeyIcon,
+  TimesIcon,
+} from '@patternfly/react-icons';
+
+import { type UseMcpConfigureModalResult } from '../hooks/useMcpConfigureModal';
+import { useTranslation } from '../hooks/useTranslation';
+
+const useStyles = makeStyles({
+  configureModal: {
+    '& .pf-v6-c-modal-box__close, & .pf-v5-c-modal-box__close': {
+      display: 'none',
+    },
+    '& .pf-v6-c-modal-box__body, & .pf-v5-c-modal-box__body': {
+      paddingTop: 0,
+    },
+  },
+  modalCloseButton: {
+    position: 'absolute',
+    top: 'var(--pf-v6-c-modal-box__close--InsetBlockStart, 1.5rem)',
+    right: 'var(--pf-v6-c-modal-box__close--InsetInlineEnd, 1.5rem)',
+    zIndex: 1,
+  },
+  modalInfoAlert: {
+    '--pf-v6-c-alert--m-custom--BorderColor':
+      'var(--pf-t--global--color--status--info--default)',
+    '--pf-v6-c-alert--m-custom__icon--Color':
+      'var(--pf-t--global--color--status--info--default)',
+    '& .pf-v6-c-alert__icon': {
+      alignSelf: 'start',
+      display: 'flex',
+      alignItems: 'flex-start',
+      justifyContent: 'center',
+      boxSizing: 'border-box',
+      marginBlockStart: 0,
+      paddingBlockStart: '18.620px',
+      paddingInline: 'var(--pf-t--global--spacer--md)',
+      paddingBlockEnd: 'var(--pf-t--global--spacer--md)',
+    },
+  },
+  sectionTitle: {
+    fontSize: '0.875rem',
+    fontWeight: 600,
+  },
+  sectionDescription: {
+    color: 'var(--pf-t--global--text--color--subtle)',
+    fontSize: '0.875rem',
+  },
+  credentialRadioDescription: {
+    color: 'var(--pf-t--global--text--color--subtle)',
+    fontSize: '0.875rem',
+  },
+  statusOk: {
+    color: 'var(--pf-t--global--icon--color--status--custom--default)',
+  },
+  statusWarn: {
+    color: 'var(--pf-t--global--icon--color--status--danger--default)',
+  },
+  statusDisabled: {
+    color: 'var(--pf-t--global--icon--color--subtle)',
+  },
+  // Shape only; danger colors come from secondary + isDanger.
+  removePersonalTokenButton: {
+    borderRadius: '1.25rem',
+    boxShadow: 'none',
+  },
+});
+
+type McpConfigureServerModalProps = UseMcpConfigureModalResult;
+
+export const McpConfigureServerModal = ({
+  isOpen,
+  editingServer,
+  close,
+  save,
+  removePersonalToken,
+  canManageMcp,
+  configureModalTitle,
+  isConfigureModalSaving,
+  isSaveTokenButtonDisabled,
+  isUpdatingModalStatus,
+  tokenInputValue,
+  onTokenInputChange,
+  clearTokenInput,
+  tokenInputValidated,
+  tokenValidationState,
+  tokenHelperVariant,
+  showTokenHelperText,
+  tokenHelperText,
+  modalCredentialMode,
+  onCredentialModeChange,
+  showCredentialRadios,
+  showPersonalTokenField,
+  onModalEnabledChange,
+  isModalEnabledChecked,
+  isModalEnabledToggleDisabled,
+  modalDisplayStatus,
+  modalStatusDetail,
+  modalStatusText,
+  modalTools,
+  modalToolCount,
+  isLoadingModalTools,
+  modalToolsError,
+  modalToolsEmptyText,
+  modalVerifiedHasToken,
+  modalEnabledDescription,
+  canRemovePersonalToken,
+  hasSavedTokenInModal,
+  hasRemovedPersonalToken,
+}: McpConfigureServerModalProps) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  const renderStatusIcon = () => {
+    if (isUpdatingModalStatus || isLoadingModalTools) {
+      return (
+        <Spinner
+          size="md"
+          aria-label={
+            isUpdatingModalStatus
+              ? t('mcp.settings.modal.loadingStatus')
+              : t('mcp.settings.modal.fetchingStatus')
+          }
+        />
+      );
+    }
+    if (modalDisplayStatus === 'disabled') {
+      return <InfoCircleIcon className={classes.statusDisabled} />;
+    }
+    if (modalDisplayStatus === 'tokenRequired') {
+      return <KeyIcon className={classes.statusWarn} />;
+    }
+    if (modalDisplayStatus === 'ok' && modalTools.length > 0) {
+      return <CheckCircleIcon className={classes.statusOk} />;
+    }
+    if (modalToolsError || modalDisplayStatus === 'failed') {
+      return <ExclamationCircleIcon className={classes.statusWarn} />;
+    }
+    return <InfoCircleIcon className={classes.statusDisabled} />;
+  };
+
+  const renderToolsContent = () => {
+    if (isLoadingModalTools) {
+      return (
+        <Spinner size="md" aria-label={t('mcp.settings.modal.loadingTools')} />
+      );
+    }
+    if (modalTools.length > 0) {
+      return (
+        <List
+          isPlain
+          aria-label={t('mcp.settings.modal.toolsHeading' as any, {
+            count: String(modalToolCount),
+          })}
+        >
+          {modalTools.map(toolName => (
+            <ListItem
+              key={toolName}
+              icon={<CheckCircleIcon className={classes.statusOk} />}
+            >
+              {toolName}
+            </ListItem>
+          ))}
+        </List>
+      );
+    }
+    return (
+      <Typography
+        component="div"
+        className={`${classes.sectionDescription} pf-v6-u-mt-xs`}
+      >
+        {modalToolsEmptyText}
+      </Typography>
+    );
+  };
+
+  const enabledSwitch = (
+    <Switch
+      id="mcp-configure-enabled-switch"
+      aria-label={t('mcp.settings.toggleServerAriaLabel' as any, {
+        serverName: editingServer?.name ?? '',
+      })}
+      isChecked={isModalEnabledChecked}
+      isDisabled={isModalEnabledToggleDisabled}
+      onChange={onModalEnabledChange}
+    />
+  );
+
+  return (
+    <Modal
+      variant="small"
+      width={608}
+      isOpen={isOpen}
+      onClose={close}
+      className={classes.configureModal}
+      aria-labelledby="mcp-configure-modal"
+      aria-describedby="mcp-configure-modal-body"
+    >
+      <ModalHeader
+        title={configureModalTitle}
+        labelId="mcp-configure-modal"
+        descriptorId="mcp-configure-modal-body"
+      />
+      <Button
+        variant="plain"
+        icon={<TimesIcon />}
+        aria-label={t('mcp.settings.closeConfigureModalAriaLabel')}
+        className={classes.modalCloseButton}
+        onClick={close}
+      />
+      <ModalBody id="mcp-configure-modal-body">
+        <Stack hasGutter>
+          <StackItem>
+            <Alert
+              variant="custom"
+              customIcon={<InfoCircleIcon />}
+              title={t('mcp.settings.modalDescription')}
+              className={classes.modalInfoAlert}
+              isInline
+            />
+          </StackItem>
+          {editingServer?.auth === 'dcr' && (
+            <StackItem>
+              <Alert
+                variant="custom"
+                customIcon={<InfoCircleIcon />}
+                title={t('mcp.settings.modalDescriptionDcr')}
+                className={classes.modalInfoAlert}
+                isInline
+              />
+            </StackItem>
+          )}
+          {hasRemovedPersonalToken && !editingServer?.hasOrgToken && (
+            <StackItem>
+              <Alert
+                variant="custom"
+                customIcon={<InfoCircleIcon />}
+                title={t('mcp.settings.modal.tokenRemovedWarning')}
+                className={classes.modalInfoAlert}
+                isInline
+              />
+            </StackItem>
+          )}
+          <StackItem>
+            <Typography
+              component="div"
+              className={`${classes.sectionTitle} pf-v6-u-mb-sm`}
+            >
+              {t('mcp.settings.status')}
+            </Typography>
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsSm' }}
+            >
+              <FlexItem>{renderStatusIcon()}</FlexItem>
+              <FlexItem>
+                <Typography component="span">{modalStatusText}</Typography>
+              </FlexItem>
+            </Flex>
+          </StackItem>
+          {modalVerifiedHasToken && modalDisplayStatus === 'ok' && (
+            <StackItem>
+              <Typography
+                component="div"
+                className={`${classes.sectionTitle} pf-v6-u-mb-sm`}
+              >
+                {t('mcp.settings.modal.toolsHeading' as any, {
+                  count: String(modalToolCount),
+                })}
+              </Typography>
+              {renderToolsContent()}
+            </StackItem>
+          )}
+          <StackItem>
+            <Flex
+              justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              alignItems={{ default: 'alignItemsFlexStart' }}
+              spaceItems={{ default: 'spaceItemsMd' }}
+            >
+              <FlexItem flex={{ default: 'flex_1' }}>
+                <Typography
+                  component="div"
+                  className={`${classes.sectionTitle} pf-v6-u-mb-sm`}
+                >
+                  {t('mcp.settings.enabled')}
+                </Typography>
+                <Typography
+                  component="div"
+                  className={`${classes.sectionDescription} pf-v6-u-mt-xs`}
+                >
+                  {modalEnabledDescription}
+                </Typography>
+              </FlexItem>
+              <FlexItem>
+                {isModalEnabledToggleDisabled ? (
+                  <Tooltip content={modalStatusDetail}>
+                    <Typography component="span">{enabledSwitch}</Typography>
+                  </Tooltip>
+                ) : (
+                  enabledSwitch
+                )}
+              </FlexItem>
+            </Flex>
+          </StackItem>
+          {(showCredentialRadios || showPersonalTokenField) && (
+            <StackItem>
+              <Form>
+                {showCredentialRadios && (
+                  <FormGroup
+                    role="radiogroup"
+                    id="mcp-credential-mode"
+                    fieldId="mcp-credential-mode"
+                    label={t('mcp.settings.modal.authenticationHeading')}
+                  >
+                    <Stack hasGutter>
+                      <StackItem>
+                        <Radio
+                          id="mcp-credential-organization"
+                          name="mcp-credential-mode"
+                          label={t(
+                            'mcp.settings.modal.credentialMode.organization',
+                          )}
+                          isChecked={modalCredentialMode === 'organization'}
+                          onChange={() =>
+                            onCredentialModeChange('organization')
+                          }
+                        />
+                        <Typography
+                          component="div"
+                          className={`${classes.credentialRadioDescription} pf-v6-u-ml-xl pf-v6-u-mt-xs`}
+                        >
+                          {t(
+                            'mcp.settings.modal.credentialMode.organizationDescription',
+                          )}
+                        </Typography>
+                      </StackItem>
+                      <StackItem>
+                        <Radio
+                          id="mcp-credential-personal"
+                          name="mcp-credential-mode"
+                          label={t(
+                            'mcp.settings.modal.credentialMode.personal',
+                          )}
+                          isChecked={modalCredentialMode === 'personal'}
+                          onChange={() => onCredentialModeChange('personal')}
+                        />
+                      </StackItem>
+                    </Stack>
+                  </FormGroup>
+                )}
+                {showPersonalTokenField && (
+                  <FormGroup
+                    label={t('mcp.settings.authenticationToken')}
+                    fieldId="mcp-pat-input"
+                  >
+                    <TextInputGroup validated={tokenInputValidated}>
+                      <TextInputGroupMain
+                        inputId="mcp-pat-input"
+                        type="password"
+                        value={tokenInputValue}
+                        onChange={(_event, value) => onTokenInputChange(value)}
+                      />
+                      {(tokenValidationState === 'idle' ||
+                        tokenValidationState === 'validating') && (
+                        <TextInputGroupUtilities>
+                          <Button
+                            variant="plain"
+                            onClick={clearTokenInput}
+                            aria-label={t('mcp.settings.token.clearAriaLabel')}
+                            icon={<TimesIcon />}
+                          />
+                        </TextInputGroupUtilities>
+                      )}
+                    </TextInputGroup>
+                    {showTokenHelperText && (
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem variant={tokenHelperVariant}>
+                            {tokenHelperText}
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    )}
+                  </FormGroup>
+                )}
+              </Form>
+            </StackItem>
+          )}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={() => void save()}
+          isDisabled={
+            !canManageMcp ||
+            isConfigureModalSaving ||
+            tokenValidationState === 'validating' ||
+            isSaveTokenButtonDisabled ||
+            isUpdatingModalStatus
+          }
+        >
+          {t('modal.save')}
+        </Button>
+        {canRemovePersonalToken && (
+          <Button
+            variant="secondary"
+            isDanger
+            onClick={() => void removePersonalToken()}
+            isDisabled={
+              !canManageMcp ||
+              isConfigureModalSaving ||
+              tokenValidationState === 'validating' ||
+              isUpdatingModalStatus ||
+              hasRemovedPersonalToken ||
+              !hasSavedTokenInModal
+            }
+            className={classes.removePersonalTokenButton}
+          >
+            {t('mcp.settings.removePersonalToken')}
+          </Button>
+        )}
+        <Button variant="link" onClick={close}>
+          {t('common.cancel')}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -789,8 +789,7 @@ export const McpServersSettings = ({
       return undefined;
     }
 
-    // DCR servers don't expose credential UI — skip tools fetch in the modal.
-    if (editingServer.auth === 'dcr' || !editingServer.hasToken) {
+    if (!editingServer.hasToken) {
       setModalTools([]);
       setModalToolsError(null);
       setIsLoadingModalTools(false);
@@ -926,6 +925,7 @@ export const McpServersSettings = ({
     hasSavedPersonalTokenInModal: hasSavedTokenInModal,
     tokenValidationState,
     hasRemovedPersonalToken,
+    isDcrServer: editingServer?.auth === 'dcr',
   });
 
   const removePersonalToken = useCallback(async () => {
@@ -1118,7 +1118,8 @@ export const McpServersSettings = ({
   };
 
   const modalVerifiedHasToken = editingServer
-    ? getModalVerifiedHasToken({
+    ? editingServer.auth === 'dcr' ||
+      getModalVerifiedHasToken({
         hasOrgToken: editingServer.hasOrgToken,
         credentialMode: modalCredentialMode,
         hasSavedPersonalTokenInModal: hasSavedTokenInModal,
@@ -1163,7 +1164,7 @@ export const McpServersSettings = ({
           aria-label={
             isUpdatingModalStatus
               ? t('mcp.settings.modal.loadingStatus')
-              : t('mcp.settings.modal.loadingTools')
+              : t('mcp.settings.modal.fetchingStatus')
           }
         />
       );
@@ -1188,7 +1189,7 @@ export const McpServersSettings = ({
       return t('mcp.settings.modal.loadingStatus');
     }
     if (isLoadingModalTools) {
-      return t('mcp.settings.modal.loadingTools');
+      return t('mcp.settings.modal.fetchingStatus');
     }
     if (modalDisplayStatus === 'disabled') {
       return t('mcp.settings.status.disabled');
@@ -1247,7 +1248,9 @@ export const McpServersSettings = ({
     return t('mcp.settings.modal.enabledDescriptionOff');
   };
 
-  const renderConfigureModalDetails = () => (
+  const renderConfigureModalDetails = (options?: {
+    showDcrAlert?: boolean;
+  }) => (
     <>
       <Alert
         variant="custom"
@@ -1256,6 +1259,15 @@ export const McpServersSettings = ({
         className={classes.modalInfoAlert}
         isInline
       />
+      {options?.showDcrAlert && (
+        <Alert
+          variant="custom"
+          customIcon={<InfoCircleIcon />}
+          title={t('mcp.settings.modalDescriptionDcr')}
+          className={classes.modalInfoAlert}
+          isInline
+        />
+      )}
       {hasRemovedPersonalToken && !editingServer?.hasOrgToken && (
         <Alert
           variant="custom"
@@ -1546,128 +1558,116 @@ export const McpServersSettings = ({
           onClick={closeConfigureModal}
         />
         <ModalBody id="mcp-configure-modal-body">
-          {editingServer?.auth === 'dcr' ? (
-            <div className={classes.modalSectionDescription}>
-              {t('mcp.settings.modalDescriptionDcr')}
-            </div>
-          ) : (
-            <>
-              {renderConfigureModalDetails()}
-              {showCredentialRadios && (
-                <div className={classes.modalSection}>
-                  <div className={classes.modalSectionTitle}>
-                    {t('mcp.settings.modal.authenticationHeading')}
-                  </div>
-                  <div
-                    className={classes.credentialRadioGroup}
-                    id="mcp-credential-mode"
-                  >
-                    <div>
-                      <Radio
-                        id="mcp-credential-organization"
-                        name="mcp-credential-mode"
-                        label={t(
-                          'mcp.settings.modal.credentialMode.organization',
-                        )}
-                        isChecked={modalCredentialMode === 'organization'}
-                        onChange={() => onCredentialModeChange('organization')}
-                      />
-                      <div className={classes.credentialRadioDescription}>
-                        {t(
-                          'mcp.settings.modal.credentialMode.organizationDescription',
-                        )}
-                      </div>
-                    </div>
-                    <Radio
-                      id="mcp-credential-personal"
-                      name="mcp-credential-mode"
-                      label={t('mcp.settings.modal.credentialMode.personal')}
-                      isChecked={modalCredentialMode === 'personal'}
-                      onChange={() => onCredentialModeChange('personal')}
-                    />
-                  </div>
+          <>
+            {renderConfigureModalDetails({
+              showDcrAlert: editingServer?.auth === 'dcr',
+            })}
+            {showCredentialRadios && (
+              <div className={classes.modalSection}>
+                <div className={classes.modalSectionTitle}>
+                  {t('mcp.settings.modal.authenticationHeading')}
                 </div>
-              )}
-              {showPersonalTokenField && (
-                <FormGroup
-                  label={t('mcp.settings.authenticationToken')}
-                  fieldId="mcp-pat-input"
+                <div
+                  className={classes.credentialRadioGroup}
+                  id="mcp-credential-mode"
                 >
-                  <TextInputGroup validated={tokenInputValidated}>
-                    <TextInputGroupMain
-                      inputId="mcp-pat-input"
-                      type="password"
-                      value={tokenInputValue}
-                      onChange={(_event, value) => onTokenInputChange(value)}
+                  <div>
+                    <Radio
+                      id="mcp-credential-organization"
+                      name="mcp-credential-mode"
+                      label={t(
+                        'mcp.settings.modal.credentialMode.organization',
+                      )}
+                      isChecked={modalCredentialMode === 'organization'}
+                      onChange={() => onCredentialModeChange('organization')}
                     />
-                    {(tokenValidationState === 'idle' ||
-                      tokenValidationState === 'validating') && (
-                      <TextInputGroupUtilities>
-                        <Button
-                          variant="plain"
-                          onClick={clearTokenInput}
-                          aria-label={t('mcp.settings.token.clearAriaLabel')}
-                          icon={<TimesIcon />}
-                        />
-                      </TextInputGroupUtilities>
-                    )}
-                  </TextInputGroup>
-                  {showTokenHelperText && (
-                    <FormHelperText>
-                      <HelperText>
-                        <HelperTextItem variant={tokenHelperVariant}>
-                          {tokenHelperText}
-                        </HelperTextItem>
-                      </HelperText>
-                    </FormHelperText>
+                    <div className={classes.credentialRadioDescription}>
+                      {t(
+                        'mcp.settings.modal.credentialMode.organizationDescription',
+                      )}
+                    </div>
+                  </div>
+                  <Radio
+                    id="mcp-credential-personal"
+                    name="mcp-credential-mode"
+                    label={t('mcp.settings.modal.credentialMode.personal')}
+                    isChecked={modalCredentialMode === 'personal'}
+                    onChange={() => onCredentialModeChange('personal')}
+                  />
+                </div>
+              </div>
+            )}
+            {showPersonalTokenField && (
+              <FormGroup
+                label={t('mcp.settings.authenticationToken')}
+                fieldId="mcp-pat-input"
+              >
+                <TextInputGroup validated={tokenInputValidated}>
+                  <TextInputGroupMain
+                    inputId="mcp-pat-input"
+                    type="password"
+                    value={tokenInputValue}
+                    onChange={(_event, value) => onTokenInputChange(value)}
+                  />
+                  {(tokenValidationState === 'idle' ||
+                    tokenValidationState === 'validating') && (
+                    <TextInputGroupUtilities>
+                      <Button
+                        variant="plain"
+                        onClick={clearTokenInput}
+                        aria-label={t('mcp.settings.token.clearAriaLabel')}
+                        icon={<TimesIcon />}
+                      />
+                    </TextInputGroupUtilities>
                   )}
-                </FormGroup>
-              )}
-            </>
-          )}
+                </TextInputGroup>
+                {showTokenHelperText && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant={tokenHelperVariant}>
+                        {tokenHelperText}
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
+              </FormGroup>
+            )}
+          </>
         </ModalBody>
         <ModalFooter>
-          {editingServer?.auth === 'dcr' ? (
-            <Button variant="primary" onClick={closeConfigureModal}>
-              {t('common.cancel')}
+          <Button
+            variant="primary"
+            onClick={() => void saveServerToken()}
+            isDisabled={
+              !canManageMcp ||
+              isConfigureModalSaving ||
+              tokenValidationState === 'validating' ||
+              isSaveTokenButtonDisabled ||
+              isUpdatingModalStatus
+            }
+          >
+            {t('modal.save')}
+          </Button>
+          {canRemovePersonalToken && (
+            <Button
+              variant="secondary"
+              onClick={() => void removePersonalToken()}
+              isDisabled={
+                !canManageMcp ||
+                isConfigureModalSaving ||
+                tokenValidationState === 'validating' ||
+                isUpdatingModalStatus ||
+                hasRemovedPersonalToken ||
+                !hasSavedTokenInModal
+              }
+              className={classes.removePersonalTokenButton}
+            >
+              {t('mcp.settings.removePersonalToken')}
             </Button>
-          ) : (
-            <>
-              <Button
-                variant="primary"
-                onClick={() => void saveServerToken()}
-                isDisabled={
-                  !canManageMcp ||
-                  isConfigureModalSaving ||
-                  tokenValidationState === 'validating' ||
-                  isSaveTokenButtonDisabled ||
-                  isUpdatingModalStatus
-                }
-              >
-                {t('modal.save')}
-              </Button>
-              {canRemovePersonalToken && (
-                <Button
-                  variant="secondary"
-                  onClick={() => void removePersonalToken()}
-                  isDisabled={
-                    !canManageMcp ||
-                    isConfigureModalSaving ||
-                    tokenValidationState === 'validating' ||
-                    isUpdatingModalStatus ||
-                    hasRemovedPersonalToken ||
-                    !hasSavedTokenInModal
-                  }
-                  className={classes.removePersonalTokenButton}
-                >
-                  {t('mcp.settings.removePersonalToken')}
-                </Button>
-              )}
-              <Button variant="link" onClick={closeConfigureModal}>
-                {t('common.cancel')}
-              </Button>
-            </>
           )}
+          <Button variant="link" onClick={closeConfigureModal}>
+            {t('common.cancel')}
+          </Button>
         </ModalFooter>
       </Modal>
     </div>

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -38,6 +38,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  Radio,
   Spinner,
   Switch,
   TextInputGroup,
@@ -65,10 +66,14 @@ import {
   formatApiError,
   getDisplayStatus,
   getEnabledToggleChecked,
+  getInitialCredentialMode,
+  getModalDisplayHasToken,
   getModalDisplayStatus,
   isModalEnabledChecked as getModalEnabledChecked,
+  getModalVerifiedHasToken,
   isSaveTokenDisabled as getSaveTokenDisabled,
   isEnabledToggleUnavailable,
+  type CredentialMode,
   type ServerStatus,
 } from './mcpServersDisplayUtils';
 
@@ -81,6 +86,7 @@ type McpServer = {
   toolCount: number;
   hasToken: boolean;
   hasUserToken: boolean;
+  hasOrgToken: boolean;
   validationError?: string;
   /** 'dcr' = tokens are minted automatically (no manual token needed). */
   auth?: string;
@@ -268,31 +274,22 @@ const useStyles = makeStyles(theme => ({
   modalEnabledLabel: {
     flex: 1,
   },
+  credentialRadioGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  },
+  credentialRadioDescription: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.875rem',
+    marginTop: theme.spacing(0.25),
+    marginLeft: theme.spacing(3),
+  },
   modalCloseButton: {
     position: 'absolute',
     top: 'var(--pf-v6-c-modal-box__close--InsetBlockStart, 1.5rem)',
     right: 'var(--pf-v6-c-modal-box__close--InsetInlineEnd, 1.5rem)',
     zIndex: 1,
-  },
-  removePersonalTokenButton: {
-    borderRadius: '1.25rem',
-    boxShadow: 'none',
-    '&:not(:disabled):not(.pf-m-disabled)': {
-      '--pf-v6-c-button--BorderColor': '#B1380B',
-      '--pf-v6-c-button--Color': '#B1380B',
-      '--pf-v6-c-button--BackgroundColor': 'transparent',
-      '--pf-v5-c-button--BorderColor': '#B1380B',
-      '--pf-v5-c-button--Color': '#B1380B',
-      '--pf-v5-c-button--BackgroundColor': 'transparent',
-      borderColor: '#B1380B',
-      color: '#B1380B',
-      backgroundColor: 'transparent',
-      '&:hover': {
-        '--pf-v6-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
-        '--pf-v5-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
-        backgroundColor: 'rgba(201, 25, 11, 0.08)',
-      },
-    },
   },
   configureModal: {
     '& .pf-v6-c-modal-box, & .pf-v5-c-modal-box': {
@@ -309,6 +306,7 @@ const useStyles = makeStyles(theme => ({
     },
     '& .pf-v6-c-modal-box__title, & .pf-v5-c-modal-box__title': {
       marginBlockEnd: 0,
+      fontWeight: 600,
     },
     '& .pf-v6-c-modal-box__body, & .pf-v5-c-modal-box__body': {
       '--pf-v6-c-modal-box__body--PaddingBlockStart': '0.5rem',
@@ -358,6 +356,7 @@ type McpServerResponse = {
   toolCount: number;
   hasToken: boolean;
   hasUserToken: boolean;
+  hasOrgToken: boolean;
   auth?: string;
 };
 
@@ -414,6 +413,7 @@ const toUiServer = (
   toolCount: server.toolCount,
   hasToken: server.hasToken,
   hasUserToken: server.hasUserToken,
+  hasOrgToken: server.hasOrgToken,
   validationError: server.status === 'error' ? validationError : undefined,
   auth: server.auth,
 });
@@ -438,7 +438,10 @@ export const McpServersSettings = ({
   const [tokenInputValue, setTokenInputValue] = useState('');
   const [initialTokenInputValue, setInitialTokenInputValue] = useState('');
   const [hasSavedTokenInModal, setHasSavedTokenInModal] = useState(false);
-  const [canRemovePersonalToken, setCanRemovePersonalToken] = useState(false);
+  const [modalCredentialMode, setModalCredentialMode] =
+    useState<CredentialMode>('personal');
+  const [initialCredentialMode, setInitialCredentialMode] =
+    useState<CredentialMode>('personal');
   const [tokenValidationState, setTokenValidationState] =
     useState<TokenValidationState>('idle');
   const [tokenValidationMessage, setTokenValidationMessage] = useState('');
@@ -446,8 +449,6 @@ export const McpServersSettings = ({
   const [modalTools, setModalTools] = useState<string[]>([]);
   const [isLoadingModalTools, setIsLoadingModalTools] = useState(false);
   const [modalToolsError, setModalToolsError] = useState<string | null>(null);
-  const [isUpdatingModalStatus, setIsUpdatingModalStatus] = useState(false);
-  const [hasRemovedPersonalToken, setHasRemovedPersonalToken] = useState(false);
 
   const getBaseUrl = useCallback(() => {
     return `${configApi.getString('backend.baseUrl')}/api/intelligent-assistant`;
@@ -672,30 +673,29 @@ export const McpServersSettings = ({
     setTokenInputValue('');
     setInitialTokenInputValue('');
     setHasSavedTokenInModal(false);
-    setCanRemovePersonalToken(false);
+    setModalCredentialMode('personal');
+    setInitialCredentialMode('personal');
     setTokenValidationState('idle');
     setTokenValidationMessage('');
     setModalEnabled(true);
     setModalTools([]);
     setIsLoadingModalTools(false);
     setModalToolsError(null);
-    setIsUpdatingModalStatus(false);
-    setHasRemovedPersonalToken(false);
   }, []);
 
   const openConfigureModal = (server: McpServer) => {
     setEditingServerId(server.id);
-    const hasSavedToken = server.hasToken;
-    setHasSavedTokenInModal(hasSavedToken);
-    setCanRemovePersonalToken(server.hasUserToken);
-    const initialToken = hasSavedToken ? SAVED_TOKEN_MASK : '';
+    const credentialMode = getInitialCredentialMode(server);
+    const hasSavedPersonalToken = server.hasUserToken;
+    setModalCredentialMode(credentialMode);
+    setInitialCredentialMode(credentialMode);
+    setHasSavedTokenInModal(hasSavedPersonalToken);
+    const initialToken = hasSavedPersonalToken ? SAVED_TOKEN_MASK : '';
     setInitialTokenInputValue(initialToken);
     setTokenInputValue(initialToken);
     setModalEnabled(server.enabled);
     setModalTools([]);
     setModalToolsError(null);
-    setIsUpdatingModalStatus(false);
-    setHasRemovedPersonalToken(false);
     if (server.status === 'error' && server.validationError) {
       setTokenValidationState('error');
       setTokenValidationMessage(
@@ -771,6 +771,32 @@ export const McpServersSettings = ({
     setTokenValidationMessage('');
   };
 
+  const onCredentialModeChange = (mode: CredentialMode) => {
+    if (mode === modalCredentialMode) {
+      return;
+    }
+    setModalCredentialMode(mode);
+    setTokenValidationState('idle');
+    setTokenValidationMessage('');
+
+    if (mode === 'organization') {
+      setHasSavedTokenInModal(false);
+      setTokenInputValue('');
+      return;
+    }
+
+    if (editingServer?.hasUserToken) {
+      setHasSavedTokenInModal(true);
+      setTokenInputValue(SAVED_TOKEN_MASK);
+      setInitialTokenInputValue(SAVED_TOKEN_MASK);
+      return;
+    }
+
+    setHasSavedTokenInModal(false);
+    setTokenInputValue('');
+    setInitialTokenInputValue('');
+  };
+
   const clearTokenInput = () => {
     if (hasSavedTokenInModal) {
       setHasSavedTokenInModal(false);
@@ -780,8 +806,12 @@ export const McpServersSettings = ({
     setTokenValidationMessage('');
   };
 
-  const isUsingOrganizationCredentialInModal =
-    hasSavedTokenInModal && !canRemovePersonalToken;
+  const showCredentialRadios = Boolean(
+    editingServer?.hasOrgToken && editingServer.auth !== 'dcr',
+  );
+  const showPersonalTokenField =
+    editingServer?.auth !== 'dcr' &&
+    (!showCredentialRadios || modalCredentialMode === 'personal');
 
   let tokenInputValidated: 'success' | 'error' | undefined;
   if (tokenValidationState === 'success') {
@@ -798,15 +828,10 @@ export const McpServersSettings = ({
   }
 
   const showTokenHelperText =
-    isUsingOrganizationCredentialInModal ||
-    !hasSavedTokenInModal ||
-    tokenValidationState !== 'idle';
+    !hasSavedTokenInModal || tokenValidationState !== 'idle';
 
   const tokenHelperText =
-    tokenValidationMessage ||
-    (isUsingOrganizationCredentialInModal
-      ? t('mcp.settings.usingAdminCredential')
-      : t('mcp.settings.enterToken'));
+    tokenValidationMessage || t('mcp.settings.enterToken');
 
   const configureModalTitle = t('mcp.settings.configureServerTitle' as any, {
     serverName: editingServer?.name ?? '',
@@ -818,18 +843,59 @@ export const McpServersSettings = ({
     initialTokenInputValue,
     modalEnabled,
     serverEnabled: editingServer?.enabled ?? true,
-    isUpdatingModalStatus,
-    hasRemovedPersonalToken,
+    credentialMode: modalCredentialMode,
+    initialCredentialMode,
+    hasOrgToken: editingServer?.hasOrgToken ?? false,
+    hasSavedPersonalTokenInModal: hasSavedTokenInModal,
+    tokenValidationState,
   });
 
   const saveServerToken = useCallback(async () => {
     if (!editingServer || !canManageMcp) return;
 
+    const hasCredentialModeChange =
+      modalCredentialMode !== initialCredentialMode;
     const hasTokenInputChange = tokenInputValue !== initialTokenInputValue;
     const hasEnabledInputChange = modalEnabled !== editingServer.enabled;
 
-    if (!hasTokenInputChange && !hasEnabledInputChange) {
+    if (
+      !hasCredentialModeChange &&
+      !hasTokenInputChange &&
+      !hasEnabledInputChange
+    ) {
       closeConfigureModal();
+      return;
+    }
+
+    if (
+      modalCredentialMode === 'organization' &&
+      (hasCredentialModeChange || hasEnabledInputChange)
+    ) {
+      setTokenValidationState('validating');
+      setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
+      try {
+        await patchServer(editingServer.name, {
+          token: null,
+          enabled: modalEnabled,
+        });
+        const validationResult = await validateServer(editingServer.name);
+        if (validationResult.status === 'error') {
+          setTokenValidationState('error');
+          setTokenValidationMessage(
+            formatApiError(validationResult.validation?.error) ||
+              t('mcp.settings.token.validationFailed'),
+          );
+          return;
+        }
+        closeConfigureModal();
+      } catch (e) {
+        setTokenValidationState('error');
+        setTokenValidationMessage(
+          e instanceof Error
+            ? e.message
+            : `Failed to update ${editingServer.name} settings`,
+        );
+      }
       return;
     }
 
@@ -838,6 +904,10 @@ export const McpServersSettings = ({
       closeConfigureModal();
       return;
     }
+
+    const markFailedTokenAttempt = () => {
+      setInitialTokenInputValue(tokenInputValue);
+    };
 
     const token = tokenInputValue.trim();
     const hasToken = token.length > 0;
@@ -852,6 +922,7 @@ export const McpServersSettings = ({
           setTokenValidationMessage(
             t('mcp.settings.token.urlUnavailableForValidation'),
           );
+          markFailedTokenAttempt();
           return;
         }
 
@@ -865,6 +936,7 @@ export const McpServersSettings = ({
             formatApiError(credentialValidation.error) ||
               t('mcp.settings.token.invalidCredentials'),
           );
+          markFailedTokenAttempt();
           return;
         }
         setModalTools(credentialValidation.tools?.map(tool => tool.name) ?? []);
@@ -882,6 +954,7 @@ export const McpServersSettings = ({
           formatApiError(validationResult.validation?.error) ||
             t('mcp.settings.token.validationFailed'),
         );
+        markFailedTokenAttempt();
         return;
       }
       if (hasToken && validationResult.status === 'connected') {
@@ -898,57 +971,21 @@ export const McpServersSettings = ({
           ? e.message
           : `Failed to update ${editingServer.name} token`,
       );
+      markFailedTokenAttempt();
     }
   }, [
     canManageMcp,
     closeConfigureModal,
     editingServer,
+    initialCredentialMode,
     initialTokenInputValue,
+    modalCredentialMode,
     modalEnabled,
     patchServer,
     t,
     tokenInputValue,
     validateCredentials,
     validateServer,
-  ]);
-
-  const removePersonalToken = useCallback(async () => {
-    if (!editingServer || !canManageMcp || isUpdatingModalStatus) {
-      return;
-    }
-
-    setIsUpdatingModalStatus(true);
-    setTokenInputValue('');
-    setTokenValidationState('idle');
-    setTokenValidationMessage('');
-    setModalTools([]);
-    setModalToolsError(null);
-    setIsLoadingModalTools(false);
-
-    try {
-      await patchServer(editingServer.name, { token: null, enabled: false });
-      setHasSavedTokenInModal(false);
-      setInitialTokenInputValue('');
-      setModalEnabled(false);
-      setHasRemovedPersonalToken(true);
-    } catch {
-      const server = servers.find(item => item.id === editingServerId);
-      if (server?.hasUserToken && server.hasToken) {
-        setHasSavedTokenInModal(true);
-        setCanRemovePersonalToken(true);
-        setTokenInputValue(SAVED_TOKEN_MASK);
-      }
-      setHasRemovedPersonalToken(false);
-    } finally {
-      setIsUpdatingModalStatus(false);
-    }
-  }, [
-    canManageMcp,
-    editingServer,
-    editingServerId,
-    isUpdatingModalStatus,
-    patchServer,
-    servers,
   ]);
 
   const onModalEnabledChange = (_event: FormEvent, checked: boolean) => {
@@ -958,13 +995,30 @@ export const McpServersSettings = ({
     setModalEnabled(checked);
   };
 
+  const modalVerifiedHasToken = editingServer
+    ? getModalVerifiedHasToken({
+        hasOrgToken: editingServer.hasOrgToken,
+        credentialMode: modalCredentialMode,
+        hasSavedPersonalTokenInModal: hasSavedTokenInModal,
+      })
+    : false;
+
   const modalDisplayStatus = editingServer
-    ? getModalDisplayStatus(editingServer, modalEnabled)
+    ? getModalDisplayStatus(
+        {
+          ...editingServer,
+          hasToken: getModalDisplayHasToken({
+            modalVerifiedHasToken,
+            modalEnabled,
+            serverHasToken: editingServer.hasToken,
+          }),
+        },
+        modalEnabled,
+      )
     : 'unknown';
   const isModalEnabledToggleDisabled =
     !canManageMcp ||
     !editingServer ||
-    isUpdatingModalStatus ||
     isEnabledToggleUnavailable(modalDisplayStatus) ||
     Boolean(isSaving[editingServer?.name ?? '']);
   const isModalEnabledChecked = getModalEnabledChecked({
@@ -979,44 +1033,37 @@ export const McpServersSettings = ({
   const modalToolCount = modalTools.length || editingServer?.toolCount || 0;
 
   const renderModalStatusIcon = () => {
-    if (isUpdatingModalStatus || isLoadingModalTools) {
+    if (isLoadingModalTools) {
       return (
-        <Spinner
-          size="md"
-          aria-label={
-            isUpdatingModalStatus
-              ? t('mcp.settings.modal.loadingStatus')
-              : t('mcp.settings.modal.loadingTools')
-          }
-        />
+        <Spinner size="md" aria-label={t('mcp.settings.modal.loadingTools')} />
       );
     }
     if (modalDisplayStatus === 'disabled') {
       return <InfoCircleIcon className={classes.statusDisabled} />;
     }
-    if (modalTools.length > 0) {
+    if (modalDisplayStatus === 'tokenRequired') {
+      return <KeyIcon className={classes.statusWarn} />;
+    }
+    if (modalDisplayStatus === 'ok' && modalTools.length > 0) {
       return <CheckCircleIcon className={classes.statusOk} />;
     }
     if (modalToolsError || modalDisplayStatus === 'failed') {
       return <ExclamationCircleIcon className={classes.statusWarn} />;
     }
-    if (modalDisplayStatus === 'tokenRequired') {
-      return <KeyIcon className={classes.statusWarn} />;
-    }
     return <InfoCircleIcon className={classes.statusDisabled} />;
   };
 
   const renderModalStatusText = () => {
-    if (isUpdatingModalStatus) {
-      return t('mcp.settings.modal.loadingStatus');
-    }
     if (isLoadingModalTools) {
       return t('mcp.settings.modal.loadingTools');
     }
     if (modalDisplayStatus === 'disabled') {
       return t('mcp.settings.status.disabled');
     }
-    if (modalTools.length > 0) {
+    if (modalDisplayStatus === 'tokenRequired') {
+      return t('mcp.settings.status.tokenRequired');
+    }
+    if (modalDisplayStatus === 'ok' && modalTools.length > 0) {
       if (modalTools.length === 1) {
         return t('mcp.settings.status.oneTool' as any, {
           count: String(modalTools.length),
@@ -1076,15 +1123,6 @@ export const McpServersSettings = ({
         className={classes.modalInfoAlert}
         isInline
       />
-      {hasRemovedPersonalToken && (
-        <Alert
-          variant="custom"
-          customIcon={<InfoCircleIcon />}
-          title={t('mcp.settings.modal.tokenRemovedWarning')}
-          className={classes.modalInfoAlert}
-          isInline
-        />
-      )}
       <div className={classes.modalSection}>
         <div className={classes.modalSectionTitle}>
           {t('mcp.settings.status')}
@@ -1094,16 +1132,17 @@ export const McpServersSettings = ({
           <Typography component="span">{renderModalStatusText()}</Typography>
         </div>
       </div>
-      {(editingServer?.hasToken || editingServer?.auth === 'dcr') && (
-        <div className={classes.modalSection}>
-          <div className={classes.modalSectionTitle}>
-            {t('mcp.settings.modal.toolsHeading' as any, {
-              count: String(modalToolCount),
-            })}
+      {(editingServer?.auth === 'dcr' || modalVerifiedHasToken) &&
+        modalDisplayStatus === 'ok' && (
+          <div className={classes.modalSection}>
+            <div className={classes.modalSectionTitle}>
+              {t('mcp.settings.modal.toolsHeading' as any, {
+                count: String(modalToolCount),
+              })}
+            </div>
+            {renderModalToolsContent()}
           </div>
-          {renderModalToolsContent()}
-        </div>
-      )}
+        )}
       <div className={classes.modalSection}>
         <div className={classes.modalEnabledRow}>
           <div className={classes.modalEnabledLabel}>
@@ -1364,39 +1403,76 @@ export const McpServersSettings = ({
           ) : (
             <>
               {renderConfigureModalDetails()}
-              <FormGroup
-                label={t('mcp.settings.authenticationToken')}
-                fieldId="mcp-pat-input"
-              >
-                <TextInputGroup validated={tokenInputValidated}>
-                  <TextInputGroupMain
-                    inputId="mcp-pat-input"
-                    type="password"
-                    value={tokenInputValue}
-                    onChange={(_event, value) => onTokenInputChange(value)}
-                  />
-                  {(tokenValidationState === 'idle' ||
-                    tokenValidationState === 'validating') && (
-                    <TextInputGroupUtilities>
-                      <Button
-                        variant="plain"
-                        onClick={clearTokenInput}
-                        aria-label={t('mcp.settings.token.clearAriaLabel')}
-                        icon={<TimesIcon />}
+              {showCredentialRadios && (
+                <div className={classes.modalSection}>
+                  <div className={classes.modalSectionTitle}>
+                    {t('mcp.settings.modal.authenticationHeading')}
+                  </div>
+                  <div
+                    className={classes.credentialRadioGroup}
+                    id="mcp-credential-mode"
+                  >
+                    <div>
+                      <Radio
+                        id="mcp-credential-organization"
+                        name="mcp-credential-mode"
+                        label={t(
+                          'mcp.settings.modal.credentialMode.organization',
+                        )}
+                        isChecked={modalCredentialMode === 'organization'}
+                        onChange={() => onCredentialModeChange('organization')}
                       />
-                    </TextInputGroupUtilities>
+                      <div className={classes.credentialRadioDescription}>
+                        {t(
+                          'mcp.settings.modal.credentialMode.organizationDescription',
+                        )}
+                      </div>
+                    </div>
+                    <Radio
+                      id="mcp-credential-personal"
+                      name="mcp-credential-mode"
+                      label={t('mcp.settings.modal.credentialMode.personal')}
+                      isChecked={modalCredentialMode === 'personal'}
+                      onChange={() => onCredentialModeChange('personal')}
+                    />
+                  </div>
+                </div>
+              )}
+              {showPersonalTokenField && (
+                <FormGroup
+                  label={t('mcp.settings.authenticationToken')}
+                  fieldId="mcp-pat-input"
+                >
+                  <TextInputGroup validated={tokenInputValidated}>
+                    <TextInputGroupMain
+                      inputId="mcp-pat-input"
+                      type="password"
+                      value={tokenInputValue}
+                      onChange={(_event, value) => onTokenInputChange(value)}
+                    />
+                    {(tokenValidationState === 'idle' ||
+                      tokenValidationState === 'validating') && (
+                      <TextInputGroupUtilities>
+                        <Button
+                          variant="plain"
+                          onClick={clearTokenInput}
+                          aria-label={t('mcp.settings.token.clearAriaLabel')}
+                          icon={<TimesIcon />}
+                        />
+                      </TextInputGroupUtilities>
+                    )}
+                  </TextInputGroup>
+                  {showTokenHelperText && (
+                    <FormHelperText>
+                      <HelperText>
+                        <HelperTextItem variant={tokenHelperVariant}>
+                          {tokenHelperText}
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormHelperText>
                   )}
-                </TextInputGroup>
-                {showTokenHelperText && (
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem variant={tokenHelperVariant}>
-                        {tokenHelperText}
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                )}
-              </FormGroup>
+                </FormGroup>
+              )}
             </>
           )}
         </ModalBody>
@@ -1414,29 +1490,11 @@ export const McpServersSettings = ({
                   !canManageMcp ||
                   isConfigureModalSaving ||
                   tokenValidationState === 'validating' ||
-                  isSaveTokenButtonDisabled ||
-                  isUpdatingModalStatus
+                  isSaveTokenButtonDisabled
                 }
               >
                 {t('modal.save')}
               </Button>
-              {canRemovePersonalToken && (
-                <Button
-                  variant="secondary"
-                  onClick={() => void removePersonalToken()}
-                  isDisabled={
-                    !canManageMcp ||
-                    isConfigureModalSaving ||
-                    tokenValidationState === 'validating' ||
-                    isUpdatingModalStatus ||
-                    hasRemovedPersonalToken ||
-                    !hasSavedTokenInModal
-                  }
-                  className={classes.removePersonalTokenButton}
-                >
-                  {t('mcp.settings.removePersonalToken')}
-                </Button>
-              )}
               <Button variant="link" onClick={closeConfigureModal}>
                 {t('common.cancel')}
               </Button>

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -14,23 +14,35 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+} from 'react';
 
 import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { makeStyles } from '@material-ui/core';
-import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
-import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import {
   Alert,
   Button,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
   Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Spinner,
   Switch,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
   Title,
   Tooltip,
 } from '@patternfly/react-core';
@@ -39,7 +51,6 @@ import {
   ExclamationCircleIcon,
   InfoCircleIcon,
   KeyIcon,
-  LockIcon,
   PencilAltIcon,
   SortAmountDownIcon,
   SortAmountUpIcon,
@@ -50,8 +61,15 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { lightspeedMcpManagePermission } from '@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common';
 
 import { useTranslation } from '../hooks/useTranslation';
-
-type ServerStatus = 'tokenRequired' | 'disabled' | 'ok' | 'failed' | 'unknown';
+import {
+  formatApiError,
+  getDisplayStatus,
+  getEnabledToggleChecked,
+  isModalEnabledChecked as getModalEnabledChecked,
+  isSaveTokenDisabled as getSaveTokenDisabled,
+  isEnabledToggleUnavailable,
+  type ServerStatus,
+} from './mcpServersDisplayUtils';
 
 type McpServer = {
   id: string;
@@ -183,141 +201,119 @@ const useStyles = makeStyles(theme => ({
       opacity: 1,
     },
   },
-  modalDescription: {
-    color: theme.palette.text.secondary,
-    fontSize: '0.875rem',
-    marginTop: theme.spacing(2),
+  modalInfoAlert: {
+    marginTop: 0,
+    marginBottom: theme.spacing(2),
+    '--pf-v6-c-alert--BorderColor': '#5e40be',
+    '--pf-v5-c-alert--BorderColor': '#5e40be',
+    borderColor: '#5e40be',
+    '& .pf-v6-c-alert, & .pf-v5-c-alert': {
+      alignItems: 'flex-start',
+    },
+    '& .pf-v6-c-alert__icon, & .pf-v5-c-alert__icon': {
+      color: '#5e40be',
+      alignSelf: 'flex-start',
+      paddingBlockStart: 0,
+      marginBlockStart: 0,
+      lineHeight: 1,
+      '& svg': {
+        display: 'block',
+      },
+    },
+    '& .pf-v6-c-alert__title, & .pf-v5-c-alert__title': {
+      margin: '-0.125rem 0 0 0.5rem',
+      lineHeight: 1.4,
+    },
+  },
+  modalSection: {
     marginBottom: theme.spacing(2),
   },
-  modalContent: {
-    position: 'relative',
-    padding: theme.spacing(3, 0, 3, 3),
-    marginRight: theme.spacing(3),
+  modalSectionTitle: {
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    marginBottom: theme.spacing(0.75),
   },
-  modalCustomCloseButton: {
-    position: 'absolute',
-    top: theme.spacing(2),
-    right: theme.spacing(-0.5),
-    color: theme.palette.text.primary,
+  modalSectionDescription: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.875rem',
+    marginTop: theme.spacing(0.25),
   },
-  modalHeading: {
+  modalStatusRow: {
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(0.75),
-    marginBottom: theme.spacing(1),
-    fontSize: '1.25rem',
-    lineHeight: 1.4,
-    fontWeight: 500,
-    '& .v5-MuiTypography-root': {
-      fontSize: '1.25rem',
-      lineHeight: 1.4,
-      fontWeight: 500,
-    },
-  },
-  tokenRow: {
-    position: 'relative',
-  },
-  tokenClearButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: '50%',
-    transform: 'translateY(-50%)',
-    zIndex: 1,
-    color: theme.palette.action.active,
-  },
-  tokenHelper: {
-    color: theme.palette.text.secondary,
-    fontSize: '0.75rem',
-    marginTop: theme.spacing(0.5),
-  },
-  tokenInput: {
-    marginTop: '1rem !important',
-    '& .MuiOutlinedInput-root': {
-      height: '3.5rem',
-    },
-    '& .MuiOutlinedInput-input': {
-      padding: '0 0.875rem',
-    },
-    '& .MuiInputLabel-root': {
-      fontSize: '0.875rem',
-    },
-  },
-  tokenInputSuccess: {
-    '& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {
-      borderColor: '#3E8635',
-      borderWidth: 1,
-    },
-    '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
-      borderColor: '#3E8635',
-    },
-    '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-      borderColor: '#3E8635',
-    },
-    '& .MuiInputLabel-root.Mui-focused': {
-      color: '#3E8635',
-    },
-  },
-  tokenInputError: {
-    '& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {
-      borderColor: '#C9190B',
-      borderWidth: 1,
-    },
-    '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
-      borderColor: '#C9190B',
-    },
-    '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-      borderColor: '#C9190B',
-    },
-    '& .MuiInputLabel-root.Mui-focused': {
-      color: '#C9190B',
-    },
-  },
-  modalActions: {
-    marginTop: theme.spacing(3),
-    display: 'flex',
     gap: theme.spacing(1),
+    fontSize: '0.875rem',
   },
-  modalActionButton: {
-    fontSize: '1rem',
+  modalToolsList: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
   },
-  modalCancelButton: {
-    fontSize: '1rem',
+  modalToolItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    fontSize: '0.875rem',
   },
-  forgetTokenButton: {
-    fontSize: '1rem',
-    border: '1px solid #B1380B',
+  modalEnabledRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: theme.spacing(2),
+  },
+  modalEnabledLabel: {
+    flex: 1,
+  },
+  modalCloseButton: {
+    position: 'absolute',
+    top: 'var(--pf-v6-c-modal-box__close--InsetBlockStart, 1.5rem)',
+    right: 'var(--pf-v6-c-modal-box__close--InsetInlineEnd, 1.5rem)',
+    zIndex: 1,
+  },
+  removePersonalTokenButton: {
     borderRadius: '1.25rem',
-    padding: '0.375rem 1rem',
-    color: '#B1380B',
-    backgroundColor: 'transparent',
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
     boxShadow: 'none',
-    '&:hover': {
-      backgroundColor: 'rgba(201, 25, 11, 0.08)',
+    '&:not(:disabled):not(.pf-m-disabled)': {
+      '--pf-v6-c-button--BorderColor': '#B1380B',
+      '--pf-v6-c-button--Color': '#B1380B',
+      '--pf-v6-c-button--BackgroundColor': 'transparent',
+      '--pf-v5-c-button--BorderColor': '#B1380B',
+      '--pf-v5-c-button--Color': '#B1380B',
+      '--pf-v5-c-button--BackgroundColor': 'transparent',
+      borderColor: '#B1380B',
+      color: '#B1380B',
+      backgroundColor: 'transparent',
+      '&:hover': {
+        '--pf-v6-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
+        '--pf-v5-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
+        backgroundColor: 'rgba(201, 25, 11, 0.08)',
+      },
     },
   },
   configureModal: {
-    '& .pf-v6-c-modal-box': {
+    '& .pf-v6-c-modal-box, & .pf-v5-c-modal-box': {
       width: '608px',
       maxWidth: '608px',
-      height: '326px',
-      minHeight: '326px',
     },
-    '& .pf-v6-c-modal-box__title, & .pf-v6-c-modal-box__title-text, & .pf-v5-c-modal-box__title, & .pf-v5-c-modal-box__title-text':
-      {
-        fontSize: '1.25rem !important',
-        lineHeight: '1.4 !important',
-      },
-    '& .pf-v6-c-modal-box__close': {
+    '& .pf-v6-c-modal-box__close, & .pf-v5-c-modal-box__close': {
       display: 'none',
     },
-    '& .pf-v5-c-modal-box__close': {
-      display: 'none',
+    '& .pf-v6-c-modal-box__header, & .pf-v5-c-modal-box__header': {
+      '--pf-v6-c-modal-box__header--PaddingBlockEnd': '0.25rem',
+      '--pf-v5-c-modal-box__header--PaddingBlockEnd': '0.25rem',
+      paddingBlockEnd: '0.25rem',
     },
-    '& .pf-v6-c-button__icon': {
-      paddingTop: '5px !important',
-      fontSize: '1.25rem !important',
+    '& .pf-v6-c-modal-box__title, & .pf-v5-c-modal-box__title': {
+      marginBlockEnd: 0,
+    },
+    '& .pf-v6-c-modal-box__body, & .pf-v5-c-modal-box__body': {
+      '--pf-v6-c-modal-box__body--PaddingBlockStart': '0.5rem',
+      '--pf-v6-c-modal-box__header--body--PaddingBlockStart': '0.5rem',
+      '--pf-v5-c-modal-box__body--PaddingBlockStart': '0.5rem',
+      paddingBlockStart: '0.5rem',
     },
   },
   toggleCell: {
@@ -375,19 +371,26 @@ type McpServersPatchResponse = {
   };
 };
 
+type McpToolInfo = {
+  name: string;
+  description?: string;
+};
+
 type McpServersValidateResponse = {
   name: string;
   status: 'connected' | 'error' | 'unknown';
   toolCount: number;
   validation?: {
-    error?: string;
+    error?: unknown;
+    tools?: McpToolInfo[];
   };
 };
 
 type McpCredentialsValidateResponse = {
   valid: boolean;
-  error?: string;
+  error?: unknown;
   toolCount: number;
+  tools?: McpToolInfo[];
 };
 
 const getStatusIcon = (status: ServerStatus, className: string) => {
@@ -396,14 +399,6 @@ const getStatusIcon = (status: ServerStatus, className: string) => {
   if (status === 'failed')
     return <ExclamationCircleIcon className={className} />;
   return <CheckCircleIcon className={className} />;
-};
-
-const getDisplayStatus = (server: McpServer): ServerStatus => {
-  if (!server.hasToken) return 'tokenRequired';
-  if (!server.enabled) return 'disabled';
-  if (server.status === 'error') return 'failed';
-  if (server.status === 'connected') return 'ok';
-  return 'unknown';
 };
 
 const toUiServer = (
@@ -445,6 +440,12 @@ export const McpServersSettings = ({
   const [tokenValidationState, setTokenValidationState] =
     useState<TokenValidationState>('idle');
   const [tokenValidationMessage, setTokenValidationMessage] = useState('');
+  const [modalEnabled, setModalEnabled] = useState(true);
+  const [modalTools, setModalTools] = useState<string[]>([]);
+  const [isLoadingModalTools, setIsLoadingModalTools] = useState(false);
+  const [modalToolsError, setModalToolsError] = useState<string | null>(null);
+  const [isUpdatingModalStatus, setIsUpdatingModalStatus] = useState(false);
+  const [hasRemovedPersonalToken, setHasRemovedPersonalToken] = useState(false);
 
   const getBaseUrl = useCallback(() => {
     return `${configApi.getString('backend.baseUrl')}/api/intelligent-assistant`;
@@ -480,15 +481,22 @@ export const McpServersSettings = ({
     [fetchApi],
   );
 
-  const validateServer = useCallback(
+  const fetchServerValidation = useCallback(
     async (serverName: string) => {
       const baseUrl = getBaseUrl();
-      const data = await fetchJson<McpServersValidateResponse>(
+      return fetchJson<McpServersValidateResponse>(
         `${baseUrl}/mcp-servers/${encodeURIComponent(serverName)}/validate`,
         {
           method: 'POST',
         },
       );
+    },
+    [fetchJson, getBaseUrl],
+  );
+
+  const validateServer = useCallback(
+    async (serverName: string) => {
+      const data = await fetchServerValidation(serverName);
 
       setServers(prev =>
         prev.map(server =>
@@ -499,7 +507,8 @@ export const McpServersSettings = ({
                 toolCount: data.toolCount,
                 validationError:
                   data.status === 'error'
-                    ? (data.validation?.error ?? 'Validation failed')
+                    ? formatApiError(data.validation?.error) ||
+                      'Validation failed'
                     : undefined,
               }
             : server,
@@ -507,7 +516,7 @@ export const McpServersSettings = ({
       );
       return data;
     },
-    [fetchJson, getBaseUrl],
+    [fetchServerValidation],
   );
 
   const validateCredentials = useCallback(
@@ -663,6 +672,12 @@ export const McpServersSettings = ({
     setCanRemovePersonalToken(false);
     setTokenValidationState('idle');
     setTokenValidationMessage('');
+    setModalEnabled(true);
+    setModalTools([]);
+    setIsLoadingModalTools(false);
+    setModalToolsError(null);
+    setIsUpdatingModalStatus(false);
+    setHasRemovedPersonalToken(false);
   }, []);
 
   const openConfigureModal = (server: McpServer) => {
@@ -671,14 +686,76 @@ export const McpServersSettings = ({
     setHasSavedTokenInModal(hasSavedToken);
     setCanRemovePersonalToken(server.hasUserToken);
     setTokenInputValue(hasSavedToken ? SAVED_TOKEN_MASK : '');
+    setModalEnabled(server.enabled);
+    setModalTools([]);
+    setModalToolsError(null);
+    setIsUpdatingModalStatus(false);
+    setHasRemovedPersonalToken(false);
     if (server.status === 'error' && server.validationError) {
       setTokenValidationState('error');
-      setTokenValidationMessage(server.validationError);
+      setTokenValidationMessage(
+        formatApiError(server.validationError) ||
+          t('mcp.settings.token.validationFailed'),
+      );
     } else {
       setTokenValidationState('idle');
       setTokenValidationMessage('');
     }
   };
+
+  useEffect(() => {
+    if (!editingServer) {
+      return undefined;
+    }
+
+    if (editingServer.auth !== 'dcr' && !editingServer.hasToken) {
+      setModalTools([]);
+      setModalToolsError(null);
+      setIsLoadingModalTools(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setIsLoadingModalTools(true);
+    setModalToolsError(null);
+
+    void fetchServerValidation(editingServer.name)
+      .then(data => {
+        if (cancelled) {
+          return;
+        }
+        const tools = data.validation?.tools?.map(tool => tool.name) ?? [];
+        setModalTools(tools);
+        if (data.status === 'error') {
+          setModalToolsError(
+            formatApiError(data.validation?.error) ||
+              t('mcp.settings.token.validationFailed'),
+          );
+        } else {
+          setModalToolsError(null);
+        }
+      })
+      .catch(e => {
+        if (cancelled) {
+          return;
+        }
+        setModalTools([]);
+        setModalToolsError(
+          e instanceof Error
+            ? e.message
+            : t('mcp.settings.modal.toolsLoadFailed'),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingModalTools(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [editingServer, fetchServerValidation, t]);
 
   const onTokenInputChange = (value: string) => {
     if (hasSavedTokenInModal && value !== SAVED_TOKEN_MASK) {
@@ -698,61 +775,45 @@ export const McpServersSettings = ({
     setTokenValidationMessage('');
   };
 
-  let tokenInputStateClass = '';
-  let tokenHelperColor: string | undefined;
-  if (tokenValidationState === 'success') {
-    tokenInputStateClass = classes.tokenInputSuccess;
-    tokenHelperColor = '#3E8635';
-  } else if (tokenValidationState === 'error') {
-    tokenInputStateClass = classes.tokenInputError;
-    tokenHelperColor = '#C9190B';
-  }
-
-  let tokenInputAdornment = (
-    <IconButton
-      aria-label={t('mcp.settings.token.clearAriaLabel')}
-      size="small"
-      className={classes.tokenClearButton}
-      onClick={clearTokenInput}
-    >
-      <CancelOutlinedIcon
-        style={{
-          fontSize: 24,
-          width: 24,
-          height: 24,
-        }}
-      />
-    </IconButton>
-  );
-
-  if (tokenValidationState === 'success') {
-    tokenInputAdornment = (
-      <CheckCircleIcon
-        style={{
-          color: '#3E8635',
-          fontSize: 20,
-          width: 20,
-          height: 20,
-          marginRight: 3,
-        }}
-      />
-    );
-  } else if (tokenValidationState === 'error') {
-    tokenInputAdornment = (
-      <ExclamationCircleIcon
-        style={{
-          color: '#C9190B',
-          fontSize: 20,
-          width: 20,
-          height: 20,
-          marginRight: 3,
-        }}
-      />
-    );
-  }
-
   const isUsingOrganizationCredentialInModal =
     hasSavedTokenInModal && !canRemovePersonalToken;
+
+  let tokenInputValidated: 'success' | 'error' | undefined;
+  if (tokenValidationState === 'success') {
+    tokenInputValidated = 'success';
+  } else if (tokenValidationState === 'error') {
+    tokenInputValidated = 'error';
+  }
+
+  let tokenHelperVariant: 'success' | 'error' | 'default' = 'default';
+  if (tokenValidationState === 'success') {
+    tokenHelperVariant = 'success';
+  } else if (tokenValidationState === 'error') {
+    tokenHelperVariant = 'error';
+  }
+
+  const showTokenHelperText =
+    isUsingOrganizationCredentialInModal ||
+    !hasSavedTokenInModal ||
+    tokenValidationState !== 'idle';
+
+  const tokenHelperText =
+    tokenValidationMessage ||
+    (isUsingOrganizationCredentialInModal
+      ? t('mcp.settings.usingAdminCredential')
+      : t('mcp.settings.enterToken'));
+
+  const configureModalTitle = t('mcp.settings.configureServerTitle' as any, {
+    serverName: editingServer?.name ?? '',
+  });
+
+  const isConfigureModalSaving = Boolean(isSaving[editingServer?.name ?? '']);
+  const isSaveTokenButtonDisabled = getSaveTokenDisabled({
+    hasSavedTokenInModal,
+    tokenInputValue,
+    savedTokenMask: SAVED_TOKEN_MASK,
+    isUpdatingModalStatus,
+  });
 
   const saveServerToken = useCallback(async () => {
     if (!editingServer || !canManageMcp) return;
@@ -785,11 +846,12 @@ export const McpServersSettings = ({
         if (!credentialValidation.valid) {
           setTokenValidationState('error');
           setTokenValidationMessage(
-            credentialValidation.error ??
+            formatApiError(credentialValidation.error) ||
               t('mcp.settings.token.invalidCredentials'),
           );
           return;
         }
+        setModalTools(credentialValidation.tools?.map(tool => tool.name) ?? []);
       }
 
       setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
@@ -801,10 +863,14 @@ export const McpServersSettings = ({
       if (validationResult.status === 'error') {
         setTokenValidationState('error');
         setTokenValidationMessage(
-          validationResult.validation?.error ??
+          formatApiError(validationResult.validation?.error) ||
             t('mcp.settings.token.validationFailed'),
         );
         return;
+      }
+      if (hasToken && validationResult.status === 'connected') {
+        await patchServer(editingServer.name, { enabled: true });
+        setModalEnabled(true);
       }
       setTokenValidationState('success');
       setTokenValidationMessage(t('mcp.settings.token.connectionSuccessful'));
@@ -829,13 +895,228 @@ export const McpServersSettings = ({
     validateServer,
   ]);
 
-  const removePersonalToken = () => {
-    setHasSavedTokenInModal(false);
-    setCanRemovePersonalToken(false);
+  const removePersonalToken = useCallback(async () => {
+    if (!editingServer || !canManageMcp || isUpdatingModalStatus) {
+      return;
+    }
+
+    setIsUpdatingModalStatus(true);
     setTokenInputValue('');
     setTokenValidationState('idle');
     setTokenValidationMessage('');
+    setModalTools([]);
+    setModalToolsError(null);
+    setIsLoadingModalTools(false);
+
+    try {
+      await patchServer(editingServer.name, { token: null });
+      setHasSavedTokenInModal(false);
+      setModalEnabled(false);
+      setHasRemovedPersonalToken(true);
+    } catch {
+      const server = servers.find(item => item.id === editingServerId);
+      if (server?.hasUserToken && server.hasToken) {
+        setHasSavedTokenInModal(true);
+        setCanRemovePersonalToken(true);
+        setTokenInputValue(SAVED_TOKEN_MASK);
+      }
+      setHasRemovedPersonalToken(false);
+    } finally {
+      setIsUpdatingModalStatus(false);
+    }
+  }, [
+    canManageMcp,
+    editingServer,
+    editingServerId,
+    isUpdatingModalStatus,
+    patchServer,
+    servers,
+  ]);
+
+  const onModalEnabledChange = (_event: FormEvent, checked: boolean) => {
+    if (!editingServer || !canManageMcp) {
+      return;
+    }
+    setModalEnabled(checked);
+    void patchServer(editingServer.name, { enabled: checked }).catch(() => {
+      setModalEnabled(!checked);
+    });
   };
+
+  const editingDisplayStatus = editingServer
+    ? getDisplayStatus(editingServer)
+    : 'unknown';
+  const isModalEnabledToggleDisabled =
+    !canManageMcp ||
+    !editingServer ||
+    isUpdatingModalStatus ||
+    isEnabledToggleUnavailable(editingDisplayStatus) ||
+    Boolean(isSaving[editingServer?.name ?? '']);
+  const isModalEnabledChecked = getModalEnabledChecked({
+    displayStatus: editingDisplayStatus,
+    modalEnabled,
+  });
+
+  const modalStatusDetail = editingServer
+    ? getDisplayDetail(editingServer, editingDisplayStatus)
+    : '';
+
+  const modalToolCount = modalTools.length || editingServer?.toolCount || 0;
+
+  const renderModalStatusIcon = () => {
+    if (isUpdatingModalStatus || isLoadingModalTools) {
+      return (
+        <Spinner
+          size="md"
+          aria-label={
+            isUpdatingModalStatus
+              ? t('mcp.settings.modal.loadingStatus')
+              : t('mcp.settings.modal.loadingTools')
+          }
+        />
+      );
+    }
+    if (modalTools.length > 0) {
+      return <CheckCircleIcon className={classes.statusOk} />;
+    }
+    if (modalToolsError || editingDisplayStatus === 'failed') {
+      return <ExclamationCircleIcon className={classes.statusWarn} />;
+    }
+    if (editingDisplayStatus === 'tokenRequired') {
+      return <KeyIcon className={classes.statusWarn} />;
+    }
+    if (editingDisplayStatus === 'disabled') {
+      return <InfoCircleIcon className={classes.statusDisabled} />;
+    }
+    return <InfoCircleIcon className={classes.statusDisabled} />;
+  };
+
+  const renderModalStatusText = () => {
+    if (isUpdatingModalStatus) {
+      return t('mcp.settings.modal.loadingStatus');
+    }
+    if (isLoadingModalTools) {
+      return t('mcp.settings.modal.loadingTools');
+    }
+    if (modalTools.length > 0) {
+      if (modalTools.length === 1) {
+        return t('mcp.settings.status.oneTool' as any, {
+          count: String(modalTools.length),
+        });
+      }
+      return t('mcp.settings.status.manyTools' as any, {
+        count: String(modalTools.length),
+      });
+    }
+    if (modalToolsError) {
+      return modalToolsError;
+    }
+    return modalStatusDetail;
+  };
+
+  const renderModalToolsContent = () => {
+    if (isLoadingModalTools) {
+      return (
+        <Spinner size="md" aria-label={t('mcp.settings.modal.loadingTools')} />
+      );
+    }
+    if (modalTools.length > 0) {
+      return (
+        <ul className={classes.modalToolsList}>
+          {modalTools.map(toolName => (
+            <li key={toolName} className={classes.modalToolItem}>
+              <CheckCircleIcon className={classes.statusOk} />
+              <Typography component="span">{toolName}</Typography>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    return (
+      <div className={classes.modalSectionDescription}>
+        {modalToolsError ?? t('mcp.settings.modal.noToolsAvailable')}
+      </div>
+    );
+  };
+
+  const renderConfigureModalDetails = () => (
+    <>
+      <Alert
+        variant="custom"
+        customIcon={<InfoCircleIcon />}
+        title={t('mcp.settings.modalDescription')}
+        className={classes.modalInfoAlert}
+        isInline
+      />
+      {hasRemovedPersonalToken && (
+        <Alert
+          variant="custom"
+          customIcon={<InfoCircleIcon />}
+          title={t('mcp.settings.modal.tokenRemovedWarning')}
+          className={classes.modalInfoAlert}
+          isInline
+        />
+      )}
+      <div className={classes.modalSection}>
+        <div className={classes.modalSectionTitle}>
+          {t('mcp.settings.status')}
+        </div>
+        <div className={classes.modalStatusRow}>
+          {renderModalStatusIcon()}
+          <Typography component="span">{renderModalStatusText()}</Typography>
+        </div>
+      </div>
+      {(editingServer?.hasToken || editingServer?.auth === 'dcr') && (
+        <div className={classes.modalSection}>
+          <div className={classes.modalSectionTitle}>
+            {t('mcp.settings.modal.toolsHeading' as any, {
+              count: String(modalToolCount),
+            })}
+          </div>
+          {renderModalToolsContent()}
+        </div>
+      )}
+      <div className={classes.modalSection}>
+        <div className={classes.modalEnabledRow}>
+          <div className={classes.modalEnabledLabel}>
+            <div className={classes.modalSectionTitle}>
+              {t('mcp.settings.enabled')}
+            </div>
+            <div className={classes.modalSectionDescription}>
+              {isModalEnabledChecked
+                ? t('mcp.settings.modal.enabledDescription')
+                : t('mcp.settings.modal.enabledDescriptionOff')}
+            </div>
+          </div>
+          {isModalEnabledToggleDisabled ? (
+            <Tooltip content={modalStatusDetail}>
+              <Typography component="span">
+                <Switch
+                  id="mcp-configure-enabled-switch"
+                  aria-label={t('mcp.settings.toggleServerAriaLabel' as any, {
+                    serverName: editingServer?.name ?? '',
+                  })}
+                  isChecked={isModalEnabledChecked}
+                  isDisabled={isModalEnabledToggleDisabled}
+                  onChange={onModalEnabledChange}
+                />
+              </Typography>
+            </Tooltip>
+          ) : (
+            <Switch
+              id="mcp-configure-enabled-switch"
+              aria-label={t('mcp.settings.toggleServerAriaLabel' as any, {
+                serverName: editingServer?.name ?? '',
+              })}
+              isChecked={isModalEnabledChecked}
+              isDisabled={isModalEnabledToggleDisabled}
+              onChange={onModalEnabledChange}
+            />
+          )}
+        </div>
+      </div>
+    </>
+  );
 
   return (
     <div
@@ -930,9 +1211,11 @@ export const McpServersSettings = ({
                 <Td width={10} className={classes.toggleCell}>
                   {(() => {
                     const isUnavailable =
-                      displayStatus === 'failed' ||
-                      displayStatus === 'tokenRequired';
-                    const isChecked = isUnavailable ? false : server.enabled;
+                      isEnabledToggleUnavailable(displayStatus);
+                    const isChecked = getEnabledToggleChecked(
+                      server,
+                      displayStatus,
+                    );
                     const isRowSaving = Boolean(isSaving[server.name]);
                     const isToggleDisabled =
                       isUnavailable || isRowSaving || !canManageMcp;
@@ -1026,128 +1309,114 @@ export const McpServersSettings = ({
       </Table>
       <Modal
         variant="small"
-        title={t('mcp.settings.configureServerTitle' as any, {
-          serverName: editingServer?.name ?? '',
-        })}
         isOpen={Boolean(editingServer)}
         onClose={closeConfigureModal}
         className={classes.configureModal}
+        aria-labelledby="mcp-configure-modal"
+        aria-describedby="mcp-configure-modal-body"
       >
-        <div className={classes.modalContent}>
-          <IconButton
-            aria-label={t('mcp.settings.closeConfigureModalAriaLabel')}
-            size="small"
-            className={classes.modalCustomCloseButton}
-            onClick={closeConfigureModal}
-          >
-            <CloseOutlinedIcon />
-          </IconButton>
-          <div className={classes.modalHeading}>
-            <LockIcon />
-            <Typography component="div">
-              {t('mcp.settings.configureServerTitle' as any, {
-                serverName: editingServer?.name ?? '',
-              })}
-            </Typography>
-          </div>
+        <ModalHeader
+          title={configureModalTitle}
+          labelId="mcp-configure-modal"
+          descriptorId="mcp-configure-modal-body"
+        />
+        <Button
+          variant="plain"
+          icon={<TimesIcon />}
+          aria-label={t('mcp.settings.closeConfigureModalAriaLabel')}
+          className={classes.modalCloseButton}
+          onClick={closeConfigureModal}
+        />
+        <ModalBody id="mcp-configure-modal-body">
           {editingServer?.auth === 'dcr' ? (
             <>
-              <div className={classes.modalDescription}>
+              {renderConfigureModalDetails()}
+              <div className={classes.modalSectionDescription}>
                 {t('mcp.settings.modalDescriptionDcr')}
-              </div>
-              <div className={classes.modalActions}>
-                <Button
-                  key="close"
-                  variant="primary"
-                  onClick={closeConfigureModal}
-                  className={classes.modalActionButton}
-                >
-                  {t('common.cancel')}
-                </Button>
               </div>
             </>
           ) : (
             <>
-              <div className={classes.modalDescription}>
-                {t('mcp.settings.modalDescription')}
-              </div>
-              <div className={classes.tokenRow}>
-                <TextField
-                  id="mcp-pat-input"
-                  type="password"
-                  variant="outlined"
-                  fullWidth
-                  value={tokenInputValue}
-                  onChange={event => onTokenInputChange(event.target.value)}
-                  className={`${classes.tokenInput} ${tokenInputStateClass}`}
-                  label={
-                    hasSavedTokenInModal
-                      ? t('mcp.settings.savedToken')
-                      : t('mcp.settings.personalAccessToken')
-                  }
-                  InputProps={{
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        {tokenInputAdornment}
-                      </InputAdornment>
-                    ),
-                  }}
-                />
-                {(isUsingOrganizationCredentialInModal ||
-                  !hasSavedTokenInModal ||
-                  tokenValidationState !== 'idle') && (
-                  <div
-                    className={classes.tokenHelper}
-                    style={{ color: tokenHelperColor }}
-                  >
-                    {tokenValidationMessage ||
-                      (isUsingOrganizationCredentialInModal
-                        ? t('mcp.settings.usingAdminCredential')
-                        : t('mcp.settings.enterToken'))}
-                  </div>
+              {renderConfigureModalDetails()}
+              <FormGroup
+                label={t('mcp.settings.authenticationToken')}
+                fieldId="mcp-pat-input"
+              >
+                <TextInputGroup validated={tokenInputValidated}>
+                  <TextInputGroupMain
+                    inputId="mcp-pat-input"
+                    type="password"
+                    value={tokenInputValue}
+                    onChange={(_event, value) => onTokenInputChange(value)}
+                  />
+                  {(tokenValidationState === 'idle' ||
+                    tokenValidationState === 'validating') && (
+                    <TextInputGroupUtilities>
+                      <Button
+                        variant="plain"
+                        onClick={clearTokenInput}
+                        aria-label={t('mcp.settings.token.clearAriaLabel')}
+                        icon={<TimesIcon />}
+                      />
+                    </TextInputGroupUtilities>
+                  )}
+                </TextInputGroup>
+                {showTokenHelperText && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant={tokenHelperVariant}>
+                        {tokenHelperText}
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
                 )}
-              </div>
-              <div className={classes.modalActions}>
-                <Button
-                  key="save"
-                  variant="primary"
-                  onClick={() => void saveServerToken()}
-                  isDisabled={
-                    !canManageMcp ||
-                    Boolean(isSaving[editingServer?.name ?? '']) ||
-                    tokenValidationState === 'validating'
-                  }
-                  className={classes.modalActionButton}
-                >
-                  {t('modal.save')}
-                </Button>
-                {canRemovePersonalToken && hasSavedTokenInModal && (
-                  <Button
-                    key="forget-token"
-                    variant="plain"
-                    onClick={removePersonalToken}
-                    isDisabled={
-                      !canManageMcp ||
-                      Boolean(isSaving[editingServer?.name ?? '']) ||
-                      tokenValidationState === 'validating'
-                    }
-                    className={classes.forgetTokenButton}
-                  >
-                    {t('mcp.settings.removePersonalToken')}
-                  </Button>
-                )}
-                <Button
-                  key="cancel"
-                  variant="link"
-                  onClick={closeConfigureModal}
-                  className={classes.modalCancelButton}
-                >
-                  {t('common.cancel')}
-                </Button>
-              </div>
+              </FormGroup>
             </>
           )}
-        </div>
+        </ModalBody>
+        <ModalFooter>
+          {editingServer?.auth === 'dcr' ? (
+            <Button variant="primary" onClick={closeConfigureModal}>
+              {t('common.cancel')}
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="primary"
+                onClick={() => void saveServerToken()}
+                isDisabled={
+                  !canManageMcp ||
+                  isConfigureModalSaving ||
+                  tokenValidationState === 'validating' ||
+                  isSaveTokenButtonDisabled ||
+                  isUpdatingModalStatus
+                }
+              >
+                {t('modal.save')}
+              </Button>
+              {canRemovePersonalToken && (
+                <Button
+                  variant="secondary"
+                  onClick={() => void removePersonalToken()}
+                  isDisabled={
+                    !canManageMcp ||
+                    isConfigureModalSaving ||
+                    tokenValidationState === 'validating' ||
+                    isUpdatingModalStatus ||
+                    hasRemovedPersonalToken ||
+                    !hasSavedTokenInModal
+                  }
+                  className={classes.removePersonalTokenButton}
+                >
+                  {t('mcp.settings.removePersonalToken')}
+                </Button>
+              )}
+              <Button variant="link" onClick={closeConfigureModal}>
+                {t('common.cancel')}
+              </Button>
+            </>
+          )}
+        </ModalFooter>
       </Modal>
     </div>
   );

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -789,7 +789,8 @@ export const McpServersSettings = ({
       return undefined;
     }
 
-    if (editingServer.auth !== 'dcr' && !editingServer.hasToken) {
+    // DCR servers don't expose credential UI — skip tools fetch in the modal.
+    if (editingServer.auth === 'dcr' || !editingServer.hasToken) {
       setModalTools([]);
       setModalToolsError(null);
       setIsLoadingModalTools(false);
@@ -1273,17 +1274,16 @@ export const McpServersSettings = ({
           <Typography component="span">{renderModalStatusText()}</Typography>
         </div>
       </div>
-      {(editingServer?.auth === 'dcr' || modalVerifiedHasToken) &&
-        modalDisplayStatus === 'ok' && (
-          <div className={classes.modalSection}>
-            <div className={classes.modalSectionTitle}>
-              {t('mcp.settings.modal.toolsHeading' as any, {
-                count: String(modalToolCount),
-              })}
-            </div>
-            {renderModalToolsContent()}
+      {modalVerifiedHasToken && modalDisplayStatus === 'ok' && (
+        <div className={classes.modalSection}>
+          <div className={classes.modalSectionTitle}>
+            {t('mcp.settings.modal.toolsHeading' as any, {
+              count: String(modalToolCount),
+            })}
           </div>
-        )}
+          {renderModalToolsContent()}
+        </div>
+      )}
       <div className={classes.modalSection}>
         <div className={classes.modalEnabledRow}>
           <div className={classes.modalEnabledLabel}>
@@ -1547,12 +1547,9 @@ export const McpServersSettings = ({
         />
         <ModalBody id="mcp-configure-modal-body">
           {editingServer?.auth === 'dcr' ? (
-            <>
-              {renderConfigureModalDetails()}
-              <div className={classes.modalSectionDescription}>
-                {t('mcp.settings.modalDescriptionDcr')}
-              </div>
-            </>
+            <div className={classes.modalSectionDescription}>
+              {t('mcp.settings.modalDescriptionDcr')}
+            </div>
           ) : (
             <>
               {renderConfigureModalDetails()}

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -65,6 +65,7 @@ import {
   formatApiError,
   getDisplayStatus,
   getEnabledToggleChecked,
+  getModalDisplayStatus,
   isModalEnabledChecked as getModalEnabledChecked,
   isSaveTokenDisabled as getSaveTokenDisabled,
   isEnabledToggleUnavailable,
@@ -435,6 +436,7 @@ export const McpServersSettings = ({
   const [error, setError] = useState<string | null>(null);
   const [editingServerId, setEditingServerId] = useState<string | null>(null);
   const [tokenInputValue, setTokenInputValue] = useState('');
+  const [initialTokenInputValue, setInitialTokenInputValue] = useState('');
   const [hasSavedTokenInModal, setHasSavedTokenInModal] = useState(false);
   const [canRemovePersonalToken, setCanRemovePersonalToken] = useState(false);
   const [tokenValidationState, setTokenValidationState] =
@@ -668,6 +670,7 @@ export const McpServersSettings = ({
   const closeConfigureModal = useCallback(() => {
     setEditingServerId(null);
     setTokenInputValue('');
+    setInitialTokenInputValue('');
     setHasSavedTokenInModal(false);
     setCanRemovePersonalToken(false);
     setTokenValidationState('idle');
@@ -685,7 +688,9 @@ export const McpServersSettings = ({
     const hasSavedToken = server.hasToken;
     setHasSavedTokenInModal(hasSavedToken);
     setCanRemovePersonalToken(server.hasUserToken);
-    setTokenInputValue(hasSavedToken ? SAVED_TOKEN_MASK : '');
+    const initialToken = hasSavedToken ? SAVED_TOKEN_MASK : '';
+    setInitialTokenInputValue(initialToken);
+    setTokenInputValue(initialToken);
     setModalEnabled(server.enabled);
     setModalTools([]);
     setModalToolsError(null);
@@ -809,16 +814,27 @@ export const McpServersSettings = ({
 
   const isConfigureModalSaving = Boolean(isSaving[editingServer?.name ?? '']);
   const isSaveTokenButtonDisabled = getSaveTokenDisabled({
-    hasSavedTokenInModal,
     tokenInputValue,
-    savedTokenMask: SAVED_TOKEN_MASK,
+    initialTokenInputValue,
+    modalEnabled,
+    serverEnabled: editingServer?.enabled ?? true,
     isUpdatingModalStatus,
+    hasRemovedPersonalToken,
   });
 
   const saveServerToken = useCallback(async () => {
     if (!editingServer || !canManageMcp) return;
 
-    if (hasSavedTokenInModal && tokenInputValue === SAVED_TOKEN_MASK) {
+    const hasTokenInputChange = tokenInputValue !== initialTokenInputValue;
+    const hasEnabledInputChange = modalEnabled !== editingServer.enabled;
+
+    if (!hasTokenInputChange && !hasEnabledInputChange) {
+      closeConfigureModal();
+      return;
+    }
+
+    if (!hasTokenInputChange && hasEnabledInputChange) {
+      await patchServer(editingServer.name, { enabled: modalEnabled });
       closeConfigureModal();
       return;
     }
@@ -856,7 +872,7 @@ export const McpServersSettings = ({
 
       setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
       await patchServer(editingServer.name, {
-        enabled: editingServer.enabled,
+        enabled: modalEnabled,
         token: hasToken ? token : null,
       });
       const validationResult = await validateServer(editingServer.name);
@@ -887,7 +903,8 @@ export const McpServersSettings = ({
     canManageMcp,
     closeConfigureModal,
     editingServer,
-    hasSavedTokenInModal,
+    initialTokenInputValue,
+    modalEnabled,
     patchServer,
     t,
     tokenInputValue,
@@ -909,8 +926,9 @@ export const McpServersSettings = ({
     setIsLoadingModalTools(false);
 
     try {
-      await patchServer(editingServer.name, { token: null });
+      await patchServer(editingServer.name, { token: null, enabled: false });
       setHasSavedTokenInModal(false);
+      setInitialTokenInputValue('');
       setModalEnabled(false);
       setHasRemovedPersonalToken(true);
     } catch {
@@ -938,27 +956,24 @@ export const McpServersSettings = ({
       return;
     }
     setModalEnabled(checked);
-    void patchServer(editingServer.name, { enabled: checked }).catch(() => {
-      setModalEnabled(!checked);
-    });
   };
 
-  const editingDisplayStatus = editingServer
-    ? getDisplayStatus(editingServer)
+  const modalDisplayStatus = editingServer
+    ? getModalDisplayStatus(editingServer, modalEnabled)
     : 'unknown';
   const isModalEnabledToggleDisabled =
     !canManageMcp ||
     !editingServer ||
     isUpdatingModalStatus ||
-    isEnabledToggleUnavailable(editingDisplayStatus) ||
+    isEnabledToggleUnavailable(modalDisplayStatus) ||
     Boolean(isSaving[editingServer?.name ?? '']);
   const isModalEnabledChecked = getModalEnabledChecked({
-    displayStatus: editingDisplayStatus,
+    displayStatus: modalDisplayStatus,
     modalEnabled,
   });
 
   const modalStatusDetail = editingServer
-    ? getDisplayDetail(editingServer, editingDisplayStatus)
+    ? getDisplayDetail(editingServer, modalDisplayStatus)
     : '';
 
   const modalToolCount = modalTools.length || editingServer?.toolCount || 0;
@@ -976,17 +991,17 @@ export const McpServersSettings = ({
         />
       );
     }
+    if (modalDisplayStatus === 'disabled') {
+      return <InfoCircleIcon className={classes.statusDisabled} />;
+    }
     if (modalTools.length > 0) {
       return <CheckCircleIcon className={classes.statusOk} />;
     }
-    if (modalToolsError || editingDisplayStatus === 'failed') {
+    if (modalToolsError || modalDisplayStatus === 'failed') {
       return <ExclamationCircleIcon className={classes.statusWarn} />;
     }
-    if (editingDisplayStatus === 'tokenRequired') {
+    if (modalDisplayStatus === 'tokenRequired') {
       return <KeyIcon className={classes.statusWarn} />;
-    }
-    if (editingDisplayStatus === 'disabled') {
-      return <InfoCircleIcon className={classes.statusDisabled} />;
     }
     return <InfoCircleIcon className={classes.statusDisabled} />;
   };
@@ -997,6 +1012,9 @@ export const McpServersSettings = ({
     }
     if (isLoadingModalTools) {
       return t('mcp.settings.modal.loadingTools');
+    }
+    if (modalDisplayStatus === 'disabled') {
+      return t('mcp.settings.status.disabled');
     }
     if (modalTools.length > 0) {
       if (modalTools.length === 1) {
@@ -1037,6 +1055,16 @@ export const McpServersSettings = ({
         {modalToolsError ?? t('mcp.settings.modal.noToolsAvailable')}
       </div>
     );
+  };
+
+  const renderModalEnabledDescription = () => {
+    if (isModalEnabledChecked) {
+      return t('mcp.settings.modal.enabledDescription');
+    }
+    if (modalDisplayStatus === 'tokenRequired') {
+      return t('mcp.settings.modal.enabledDescriptionTokenRequired');
+    }
+    return t('mcp.settings.modal.enabledDescriptionOff');
   };
 
   const renderConfigureModalDetails = () => (
@@ -1083,9 +1111,7 @@ export const McpServersSettings = ({
               {t('mcp.settings.enabled')}
             </div>
             <div className={classes.modalSectionDescription}>
-              {isModalEnabledChecked
-                ? t('mcp.settings.modal.enabledDescription')
-                : t('mcp.settings.modal.enabledDescriptionOff')}
+              {renderModalEnabledDescription()}
             </div>
           </div>
           {isModalEnabledToggleDisabled ? (

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -63,6 +63,7 @@ import { lightspeedMcpManagePermission } from '@red-hat-developer-hub/backstage-
 
 import { useTranslation } from '../hooks/useTranslation';
 import {
+  compareMcpServers,
   formatApiError,
   getDisplayStatus,
   getEnabledToggleChecked,
@@ -74,6 +75,7 @@ import {
   isSaveTokenDisabled as getSaveTokenDisabled,
   isEnabledToggleUnavailable,
   type CredentialMode,
+  type McpServerSortColumn,
   type ServerStatus,
 } from './mcpServersDisplayUtils';
 
@@ -152,6 +154,25 @@ const useStyles = makeStyles(theme => ({
     textDecoration: 'none !important',
     display: 'inline-flex',
     alignItems: 'center',
+  },
+  statusHeaderButton: {
+    paddingLeft: 0,
+    paddingTop: 0,
+    paddingBottom: 0,
+    fontWeight: 600,
+    fontSize: '0.75rem',
+    lineHeight: '1.25rem',
+    minHeight: 'auto',
+    color: theme.palette.text.primary,
+    textDecoration: 'none !important',
+    display: 'inline-flex',
+    alignItems: 'center',
+  },
+  sortHeaderIconActive: {
+    color: 'var(--pf-t--global--icon--color--brand--default, #0066cc)',
+  },
+  sortHeaderIconInactive: {
+    color: 'var(--pf-t--global--icon--color--subtle, #6a6e73)',
   },
   nameHeaderText: {
     paddingLeft: '7px',
@@ -290,6 +311,26 @@ const useStyles = makeStyles(theme => ({
     top: 'var(--pf-v6-c-modal-box__close--InsetBlockStart, 1.5rem)',
     right: 'var(--pf-v6-c-modal-box__close--InsetInlineEnd, 1.5rem)',
     zIndex: 1,
+  },
+  removePersonalTokenButton: {
+    borderRadius: '1.25rem',
+    boxShadow: 'none',
+    '&:not(:disabled):not(.pf-m-disabled)': {
+      '--pf-v6-c-button--BorderColor': '#B1380B',
+      '--pf-v6-c-button--Color': '#B1380B',
+      '--pf-v6-c-button--BackgroundColor': 'transparent',
+      '--pf-v5-c-button--BorderColor': '#B1380B',
+      '--pf-v5-c-button--Color': '#B1380B',
+      '--pf-v5-c-button--BackgroundColor': 'transparent',
+      borderColor: '#B1380B',
+      color: '#B1380B',
+      backgroundColor: 'transparent',
+      '&:hover': {
+        '--pf-v6-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
+        '--pf-v5-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
+        backgroundColor: 'rgba(201, 25, 11, 0.08)',
+      },
+    },
   },
   configureModal: {
     '& .pf-v6-c-modal-box, & .pf-v5-c-modal-box': {
@@ -430,6 +471,7 @@ export const McpServersSettings = ({
   });
   const canManageMcp = mcpManagePermission.allowed;
   const [servers, setServers] = useState<McpServer[]>([]);
+  const [sortColumn, setSortColumn] = useState<McpServerSortColumn>('name');
   const [sortAsc, setSortAsc] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState<Record<string, boolean>>({});
@@ -449,6 +491,9 @@ export const McpServersSettings = ({
   const [modalTools, setModalTools] = useState<string[]>([]);
   const [isLoadingModalTools, setIsLoadingModalTools] = useState(false);
   const [modalToolsError, setModalToolsError] = useState<string | null>(null);
+  const [canRemovePersonalToken, setCanRemovePersonalToken] = useState(false);
+  const [isUpdatingModalStatus, setIsUpdatingModalStatus] = useState(false);
+  const [hasRemovedPersonalToken, setHasRemovedPersonalToken] = useState(false);
 
   const getBaseUrl = useCallback(() => {
     return `${configApi.getString('backend.baseUrl')}/api/intelligent-assistant`;
@@ -640,11 +685,36 @@ export const McpServersSettings = ({
 
   const sortedServers = useMemo(() => {
     const next = [...servers];
-    next.sort((a, b) =>
-      sortAsc ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name),
-    );
+    next.sort((a, b) => compareMcpServers(a, b, sortColumn, sortAsc));
     return next;
-  }, [servers, sortAsc]);
+  }, [servers, sortAsc, sortColumn]);
+
+  const onSortColumnClick = (column: McpServerSortColumn) => {
+    if (sortColumn === column) {
+      setSortAsc(prev => !prev);
+      return;
+    }
+    setSortColumn(column);
+    setSortAsc(true);
+  };
+
+  const renderSortIcon = (column: McpServerSortColumn) => {
+    const isActive = sortColumn === column;
+    let Icon = SortAmountDownIcon;
+    if (isActive && !sortAsc) {
+      Icon = SortAmountUpIcon;
+    }
+
+    return (
+      <Icon
+        className={
+          isActive
+            ? classes.sortHeaderIconActive
+            : classes.sortHeaderIconInactive
+        }
+      />
+    );
+  };
 
   const getDisplayDetail = useCallback(
     (server: McpServer, displayStatus: ServerStatus): string => {
@@ -681,6 +751,9 @@ export const McpServersSettings = ({
     setModalTools([]);
     setIsLoadingModalTools(false);
     setModalToolsError(null);
+    setCanRemovePersonalToken(false);
+    setIsUpdatingModalStatus(false);
+    setHasRemovedPersonalToken(false);
   }, []);
 
   const openConfigureModal = (server: McpServer) => {
@@ -690,12 +763,15 @@ export const McpServersSettings = ({
     setModalCredentialMode(credentialMode);
     setInitialCredentialMode(credentialMode);
     setHasSavedTokenInModal(hasSavedPersonalToken);
+    setCanRemovePersonalToken(server.hasUserToken && !server.hasOrgToken);
     const initialToken = hasSavedPersonalToken ? SAVED_TOKEN_MASK : '';
     setInitialTokenInputValue(initialToken);
     setTokenInputValue(initialToken);
     setModalEnabled(server.enabled);
     setModalTools([]);
     setModalToolsError(null);
+    setIsUpdatingModalStatus(false);
+    setHasRemovedPersonalToken(false);
     if (server.status === 'error' && server.validationError) {
       setTokenValidationState('error');
       setTokenValidationMessage(
@@ -848,7 +924,52 @@ export const McpServersSettings = ({
     hasOrgToken: editingServer?.hasOrgToken ?? false,
     hasSavedPersonalTokenInModal: hasSavedTokenInModal,
     tokenValidationState,
+    hasRemovedPersonalToken,
   });
+
+  const removePersonalToken = useCallback(async () => {
+    if (
+      !editingServer ||
+      !canManageMcp ||
+      isUpdatingModalStatus ||
+      editingServer.hasOrgToken
+    ) {
+      return;
+    }
+
+    setIsUpdatingModalStatus(true);
+    setTokenInputValue('');
+    setTokenValidationState('idle');
+    setTokenValidationMessage('');
+    setModalTools([]);
+    setModalToolsError(null);
+    setIsLoadingModalTools(false);
+
+    try {
+      await patchServer(editingServer.name, { token: null, enabled: false });
+      setHasSavedTokenInModal(false);
+      setInitialTokenInputValue('');
+      setModalEnabled(false);
+      setHasRemovedPersonalToken(true);
+    } catch {
+      const server = servers.find(item => item.id === editingServerId);
+      if (server?.hasUserToken) {
+        setHasSavedTokenInModal(true);
+        setCanRemovePersonalToken(true);
+        setTokenInputValue(SAVED_TOKEN_MASK);
+      }
+      setHasRemovedPersonalToken(false);
+    } finally {
+      setIsUpdatingModalStatus(false);
+    }
+  }, [
+    canManageMcp,
+    editingServer,
+    editingServerId,
+    isUpdatingModalStatus,
+    patchServer,
+    servers,
+  ]);
 
   const saveServerToken = useCallback(async () => {
     if (!editingServer || !canManageMcp) return;
@@ -1019,6 +1140,7 @@ export const McpServersSettings = ({
   const isModalEnabledToggleDisabled =
     !canManageMcp ||
     !editingServer ||
+    isUpdatingModalStatus ||
     isEnabledToggleUnavailable(modalDisplayStatus) ||
     Boolean(isSaving[editingServer?.name ?? '']);
   const isModalEnabledChecked = getModalEnabledChecked({
@@ -1033,9 +1155,16 @@ export const McpServersSettings = ({
   const modalToolCount = modalTools.length || editingServer?.toolCount || 0;
 
   const renderModalStatusIcon = () => {
-    if (isLoadingModalTools) {
+    if (isUpdatingModalStatus || isLoadingModalTools) {
       return (
-        <Spinner size="md" aria-label={t('mcp.settings.modal.loadingTools')} />
+        <Spinner
+          size="md"
+          aria-label={
+            isUpdatingModalStatus
+              ? t('mcp.settings.modal.loadingStatus')
+              : t('mcp.settings.modal.loadingTools')
+          }
+        />
       );
     }
     if (modalDisplayStatus === 'disabled') {
@@ -1054,6 +1183,9 @@ export const McpServersSettings = ({
   };
 
   const renderModalStatusText = () => {
+    if (isUpdatingModalStatus) {
+      return t('mcp.settings.modal.loadingStatus');
+    }
     if (isLoadingModalTools) {
       return t('mcp.settings.modal.loadingTools');
     }
@@ -1123,6 +1255,15 @@ export const McpServersSettings = ({
         className={classes.modalInfoAlert}
         isInline
       />
+      {hasRemovedPersonalToken && !editingServer?.hasOrgToken && (
+        <Alert
+          variant="custom"
+          customIcon={<InfoCircleIcon />}
+          title={t('mcp.settings.modal.tokenRemovedWarning')}
+          className={classes.modalInfoAlert}
+          isInline
+        />
+      )}
       <div className={classes.modalSection}>
         <div className={classes.modalSectionTitle}>
           {t('mcp.settings.status')}
@@ -1237,16 +1378,28 @@ export const McpServersSettings = ({
               <Button
                 variant="link"
                 className={classes.nameHeaderButton}
-                icon={sortAsc ? <SortAmountDownIcon /> : <SortAmountUpIcon />}
+                icon={renderSortIcon('name')}
                 iconPosition="right"
-                onClick={() => setSortAsc(prev => !prev)}
+                onClick={() => onSortColumnClick('name')}
               >
                 <Typography component="span" className={classes.nameHeaderText}>
                   {t('mcp.settings.name')}
                 </Typography>
               </Button>
             </Th>
-            <Th className={classes.statusHeader}>{t('mcp.settings.status')}</Th>
+            <Th className={classes.statusHeader}>
+              <Button
+                variant="link"
+                className={classes.statusHeaderButton}
+                icon={renderSortIcon('status')}
+                iconPosition="right"
+                onClick={() => onSortColumnClick('status')}
+              >
+                <Typography component="span" className={classes.nameHeaderText}>
+                  {t('mcp.settings.status')}
+                </Typography>
+              </Button>
+            </Th>
             <Th screenReaderText={t('mcp.settings.edit')} />
           </Tr>
         </Thead>
@@ -1490,11 +1643,29 @@ export const McpServersSettings = ({
                   !canManageMcp ||
                   isConfigureModalSaving ||
                   tokenValidationState === 'validating' ||
-                  isSaveTokenButtonDisabled
+                  isSaveTokenButtonDisabled ||
+                  isUpdatingModalStatus
                 }
               >
                 {t('modal.save')}
               </Button>
+              {canRemovePersonalToken && (
+                <Button
+                  variant="secondary"
+                  onClick={() => void removePersonalToken()}
+                  isDisabled={
+                    !canManageMcp ||
+                    isConfigureModalSaving ||
+                    tokenValidationState === 'validating' ||
+                    isUpdatingModalStatus ||
+                    hasRemovedPersonalToken ||
+                    !hasSavedTokenInModal
+                  }
+                  className={classes.removePersonalTokenButton}
+                >
+                  {t('mcp.settings.removePersonalToken')}
+                </Button>
+              )}
               <Button variant="link" onClick={closeConfigureModal}>
                 {t('common.cancel')}
               </Button>

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/McpServersSettings.tsx
@@ -14,39 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type FormEvent,
-} from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { makeStyles } from '@material-ui/core';
 import Typography from '@mui/material/Typography';
-import {
-  Alert,
-  Button,
-  FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Radio,
-  Spinner,
-  Switch,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-  Title,
-  Tooltip,
-} from '@patternfly/react-core';
+import { Alert, Button, Switch, Title, Tooltip } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -61,47 +36,27 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { lightspeedMcpManagePermission } from '@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common';
 
+import { useMcpConfigureModal } from '../hooks/useMcpConfigureModal';
 import { useTranslation } from '../hooks/useTranslation';
+import { McpConfigureServerModal } from './McpConfigureServerModal';
 import {
   compareMcpServers,
   formatApiError,
+  getDisplayDetail,
   getDisplayStatus,
   getEnabledToggleChecked,
-  getInitialCredentialMode,
-  getModalDisplayHasToken,
-  getModalDisplayStatus,
-  isModalEnabledChecked as getModalEnabledChecked,
-  getModalVerifiedHasToken,
-  isSaveTokenDisabled as getSaveTokenDisabled,
   isEnabledToggleUnavailable,
-  type CredentialMode,
+  type McpConfigureServer,
   type McpServerSortColumn,
   type ServerStatus,
 } from './mcpServersDisplayUtils';
 
-type McpServer = {
-  id: string;
-  name: string;
-  url?: string;
-  enabled: boolean;
-  status: 'connected' | 'error' | 'unknown';
-  toolCount: number;
-  hasToken: boolean;
-  hasUserToken: boolean;
-  hasOrgToken: boolean;
-  validationError?: string;
-  /** 'dcr' = tokens are minted automatically (no manual token needed). */
-  auth?: string;
-};
+type McpServer = McpConfigureServer;
 
 type McpServersSettingsProps = {
   onClose: () => void;
   backgroundColor?: string;
 };
-
-type TokenValidationState = 'idle' | 'validating' | 'success' | 'error';
-
-const SAVED_TOKEN_MASK = '********************';
 
 const useStyles = makeStyles(theme => ({
   '@global': {
@@ -169,10 +124,10 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
   sortHeaderIconActive: {
-    color: 'var(--pf-t--global--icon--color--brand--default, #0066cc)',
+    color: 'var(--pf-t--global--icon--color--brand--default)',
   },
   sortHeaderIconInactive: {
-    color: 'var(--pf-t--global--icon--color--subtle, #6a6e73)',
+    color: 'var(--pf-t--global--icon--color--subtle)',
   },
   nameHeaderText: {
     paddingLeft: '7px',
@@ -208,16 +163,13 @@ const useStyles = makeStyles(theme => ({
     fontSize: '0.875rem',
   },
   statusOk: {
-    color: '#147878',
+    color: 'var(--pf-t--global--icon--color--status--custom--default)',
   },
   statusWarn: {
-    color: '#B1380B',
+    color: 'var(--pf-t--global--icon--color--status--danger--default)',
   },
   statusDisabled: {
-    color:
-      theme.palette.type === 'dark'
-        ? 'var(--pf-t--global--text--color--subtle, #c7c7c7)'
-        : 'var(--pf-t--global--text--color--subtle, #4d4d4d)',
+    color: 'var(--pf-t--global--icon--color--subtle)',
   },
   actionButton: {
     color: theme.palette.text.secondary,
@@ -227,133 +179,6 @@ const useStyles = makeStyles(theme => ({
   tableRow: {
     '&:hover $actionButton, &:focus-within $actionButton': {
       opacity: 1,
-    },
-  },
-  modalInfoAlert: {
-    marginTop: 0,
-    marginBottom: theme.spacing(2),
-    '--pf-v6-c-alert--BorderColor': '#5e40be',
-    '--pf-v5-c-alert--BorderColor': '#5e40be',
-    borderColor: '#5e40be',
-    '& .pf-v6-c-alert, & .pf-v5-c-alert': {
-      alignItems: 'flex-start',
-    },
-    '& .pf-v6-c-alert__icon, & .pf-v5-c-alert__icon': {
-      color: '#5e40be',
-      alignSelf: 'flex-start',
-      paddingBlockStart: 0,
-      marginBlockStart: 0,
-      lineHeight: 1,
-      '& svg': {
-        display: 'block',
-      },
-    },
-    '& .pf-v6-c-alert__title, & .pf-v5-c-alert__title': {
-      margin: '-0.125rem 0 0 0.5rem',
-      lineHeight: 1.4,
-    },
-  },
-  modalSection: {
-    marginBottom: theme.spacing(2),
-  },
-  modalSectionTitle: {
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    marginBottom: theme.spacing(0.75),
-  },
-  modalSectionDescription: {
-    color: theme.palette.text.secondary,
-    fontSize: '0.875rem',
-    marginTop: theme.spacing(0.25),
-  },
-  modalStatusRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    fontSize: '0.875rem',
-  },
-  modalToolsList: {
-    listStyle: 'none',
-    margin: 0,
-    padding: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-  },
-  modalToolItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    fontSize: '0.875rem',
-  },
-  modalEnabledRow: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    gap: theme.spacing(2),
-  },
-  modalEnabledLabel: {
-    flex: 1,
-  },
-  credentialRadioGroup: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(1.5),
-  },
-  credentialRadioDescription: {
-    color: theme.palette.text.secondary,
-    fontSize: '0.875rem',
-    marginTop: theme.spacing(0.25),
-    marginLeft: theme.spacing(3),
-  },
-  modalCloseButton: {
-    position: 'absolute',
-    top: 'var(--pf-v6-c-modal-box__close--InsetBlockStart, 1.5rem)',
-    right: 'var(--pf-v6-c-modal-box__close--InsetInlineEnd, 1.5rem)',
-    zIndex: 1,
-  },
-  removePersonalTokenButton: {
-    borderRadius: '1.25rem',
-    boxShadow: 'none',
-    '&:not(:disabled):not(.pf-m-disabled)': {
-      '--pf-v6-c-button--BorderColor': '#B1380B',
-      '--pf-v6-c-button--Color': '#B1380B',
-      '--pf-v6-c-button--BackgroundColor': 'transparent',
-      '--pf-v5-c-button--BorderColor': '#B1380B',
-      '--pf-v5-c-button--Color': '#B1380B',
-      '--pf-v5-c-button--BackgroundColor': 'transparent',
-      borderColor: '#B1380B',
-      color: '#B1380B',
-      backgroundColor: 'transparent',
-      '&:hover': {
-        '--pf-v6-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
-        '--pf-v5-c-button--BackgroundColor': 'rgba(201, 25, 11, 0.08)',
-        backgroundColor: 'rgba(201, 25, 11, 0.08)',
-      },
-    },
-  },
-  configureModal: {
-    '& .pf-v6-c-modal-box, & .pf-v5-c-modal-box': {
-      width: '608px',
-      maxWidth: '608px',
-    },
-    '& .pf-v6-c-modal-box__close, & .pf-v5-c-modal-box__close': {
-      display: 'none',
-    },
-    '& .pf-v6-c-modal-box__header, & .pf-v5-c-modal-box__header': {
-      '--pf-v6-c-modal-box__header--PaddingBlockEnd': '0.25rem',
-      '--pf-v5-c-modal-box__header--PaddingBlockEnd': '0.25rem',
-      paddingBlockEnd: '0.25rem',
-    },
-    '& .pf-v6-c-modal-box__title, & .pf-v5-c-modal-box__title': {
-      marginBlockEnd: 0,
-      fontWeight: 600,
-    },
-    '& .pf-v6-c-modal-box__body, & .pf-v5-c-modal-box__body': {
-      '--pf-v6-c-modal-box__body--PaddingBlockStart': '0.5rem',
-      '--pf-v6-c-modal-box__header--body--PaddingBlockStart': '0.5rem',
-      '--pf-v5-c-modal-box__body--PaddingBlockStart': '0.5rem',
-      paddingBlockStart: '0.5rem',
     },
   },
   toggleCell: {
@@ -476,24 +301,6 @@ export const McpServersSettings = ({
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
-  const [editingServerId, setEditingServerId] = useState<string | null>(null);
-  const [tokenInputValue, setTokenInputValue] = useState('');
-  const [initialTokenInputValue, setInitialTokenInputValue] = useState('');
-  const [hasSavedTokenInModal, setHasSavedTokenInModal] = useState(false);
-  const [modalCredentialMode, setModalCredentialMode] =
-    useState<CredentialMode>('personal');
-  const [initialCredentialMode, setInitialCredentialMode] =
-    useState<CredentialMode>('personal');
-  const [tokenValidationState, setTokenValidationState] =
-    useState<TokenValidationState>('idle');
-  const [tokenValidationMessage, setTokenValidationMessage] = useState('');
-  const [modalEnabled, setModalEnabled] = useState(true);
-  const [modalTools, setModalTools] = useState<string[]>([]);
-  const [isLoadingModalTools, setIsLoadingModalTools] = useState(false);
-  const [modalToolsError, setModalToolsError] = useState<string | null>(null);
-  const [canRemovePersonalToken, setCanRemovePersonalToken] = useState(false);
-  const [isUpdatingModalStatus, setIsUpdatingModalStatus] = useState(false);
-  const [hasRemovedPersonalToken, setHasRemovedPersonalToken] = useState(false);
 
   const getBaseUrl = useCallback(() => {
     return `${configApi.getString('backend.baseUrl')}/api/intelligent-assistant`;
@@ -667,27 +474,26 @@ export const McpServersSettings = ({
     [canManageMcp, fetchJson, getBaseUrl, loadServers],
   );
 
-  const editingServer = useMemo(
-    () => servers.find(server => server.id === editingServerId),
-    [servers, editingServerId],
-  );
+  const configureModal = useMcpConfigureModal({
+    servers,
+    canManageMcp,
+    isSaving,
+    patchServer,
+    validateServer,
+    validateCredentials,
+    fetchServerValidation,
+  });
 
-  const selectedCount = useMemo(
-    () =>
-      servers.filter(server => {
-        const displayStatus = getDisplayStatus(server);
-        const isUnavailable =
-          displayStatus === 'failed' || displayStatus === 'tokenRequired';
-        return server.enabled && !isUnavailable;
-      }).length,
-    [servers],
-  );
+  const selectedCount = servers.filter(server => {
+    const displayStatus = getDisplayStatus(server);
+    const isUnavailable =
+      displayStatus === 'failed' || displayStatus === 'tokenRequired';
+    return server.enabled && !isUnavailable;
+  }).length;
 
-  const sortedServers = useMemo(() => {
-    const next = [...servers];
-    next.sort((a, b) => compareMcpServers(a, b, sortColumn, sortAsc));
-    return next;
-  }, [servers, sortAsc, sortColumn]);
+  const sortedServers = [...servers].sort((a, b) =>
+    compareMcpServers(a, b, sortColumn, sortAsc),
+  );
 
   const onSortColumnClick = (column: McpServerSortColumn) => {
     if (sortColumn === column) {
@@ -715,626 +521,6 @@ export const McpServersSettings = ({
       />
     );
   };
-
-  const getDisplayDetail = useCallback(
-    (server: McpServer, displayStatus: ServerStatus): string => {
-      if (displayStatus === 'disabled')
-        return t('mcp.settings.status.disabled');
-      if (displayStatus === 'tokenRequired')
-        return t('mcp.settings.status.tokenRequired');
-      if (displayStatus === 'failed') return t('mcp.settings.status.failed');
-      if (displayStatus === 'ok') {
-        if (server.toolCount === 1) {
-          return t('mcp.settings.status.oneTool' as any, {
-            count: String(server.toolCount),
-          });
-        }
-        return t('mcp.settings.status.manyTools' as any, {
-          count: String(server.toolCount),
-        });
-      }
-      return t('mcp.settings.status.unknown');
-    },
-    [t],
-  );
-
-  const closeConfigureModal = useCallback(() => {
-    setEditingServerId(null);
-    setTokenInputValue('');
-    setInitialTokenInputValue('');
-    setHasSavedTokenInModal(false);
-    setModalCredentialMode('personal');
-    setInitialCredentialMode('personal');
-    setTokenValidationState('idle');
-    setTokenValidationMessage('');
-    setModalEnabled(true);
-    setModalTools([]);
-    setIsLoadingModalTools(false);
-    setModalToolsError(null);
-    setCanRemovePersonalToken(false);
-    setIsUpdatingModalStatus(false);
-    setHasRemovedPersonalToken(false);
-  }, []);
-
-  const openConfigureModal = (server: McpServer) => {
-    setEditingServerId(server.id);
-    const credentialMode = getInitialCredentialMode(server);
-    const hasSavedPersonalToken = server.hasUserToken;
-    setModalCredentialMode(credentialMode);
-    setInitialCredentialMode(credentialMode);
-    setHasSavedTokenInModal(hasSavedPersonalToken);
-    setCanRemovePersonalToken(server.hasUserToken && !server.hasOrgToken);
-    const initialToken = hasSavedPersonalToken ? SAVED_TOKEN_MASK : '';
-    setInitialTokenInputValue(initialToken);
-    setTokenInputValue(initialToken);
-    setModalEnabled(server.enabled);
-    setModalTools([]);
-    setModalToolsError(null);
-    setIsUpdatingModalStatus(false);
-    setHasRemovedPersonalToken(false);
-    if (server.status === 'error' && server.validationError) {
-      setTokenValidationState('error');
-      setTokenValidationMessage(
-        formatApiError(server.validationError) ||
-          t('mcp.settings.token.validationFailed'),
-      );
-    } else {
-      setTokenValidationState('idle');
-      setTokenValidationMessage('');
-    }
-  };
-
-  useEffect(() => {
-    if (!editingServer) {
-      return undefined;
-    }
-
-    if (!editingServer.hasToken) {
-      setModalTools([]);
-      setModalToolsError(null);
-      setIsLoadingModalTools(false);
-      return undefined;
-    }
-
-    let cancelled = false;
-    setIsLoadingModalTools(true);
-    setModalToolsError(null);
-
-    void fetchServerValidation(editingServer.name)
-      .then(data => {
-        if (cancelled) {
-          return;
-        }
-        const tools = data.validation?.tools?.map(tool => tool.name) ?? [];
-        setModalTools(tools);
-        if (data.status === 'error') {
-          setModalToolsError(
-            formatApiError(data.validation?.error) ||
-              t('mcp.settings.token.validationFailed'),
-          );
-        } else {
-          setModalToolsError(null);
-        }
-      })
-      .catch(e => {
-        if (cancelled) {
-          return;
-        }
-        setModalTools([]);
-        setModalToolsError(
-          e instanceof Error
-            ? e.message
-            : t('mcp.settings.modal.toolsLoadFailed'),
-        );
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingModalTools(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [editingServer, fetchServerValidation, t]);
-
-  const onTokenInputChange = (value: string) => {
-    if (hasSavedTokenInModal && value !== SAVED_TOKEN_MASK) {
-      setHasSavedTokenInModal(false);
-    }
-    setTokenInputValue(value);
-    setTokenValidationState('idle');
-    setTokenValidationMessage('');
-  };
-
-  const onCredentialModeChange = (mode: CredentialMode) => {
-    if (mode === modalCredentialMode) {
-      return;
-    }
-    setModalCredentialMode(mode);
-    setTokenValidationState('idle');
-    setTokenValidationMessage('');
-
-    if (mode === 'organization') {
-      setHasSavedTokenInModal(false);
-      setTokenInputValue('');
-      return;
-    }
-
-    if (editingServer?.hasUserToken) {
-      setHasSavedTokenInModal(true);
-      setTokenInputValue(SAVED_TOKEN_MASK);
-      setInitialTokenInputValue(SAVED_TOKEN_MASK);
-      return;
-    }
-
-    setHasSavedTokenInModal(false);
-    setTokenInputValue('');
-    setInitialTokenInputValue('');
-  };
-
-  const clearTokenInput = () => {
-    if (hasSavedTokenInModal) {
-      setHasSavedTokenInModal(false);
-    }
-    setTokenInputValue('');
-    setTokenValidationState('idle');
-    setTokenValidationMessage('');
-  };
-
-  const showCredentialRadios = Boolean(
-    editingServer?.hasOrgToken && editingServer.auth !== 'dcr',
-  );
-  const showPersonalTokenField =
-    editingServer?.auth !== 'dcr' &&
-    (!showCredentialRadios || modalCredentialMode === 'personal');
-
-  let tokenInputValidated: 'success' | 'error' | undefined;
-  if (tokenValidationState === 'success') {
-    tokenInputValidated = 'success';
-  } else if (tokenValidationState === 'error') {
-    tokenInputValidated = 'error';
-  }
-
-  let tokenHelperVariant: 'success' | 'error' | 'default' = 'default';
-  if (tokenValidationState === 'success') {
-    tokenHelperVariant = 'success';
-  } else if (tokenValidationState === 'error') {
-    tokenHelperVariant = 'error';
-  }
-
-  const showTokenHelperText =
-    !hasSavedTokenInModal || tokenValidationState !== 'idle';
-
-  const tokenHelperText =
-    tokenValidationMessage || t('mcp.settings.enterToken');
-
-  const configureModalTitle = t('mcp.settings.configureServerTitle' as any, {
-    serverName: editingServer?.name ?? '',
-  });
-
-  const isConfigureModalSaving = Boolean(isSaving[editingServer?.name ?? '']);
-  const isSaveTokenButtonDisabled = getSaveTokenDisabled({
-    tokenInputValue,
-    initialTokenInputValue,
-    modalEnabled,
-    serverEnabled: editingServer?.enabled ?? true,
-    credentialMode: modalCredentialMode,
-    initialCredentialMode,
-    hasOrgToken: editingServer?.hasOrgToken ?? false,
-    hasSavedPersonalTokenInModal: hasSavedTokenInModal,
-    tokenValidationState,
-    hasRemovedPersonalToken,
-    isDcrServer: editingServer?.auth === 'dcr',
-  });
-
-  const removePersonalToken = useCallback(async () => {
-    if (
-      !editingServer ||
-      !canManageMcp ||
-      isUpdatingModalStatus ||
-      editingServer.hasOrgToken
-    ) {
-      return;
-    }
-
-    setIsUpdatingModalStatus(true);
-    setTokenInputValue('');
-    setTokenValidationState('idle');
-    setTokenValidationMessage('');
-    setModalTools([]);
-    setModalToolsError(null);
-    setIsLoadingModalTools(false);
-
-    try {
-      await patchServer(editingServer.name, { token: null, enabled: false });
-      setHasSavedTokenInModal(false);
-      setInitialTokenInputValue('');
-      setModalEnabled(false);
-      setHasRemovedPersonalToken(true);
-    } catch {
-      const server = servers.find(item => item.id === editingServerId);
-      if (server?.hasUserToken) {
-        setHasSavedTokenInModal(true);
-        setCanRemovePersonalToken(true);
-        setTokenInputValue(SAVED_TOKEN_MASK);
-      }
-      setHasRemovedPersonalToken(false);
-    } finally {
-      setIsUpdatingModalStatus(false);
-    }
-  }, [
-    canManageMcp,
-    editingServer,
-    editingServerId,
-    isUpdatingModalStatus,
-    patchServer,
-    servers,
-  ]);
-
-  const saveServerToken = useCallback(async () => {
-    if (!editingServer || !canManageMcp) return;
-
-    const hasCredentialModeChange =
-      modalCredentialMode !== initialCredentialMode;
-    const hasTokenInputChange = tokenInputValue !== initialTokenInputValue;
-    const hasEnabledInputChange = modalEnabled !== editingServer.enabled;
-
-    if (
-      !hasCredentialModeChange &&
-      !hasTokenInputChange &&
-      !hasEnabledInputChange
-    ) {
-      closeConfigureModal();
-      return;
-    }
-
-    if (
-      modalCredentialMode === 'organization' &&
-      (hasCredentialModeChange || hasEnabledInputChange)
-    ) {
-      setTokenValidationState('validating');
-      setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
-      try {
-        await patchServer(editingServer.name, {
-          token: null,
-          enabled: modalEnabled,
-        });
-        const validationResult = await validateServer(editingServer.name);
-        if (validationResult.status === 'error') {
-          setTokenValidationState('error');
-          setTokenValidationMessage(
-            formatApiError(validationResult.validation?.error) ||
-              t('mcp.settings.token.validationFailed'),
-          );
-          return;
-        }
-        closeConfigureModal();
-      } catch (e) {
-        setTokenValidationState('error');
-        setTokenValidationMessage(
-          e instanceof Error
-            ? e.message
-            : `Failed to update ${editingServer.name} settings`,
-        );
-      }
-      return;
-    }
-
-    if (!hasTokenInputChange && hasEnabledInputChange) {
-      await patchServer(editingServer.name, { enabled: modalEnabled });
-      closeConfigureModal();
-      return;
-    }
-
-    const markFailedTokenAttempt = () => {
-      setInitialTokenInputValue(tokenInputValue);
-    };
-
-    const token = tokenInputValue.trim();
-    const hasToken = token.length > 0;
-
-    setTokenValidationState('validating');
-    setTokenValidationMessage(t('mcp.settings.token.validating'));
-
-    try {
-      if (hasToken) {
-        if (!editingServer.url) {
-          setTokenValidationState('error');
-          setTokenValidationMessage(
-            t('mcp.settings.token.urlUnavailableForValidation'),
-          );
-          markFailedTokenAttempt();
-          return;
-        }
-
-        const credentialValidation = await validateCredentials(
-          editingServer.url,
-          token,
-        );
-        if (!credentialValidation.valid) {
-          setTokenValidationState('error');
-          setTokenValidationMessage(
-            formatApiError(credentialValidation.error) ||
-              t('mcp.settings.token.invalidCredentials'),
-          );
-          markFailedTokenAttempt();
-          return;
-        }
-        setModalTools(credentialValidation.tools?.map(tool => tool.name) ?? []);
-      }
-
-      setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
-      await patchServer(editingServer.name, {
-        enabled: modalEnabled,
-        token: hasToken ? token : null,
-      });
-      const validationResult = await validateServer(editingServer.name);
-      if (validationResult.status === 'error') {
-        setTokenValidationState('error');
-        setTokenValidationMessage(
-          formatApiError(validationResult.validation?.error) ||
-            t('mcp.settings.token.validationFailed'),
-        );
-        markFailedTokenAttempt();
-        return;
-      }
-      if (hasToken && validationResult.status === 'connected') {
-        await patchServer(editingServer.name, { enabled: true });
-        setModalEnabled(true);
-      }
-      setTokenValidationState('success');
-      setTokenValidationMessage(t('mcp.settings.token.connectionSuccessful'));
-      closeConfigureModal();
-    } catch (e) {
-      setTokenValidationState('error');
-      setTokenValidationMessage(
-        e instanceof Error
-          ? e.message
-          : `Failed to update ${editingServer.name} token`,
-      );
-      markFailedTokenAttempt();
-    }
-  }, [
-    canManageMcp,
-    closeConfigureModal,
-    editingServer,
-    initialCredentialMode,
-    initialTokenInputValue,
-    modalCredentialMode,
-    modalEnabled,
-    patchServer,
-    t,
-    tokenInputValue,
-    validateCredentials,
-    validateServer,
-  ]);
-
-  const onModalEnabledChange = (_event: FormEvent, checked: boolean) => {
-    if (!editingServer || !canManageMcp) {
-      return;
-    }
-    setModalEnabled(checked);
-  };
-
-  const modalVerifiedHasToken = editingServer
-    ? editingServer.auth === 'dcr' ||
-      getModalVerifiedHasToken({
-        hasOrgToken: editingServer.hasOrgToken,
-        credentialMode: modalCredentialMode,
-        hasSavedPersonalTokenInModal: hasSavedTokenInModal,
-      })
-    : false;
-
-  const modalDisplayStatus = editingServer
-    ? getModalDisplayStatus(
-        {
-          ...editingServer,
-          hasToken: getModalDisplayHasToken({
-            modalVerifiedHasToken,
-            modalEnabled,
-            serverHasToken: editingServer.hasToken,
-          }),
-        },
-        modalEnabled,
-      )
-    : 'unknown';
-  const isModalEnabledToggleDisabled =
-    !canManageMcp ||
-    !editingServer ||
-    isUpdatingModalStatus ||
-    isEnabledToggleUnavailable(modalDisplayStatus) ||
-    Boolean(isSaving[editingServer?.name ?? '']);
-  const isModalEnabledChecked = getModalEnabledChecked({
-    displayStatus: modalDisplayStatus,
-    modalEnabled,
-  });
-
-  const modalStatusDetail = editingServer
-    ? getDisplayDetail(editingServer, modalDisplayStatus)
-    : '';
-
-  const modalToolCount = modalTools.length || editingServer?.toolCount || 0;
-
-  const renderModalStatusIcon = () => {
-    if (isUpdatingModalStatus || isLoadingModalTools) {
-      return (
-        <Spinner
-          size="md"
-          aria-label={
-            isUpdatingModalStatus
-              ? t('mcp.settings.modal.loadingStatus')
-              : t('mcp.settings.modal.fetchingStatus')
-          }
-        />
-      );
-    }
-    if (modalDisplayStatus === 'disabled') {
-      return <InfoCircleIcon className={classes.statusDisabled} />;
-    }
-    if (modalDisplayStatus === 'tokenRequired') {
-      return <KeyIcon className={classes.statusWarn} />;
-    }
-    if (modalDisplayStatus === 'ok' && modalTools.length > 0) {
-      return <CheckCircleIcon className={classes.statusOk} />;
-    }
-    if (modalToolsError || modalDisplayStatus === 'failed') {
-      return <ExclamationCircleIcon className={classes.statusWarn} />;
-    }
-    return <InfoCircleIcon className={classes.statusDisabled} />;
-  };
-
-  const renderModalStatusText = () => {
-    if (isUpdatingModalStatus) {
-      return t('mcp.settings.modal.loadingStatus');
-    }
-    if (isLoadingModalTools) {
-      return t('mcp.settings.modal.fetchingStatus');
-    }
-    if (modalDisplayStatus === 'disabled') {
-      return t('mcp.settings.status.disabled');
-    }
-    if (modalDisplayStatus === 'tokenRequired') {
-      return t('mcp.settings.status.tokenRequired');
-    }
-    if (modalDisplayStatus === 'ok' && modalTools.length > 0) {
-      if (modalTools.length === 1) {
-        return t('mcp.settings.status.oneTool' as any, {
-          count: String(modalTools.length),
-        });
-      }
-      return t('mcp.settings.status.manyTools' as any, {
-        count: String(modalTools.length),
-      });
-    }
-    if (modalToolsError) {
-      return modalToolsError;
-    }
-    return modalStatusDetail;
-  };
-
-  const renderModalToolsContent = () => {
-    if (isLoadingModalTools) {
-      return (
-        <Spinner size="md" aria-label={t('mcp.settings.modal.loadingTools')} />
-      );
-    }
-    if (modalTools.length > 0) {
-      return (
-        <ul className={classes.modalToolsList}>
-          {modalTools.map(toolName => (
-            <li key={toolName} className={classes.modalToolItem}>
-              <CheckCircleIcon className={classes.statusOk} />
-              <Typography component="span">{toolName}</Typography>
-            </li>
-          ))}
-        </ul>
-      );
-    }
-    return (
-      <div className={classes.modalSectionDescription}>
-        {modalToolsError ?? t('mcp.settings.modal.noToolsAvailable')}
-      </div>
-    );
-  };
-
-  const renderModalEnabledDescription = () => {
-    if (isModalEnabledChecked) {
-      return t('mcp.settings.modal.enabledDescription');
-    }
-    if (modalDisplayStatus === 'tokenRequired') {
-      return t('mcp.settings.modal.enabledDescriptionTokenRequired');
-    }
-    return t('mcp.settings.modal.enabledDescriptionOff');
-  };
-
-  const renderConfigureModalDetails = (options?: {
-    showDcrAlert?: boolean;
-  }) => (
-    <>
-      <Alert
-        variant="custom"
-        customIcon={<InfoCircleIcon />}
-        title={t('mcp.settings.modalDescription')}
-        className={classes.modalInfoAlert}
-        isInline
-      />
-      {options?.showDcrAlert && (
-        <Alert
-          variant="custom"
-          customIcon={<InfoCircleIcon />}
-          title={t('mcp.settings.modalDescriptionDcr')}
-          className={classes.modalInfoAlert}
-          isInline
-        />
-      )}
-      {hasRemovedPersonalToken && !editingServer?.hasOrgToken && (
-        <Alert
-          variant="custom"
-          customIcon={<InfoCircleIcon />}
-          title={t('mcp.settings.modal.tokenRemovedWarning')}
-          className={classes.modalInfoAlert}
-          isInline
-        />
-      )}
-      <div className={classes.modalSection}>
-        <div className={classes.modalSectionTitle}>
-          {t('mcp.settings.status')}
-        </div>
-        <div className={classes.modalStatusRow}>
-          {renderModalStatusIcon()}
-          <Typography component="span">{renderModalStatusText()}</Typography>
-        </div>
-      </div>
-      {modalVerifiedHasToken && modalDisplayStatus === 'ok' && (
-        <div className={classes.modalSection}>
-          <div className={classes.modalSectionTitle}>
-            {t('mcp.settings.modal.toolsHeading' as any, {
-              count: String(modalToolCount),
-            })}
-          </div>
-          {renderModalToolsContent()}
-        </div>
-      )}
-      <div className={classes.modalSection}>
-        <div className={classes.modalEnabledRow}>
-          <div className={classes.modalEnabledLabel}>
-            <div className={classes.modalSectionTitle}>
-              {t('mcp.settings.enabled')}
-            </div>
-            <div className={classes.modalSectionDescription}>
-              {renderModalEnabledDescription()}
-            </div>
-          </div>
-          {isModalEnabledToggleDisabled ? (
-            <Tooltip content={modalStatusDetail}>
-              <Typography component="span">
-                <Switch
-                  id="mcp-configure-enabled-switch"
-                  aria-label={t('mcp.settings.toggleServerAriaLabel' as any, {
-                    serverName: editingServer?.name ?? '',
-                  })}
-                  isChecked={isModalEnabledChecked}
-                  isDisabled={isModalEnabledToggleDisabled}
-                  onChange={onModalEnabledChange}
-                />
-              </Typography>
-            </Tooltip>
-          ) : (
-            <Switch
-              id="mcp-configure-enabled-switch"
-              aria-label={t('mcp.settings.toggleServerAriaLabel' as any, {
-                serverName: editingServer?.name ?? '',
-              })}
-              isChecked={isModalEnabledChecked}
-              isDisabled={isModalEnabledToggleDisabled}
-              onChange={onModalEnabledChange}
-            />
-          )}
-        </div>
-      </div>
-    </>
-  );
 
   return (
     <div
@@ -1428,7 +614,7 @@ export const McpServersSettings = ({
           )}
           {sortedServers.map(server => {
             const displayStatus = getDisplayStatus(server);
-            const displayDetail = getDisplayDetail(server, displayStatus);
+            const displayDetail = getDisplayDetail(server, displayStatus, t);
             let statusClass = classes.statusWarn;
             if (displayStatus === 'ok') {
               statusClass = classes.statusOk;
@@ -1529,7 +715,7 @@ export const McpServersSettings = ({
                     variant="plain"
                     className={classes.actionButton}
                     isDisabled={!canManageMcp}
-                    onClick={() => openConfigureModal(server)}
+                    onClick={() => configureModal.open(server)}
                   />
                 </Td>
               </Tr>
@@ -1537,139 +723,7 @@ export const McpServersSettings = ({
           })}
         </Tbody>
       </Table>
-      <Modal
-        variant="small"
-        isOpen={Boolean(editingServer)}
-        onClose={closeConfigureModal}
-        className={classes.configureModal}
-        aria-labelledby="mcp-configure-modal"
-        aria-describedby="mcp-configure-modal-body"
-      >
-        <ModalHeader
-          title={configureModalTitle}
-          labelId="mcp-configure-modal"
-          descriptorId="mcp-configure-modal-body"
-        />
-        <Button
-          variant="plain"
-          icon={<TimesIcon />}
-          aria-label={t('mcp.settings.closeConfigureModalAriaLabel')}
-          className={classes.modalCloseButton}
-          onClick={closeConfigureModal}
-        />
-        <ModalBody id="mcp-configure-modal-body">
-          <>
-            {renderConfigureModalDetails({
-              showDcrAlert: editingServer?.auth === 'dcr',
-            })}
-            {showCredentialRadios && (
-              <div className={classes.modalSection}>
-                <div className={classes.modalSectionTitle}>
-                  {t('mcp.settings.modal.authenticationHeading')}
-                </div>
-                <div
-                  className={classes.credentialRadioGroup}
-                  id="mcp-credential-mode"
-                >
-                  <div>
-                    <Radio
-                      id="mcp-credential-organization"
-                      name="mcp-credential-mode"
-                      label={t(
-                        'mcp.settings.modal.credentialMode.organization',
-                      )}
-                      isChecked={modalCredentialMode === 'organization'}
-                      onChange={() => onCredentialModeChange('organization')}
-                    />
-                    <div className={classes.credentialRadioDescription}>
-                      {t(
-                        'mcp.settings.modal.credentialMode.organizationDescription',
-                      )}
-                    </div>
-                  </div>
-                  <Radio
-                    id="mcp-credential-personal"
-                    name="mcp-credential-mode"
-                    label={t('mcp.settings.modal.credentialMode.personal')}
-                    isChecked={modalCredentialMode === 'personal'}
-                    onChange={() => onCredentialModeChange('personal')}
-                  />
-                </div>
-              </div>
-            )}
-            {showPersonalTokenField && (
-              <FormGroup
-                label={t('mcp.settings.authenticationToken')}
-                fieldId="mcp-pat-input"
-              >
-                <TextInputGroup validated={tokenInputValidated}>
-                  <TextInputGroupMain
-                    inputId="mcp-pat-input"
-                    type="password"
-                    value={tokenInputValue}
-                    onChange={(_event, value) => onTokenInputChange(value)}
-                  />
-                  {(tokenValidationState === 'idle' ||
-                    tokenValidationState === 'validating') && (
-                    <TextInputGroupUtilities>
-                      <Button
-                        variant="plain"
-                        onClick={clearTokenInput}
-                        aria-label={t('mcp.settings.token.clearAriaLabel')}
-                        icon={<TimesIcon />}
-                      />
-                    </TextInputGroupUtilities>
-                  )}
-                </TextInputGroup>
-                {showTokenHelperText && (
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem variant={tokenHelperVariant}>
-                        {tokenHelperText}
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                )}
-              </FormGroup>
-            )}
-          </>
-        </ModalBody>
-        <ModalFooter>
-          <Button
-            variant="primary"
-            onClick={() => void saveServerToken()}
-            isDisabled={
-              !canManageMcp ||
-              isConfigureModalSaving ||
-              tokenValidationState === 'validating' ||
-              isSaveTokenButtonDisabled ||
-              isUpdatingModalStatus
-            }
-          >
-            {t('modal.save')}
-          </Button>
-          {canRemovePersonalToken && (
-            <Button
-              variant="secondary"
-              onClick={() => void removePersonalToken()}
-              isDisabled={
-                !canManageMcp ||
-                isConfigureModalSaving ||
-                tokenValidationState === 'validating' ||
-                isUpdatingModalStatus ||
-                hasRemovedPersonalToken ||
-                !hasSavedTokenInModal
-              }
-              className={classes.removePersonalTokenButton}
-            >
-              {t('mcp.settings.removePersonalToken')}
-            </Button>
-          )}
-          <Button variant="link" onClick={closeConfigureModal}>
-            {t('common.cancel')}
-          </Button>
-        </ModalFooter>
-      </Modal>
+      <McpConfigureServerModal {...configureModal} />
     </div>
   );
 };

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -82,6 +82,20 @@ const resolveTokenFieldAfterPatch = (
   return currentValue;
 };
 
+const resolveStatusAfterPatch = (
+  token: string | null | undefined,
+  enabled: boolean | undefined,
+  currentStatus: McpServerResponse['status'],
+): McpServerResponse['status'] => {
+  if (token === null) {
+    return 'unknown';
+  }
+  if (enabled === true) {
+    return 'connected';
+  }
+  return currentStatus;
+};
+
 describe('McpServersSettings', () => {
   const onClose = jest.fn();
   let servers: McpServerResponse[];
@@ -175,10 +189,11 @@ describe('McpServersSettings', () => {
             body.token,
             current.hasUserToken,
           ),
-          status:
-            body.token === null
-              ? 'unknown'
-              : body.enabled === true || current.status,
+          status: resolveStatusAfterPatch(
+            body.token,
+            body.enabled,
+            current.status,
+          ),
           toolCount: body.token === null ? 0 : current.toolCount,
         };
         servers = servers.map(server =>

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -48,7 +48,7 @@ type McpServerResponse = {
   auth?: string;
 };
 
-const BASE_URL = 'http://localhost:7007/api/lightspeed';
+const BASE_URL = 'http://localhost:7007/api/intelligent-assistant';
 
 const jsonResponse = (body: unknown, ok = true) => ({
   ok,

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -44,6 +44,7 @@ type McpServerResponse = {
   toolCount: number;
   hasToken: boolean;
   hasUserToken: boolean;
+  hasOrgToken: boolean;
 };
 
 const BASE_URL = 'http://localhost:7007/api/lightspeed';
@@ -66,6 +67,7 @@ const connectedServer = (
   toolCount: 2,
   hasToken: true,
   hasUserToken: false,
+  hasOrgToken: true,
   ...overrides,
 });
 
@@ -128,6 +130,7 @@ describe('McpServersSettings', () => {
     servers = [
       connectedServer('personal-server', {
         hasUserToken: true,
+        hasOrgToken: true,
         toolCount: 3,
       }),
       connectedServer('test-mcp-server', {
@@ -135,6 +138,7 @@ describe('McpServersSettings', () => {
         enabled: true,
         hasToken: false,
         hasUserToken: false,
+        hasOrgToken: false,
         status: 'unknown',
         toolCount: 0,
       }),
@@ -244,6 +248,35 @@ describe('McpServersSettings', () => {
     expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
+  it('shows credential radios for servers with organization default token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    expect(
+      within(dialog).getByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole('radio', { name: 'Use personal token' }),
+    ).toBeChecked();
+  });
+
+  it('does not show credential radios when no organization default token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('test-mcp-server');
+
+    const dialog = getModalDialog();
+    expect(
+      within(dialog).queryByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it('updates modal status locally when enabled is toggled off without PATCH', async () => {
     renderSettings();
     await waitForServersLoaded();
@@ -265,6 +298,7 @@ describe('McpServersSettings', () => {
     );
 
     expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Tools (2)')).not.toBeInTheDocument();
     expect(
       within(dialog).getByText(
         'This server is disabled and unavailable in chat.',
@@ -358,52 +392,183 @@ describe('McpServersSettings', () => {
     ).toBeInTheDocument();
   });
 
-  it('removes personal token, shows disconnecting state, warning, and enables Save', async () => {
+  it('keeps status Disabled when switching to personal token with enabled off', async () => {
+    servers = [
+      connectedServer('org-disabled-server', {
+        enabled: false,
+        hasUserToken: false,
+        hasOrgToken: true,
+        hasToken: true,
+        toolCount: 2,
+      }),
+    ];
+
     renderSettings();
-    await waitForServersLoaded();
-    await openConfigureModal('personal-server');
+    await waitFor(() => {
+      expect(screen.getByText('org-disabled-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('org-disabled-server');
 
     const dialog = getModalDialog();
-    fireEvent.click(
-      within(dialog).getByRole('button', { name: 'Remove personal token' }),
-    );
-
-    expect(within(dialog).getByText('Disconnecting...')).toBeInTheDocument();
-
     await waitFor(() => {
       expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
     });
 
-    expect(
-      within(dialog).getByText(
-        'Token has been removed. To use this MCP server again, provide a new token.',
-      ),
-    ).toBeInTheDocument();
-    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
-    expect(
-      within(dialog).getByRole('button', { name: 'Remove personal token' }),
-    ).toBeDisabled();
+    fireEvent.click(
+      within(dialog).getByRole('radio', { name: 'Use personal token' }),
+    );
+
+    expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
+    expect(within(dialog).queryByText('2 tools')).not.toBeInTheDocument();
+
+    fireEvent.change(within(dialog).getByLabelText('Type to filter'), {
+      target: { value: 'draft-token' },
+    });
+
+    expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
+    expect(within(dialog).queryByText('2 tools')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Tools (2)')).not.toBeInTheDocument();
     expect(
       within(dialog).getByRole('switch', {
-        name: 'Toggle personal-server',
+        name: 'Toggle org-disabled-server',
       }),
     ).not.toBeChecked();
   });
 
-  it('enables Save after removing personal token and re-enabling with org token', async () => {
+  it('does not show connected status while drafting a personal token', async () => {
+    servers = [
+      connectedServer('org-enabled-server', {
+        enabled: true,
+        hasUserToken: false,
+        hasOrgToken: true,
+        hasToken: true,
+        toolCount: 2,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('org-enabled-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('org-enabled-server');
+
+    const dialog = getModalDialog();
+    await waitFor(() => {
+      expect(within(dialog).getByText('2 tools')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      within(dialog).getByRole('radio', { name: 'Use personal token' }),
+    );
+    fireEvent.change(within(dialog).getByLabelText('Type to filter'), {
+      target: { value: 'draft-token' },
+    });
+
+    expect(within(dialog).queryByText('2 tools')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Tools (2)')).not.toBeInTheDocument();
+    expect(within(dialog).getByText('Token required')).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle org-enabled-server',
+      }),
+    ).not.toBeChecked();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('disables Save after failed token save with credential mode change until input is edited', async () => {
+    servers = [
+      connectedServer('org-enabled-server', {
+        enabled: true,
+        hasUserToken: false,
+        hasOrgToken: true,
+        hasToken: true,
+        toolCount: 2,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('org-enabled-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('org-enabled-server');
+
+    const dialog = getModalDialog();
+    fireEvent.click(
+      within(dialog).getByRole('radio', { name: 'Use personal token' }),
+    );
+    fireEvent.change(within(dialog).getByLabelText('Type to filter'), {
+      target: { value: 'bad-token' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByText(
+          'Invalid credentials. Check server URL and token.',
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.change(within(dialog).getByLabelText('Type to filter'), {
+      target: { value: 'bad-token!' },
+    });
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('hides token field when organization default token is selected', async () => {
     renderSettings();
     await waitForServersLoaded();
     await openConfigureModal('personal-server');
 
     const dialog = getModalDialog();
     fireEvent.click(
-      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+      within(dialog).getByRole('radio', {
+        name: 'Use organization default token',
+      }),
     );
 
-    await waitFor(() => {
-      expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
-    });
+    expect(
+      within(dialog).queryByLabelText('Type to filter'),
+    ).not.toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
 
+  it('saves organization credential mode by clearing personal token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    fireEvent.click(
+      within(dialog).getByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    );
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/mcp-servers/personal-server`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ token: null, enabled: true }),
+        }),
+      );
+    });
+  });
+
+  it('enables Save after switching to organization token and re-enabling', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    fireEvent.click(
+      within(dialog).getByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    );
     fireEvent.click(
       within(dialog).getByRole('switch', {
         name: 'Toggle personal-server',
@@ -419,10 +584,49 @@ describe('McpServersSettings', () => {
         `${BASE_URL}/mcp-servers/personal-server`,
         expect.objectContaining({
           method: 'PATCH',
-          body: JSON.stringify({ enabled: true }),
+          body: JSON.stringify({ token: null, enabled: false }),
         }),
       );
     });
+  });
+
+  it('disables Save after failed token save until input is edited', async () => {
+    servers = [
+      connectedServer('credential-test-mcp', {
+        url: 'http://127.0.0.1:7777/mcp',
+        enabled: false,
+        hasToken: false,
+        hasUserToken: false,
+        hasOrgToken: false,
+        status: 'unknown',
+        toolCount: 0,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('credential-test-mcp')).toBeInTheDocument();
+    });
+    await openConfigureModal('credential-test-mcp');
+
+    const dialog = getModalDialog();
+    const tokenField = within(dialog).getByLabelText('Type to filter');
+    fireEvent.change(tokenField, { target: { value: 'bad-token' } });
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByText(
+          'Invalid credentials. Check server URL and token.',
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.change(tokenField, { target: { value: 'bad-token!' } });
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
   });
 
   it('auto-enables server after saving a valid token', async () => {
@@ -432,6 +636,7 @@ describe('McpServersSettings', () => {
         enabled: false,
         hasToken: false,
         hasUserToken: false,
+        hasOrgToken: false,
         status: 'unknown',
         toolCount: 0,
       }),

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -74,7 +74,7 @@ const resolveTokenFieldAfterPatch = (
   currentValue: boolean,
 ): boolean => {
   if (token === null) {
-    return false;
+    return currentValue;
   }
   if (token) {
     return true;
@@ -185,10 +185,10 @@ describe('McpServersSettings', () => {
           ...current,
           enabled: body.enabled ?? current.enabled,
           hasToken: resolveTokenFieldAfterPatch(body.token, current.hasToken),
-          hasUserToken: resolveTokenFieldAfterPatch(
-            body.token,
-            current.hasUserToken,
-          ),
+          hasUserToken:
+            body.token === null
+              ? false
+              : resolveTokenFieldAfterPatch(body.token, current.hasUserToken),
           status: resolveStatusAfterPatch(
             body.token,
             body.enabled,
@@ -244,6 +244,102 @@ describe('McpServersSettings', () => {
     expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
+  it('updates modal status locally when enabled is toggled off without PATCH', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    await waitFor(() => {
+      expect(within(dialog).getByText('2 tools')).toBeInTheDocument();
+    });
+
+    const patchCallsBefore = mockFetch.mock.calls.filter(
+      ([, init]) => init?.method === 'PATCH',
+    ).length;
+
+    fireEvent.click(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle personal-server',
+      }),
+    );
+
+    expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        'This server is disabled and unavailable in chat.',
+      ),
+    ).toBeInTheDocument();
+
+    const patchCallsAfter = mockFetch.mock.calls.filter(
+      ([, init]) => init?.method === 'PATCH',
+    ).length;
+    expect(patchCallsAfter).toBe(patchCallsBefore);
+
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('persists enabled change when saving with unchanged masked token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    await waitFor(() => {
+      expect(within(dialog).getByText('2 tools')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle personal-server',
+      }),
+    );
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/mcp-servers/personal-server`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ enabled: false }),
+        }),
+      );
+    });
+  });
+
+  it('enables Save when token input is edited', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.change(within(dialog).getByLabelText('Type to filter'), {
+      target: { value: 'edited-token' },
+    });
+
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('enables Save when enabled toggle changes with unchanged masked token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.click(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle personal-server',
+      }),
+    );
+
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
   it('shows modal enabled toggle off when token is required', async () => {
     renderSettings();
     await waitForServersLoaded();
@@ -255,9 +351,14 @@ describe('McpServersSettings', () => {
         name: 'Toggle test-mcp-server',
       }),
     ).not.toBeChecked();
+    expect(
+      within(dialog).getByText(
+        'This server is currently disabled. Provide a token to enable.',
+      ),
+    ).toBeInTheDocument();
   });
 
-  it('removes personal token, shows disconnecting state, warning, and disables actions', async () => {
+  it('removes personal token, shows disconnecting state, warning, and enables Save', async () => {
     renderSettings();
     await waitForServersLoaded();
     await openConfigureModal('personal-server');
@@ -270,7 +371,7 @@ describe('McpServersSettings', () => {
     expect(within(dialog).getByText('Disconnecting...')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(within(dialog).getByText('Token required')).toBeInTheDocument();
+      expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
     });
 
     expect(
@@ -278,7 +379,7 @@ describe('McpServersSettings', () => {
         'Token has been removed. To use this MCP server again, provide a new token.',
       ),
     ).toBeInTheDocument();
-    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
     expect(
       within(dialog).getByRole('button', { name: 'Remove personal token' }),
     ).toBeDisabled();
@@ -287,6 +388,41 @@ describe('McpServersSettings', () => {
         name: 'Toggle personal-server',
       }),
     ).not.toBeChecked();
+  });
+
+  it('enables Save after removing personal token and re-enabling with org token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+    );
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('Disabled')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle personal-server',
+      }),
+    );
+
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/mcp-servers/personal-server`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ enabled: true }),
+        }),
+      );
+    });
   });
 
   it('auto-enables server after saving a valid token', async () => {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -45,6 +45,7 @@ type McpServerResponse = {
   hasToken: boolean;
   hasUserToken: boolean;
   hasOrgToken: boolean;
+  auth?: string;
 };
 
 const BASE_URL = 'http://localhost:7007/api/lightspeed';
@@ -276,6 +277,47 @@ describe('McpServersSettings', () => {
     expect(
       within(dialog).getByRole('button', { name: 'Remove personal token' }),
     ).toBeInTheDocument();
+  });
+
+  it('shows only the DCR message and Cancel for DCR servers', async () => {
+    servers = [
+      connectedServer('dcr-server', {
+        auth: 'dcr',
+        hasToken: true,
+        hasUserToken: false,
+        hasOrgToken: false,
+        toolCount: 4,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('dcr-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('dcr-server');
+
+    const dialog = getModalDialog();
+    expect(
+      within(dialog).getByText(
+        'This server uses Dynamic Client Registration (DCR). Tokens are minted automatically using your Backstage identity — no manual token is needed.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole('button', { name: 'Cancel' }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole('button', { name: 'Save' }),
+    ).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Status')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Enabled')).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByLabelText('Type to filter'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it('does not show remove personal token when organization default token exists', async () => {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -279,7 +279,7 @@ describe('McpServersSettings', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows only the DCR message and Cancel for DCR servers', async () => {
+  it('shows DCR modal layout aligned with personal-token servers without token input', async () => {
     servers = [
       connectedServer('dcr-server', {
         auth: 'dcr',
@@ -299,17 +299,25 @@ describe('McpServersSettings', () => {
     const dialog = getModalDialog();
     expect(
       within(dialog).getByText(
+        'Credentials are encrypted and operations use your exact permissions.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
         'This server uses Dynamic Client Registration (DCR). Tokens are minted automatically using your Backstage identity — no manual token is needed.',
       ),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('Status')).toBeInTheDocument();
+    expect(within(dialog).getByText('Enabled')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(within(dialog).getByText('Tools (2)')).toBeInTheDocument();
+    });
+    expect(
+      within(dialog).getByRole('button', { name: 'Save' }),
     ).toBeInTheDocument();
     expect(
       within(dialog).getByRole('button', { name: 'Cancel' }),
     ).toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole('button', { name: 'Save' }),
-    ).not.toBeInTheDocument();
-    expect(within(dialog).queryByText('Status')).not.toBeInTheDocument();
-    expect(within(dialog).queryByText('Enabled')).not.toBeInTheDocument();
     expect(
       within(dialog).queryByLabelText('Type to filter'),
     ).not.toBeInTheDocument();
@@ -318,6 +326,49 @@ describe('McpServersSettings', () => {
         name: 'Use organization default token',
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it('persists enabled change when saving a DCR server', async () => {
+    servers = [
+      connectedServer('dcr-server', {
+        auth: 'dcr',
+        hasToken: true,
+        hasUserToken: false,
+        hasOrgToken: false,
+        toolCount: 4,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('dcr-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('dcr-server');
+
+    const dialog = getModalDialog();
+    await waitFor(() => {
+      expect(within(dialog).getByText('Tools (2)')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle dcr-server',
+      }),
+    );
+
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/mcp-servers/dcr-server`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ enabled: false }),
+        }),
+      );
+    });
   });
 
   it('does not show remove personal token when organization default token exists', async () => {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -188,7 +188,10 @@ describe('McpServersSettings', () => {
         const updated: McpServerResponse = {
           ...current,
           enabled: body.enabled ?? current.enabled,
-          hasToken: resolveTokenFieldAfterPatch(body.token, current.hasToken),
+          hasToken:
+            body.token === null
+              ? current.hasOrgToken
+              : resolveTokenFieldAfterPatch(body.token, current.hasToken),
           hasUserToken:
             body.token === null
               ? false
@@ -246,6 +249,87 @@ describe('McpServersSettings', () => {
 
     const dialog = getModalDialog();
     expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('shows remove personal token only when no organization default token exists', async () => {
+    servers = [
+      connectedServer('personal-only-server', {
+        hasUserToken: true,
+        hasOrgToken: false,
+        hasToken: true,
+        toolCount: 2,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('personal-only-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('personal-only-server');
+
+    const dialog = getModalDialog();
+    expect(
+      within(dialog).queryByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show remove personal token when organization default token exists', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    expect(
+      within(dialog).getByRole('radio', {
+        name: 'Use organization default token',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole('button', { name: 'Remove personal token' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('removes personal token for servers without organization default token', async () => {
+    servers = [
+      connectedServer('personal-only-server', {
+        hasUserToken: true,
+        hasOrgToken: false,
+        hasToken: true,
+        toolCount: 2,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('personal-only-server')).toBeInTheDocument();
+    });
+    await openConfigureModal('personal-only-server');
+
+    const dialog = getModalDialog();
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+    );
+
+    expect(within(dialog).getByText('Disconnecting...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('Token required')).toBeInTheDocument();
+    });
+
+    expect(
+      within(dialog).getByText(
+        'Token has been removed. To use this MCP server again, provide a new token.',
+      ),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeEnabled();
+    expect(
+      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+    ).toBeDisabled();
   });
 
   it('shows credential radios for servers with organization default token', async () => {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/McpServersSettings.test.tsx
@@ -1,0 +1,312 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configApiRef, fetchApiRef } from '@backstage/core-plugin-api';
+import { TestApiProvider } from '@backstage/test-utils';
+
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+
+import { mockUseTranslation } from '../../test-utils/mockTranslations';
+import { McpServersSettings } from '../McpServersSettings';
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: jest.fn(() => mockUseTranslation()),
+}));
+
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: jest.fn(() => ({ loading: false, allowed: true })),
+}));
+
+type McpServerResponse = {
+  name: string;
+  url?: string;
+  enabled: boolean;
+  status: 'connected' | 'error' | 'unknown';
+  toolCount: number;
+  hasToken: boolean;
+  hasUserToken: boolean;
+};
+
+const BASE_URL = 'http://localhost:7007/api/lightspeed';
+
+const jsonResponse = (body: unknown, ok = true) => ({
+  ok,
+  status: ok ? 200 : 500,
+  statusText: ok ? 'OK' : 'Error',
+  text: async () => JSON.stringify(body),
+});
+
+const connectedServer = (
+  name: string,
+  overrides: Partial<McpServerResponse> = {},
+): McpServerResponse => ({
+  name,
+  url: `http://localhost/${name}`,
+  enabled: true,
+  status: 'connected',
+  toolCount: 2,
+  hasToken: true,
+  hasUserToken: false,
+  ...overrides,
+});
+
+const resolveTokenFieldAfterPatch = (
+  token: string | null | undefined,
+  currentValue: boolean,
+): boolean => {
+  if (token === null) {
+    return false;
+  }
+  if (token) {
+    return true;
+  }
+  return currentValue;
+};
+
+describe('McpServersSettings', () => {
+  const onClose = jest.fn();
+  let servers: McpServerResponse[];
+  const mockFetch = jest.fn();
+
+  const renderSettings = () =>
+    render(
+      <TestApiProvider
+        apis={[
+          [
+            configApiRef,
+            {
+              getString: (key: string) => {
+                if (key === 'backend.baseUrl') {
+                  return 'http://localhost:7007';
+                }
+                throw new Error(`Unexpected config key: ${key}`);
+              },
+            },
+          ],
+          [fetchApiRef, { fetch: mockFetch }],
+        ]}
+      >
+        <McpServersSettings onClose={onClose} />
+      </TestApiProvider>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    servers = [
+      connectedServer('personal-server', {
+        hasUserToken: true,
+        toolCount: 3,
+      }),
+      connectedServer('test-mcp-server', {
+        url: 'http://localhost:8888/mcp',
+        enabled: true,
+        hasToken: false,
+        hasUserToken: false,
+        status: 'unknown',
+        toolCount: 0,
+      }),
+    ];
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+
+      if (url === `${BASE_URL}/mcp-servers` && method === 'GET') {
+        return jsonResponse({ servers });
+      }
+
+      if (method === 'POST' && url === `${BASE_URL}/mcp-servers/validate`) {
+        const body = JSON.parse(String(init?.body ?? '{}')) as {
+          url: string;
+          token: string;
+        };
+        return jsonResponse({
+          valid: body.token === 'valid-token',
+          toolCount: 2,
+          tools: [{ name: 'tool.one' }, { name: 'tool.two' }],
+        });
+      }
+
+      if (method === 'POST' && url.endsWith('/validate')) {
+        return jsonResponse({
+          name: url.split('/').slice(-2, -1)[0],
+          status: 'connected',
+          toolCount: 2,
+          validation: {
+            tools: [{ name: 'tool.one' }, { name: 'tool.two' }],
+          },
+        });
+      }
+
+      if (method === 'PATCH') {
+        const serverName = decodeURIComponent(url.split('/').pop() ?? '');
+        const body = JSON.parse(String(init?.body ?? '{}')) as {
+          enabled?: boolean;
+          token?: string | null;
+        };
+        const current = servers.find(server => server.name === serverName);
+        if (!current) {
+          return jsonResponse({ error: 'Not found' }, false);
+        }
+
+        const updated: McpServerResponse = {
+          ...current,
+          enabled: body.enabled ?? current.enabled,
+          hasToken: resolveTokenFieldAfterPatch(body.token, current.hasToken),
+          hasUserToken: resolveTokenFieldAfterPatch(
+            body.token,
+            current.hasUserToken,
+          ),
+          status:
+            body.token === null
+              ? 'unknown'
+              : body.enabled === true || current.status,
+          toolCount: body.token === null ? 0 : current.toolCount,
+        };
+        servers = servers.map(server =>
+          server.name === serverName ? updated : server,
+        );
+        return jsonResponse({ server: updated });
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    });
+  });
+
+  const waitForServersLoaded = async () => {
+    await waitFor(() => {
+      expect(screen.getByText('personal-server')).toBeInTheDocument();
+    });
+  };
+
+  const openConfigureModal = async (serverName: string) => {
+    fireEvent.click(screen.getByRole('button', { name: `Edit ${serverName}` }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', {
+          name: `${serverName} MCP server settings`,
+        }),
+      ).toBeInTheDocument();
+    });
+  };
+
+  const getModalDialog = () => screen.getByRole('dialog');
+
+  it('shows enabled toggle off in table when token is required', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+
+    const tableToggle = screen.getByRole('switch', {
+      name: 'Toggle test-mcp-server',
+    });
+    expect(tableToggle).not.toBeChecked();
+  });
+
+  it('disables Save when opening modal with unchanged personal token', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('shows modal enabled toggle off when token is required', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('test-mcp-server');
+
+    const dialog = getModalDialog();
+    expect(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle test-mcp-server',
+      }),
+    ).not.toBeChecked();
+  });
+
+  it('removes personal token, shows disconnecting state, warning, and disables actions', async () => {
+    renderSettings();
+    await waitForServersLoaded();
+    await openConfigureModal('personal-server');
+
+    const dialog = getModalDialog();
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+    );
+
+    expect(within(dialog).getByText('Disconnecting...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('Token required')).toBeInTheDocument();
+    });
+
+    expect(
+      within(dialog).getByText(
+        'Token has been removed. To use this MCP server again, provide a new token.',
+      ),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(
+      within(dialog).getByRole('button', { name: 'Remove personal token' }),
+    ).toBeDisabled();
+    expect(
+      within(dialog).getByRole('switch', {
+        name: 'Toggle personal-server',
+      }),
+    ).not.toBeChecked();
+  });
+
+  it('auto-enables server after saving a valid token', async () => {
+    servers = [
+      connectedServer('credential-test-mcp', {
+        url: 'http://127.0.0.1:7777/mcp',
+        enabled: false,
+        hasToken: false,
+        hasUserToken: false,
+        status: 'unknown',
+        toolCount: 0,
+      }),
+    ];
+
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText('credential-test-mcp')).toBeInTheDocument();
+    });
+    await openConfigureModal('credential-test-mcp');
+
+    const dialog = getModalDialog();
+    fireEvent.change(within(dialog).getByLabelText('Type to filter'), {
+      target: { value: 'valid-token' },
+    });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${BASE_URL}/mcp-servers/credential-test-mcp`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ enabled: true }),
+        }),
+      );
+    });
+  });
+});

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
@@ -18,6 +18,10 @@ import {
   formatApiError,
   getDisplayStatus,
   getEnabledToggleChecked,
+  getModalDisplayStatus,
+  getModalEnabledDescriptionKey,
+  hasModalEnabledStateChange,
+  hasModalUnsavedChanges,
   isEnabledToggleUnavailable,
   isModalEnabledChecked,
   isSaveTokenDisabled,
@@ -135,6 +139,106 @@ describe('mcpServersDisplayUtils', () => {
     });
   });
 
+  describe('getModalDisplayStatus', () => {
+    const server = {
+      hasToken: true,
+      enabled: true,
+      status: 'connected' as const,
+    };
+
+    it('returns disabled when modal toggle is off', () => {
+      expect(getModalDisplayStatus(server, false)).toBe('disabled');
+    });
+
+    it('returns ok when modal toggle is on and server is connected', () => {
+      expect(getModalDisplayStatus(server, true)).toBe('ok');
+    });
+  });
+
+  describe('getModalEnabledDescriptionKey', () => {
+    it('returns active description when enabled', () => {
+      expect(getModalEnabledDescriptionKey(true, 'ok')).toBe(
+        'mcp.settings.modal.enabledDescription',
+      );
+    });
+
+    it('returns token-required description when token is missing', () => {
+      expect(getModalEnabledDescriptionKey(false, 'tokenRequired')).toBe(
+        'mcp.settings.modal.enabledDescriptionTokenRequired',
+      );
+    });
+
+    it('returns user-disabled description when server has a token', () => {
+      expect(getModalEnabledDescriptionKey(false, 'disabled')).toBe(
+        'mcp.settings.modal.enabledDescriptionOff',
+      );
+    });
+  });
+
+  describe('hasModalEnabledStateChange', () => {
+    const server = {
+      hasToken: true,
+      hasUserToken: false,
+      enabled: false,
+      status: 'connected' as const,
+    };
+
+    it('returns true when enabled state changed', () => {
+      expect(
+        hasModalEnabledStateChange({
+          server,
+          modalEnabled: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when enabled state is unchanged', () => {
+      expect(
+        hasModalEnabledStateChange({
+          server,
+          modalEnabled: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('hasModalUnsavedChanges', () => {
+    const savedTokenMask = '********************';
+
+    it('returns true when token input changed', () => {
+      expect(
+        hasModalUnsavedChanges({
+          tokenInputValue: 'new-token',
+          initialTokenInputValue: '',
+          modalEnabled: true,
+          serverEnabled: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when enabled state changed', () => {
+      expect(
+        hasModalUnsavedChanges({
+          tokenInputValue: savedTokenMask,
+          initialTokenInputValue: savedTokenMask,
+          modalEnabled: false,
+          serverEnabled: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when nothing changed', () => {
+      expect(
+        hasModalUnsavedChanges({
+          tokenInputValue: savedTokenMask,
+          initialTokenInputValue: savedTokenMask,
+          modalEnabled: true,
+          serverEnabled: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('isModalEnabledChecked', () => {
     it('shows off in modal when token is required', () => {
       expect(
@@ -158,45 +262,62 @@ describe('mcpServersDisplayUtils', () => {
   describe('isSaveTokenDisabled', () => {
     const savedTokenMask = '********************';
 
-    it('disables save for unchanged masked token', () => {
+    it('disables save when nothing changed', () => {
       expect(
         isSaveTokenDisabled({
-          hasSavedTokenInModal: true,
           tokenInputValue: savedTokenMask,
-          savedTokenMask,
+          initialTokenInputValue: savedTokenMask,
+          modalEnabled: true,
+          serverEnabled: true,
           isUpdatingModalStatus: false,
         }),
       ).toBe(true);
     });
 
-    it('disables save for empty token input', () => {
+    it('enables save after personal token was removed', () => {
       expect(
         isSaveTokenDisabled({
-          hasSavedTokenInModal: false,
           tokenInputValue: '',
-          savedTokenMask,
+          initialTokenInputValue: '',
+          modalEnabled: false,
+          serverEnabled: false,
           isUpdatingModalStatus: false,
+          hasRemovedPersonalToken: true,
         }),
-      ).toBe(true);
+      ).toBe(false);
     });
 
-    it('disables save while status is updating', () => {
+    it('disables save while status is updating even with changes', () => {
       expect(
         isSaveTokenDisabled({
-          hasSavedTokenInModal: false,
           tokenInputValue: 'new-token',
-          savedTokenMask,
+          initialTokenInputValue: '',
+          modalEnabled: true,
+          serverEnabled: true,
           isUpdatingModalStatus: true,
         }),
       ).toBe(true);
     });
 
-    it('enables save when user entered a new token', () => {
+    it('enables save when only enabled state changed', () => {
       expect(
         isSaveTokenDisabled({
-          hasSavedTokenInModal: false,
+          tokenInputValue: savedTokenMask,
+          initialTokenInputValue: savedTokenMask,
+          modalEnabled: false,
+          serverEnabled: true,
+          isUpdatingModalStatus: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('enables save when token input changed', () => {
+      expect(
+        isSaveTokenDisabled({
           tokenInputValue: 'new-token',
-          savedTokenMask,
+          initialTokenInputValue: '',
+          modalEnabled: true,
+          serverEnabled: true,
           isUpdatingModalStatus: false,
         }),
       ).toBe(false);

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
@@ -18,8 +18,12 @@ import {
   formatApiError,
   getDisplayStatus,
   getEnabledToggleChecked,
+  getInitialCredentialMode,
+  getModalDisplayHasToken,
   getModalDisplayStatus,
+  getModalEffectiveHasToken,
   getModalEnabledDescriptionKey,
+  getModalVerifiedHasToken,
   hasModalEnabledStateChange,
   hasModalUnsavedChanges,
   isEnabledToggleUnavailable,
@@ -202,6 +206,115 @@ describe('mcpServersDisplayUtils', () => {
     });
   });
 
+  describe('getInitialCredentialMode', () => {
+    it('returns personal when user token is saved', () => {
+      expect(
+        getInitialCredentialMode({ hasUserToken: true, hasOrgToken: true }),
+      ).toBe('personal');
+    });
+
+    it('returns organization when only org token exists', () => {
+      expect(
+        getInitialCredentialMode({ hasUserToken: false, hasOrgToken: true }),
+      ).toBe('organization');
+    });
+
+    it('returns personal when no org token exists', () => {
+      expect(
+        getInitialCredentialMode({ hasUserToken: false, hasOrgToken: false }),
+      ).toBe('personal');
+    });
+  });
+
+  describe('getModalEffectiveHasToken', () => {
+    it('returns true for organization mode when org token exists', () => {
+      expect(
+        getModalEffectiveHasToken({
+          hasOrgToken: true,
+          credentialMode: 'organization',
+          tokenInputValue: '',
+          hasSavedPersonalTokenInModal: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true for personal mode with saved token', () => {
+      expect(
+        getModalEffectiveHasToken({
+          hasOrgToken: true,
+          credentialMode: 'personal',
+          tokenInputValue: '',
+          hasSavedPersonalTokenInModal: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false for personal mode without token', () => {
+      expect(
+        getModalEffectiveHasToken({
+          hasOrgToken: true,
+          credentialMode: 'personal',
+          tokenInputValue: '',
+          hasSavedPersonalTokenInModal: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('getModalDisplayHasToken', () => {
+    it('uses server token when disabled and draft personal mode has no token', () => {
+      expect(
+        getModalDisplayHasToken({
+          modalVerifiedHasToken: false,
+          modalEnabled: false,
+          serverHasToken: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('does not use server token when enabled without verified personal token', () => {
+      expect(
+        getModalDisplayHasToken({
+          modalVerifiedHasToken: false,
+          modalEnabled: true,
+          serverHasToken: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('getModalVerifiedHasToken', () => {
+    it('returns true for organization mode when org token exists', () => {
+      expect(
+        getModalVerifiedHasToken({
+          hasOrgToken: true,
+          credentialMode: 'organization',
+          hasSavedPersonalTokenInModal: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false for personal mode with only draft input', () => {
+      expect(
+        getModalVerifiedHasToken({
+          hasOrgToken: true,
+          credentialMode: 'personal',
+          hasSavedPersonalTokenInModal: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true for personal mode with saved token', () => {
+      expect(
+        getModalVerifiedHasToken({
+          hasOrgToken: true,
+          credentialMode: 'personal',
+          hasSavedPersonalTokenInModal: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
   describe('hasModalUnsavedChanges', () => {
     const savedTokenMask = '********************';
 
@@ -223,6 +336,19 @@ describe('mcpServersDisplayUtils', () => {
           initialTokenInputValue: savedTokenMask,
           modalEnabled: false,
           serverEnabled: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when credential mode changed', () => {
+      expect(
+        hasModalUnsavedChanges({
+          tokenInputValue: '',
+          initialTokenInputValue: '',
+          modalEnabled: true,
+          serverEnabled: true,
+          credentialMode: 'organization',
+          initialCredentialMode: 'personal',
         }),
       ).toBe(true);
     });
@@ -261,40 +387,41 @@ describe('mcpServersDisplayUtils', () => {
 
   describe('isSaveTokenDisabled', () => {
     const savedTokenMask = '********************';
+    const baseArgs = {
+      tokenInputValue: savedTokenMask,
+      initialTokenInputValue: savedTokenMask,
+      modalEnabled: true,
+      serverEnabled: true,
+      credentialMode: 'personal' as const,
+      initialCredentialMode: 'personal' as const,
+      hasOrgToken: true,
+      hasSavedPersonalTokenInModal: true,
+    };
 
     it('disables save when nothing changed', () => {
-      expect(
-        isSaveTokenDisabled({
-          tokenInputValue: savedTokenMask,
-          initialTokenInputValue: savedTokenMask,
-          modalEnabled: true,
-          serverEnabled: true,
-          isUpdatingModalStatus: false,
-        }),
-      ).toBe(true);
+      expect(isSaveTokenDisabled(baseArgs)).toBe(true);
     });
 
-    it('enables save after personal token was removed', () => {
+    it('enables save when credential mode changed to organization', () => {
       expect(
         isSaveTokenDisabled({
+          ...baseArgs,
           tokenInputValue: '',
-          initialTokenInputValue: '',
-          modalEnabled: false,
-          serverEnabled: false,
-          isUpdatingModalStatus: false,
-          hasRemovedPersonalToken: true,
+          hasSavedPersonalTokenInModal: false,
+          credentialMode: 'organization',
         }),
       ).toBe(false);
     });
 
-    it('disables save while status is updating even with changes', () => {
+    it('disables save for personal mode without token', () => {
       expect(
         isSaveTokenDisabled({
-          tokenInputValue: 'new-token',
+          ...baseArgs,
+          tokenInputValue: '',
           initialTokenInputValue: '',
-          modalEnabled: true,
-          serverEnabled: true,
-          isUpdatingModalStatus: true,
+          hasSavedPersonalTokenInModal: false,
+          credentialMode: 'personal',
+          initialCredentialMode: 'organization',
         }),
       ).toBe(true);
     });
@@ -302,23 +429,44 @@ describe('mcpServersDisplayUtils', () => {
     it('enables save when only enabled state changed', () => {
       expect(
         isSaveTokenDisabled({
-          tokenInputValue: savedTokenMask,
-          initialTokenInputValue: savedTokenMask,
+          ...baseArgs,
           modalEnabled: false,
-          serverEnabled: true,
-          isUpdatingModalStatus: false,
         }),
       ).toBe(false);
+    });
+
+    it('disables save when token input matches baseline after failed attempt', () => {
+      expect(
+        isSaveTokenDisabled({
+          ...baseArgs,
+          tokenInputValue: 'bad-token',
+          initialTokenInputValue: 'bad-token',
+          hasSavedPersonalTokenInModal: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('disables save after failed validation until token input changes', () => {
+      expect(
+        isSaveTokenDisabled({
+          ...baseArgs,
+          tokenInputValue: 'bad-token',
+          initialTokenInputValue: 'bad-token',
+          hasSavedPersonalTokenInModal: false,
+          credentialMode: 'personal',
+          initialCredentialMode: 'organization',
+          tokenValidationState: 'error',
+        }),
+      ).toBe(true);
     });
 
     it('enables save when token input changed', () => {
       expect(
         isSaveTokenDisabled({
+          ...baseArgs,
           tokenInputValue: 'new-token',
           initialTokenInputValue: '',
-          modalEnabled: true,
-          serverEnabled: true,
-          isUpdatingModalStatus: false,
+          hasSavedPersonalTokenInModal: false,
         }),
       ).toBe(false);
     });

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  formatApiError,
+  getDisplayStatus,
+  getEnabledToggleChecked,
+  isEnabledToggleUnavailable,
+  isModalEnabledChecked,
+  isSaveTokenDisabled,
+} from '../mcpServersDisplayUtils';
+
+describe('mcpServersDisplayUtils', () => {
+  describe('formatApiError', () => {
+    it('returns strings as-is', () => {
+      expect(formatApiError('Token required')).toBe('Token required');
+    });
+
+    it('returns Error message', () => {
+      expect(formatApiError(new Error('Validation failed'))).toBe(
+        'Validation failed',
+      );
+    });
+
+    it('extracts nested message objects', () => {
+      expect(formatApiError({ message: 'Invalid token' })).toBe(
+        'Invalid token',
+      );
+    });
+
+    it('extracts nested error fields', () => {
+      expect(formatApiError({ error: 'Connection refused' })).toBe(
+        'Connection refused',
+      );
+    });
+
+    it('returns empty string for unknown values', () => {
+      expect(formatApiError({ code: 500 })).toBe('');
+    });
+  });
+
+  describe('getDisplayStatus', () => {
+    it('returns tokenRequired when no token is saved', () => {
+      expect(
+        getDisplayStatus({
+          hasToken: false,
+          enabled: true,
+          status: 'connected',
+        }),
+      ).toBe('tokenRequired');
+    });
+
+    it('returns disabled when server is disabled', () => {
+      expect(
+        getDisplayStatus({
+          hasToken: true,
+          enabled: false,
+          status: 'connected',
+        }),
+      ).toBe('disabled');
+    });
+
+    it('returns failed when validation status is error', () => {
+      expect(
+        getDisplayStatus({
+          hasToken: true,
+          enabled: true,
+          status: 'error',
+        }),
+      ).toBe('failed');
+    });
+
+    it('returns ok when connected with token and enabled', () => {
+      expect(
+        getDisplayStatus({
+          hasToken: true,
+          enabled: true,
+          status: 'connected',
+        }),
+      ).toBe('ok');
+    });
+  });
+
+  describe('getEnabledToggleChecked', () => {
+    it('shows off when token is required even if enabled in settings', () => {
+      expect(
+        getEnabledToggleChecked(
+          { hasToken: false, enabled: true, status: 'unknown' },
+          'tokenRequired',
+        ),
+      ).toBe(false);
+    });
+
+    it('shows off when validation failed even if enabled in settings', () => {
+      expect(
+        getEnabledToggleChecked(
+          { hasToken: true, enabled: true, status: 'error' },
+          'failed',
+        ),
+      ).toBe(false);
+    });
+
+    it('reflects enabled state when server is available', () => {
+      expect(
+        getEnabledToggleChecked(
+          { hasToken: true, enabled: true, status: 'connected' },
+          'ok',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('isEnabledToggleUnavailable', () => {
+    it('returns true for tokenRequired and failed statuses', () => {
+      expect(isEnabledToggleUnavailable('tokenRequired')).toBe(true);
+      expect(isEnabledToggleUnavailable('failed')).toBe(true);
+    });
+
+    it('returns false for ok and disabled statuses', () => {
+      expect(isEnabledToggleUnavailable('ok')).toBe(false);
+      expect(isEnabledToggleUnavailable('disabled')).toBe(false);
+    });
+  });
+
+  describe('isModalEnabledChecked', () => {
+    it('shows off in modal when token is required', () => {
+      expect(
+        isModalEnabledChecked({
+          displayStatus: 'tokenRequired',
+          modalEnabled: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('uses modalEnabled when server is available', () => {
+      expect(
+        isModalEnabledChecked({
+          displayStatus: 'ok',
+          modalEnabled: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isSaveTokenDisabled', () => {
+    const savedTokenMask = '********************';
+
+    it('disables save for unchanged masked token', () => {
+      expect(
+        isSaveTokenDisabled({
+          hasSavedTokenInModal: true,
+          tokenInputValue: savedTokenMask,
+          savedTokenMask,
+          isUpdatingModalStatus: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('disables save for empty token input', () => {
+      expect(
+        isSaveTokenDisabled({
+          hasSavedTokenInModal: false,
+          tokenInputValue: '',
+          savedTokenMask,
+          isUpdatingModalStatus: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('disables save while status is updating', () => {
+      expect(
+        isSaveTokenDisabled({
+          hasSavedTokenInModal: false,
+          tokenInputValue: 'new-token',
+          savedTokenMask,
+          isUpdatingModalStatus: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('enables save when user entered a new token', () => {
+      expect(
+        isSaveTokenDisabled({
+          hasSavedTokenInModal: false,
+          tokenInputValue: 'new-token',
+          savedTokenMask,
+          isUpdatingModalStatus: false,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
@@ -476,6 +476,20 @@ describe('mcpServersDisplayUtils', () => {
       ).toBe(true);
     });
 
+    it('enables save when only enabled state changed on DCR servers', () => {
+      expect(
+        isSaveTokenDisabled({
+          ...baseArgs,
+          modalEnabled: false,
+          hasOrgToken: false,
+          hasSavedPersonalTokenInModal: false,
+          tokenInputValue: '',
+          initialTokenInputValue: '',
+          isDcrServer: true,
+        }),
+      ).toBe(false);
+    });
+
     it('enables save when token input changed', () => {
       expect(
         isSaveTokenDisabled({

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/mcpServersDisplayUtils.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  compareMcpServers,
   formatApiError,
   getDisplayStatus,
   getEnabledToggleChecked,
@@ -24,6 +25,7 @@ import {
   getModalEffectiveHasToken,
   getModalEnabledDescriptionKey,
   getModalVerifiedHasToken,
+  getStatusSortRank,
   hasModalEnabledStateChange,
   hasModalUnsavedChanges,
   isEnabledToggleUnavailable,
@@ -446,6 +448,20 @@ describe('mcpServersDisplayUtils', () => {
       ).toBe(true);
     });
 
+    it('enables save after personal token was removed', () => {
+      expect(
+        isSaveTokenDisabled({
+          ...baseArgs,
+          tokenInputValue: '',
+          initialTokenInputValue: '',
+          modalEnabled: false,
+          serverEnabled: false,
+          hasSavedPersonalTokenInModal: false,
+          hasRemovedPersonalToken: true,
+        }),
+      ).toBe(false);
+    });
+
     it('disables save after failed validation until token input changes', () => {
       expect(
         isSaveTokenDisabled({
@@ -469,6 +485,65 @@ describe('mcpServersDisplayUtils', () => {
           hasSavedPersonalTokenInModal: false,
         }),
       ).toBe(false);
+    });
+  });
+
+  describe('compareMcpServers', () => {
+    const server = (
+      name: string,
+      overrides: {
+        hasToken?: boolean;
+        enabled?: boolean;
+        status?: 'connected' | 'error' | 'unknown';
+        toolCount?: number;
+      } = {},
+    ) => ({
+      name,
+      hasToken: true,
+      enabled: true,
+      status: 'connected' as const,
+      toolCount: 0,
+      ...overrides,
+    });
+
+    it('sorts by name ascending', () => {
+      expect(
+        compareMcpServers(server('beta'), server('alpha'), 'name', true),
+      ).toBeGreaterThan(0);
+    });
+
+    it('sorts by name descending', () => {
+      expect(
+        compareMcpServers(server('alpha'), server('beta'), 'name', false),
+      ).toBeGreaterThan(0);
+    });
+
+    it('sorts by status rank ascending with name tie-breaker', () => {
+      const connected = server('beta', { status: 'connected' });
+      const failed = server('alpha', { status: 'error' });
+      expect(compareMcpServers(connected, failed, 'status', true)).toBeLessThan(
+        0,
+      );
+      expect(
+        compareMcpServers(failed, connected, 'status', true),
+      ).toBeGreaterThan(0);
+    });
+
+    it('sorts connected servers by tool count when status rank matches', () => {
+      const fewerTools = server('beta', { toolCount: 1 });
+      const moreTools = server('alpha', { toolCount: 5 });
+      expect(
+        compareMcpServers(fewerTools, moreTools, 'status', true),
+      ).toBeLessThan(0);
+    });
+  });
+
+  describe('getStatusSortRank', () => {
+    it('orders healthy statuses before error states', () => {
+      expect(getStatusSortRank('ok')).toBeLessThan(getStatusSortRank('failed'));
+      expect(getStatusSortRank('tokenRequired')).toBeLessThan(
+        getStatusSortRank('failed'),
+      );
     });
   });
 });

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
@@ -207,6 +207,7 @@ export const isSaveTokenDisabled = ({
   hasSavedPersonalTokenInModal,
   tokenValidationState = 'idle',
   hasRemovedPersonalToken = false,
+  isDcrServer = false,
 }: {
   tokenInputValue: string;
   initialTokenInputValue: string;
@@ -218,6 +219,7 @@ export const isSaveTokenDisabled = ({
   hasSavedPersonalTokenInModal: boolean;
   tokenValidationState?: TokenValidationState;
   hasRemovedPersonalToken?: boolean;
+  isDcrServer?: boolean;
 }): boolean => {
   if (
     tokenValidationState === 'error' &&
@@ -241,6 +243,10 @@ export const isSaveTokenDisabled = ({
     })
   ) {
     return true;
+  }
+
+  if (isDcrServer) {
+    return false;
   }
 
   if (credentialMode === 'personal') {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
@@ -65,21 +65,81 @@ export const getEnabledToggleChecked = (
 ): boolean =>
   isEnabledToggleUnavailable(displayStatus) ? false : server.enabled;
 
-export const isSaveTokenDisabled = ({
-  hasSavedTokenInModal,
+export const hasModalUnsavedChanges = ({
   tokenInputValue,
-  savedTokenMask,
-  isUpdatingModalStatus,
+  initialTokenInputValue,
+  modalEnabled,
+  serverEnabled,
 }: {
-  hasSavedTokenInModal: boolean;
   tokenInputValue: string;
-  savedTokenMask: string;
+  initialTokenInputValue: string;
+  modalEnabled: boolean;
+  serverEnabled: boolean;
+}): boolean =>
+  tokenInputValue !== initialTokenInputValue || modalEnabled !== serverEnabled;
+
+export const isSaveTokenDisabled = ({
+  tokenInputValue,
+  initialTokenInputValue,
+  modalEnabled,
+  serverEnabled,
+  isUpdatingModalStatus,
+  hasRemovedPersonalToken = false,
+}: {
+  tokenInputValue: string;
+  initialTokenInputValue: string;
+  modalEnabled: boolean;
+  serverEnabled: boolean;
   isUpdatingModalStatus: boolean;
+  hasRemovedPersonalToken?: boolean;
 }): boolean => {
-  const isTokenInputUnchanged =
-    hasSavedTokenInModal && tokenInputValue === savedTokenMask;
-  const isTokenInputEmpty = tokenInputValue.trim() === '';
-  return isTokenInputUnchanged || isTokenInputEmpty || isUpdatingModalStatus;
+  if (isUpdatingModalStatus) {
+    return true;
+  }
+  if (hasRemovedPersonalToken) {
+    return false;
+  }
+  return !hasModalUnsavedChanges({
+    tokenInputValue,
+    initialTokenInputValue,
+    modalEnabled,
+    serverEnabled,
+  });
+};
+
+export type McpServerModalInput = McpServerDisplayInput & {
+  hasUserToken?: boolean;
+};
+
+export const hasModalEnabledStateChange = ({
+  server,
+  modalEnabled,
+}: {
+  server?: McpServerModalInput;
+  modalEnabled: boolean;
+}): boolean => Boolean(server && modalEnabled !== server.enabled);
+
+export const getModalDisplayStatus = (
+  server: McpServerDisplayInput,
+  modalEnabled: boolean,
+): ServerStatus => getDisplayStatus({ ...server, enabled: modalEnabled });
+
+export type ModalEnabledDescriptionKey =
+  | 'mcp.settings.modal.enabledDescription'
+  | 'mcp.settings.modal.enabledDescriptionOff'
+  | 'mcp.settings.modal.enabledDescriptionTokenRequired';
+
+export const getModalEnabledDescriptionKey = (
+  isChecked: boolean,
+  displayStatus: ServerStatus,
+): ModalEnabledDescriptionKey => {
+  if (isChecked) {
+    return 'mcp.settings.modal.enabledDescription';
+  }
+  if (displayStatus === 'tokenRequired') {
+    return 'mcp.settings.modal.enabledDescriptionTokenRequired';
+  }
+  return 'mcp.settings.modal.enabledDescriptionOff';
 };
 
 export const isModalEnabledChecked = ({

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
@@ -21,6 +21,8 @@ export type ServerStatus =
   | 'failed'
   | 'unknown';
 
+export type CredentialMode = 'organization' | 'personal';
+
 export type McpServerDisplayInput = {
   enabled: boolean;
   status: 'connected' | 'error' | 'unknown';
@@ -65,46 +67,135 @@ export const getEnabledToggleChecked = (
 ): boolean =>
   isEnabledToggleUnavailable(displayStatus) ? false : server.enabled;
 
+export const getInitialCredentialMode = (server: {
+  hasUserToken: boolean;
+  hasOrgToken: boolean;
+}): CredentialMode => {
+  if (server.hasUserToken) {
+    return 'personal';
+  }
+  if (server.hasOrgToken) {
+    return 'organization';
+  }
+  return 'personal';
+};
+
+export const getModalEffectiveHasToken = ({
+  hasOrgToken,
+  credentialMode,
+  tokenInputValue,
+  hasSavedPersonalTokenInModal,
+}: {
+  hasOrgToken: boolean;
+  credentialMode: CredentialMode;
+  tokenInputValue: string;
+  hasSavedPersonalTokenInModal: boolean;
+}): boolean => {
+  if (credentialMode === 'organization') {
+    return hasOrgToken;
+  }
+  return tokenInputValue.trim().length > 0 || hasSavedPersonalTokenInModal;
+};
+
+export const getModalVerifiedHasToken = ({
+  hasOrgToken,
+  credentialMode,
+  hasSavedPersonalTokenInModal,
+}: {
+  hasOrgToken: boolean;
+  credentialMode: CredentialMode;
+  hasSavedPersonalTokenInModal: boolean;
+}): boolean => {
+  if (credentialMode === 'organization') {
+    return hasOrgToken;
+  }
+  return hasSavedPersonalTokenInModal;
+};
+
+export const getModalDisplayHasToken = ({
+  modalVerifiedHasToken,
+  modalEnabled,
+  serverHasToken,
+}: {
+  modalVerifiedHasToken: boolean;
+  modalEnabled: boolean;
+  serverHasToken: boolean;
+}): boolean => modalVerifiedHasToken || (!modalEnabled && serverHasToken);
+
 export const hasModalUnsavedChanges = ({
   tokenInputValue,
   initialTokenInputValue,
   modalEnabled,
   serverEnabled,
+  credentialMode,
+  initialCredentialMode,
 }: {
   tokenInputValue: string;
   initialTokenInputValue: string;
   modalEnabled: boolean;
   serverEnabled: boolean;
+  credentialMode?: CredentialMode;
+  initialCredentialMode?: CredentialMode;
 }): boolean =>
-  tokenInputValue !== initialTokenInputValue || modalEnabled !== serverEnabled;
+  tokenInputValue !== initialTokenInputValue ||
+  modalEnabled !== serverEnabled ||
+  (credentialMode !== undefined &&
+    initialCredentialMode !== undefined &&
+    credentialMode !== initialCredentialMode);
+
+export type TokenValidationState = 'idle' | 'validating' | 'success' | 'error';
 
 export const isSaveTokenDisabled = ({
   tokenInputValue,
   initialTokenInputValue,
   modalEnabled,
   serverEnabled,
-  isUpdatingModalStatus,
-  hasRemovedPersonalToken = false,
+  credentialMode,
+  initialCredentialMode,
+  hasOrgToken,
+  hasSavedPersonalTokenInModal,
+  tokenValidationState = 'idle',
 }: {
   tokenInputValue: string;
   initialTokenInputValue: string;
   modalEnabled: boolean;
   serverEnabled: boolean;
-  isUpdatingModalStatus: boolean;
-  hasRemovedPersonalToken?: boolean;
+  credentialMode: CredentialMode;
+  initialCredentialMode: CredentialMode;
+  hasOrgToken: boolean;
+  hasSavedPersonalTokenInModal: boolean;
+  tokenValidationState?: TokenValidationState;
 }): boolean => {
-  if (isUpdatingModalStatus) {
+  if (
+    tokenValidationState === 'error' &&
+    tokenInputValue === initialTokenInputValue
+  ) {
     return true;
   }
-  if (hasRemovedPersonalToken) {
-    return false;
+
+  if (
+    !hasModalUnsavedChanges({
+      tokenInputValue,
+      initialTokenInputValue,
+      modalEnabled,
+      serverEnabled,
+      credentialMode,
+      initialCredentialMode,
+    })
+  ) {
+    return true;
   }
-  return !hasModalUnsavedChanges({
-    tokenInputValue,
-    initialTokenInputValue,
-    modalEnabled,
-    serverEnabled,
-  });
+
+  if (credentialMode === 'personal') {
+    return !getModalEffectiveHasToken({
+      hasOrgToken,
+      credentialMode,
+      tokenInputValue,
+      hasSavedPersonalTokenInModal,
+    });
+  }
+
+  return false;
 };
 
 export type McpServerModalInput = McpServerDisplayInput & {

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ServerStatus =
+  | 'tokenRequired'
+  | 'disabled'
+  | 'ok'
+  | 'failed'
+  | 'unknown';
+
+export type McpServerDisplayInput = {
+  enabled: boolean;
+  status: 'connected' | 'error' | 'unknown';
+  hasToken: boolean;
+};
+
+export const formatApiError = (error: unknown): string => {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (error && typeof error === 'object') {
+    if ('message' in error && typeof error.message === 'string') {
+      return error.message;
+    }
+    if ('error' in error) {
+      return formatApiError((error as { error: unknown }).error);
+    }
+  }
+  return '';
+};
+
+export const getDisplayStatus = (
+  server: McpServerDisplayInput,
+): ServerStatus => {
+  if (!server.hasToken) return 'tokenRequired';
+  if (!server.enabled) return 'disabled';
+  if (server.status === 'error') return 'failed';
+  if (server.status === 'connected') return 'ok';
+  return 'unknown';
+};
+
+export const isEnabledToggleUnavailable = (
+  displayStatus: ServerStatus,
+): boolean => displayStatus === 'failed' || displayStatus === 'tokenRequired';
+
+export const getEnabledToggleChecked = (
+  server: McpServerDisplayInput,
+  displayStatus: ServerStatus,
+): boolean =>
+  isEnabledToggleUnavailable(displayStatus) ? false : server.enabled;
+
+export const isSaveTokenDisabled = ({
+  hasSavedTokenInModal,
+  tokenInputValue,
+  savedTokenMask,
+  isUpdatingModalStatus,
+}: {
+  hasSavedTokenInModal: boolean;
+  tokenInputValue: string;
+  savedTokenMask: string;
+  isUpdatingModalStatus: boolean;
+}): boolean => {
+  const isTokenInputUnchanged =
+    hasSavedTokenInModal && tokenInputValue === savedTokenMask;
+  const isTokenInputEmpty = tokenInputValue.trim() === '';
+  return isTokenInputUnchanged || isTokenInputEmpty || isUpdatingModalStatus;
+};
+
+export const isModalEnabledChecked = ({
+  displayStatus,
+  modalEnabled,
+}: {
+  displayStatus: ServerStatus;
+  modalEnabled: boolean;
+}): boolean =>
+  isEnabledToggleUnavailable(displayStatus) ? false : modalEnabled;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
@@ -31,6 +31,22 @@ export type McpServerDisplayInput = {
   hasToken: boolean;
 };
 
+/** Shared server shape used by the configure-server modal and its hook. */
+export type McpConfigureServer = {
+  id: string;
+  name: string;
+  url?: string;
+  enabled: boolean;
+  status: 'connected' | 'error' | 'unknown';
+  toolCount: number;
+  hasToken: boolean;
+  hasUserToken: boolean;
+  hasOrgToken: boolean;
+  validationError?: string;
+  /** 'dcr' = tokens are minted automatically (no manual token needed). */
+  auth?: string;
+};
+
 export const formatApiError = (error: unknown): string => {
   if (typeof error === 'string') {
     return error;
@@ -304,3 +320,28 @@ export const isModalEnabledChecked = ({
   modalEnabled: boolean;
 }): boolean =>
   isEnabledToggleUnavailable(displayStatus) ? false : modalEnabled;
+
+/** Translation function shape accepted by {@link getDisplayDetail}. */
+type TranslateFn = (key: any, options?: any) => string;
+
+export const getDisplayDetail = (
+  server: { toolCount: number },
+  displayStatus: ServerStatus,
+  t: TranslateFn,
+): string => {
+  if (displayStatus === 'disabled') return t('mcp.settings.status.disabled');
+  if (displayStatus === 'tokenRequired')
+    return t('mcp.settings.status.tokenRequired');
+  if (displayStatus === 'failed') return t('mcp.settings.status.failed');
+  if (displayStatus === 'ok') {
+    if (server.toolCount === 1) {
+      return t('mcp.settings.status.oneTool', {
+        count: String(server.toolCount),
+      });
+    }
+    return t('mcp.settings.status.manyTools', {
+      count: String(server.toolCount),
+    });
+  }
+  return t('mcp.settings.status.unknown');
+};

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/mcpServersDisplayUtils.ts
@@ -21,6 +21,8 @@ export type ServerStatus =
   | 'failed'
   | 'unknown';
 
+export type McpServerSortColumn = 'name' | 'status';
+
 export type CredentialMode = 'organization' | 'personal';
 
 export type McpServerDisplayInput = {
@@ -55,6 +57,55 @@ export const getDisplayStatus = (
   if (server.status === 'error') return 'failed';
   if (server.status === 'connected') return 'ok';
   return 'unknown';
+};
+
+export const getStatusSortRank = (status: ServerStatus): number => {
+  switch (status) {
+    case 'ok':
+      return 0;
+    case 'disabled':
+      return 1;
+    case 'unknown':
+      return 2;
+    case 'tokenRequired':
+      return 3;
+    case 'failed':
+      return 4;
+    default:
+      return 5;
+  }
+};
+
+export type McpServerSortInput = McpServerDisplayInput & {
+  name: string;
+  toolCount?: number;
+};
+
+export const compareMcpServers = (
+  a: McpServerSortInput,
+  b: McpServerSortInput,
+  sortColumn: McpServerSortColumn,
+  sortAsc: boolean,
+): number => {
+  const direction = sortAsc ? 1 : -1;
+
+  if (sortColumn === 'name') {
+    return direction * a.name.localeCompare(b.name);
+  }
+
+  const statusCompare =
+    getStatusSortRank(getDisplayStatus(a)) -
+    getStatusSortRank(getDisplayStatus(b));
+  if (statusCompare !== 0) {
+    return direction * statusCompare;
+  }
+
+  const toolCompare = (a.toolCount ?? 0) - (b.toolCount ?? 0);
+  if (toolCompare !== 0) {
+    return direction * toolCompare;
+  }
+
+  return direction * a.name.localeCompare(b.name);
 };
 
 export const isEnabledToggleUnavailable = (
@@ -155,6 +206,7 @@ export const isSaveTokenDisabled = ({
   hasOrgToken,
   hasSavedPersonalTokenInModal,
   tokenValidationState = 'idle',
+  hasRemovedPersonalToken = false,
 }: {
   tokenInputValue: string;
   initialTokenInputValue: string;
@@ -165,12 +217,17 @@ export const isSaveTokenDisabled = ({
   hasOrgToken: boolean;
   hasSavedPersonalTokenInModal: boolean;
   tokenValidationState?: TokenValidationState;
+  hasRemovedPersonalToken?: boolean;
 }): boolean => {
   if (
     tokenValidationState === 'error' &&
     tokenInputValue === initialTokenInputValue
   ) {
     return true;
+  }
+
+  if (hasRemovedPersonalToken) {
+    return false;
   }
 
   if (

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/hooks/index.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/hooks/index.ts
@@ -25,6 +25,7 @@ export * from './useLastOpenedConversation';
 export * from './useLightspeedDeletePermission';
 export * from './notebooks/useLightspeedNotebooksPermission';
 export * from './useLightspeedViewPermission';
+export * from './useMcpConfigureModal';
 export * from './useNotebookConversationIds';
 export * from './useDisplayModeSettings';
 export * from './notebooks/useNotebookSession';

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/hooks/useMcpConfigureModal.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/hooks/useMcpConfigureModal.ts
@@ -1,0 +1,640 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+} from 'react';
+
+import {
+  formatApiError,
+  getDisplayDetail,
+  getInitialCredentialMode,
+  getModalDisplayHasToken,
+  getModalDisplayStatus,
+  isModalEnabledChecked as getModalEnabledChecked,
+  getModalVerifiedHasToken,
+  isSaveTokenDisabled as getSaveTokenDisabled,
+  isEnabledToggleUnavailable,
+  type CredentialMode,
+  type McpConfigureServer,
+  type ServerStatus,
+  type TokenValidationState,
+} from '../components/mcpServersDisplayUtils';
+import { useTranslation } from './useTranslation';
+
+const SAVED_TOKEN_MASK = '********************';
+
+export type McpToolInfo = {
+  name: string;
+  description?: string;
+};
+
+export type McpServerValidationResult = {
+  status: 'connected' | 'error' | 'unknown';
+  toolCount: number;
+  validation?: {
+    error?: unknown;
+    tools?: McpToolInfo[];
+  };
+};
+
+export type McpCredentialsValidationResult = {
+  valid: boolean;
+  error?: unknown;
+  toolCount: number;
+  tools?: McpToolInfo[];
+};
+
+export type UseMcpConfigureModalOptions = {
+  servers: McpConfigureServer[];
+  canManageMcp: boolean;
+  isSaving: Record<string, boolean>;
+  patchServer: (
+    serverName: string,
+    body: { enabled?: boolean; token?: string | null },
+  ) => Promise<void>;
+  validateServer: (serverName: string) => Promise<McpServerValidationResult>;
+  validateCredentials: (
+    url: string,
+    token: string,
+  ) => Promise<McpCredentialsValidationResult>;
+  fetchServerValidation: (
+    serverName: string,
+  ) => Promise<McpServerValidationResult>;
+};
+
+/**
+ * Owns all state, handlers and derived display data for the MCP "configure
+ * server" modal. Rendering (JSX/styles) lives in `McpConfigureServerModal`.
+ */
+export const useMcpConfigureModal = ({
+  servers,
+  canManageMcp,
+  isSaving,
+  patchServer,
+  validateServer,
+  validateCredentials,
+  fetchServerValidation,
+}: UseMcpConfigureModalOptions) => {
+  const { t } = useTranslation();
+  const [editingServerId, setEditingServerId] = useState<string | null>(null);
+  const [tokenInputValue, setTokenInputValue] = useState('');
+  const [initialTokenInputValue, setInitialTokenInputValue] = useState('');
+  const [hasSavedTokenInModal, setHasSavedTokenInModal] = useState(false);
+  const [modalCredentialMode, setModalCredentialMode] =
+    useState<CredentialMode>('personal');
+  const [initialCredentialMode, setInitialCredentialMode] =
+    useState<CredentialMode>('personal');
+  const [tokenValidationState, setTokenValidationState] =
+    useState<TokenValidationState>('idle');
+  const [tokenValidationMessage, setTokenValidationMessage] = useState('');
+  const [modalEnabled, setModalEnabled] = useState(true);
+  const [modalTools, setModalTools] = useState<string[]>([]);
+  const [isLoadingModalTools, setIsLoadingModalTools] = useState(false);
+  const [modalToolsError, setModalToolsError] = useState<string | null>(null);
+  const [canRemovePersonalToken, setCanRemovePersonalToken] = useState(false);
+  const [isUpdatingModalStatus, setIsUpdatingModalStatus] = useState(false);
+  const [hasRemovedPersonalToken, setHasRemovedPersonalToken] = useState(false);
+
+  const editingServer = useMemo(
+    () => servers.find(server => server.id === editingServerId),
+    [servers, editingServerId],
+  );
+
+  const close = useCallback(() => {
+    setEditingServerId(null);
+    setTokenInputValue('');
+    setInitialTokenInputValue('');
+    setHasSavedTokenInModal(false);
+    setModalCredentialMode('personal');
+    setInitialCredentialMode('personal');
+    setTokenValidationState('idle');
+    setTokenValidationMessage('');
+    setModalEnabled(true);
+    setModalTools([]);
+    setIsLoadingModalTools(false);
+    setModalToolsError(null);
+    setCanRemovePersonalToken(false);
+    setIsUpdatingModalStatus(false);
+    setHasRemovedPersonalToken(false);
+  }, []);
+
+  const open = useCallback(
+    (server: McpConfigureServer) => {
+      setEditingServerId(server.id);
+      const credentialMode = getInitialCredentialMode(server);
+      const hasSavedPersonalToken = server.hasUserToken;
+      setModalCredentialMode(credentialMode);
+      setInitialCredentialMode(credentialMode);
+      setHasSavedTokenInModal(hasSavedPersonalToken);
+      setCanRemovePersonalToken(server.hasUserToken && !server.hasOrgToken);
+      const initialToken = hasSavedPersonalToken ? SAVED_TOKEN_MASK : '';
+      setInitialTokenInputValue(initialToken);
+      setTokenInputValue(initialToken);
+      setModalEnabled(server.enabled);
+      setModalTools([]);
+      setModalToolsError(null);
+      setIsUpdatingModalStatus(false);
+      setHasRemovedPersonalToken(false);
+      if (server.status === 'error' && server.validationError) {
+        setTokenValidationState('error');
+        setTokenValidationMessage(
+          formatApiError(server.validationError) ||
+            t('mcp.settings.token.validationFailed'),
+        );
+      } else {
+        setTokenValidationState('idle');
+        setTokenValidationMessage('');
+      }
+    },
+    [t],
+  );
+
+  useEffect(() => {
+    if (!editingServer) {
+      return undefined;
+    }
+
+    if (!editingServer.hasToken) {
+      setModalTools([]);
+      setModalToolsError(null);
+      setIsLoadingModalTools(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setIsLoadingModalTools(true);
+    setModalToolsError(null);
+
+    void fetchServerValidation(editingServer.name)
+      .then(data => {
+        if (cancelled) {
+          return;
+        }
+        const tools = data.validation?.tools?.map(tool => tool.name) ?? [];
+        setModalTools(tools);
+        if (data.status === 'error') {
+          setModalToolsError(
+            formatApiError(data.validation?.error) ||
+              t('mcp.settings.token.validationFailed'),
+          );
+        } else {
+          setModalToolsError(null);
+        }
+      })
+      .catch(e => {
+        if (cancelled) {
+          return;
+        }
+        setModalTools([]);
+        setModalToolsError(
+          e instanceof Error
+            ? e.message
+            : t('mcp.settings.modal.toolsLoadFailed'),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingModalTools(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [editingServer, fetchServerValidation, t]);
+
+  const onTokenInputChange = useCallback(
+    (value: string) => {
+      if (hasSavedTokenInModal && value !== SAVED_TOKEN_MASK) {
+        setHasSavedTokenInModal(false);
+      }
+      setTokenInputValue(value);
+      setTokenValidationState('idle');
+      setTokenValidationMessage('');
+    },
+    [hasSavedTokenInModal],
+  );
+
+  const onCredentialModeChange = useCallback(
+    (mode: CredentialMode) => {
+      if (mode === modalCredentialMode) {
+        return;
+      }
+      setModalCredentialMode(mode);
+      setTokenValidationState('idle');
+      setTokenValidationMessage('');
+
+      if (mode === 'organization') {
+        setHasSavedTokenInModal(false);
+        setTokenInputValue('');
+        return;
+      }
+
+      if (editingServer?.hasUserToken) {
+        setHasSavedTokenInModal(true);
+        setTokenInputValue(SAVED_TOKEN_MASK);
+        setInitialTokenInputValue(SAVED_TOKEN_MASK);
+        return;
+      }
+
+      setHasSavedTokenInModal(false);
+      setTokenInputValue('');
+      setInitialTokenInputValue('');
+    },
+    [modalCredentialMode, editingServer],
+  );
+
+  const clearTokenInput = useCallback(() => {
+    if (hasSavedTokenInModal) {
+      setHasSavedTokenInModal(false);
+    }
+    setTokenInputValue('');
+    setTokenValidationState('idle');
+    setTokenValidationMessage('');
+  }, [hasSavedTokenInModal]);
+
+  const showCredentialRadios = Boolean(
+    editingServer?.hasOrgToken && editingServer.auth !== 'dcr',
+  );
+  const showPersonalTokenField =
+    editingServer?.auth !== 'dcr' &&
+    (!showCredentialRadios || modalCredentialMode === 'personal');
+
+  let tokenInputValidated: 'success' | 'error' | undefined;
+  if (tokenValidationState === 'success') {
+    tokenInputValidated = 'success';
+  } else if (tokenValidationState === 'error') {
+    tokenInputValidated = 'error';
+  }
+
+  let tokenHelperVariant: 'success' | 'error' | 'default' = 'default';
+  if (tokenValidationState === 'success') {
+    tokenHelperVariant = 'success';
+  } else if (tokenValidationState === 'error') {
+    tokenHelperVariant = 'error';
+  }
+
+  const showTokenHelperText =
+    !hasSavedTokenInModal || tokenValidationState !== 'idle';
+
+  const tokenHelperText =
+    tokenValidationMessage || t('mcp.settings.enterToken');
+
+  const configureModalTitle = t('mcp.settings.configureServerTitle' as any, {
+    serverName: editingServer?.name ?? '',
+  });
+
+  const isConfigureModalSaving = Boolean(isSaving[editingServer?.name ?? '']);
+  const isSaveTokenButtonDisabled = getSaveTokenDisabled({
+    tokenInputValue,
+    initialTokenInputValue,
+    modalEnabled,
+    serverEnabled: editingServer?.enabled ?? true,
+    credentialMode: modalCredentialMode,
+    initialCredentialMode,
+    hasOrgToken: editingServer?.hasOrgToken ?? false,
+    hasSavedPersonalTokenInModal: hasSavedTokenInModal,
+    tokenValidationState,
+    hasRemovedPersonalToken,
+    isDcrServer: editingServer?.auth === 'dcr',
+  });
+
+  const removePersonalToken = useCallback(async () => {
+    if (
+      !editingServer ||
+      !canManageMcp ||
+      isUpdatingModalStatus ||
+      editingServer.hasOrgToken
+    ) {
+      return;
+    }
+
+    setIsUpdatingModalStatus(true);
+    setTokenInputValue('');
+    setTokenValidationState('idle');
+    setTokenValidationMessage('');
+    setModalTools([]);
+    setModalToolsError(null);
+    setIsLoadingModalTools(false);
+
+    try {
+      await patchServer(editingServer.name, { token: null, enabled: false });
+      setHasSavedTokenInModal(false);
+      setInitialTokenInputValue('');
+      setModalEnabled(false);
+      setHasRemovedPersonalToken(true);
+    } catch {
+      const server = servers.find(item => item.id === editingServerId);
+      if (server?.hasUserToken) {
+        setHasSavedTokenInModal(true);
+        setCanRemovePersonalToken(true);
+        setTokenInputValue(SAVED_TOKEN_MASK);
+      }
+      setHasRemovedPersonalToken(false);
+    } finally {
+      setIsUpdatingModalStatus(false);
+    }
+  }, [
+    canManageMcp,
+    editingServer,
+    editingServerId,
+    isUpdatingModalStatus,
+    patchServer,
+    servers,
+  ]);
+
+  const save = useCallback(async () => {
+    if (!editingServer || !canManageMcp) return;
+
+    const hasCredentialModeChange =
+      modalCredentialMode !== initialCredentialMode;
+    const hasTokenInputChange = tokenInputValue !== initialTokenInputValue;
+    const hasEnabledInputChange = modalEnabled !== editingServer.enabled;
+
+    if (
+      !hasCredentialModeChange &&
+      !hasTokenInputChange &&
+      !hasEnabledInputChange
+    ) {
+      close();
+      return;
+    }
+
+    if (
+      modalCredentialMode === 'organization' &&
+      (hasCredentialModeChange || hasEnabledInputChange)
+    ) {
+      setTokenValidationState('validating');
+      setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
+      try {
+        await patchServer(editingServer.name, {
+          token: null,
+          enabled: modalEnabled,
+        });
+        const validationResult = await validateServer(editingServer.name);
+        if (validationResult.status === 'error') {
+          setTokenValidationState('error');
+          setTokenValidationMessage(
+            formatApiError(validationResult.validation?.error) ||
+              t('mcp.settings.token.validationFailed'),
+          );
+          return;
+        }
+        close();
+      } catch (e) {
+        setTokenValidationState('error');
+        setTokenValidationMessage(
+          e instanceof Error
+            ? e.message
+            : `Failed to update ${editingServer.name} settings`,
+        );
+      }
+      return;
+    }
+
+    if (!hasTokenInputChange && hasEnabledInputChange) {
+      await patchServer(editingServer.name, { enabled: modalEnabled });
+      close();
+      return;
+    }
+
+    const markFailedTokenAttempt = () => {
+      setInitialTokenInputValue(tokenInputValue);
+    };
+
+    const token = tokenInputValue.trim();
+    const hasToken = token.length > 0;
+
+    setTokenValidationState('validating');
+    setTokenValidationMessage(t('mcp.settings.token.validating'));
+
+    try {
+      if (hasToken) {
+        if (!editingServer.url) {
+          setTokenValidationState('error');
+          setTokenValidationMessage(
+            t('mcp.settings.token.urlUnavailableForValidation'),
+          );
+          markFailedTokenAttempt();
+          return;
+        }
+
+        const credentialValidation = await validateCredentials(
+          editingServer.url,
+          token,
+        );
+        if (!credentialValidation.valid) {
+          setTokenValidationState('error');
+          setTokenValidationMessage(
+            formatApiError(credentialValidation.error) ||
+              t('mcp.settings.token.invalidCredentials'),
+          );
+          markFailedTokenAttempt();
+          return;
+        }
+        setModalTools(credentialValidation.tools?.map(tool => tool.name) ?? []);
+      }
+
+      setTokenValidationMessage(t('mcp.settings.token.savingAndValidating'));
+      await patchServer(editingServer.name, {
+        enabled: modalEnabled,
+        token: hasToken ? token : null,
+      });
+      const validationResult = await validateServer(editingServer.name);
+      if (validationResult.status === 'error') {
+        setTokenValidationState('error');
+        setTokenValidationMessage(
+          formatApiError(validationResult.validation?.error) ||
+            t('mcp.settings.token.validationFailed'),
+        );
+        markFailedTokenAttempt();
+        return;
+      }
+      if (hasToken && validationResult.status === 'connected') {
+        await patchServer(editingServer.name, { enabled: true });
+        setModalEnabled(true);
+      }
+      setTokenValidationState('success');
+      setTokenValidationMessage(t('mcp.settings.token.connectionSuccessful'));
+      close();
+    } catch (e) {
+      setTokenValidationState('error');
+      setTokenValidationMessage(
+        e instanceof Error
+          ? e.message
+          : `Failed to update ${editingServer.name} token`,
+      );
+      markFailedTokenAttempt();
+    }
+  }, [
+    canManageMcp,
+    close,
+    editingServer,
+    initialCredentialMode,
+    initialTokenInputValue,
+    modalCredentialMode,
+    modalEnabled,
+    patchServer,
+    t,
+    tokenInputValue,
+    validateCredentials,
+    validateServer,
+  ]);
+
+  const onModalEnabledChange = useCallback(
+    (_event: FormEvent, checked: boolean) => {
+      if (!editingServer || !canManageMcp) {
+        return;
+      }
+      setModalEnabled(checked);
+    },
+    [editingServer, canManageMcp],
+  );
+
+  const modalVerifiedHasToken = editingServer
+    ? editingServer.auth === 'dcr' ||
+      getModalVerifiedHasToken({
+        hasOrgToken: editingServer.hasOrgToken,
+        credentialMode: modalCredentialMode,
+        hasSavedPersonalTokenInModal: hasSavedTokenInModal,
+      })
+    : false;
+
+  const modalDisplayStatus: ServerStatus = editingServer
+    ? getModalDisplayStatus(
+        {
+          ...editingServer,
+          hasToken: getModalDisplayHasToken({
+            modalVerifiedHasToken,
+            modalEnabled,
+            serverHasToken: editingServer.hasToken,
+          }),
+        },
+        modalEnabled,
+      )
+    : 'unknown';
+
+  const isModalEnabledToggleDisabled =
+    !canManageMcp ||
+    !editingServer ||
+    isUpdatingModalStatus ||
+    isEnabledToggleUnavailable(modalDisplayStatus) ||
+    Boolean(isSaving[editingServer?.name ?? '']);
+
+  const isModalEnabledChecked = getModalEnabledChecked({
+    displayStatus: modalDisplayStatus,
+    modalEnabled,
+  });
+
+  const modalStatusDetail = editingServer
+    ? getDisplayDetail(editingServer, modalDisplayStatus, t)
+    : '';
+
+  const modalToolCount = modalTools.length || editingServer?.toolCount || 0;
+
+  const modalEnabledDescription = (() => {
+    if (isModalEnabledChecked) {
+      return t('mcp.settings.modal.enabledDescription');
+    }
+    if (modalDisplayStatus === 'tokenRequired') {
+      return t('mcp.settings.modal.enabledDescriptionTokenRequired');
+    }
+    return t('mcp.settings.modal.enabledDescriptionOff');
+  })();
+
+  const modalStatusText = (() => {
+    if (isUpdatingModalStatus) {
+      return t('mcp.settings.modal.loadingStatus');
+    }
+    if (isLoadingModalTools) {
+      return t('mcp.settings.modal.fetchingStatus');
+    }
+    if (modalDisplayStatus === 'disabled') {
+      return t('mcp.settings.status.disabled');
+    }
+    if (modalDisplayStatus === 'tokenRequired') {
+      return t('mcp.settings.status.tokenRequired');
+    }
+    if (modalDisplayStatus === 'ok' && modalTools.length > 0) {
+      if (modalTools.length === 1) {
+        return t('mcp.settings.status.oneTool' as any, {
+          count: String(modalTools.length),
+        });
+      }
+      return t('mcp.settings.status.manyTools' as any, {
+        count: String(modalTools.length),
+      });
+    }
+    if (modalToolsError) {
+      return modalToolsError;
+    }
+    return modalStatusDetail;
+  })();
+
+  const modalToolsEmptyText =
+    modalToolsError ?? t('mcp.settings.modal.noToolsAvailable');
+
+  return {
+    isOpen: Boolean(editingServer),
+    editingServer,
+    open,
+    close,
+    save,
+    removePersonalToken,
+    canManageMcp,
+    configureModalTitle,
+    isConfigureModalSaving,
+    isSaveTokenButtonDisabled,
+    isUpdatingModalStatus,
+    tokenInputValue,
+    onTokenInputChange,
+    clearTokenInput,
+    tokenInputValidated,
+    tokenValidationState,
+    tokenHelperVariant,
+    showTokenHelperText,
+    tokenHelperText,
+    modalCredentialMode,
+    onCredentialModeChange,
+    showCredentialRadios,
+    showPersonalTokenField,
+    onModalEnabledChange,
+    isModalEnabledChecked,
+    isModalEnabledToggleDisabled,
+    modalDisplayStatus,
+    modalStatusDetail,
+    modalStatusText,
+    modalTools,
+    modalToolCount,
+    isLoadingModalTools,
+    modalToolsError,
+    modalToolsEmptyText,
+    modalVerifiedHasToken,
+    modalEnabledDescription,
+    canRemovePersonalToken,
+    hasSavedTokenInModal,
+    hasRemovedPersonalToken,
+  };
+};
+
+export type UseMcpConfigureModalResult = ReturnType<
+  typeof useMcpConfigureModal
+>;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
@@ -150,6 +150,9 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
       'Persönlichen Token verwenden',
     'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
     'mcp.settings.modal.loadingTools': 'Tools werden geladen...',
+    'mcp.settings.modal.loadingStatus': 'Verbindung wird getrennt...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Token wurde entfernt. Um diesen MCP-Server erneut zu verwenden, geben Sie einen neuen Token ein.',
     'mcp.settings.modal.noToolsAvailable': 'Keine Tools verfügbar.',
     'mcp.settings.modal.toolsLoadFailed': 'Tools konnten nicht geladen werden.',
     'mcp.settings.modal.enabledDescription':
@@ -163,6 +166,7 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
     'mcp.settings.personalAccessToken': 'Persönlicher Zugriffstoken',
     'mcp.settings.readOnlyAccess':
       'Sie haben schreibgeschützten Zugriff auf MCP-Server.',
+    'mcp.settings.removePersonalToken': 'Persönlichen Token entfernen',
     'mcp.settings.savedToken': 'Gespeicherter Token',
     'mcp.settings.selectedCount':
       '{{selectedCount}} von {{totalCount}} ausgewählt',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
@@ -150,6 +150,7 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
       'Persönlichen Token verwenden',
     'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
     'mcp.settings.modal.loadingTools': 'Tools werden geladen...',
+    'mcp.settings.modal.fetchingStatus': 'Status wird abgerufen...',
     'mcp.settings.modal.loadingStatus': 'Verbindung wird getrennt...',
     'mcp.settings.modal.tokenRemovedWarning':
       'Token wurde entfernt. Um diesen MCP-Server erneut zu verwenden, geben Sie einen neuen Token ein.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
@@ -141,11 +141,15 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
     'mcp.settings.modalDescriptionDcr':
       'Dieser Server verwendet Dynamic Client Registration (DCR). Token werden automatisch mit Ihrer Backstage-Identität erstellt — kein manuelles Token erforderlich.',
     'mcp.settings.authenticationToken': 'Authentifizierungstoken',
+    'mcp.settings.modal.authenticationHeading': 'Authentifizierung',
+    'mcp.settings.modal.credentialMode.organization':
+      'Organisations-Standard-Token verwenden',
+    'mcp.settings.modal.credentialMode.organizationDescription':
+      'Verwendet den von Ihrem Administrator konfigurierten Token.',
+    'mcp.settings.modal.credentialMode.personal':
+      'Persönlichen Token verwenden',
     'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
     'mcp.settings.modal.loadingTools': 'Tools werden geladen...',
-    'mcp.settings.modal.loadingStatus': 'Verbindung wird getrennt...',
-    'mcp.settings.modal.tokenRemovedWarning':
-      'Token wurde entfernt. Um diesen MCP-Server erneut zu verwenden, geben Sie einen neuen Token ein.',
     'mcp.settings.modal.noToolsAvailable': 'Keine Tools verfügbar.',
     'mcp.settings.modal.toolsLoadFailed': 'Tools konnten nicht geladen werden.',
     'mcp.settings.modal.enabledDescription':
@@ -159,7 +163,6 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
     'mcp.settings.personalAccessToken': 'Persönlicher Zugriffstoken',
     'mcp.settings.readOnlyAccess':
       'Sie haben schreibgeschützten Zugriff auf MCP-Server.',
-    'mcp.settings.removePersonalToken': 'Persönlichen Token entfernen',
     'mcp.settings.savedToken': 'Gespeicherter Token',
     'mcp.settings.selectedCount':
       '{{selectedCount}} von {{totalCount}} ausgewählt',
@@ -184,8 +187,6 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
     'mcp.settings.token.validating': 'Token wird validiert...',
     'mcp.settings.token.validationFailed':
       'Validierung fehlgeschlagen. Überprüfen Sie Server-URL und Token.',
-    'mcp.settings.usingAdminCredential':
-      'Administratoranmeldedaten werden verwendet. Geben Sie einen persönlichen Token ein, um ihn für Ihr Konto zu überschreiben.',
     'menu.newConversation': 'Neuer Chat',
     'message.options.label': 'Optionen',
     'modal.cancel': 'Abbrechen',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
@@ -129,7 +129,8 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
     'mcp.settings.closeAriaLabel': 'MCP-Einstellungen schließen',
     'mcp.settings.closeConfigureModalAriaLabel':
       'Konfigurationsdialog schließen',
-    'mcp.settings.configureServerTitle': 'Server {{serverName}} konfigurieren',
+    'mcp.settings.configureServerTitle':
+      '{{serverName}} MCP-Server-Einstellungen',
     'mcp.settings.edit': 'Bearbeiten',
     'mcp.settings.editServerAriaLabel': '{{serverName}} bearbeiten',
     'mcp.settings.enabled': 'Aktiviert',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
@@ -140,6 +140,20 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
       'Anmeldedaten werden verschlüsselt gespeichert und sind auf Ihr Profil beschränkt. Der intelligente Assistent arbeitet mit genau Ihren Berechtigungen.',
     'mcp.settings.modalDescriptionDcr':
       'Dieser Server verwendet Dynamic Client Registration (DCR). Token werden automatisch mit Ihrer Backstage-Identität erstellt — kein manuelles Token erforderlich.',
+    'mcp.settings.authenticationToken': 'Authentifizierungstoken',
+    'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
+    'mcp.settings.modal.loadingTools': 'Tools werden geladen...',
+    'mcp.settings.modal.loadingStatus': 'Verbindung wird getrennt...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Token wurde entfernt. Um diesen MCP-Server erneut zu verwenden, geben Sie einen neuen Token ein.',
+    'mcp.settings.modal.noToolsAvailable': 'Keine Tools verfügbar.',
+    'mcp.settings.modal.toolsLoadFailed': 'Tools konnten nicht geladen werden.',
+    'mcp.settings.modal.enabledDescription':
+      'Dieser Server ist aktiv und im Chat verfügbar.',
+    'mcp.settings.modal.enabledDescriptionOff':
+      'Dieser Server ist deaktiviert und im Chat nicht verfügbar.',
+    'mcp.settings.modal.enabledDescriptionTokenRequired':
+      'Dieser Server ist derzeit deaktiviert. Geben Sie einen Token ein, um ihn zu aktivieren.',
     'mcp.settings.name': 'Name',
     'mcp.settings.noneAvailable': 'Keine MCP-Server verfügbar.',
     'mcp.settings.personalAccessToken': 'Persönlicher Zugriffstoken',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
@@ -137,6 +137,21 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
       'Las credenciales se almacenan cifradas y se limitan a tu perfil. El asistente inteligente funcionará con exactamente tus permisos.',
     'mcp.settings.modalDescriptionDcr':
       'Este servidor utiliza Dynamic Client Registration (DCR). Los tokens se generan automáticamente usando tu identidad de Backstage — no se necesita un token manual.',
+    'mcp.settings.authenticationToken': 'Token de autenticación',
+    'mcp.settings.modal.toolsHeading': 'Herramientas ({{count}})',
+    'mcp.settings.modal.loadingTools': 'Cargando herramientas...',
+    'mcp.settings.modal.loadingStatus': 'Desconectando...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Se eliminó el token. Para volver a usar este servidor MCP, proporcione un nuevo token.',
+    'mcp.settings.modal.noToolsAvailable': 'No hay herramientas disponibles.',
+    'mcp.settings.modal.toolsLoadFailed':
+      'No se pudieron cargar las herramientas.',
+    'mcp.settings.modal.enabledDescription':
+      'Este servidor está activo y disponible en el chat.',
+    'mcp.settings.modal.enabledDescriptionOff':
+      'Este servidor está deshabilitado y no está disponible en el chat.',
+    'mcp.settings.modal.enabledDescriptionTokenRequired':
+      'Este servidor está deshabilitado actualmente. Proporcione un token para habilitarlo.',
     'mcp.settings.name': 'Nombre',
     'mcp.settings.noneAvailable': 'No hay servidores MCP disponibles.',
     'mcp.settings.personalAccessToken': 'Token de acceso personal',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
@@ -138,11 +138,14 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.modalDescriptionDcr':
       'Este servidor utiliza Dynamic Client Registration (DCR). Los tokens se generan automáticamente usando tu identidad de Backstage — no se necesita un token manual.',
     'mcp.settings.authenticationToken': 'Token de autenticación',
+    'mcp.settings.modal.authenticationHeading': 'Autenticación',
+    'mcp.settings.modal.credentialMode.organization':
+      'Usar token predeterminado de la organización',
+    'mcp.settings.modal.credentialMode.organizationDescription':
+      'Usa el token configurado por su administrador.',
+    'mcp.settings.modal.credentialMode.personal': 'Usar token personal',
     'mcp.settings.modal.toolsHeading': 'Herramientas ({{count}})',
     'mcp.settings.modal.loadingTools': 'Cargando herramientas...',
-    'mcp.settings.modal.loadingStatus': 'Desconectando...',
-    'mcp.settings.modal.tokenRemovedWarning':
-      'Se eliminó el token. Para volver a usar este servidor MCP, proporcione un nuevo token.',
     'mcp.settings.modal.noToolsAvailable': 'No hay herramientas disponibles.',
     'mcp.settings.modal.toolsLoadFailed':
       'No se pudieron cargar las herramientas.',
@@ -157,7 +160,6 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.personalAccessToken': 'Token de acceso personal',
     'mcp.settings.readOnlyAccess':
       'Tienes acceso de solo lectura a los servidores MCP.',
-    'mcp.settings.removePersonalToken': 'Eliminar token personal',
     'mcp.settings.savedToken': 'Token guardado',
     'mcp.settings.selectedCount':
       '{{selectedCount}} de {{totalCount}} seleccionados',
@@ -181,8 +183,6 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.token.validating': 'Validando token...',
     'mcp.settings.token.validationFailed':
       'La validación falló. Revisa la URL del servidor y el token.',
-    'mcp.settings.usingAdminCredential':
-      'Se están usando credenciales proporcionadas por el administrador. Introduce un token personal para reemplazarlas en tu cuenta.',
     'menu.newConversation': 'Nuevo chat',
     'message.options.label': 'Opciones',
     'modal.cancel': 'Cancelar',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
@@ -146,6 +146,9 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': 'Usar token personal',
     'mcp.settings.modal.toolsHeading': 'Herramientas ({{count}})',
     'mcp.settings.modal.loadingTools': 'Cargando herramientas...',
+    'mcp.settings.modal.loadingStatus': 'Desconectando...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Se eliminó el token. Para volver a usar este servidor MCP, proporcione un nuevo token.',
     'mcp.settings.modal.noToolsAvailable': 'No hay herramientas disponibles.',
     'mcp.settings.modal.toolsLoadFailed':
       'No se pudieron cargar las herramientas.',
@@ -160,6 +163,7 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.personalAccessToken': 'Token de acceso personal',
     'mcp.settings.readOnlyAccess':
       'Tienes acceso de solo lectura a los servidores MCP.',
+    'mcp.settings.removePersonalToken': 'Eliminar token personal',
     'mcp.settings.savedToken': 'Token guardado',
     'mcp.settings.selectedCount':
       '{{selectedCount}} de {{totalCount}} seleccionados',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
@@ -126,7 +126,8 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.closeAriaLabel': 'Cerrar configuración de MCP',
     'mcp.settings.closeConfigureModalAriaLabel':
       'Cerrar modal de configuración',
-    'mcp.settings.configureServerTitle': 'Configurar servidor {{serverName}}',
+    'mcp.settings.configureServerTitle':
+      '{{serverName}} — configuración del servidor MCP',
     'mcp.settings.edit': 'Editar',
     'mcp.settings.editServerAriaLabel': 'Editar {{serverName}}',
     'mcp.settings.enabled': 'Habilitado',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
@@ -146,6 +146,7 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': 'Usar token personal',
     'mcp.settings.modal.toolsHeading': 'Herramientas ({{count}})',
     'mcp.settings.modal.loadingTools': 'Cargando herramientas...',
+    'mcp.settings.modal.fetchingStatus': 'Obteniendo estado...',
     'mcp.settings.modal.loadingStatus': 'Desconectando...',
     'mcp.settings.modal.tokenRemovedWarning':
       'Se eliminó el token. Para volver a usar este servidor MCP, proporcione un nuevo token.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
@@ -149,6 +149,7 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': 'Utiliser un jeton personnel',
     'mcp.settings.modal.toolsHeading': 'Outils ({{count}})',
     'mcp.settings.modal.loadingTools': 'Chargement des outils...',
+    'mcp.settings.modal.fetchingStatus': 'Récupération du statut...',
     'mcp.settings.modal.loadingStatus': 'Déconnexion...',
     'mcp.settings.modal.tokenRemovedWarning':
       'Le jeton a été supprimé. Pour réutiliser ce serveur MCP, fournissez un nouveau jeton.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
@@ -140,6 +140,20 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
       'Les identifiants sont chiffrés au repos et limités à votre profil. L\u2019assistant intelligent fonctionnera avec exactement vos autorisations.',
     'mcp.settings.modalDescriptionDcr':
       'Ce serveur utilise Dynamic Client Registration (DCR). Les jetons sont générés automatiquement à partir de votre identité Backstage — aucun jeton manuel n\u2019est nécessaire.',
+    'mcp.settings.authenticationToken': "Jeton d'authentification",
+    'mcp.settings.modal.toolsHeading': 'Outils ({{count}})',
+    'mcp.settings.modal.loadingTools': 'Chargement des outils...',
+    'mcp.settings.modal.loadingStatus': 'Déconnexion...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Le jeton a été supprimé. Pour réutiliser ce serveur MCP, fournissez un nouveau jeton.',
+    'mcp.settings.modal.noToolsAvailable': 'Aucun outil disponible.',
+    'mcp.settings.modal.toolsLoadFailed': 'Échec du chargement des outils.',
+    'mcp.settings.modal.enabledDescription':
+      'Ce serveur est actif et disponible dans le chat.',
+    'mcp.settings.modal.enabledDescriptionOff':
+      'Ce serveur est désactivé et indisponible dans le chat.',
+    'mcp.settings.modal.enabledDescriptionTokenRequired':
+      'Ce serveur est actuellement désactivé. Fournissez un jeton pour l\u2019activer.',
     'mcp.settings.name': 'Nom',
     'mcp.settings.noneAvailable': 'Aucun serveur MCP disponible.',
     'mcp.settings.personalAccessToken': "Jeton d'accès personnel",

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
@@ -129,7 +129,8 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.closeAriaLabel': 'Fermer les paramètres MCP',
     'mcp.settings.closeConfigureModalAriaLabel':
       'Fermer la fenêtre de configuration',
-    'mcp.settings.configureServerTitle': 'Configurer le serveur {{serverName}}',
+    'mcp.settings.configureServerTitle':
+      '{{serverName}} — paramètres du serveur MCP',
     'mcp.settings.edit': 'Modifier',
     'mcp.settings.editServerAriaLabel': 'Modifier {{serverName}}',
     'mcp.settings.enabled': 'Activé',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
@@ -149,6 +149,9 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': 'Utiliser un jeton personnel',
     'mcp.settings.modal.toolsHeading': 'Outils ({{count}})',
     'mcp.settings.modal.loadingTools': 'Chargement des outils...',
+    'mcp.settings.modal.loadingStatus': 'Déconnexion...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Le jeton a été supprimé. Pour réutiliser ce serveur MCP, fournissez un nouveau jeton.',
     'mcp.settings.modal.noToolsAvailable': 'Aucun outil disponible.',
     'mcp.settings.modal.toolsLoadFailed': 'Échec du chargement des outils.',
     'mcp.settings.modal.enabledDescription':
@@ -162,6 +165,7 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.personalAccessToken': "Jeton d'accès personnel",
     'mcp.settings.readOnlyAccess':
       'Vous disposez d’un accès en lecture seule aux serveurs MCP.',
+    'mcp.settings.removePersonalToken': 'Supprimer le jeton personnel',
     'mcp.settings.savedToken': 'Jeton enregistré',
     'mcp.settings.selectedCount':
       '{{selectedCount}} sur {{totalCount}} sélectionnés',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
@@ -141,11 +141,14 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.modalDescriptionDcr':
       'Ce serveur utilise Dynamic Client Registration (DCR). Les jetons sont générés automatiquement à partir de votre identité Backstage — aucun jeton manuel n\u2019est nécessaire.',
     'mcp.settings.authenticationToken': "Jeton d'authentification",
+    'mcp.settings.modal.authenticationHeading': 'Authentification',
+    'mcp.settings.modal.credentialMode.organization':
+      'Utiliser le jeton par défaut de l\u2019organisation',
+    'mcp.settings.modal.credentialMode.organizationDescription':
+      'Utilise le jeton configuré par votre administrateur.',
+    'mcp.settings.modal.credentialMode.personal': 'Utiliser un jeton personnel',
     'mcp.settings.modal.toolsHeading': 'Outils ({{count}})',
     'mcp.settings.modal.loadingTools': 'Chargement des outils...',
-    'mcp.settings.modal.loadingStatus': 'Déconnexion...',
-    'mcp.settings.modal.tokenRemovedWarning':
-      'Le jeton a été supprimé. Pour réutiliser ce serveur MCP, fournissez un nouveau jeton.',
     'mcp.settings.modal.noToolsAvailable': 'Aucun outil disponible.',
     'mcp.settings.modal.toolsLoadFailed': 'Échec du chargement des outils.',
     'mcp.settings.modal.enabledDescription':
@@ -159,7 +162,6 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.personalAccessToken': "Jeton d'accès personnel",
     'mcp.settings.readOnlyAccess':
       'Vous disposez d’un accès en lecture seule aux serveurs MCP.',
-    'mcp.settings.removePersonalToken': 'Supprimer le jeton personnel',
     'mcp.settings.savedToken': 'Jeton enregistré',
     'mcp.settings.selectedCount':
       '{{selectedCount}} sur {{totalCount}} sélectionnés',
@@ -184,8 +186,6 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'mcp.settings.token.validating': 'Validation du jeton...',
     'mcp.settings.token.validationFailed':
       'Échec de la validation. Vérifiez l’URL du serveur et le jeton.',
-    'mcp.settings.usingAdminCredential':
-      'Les identifiants fournis par l’administrateur sont utilisés. Saisissez un jeton personnel pour les remplacer pour votre compte.',
     'menu.newConversation': 'Nouvelle Conversation',
     'message.options.label': 'Options',
     'modal.cancel': 'Annuler',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
@@ -127,7 +127,8 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.closeAriaLabel': 'Chiudi impostazioni MCP',
     'mcp.settings.closeConfigureModalAriaLabel':
       'Chiudi finestra di configurazione',
-    'mcp.settings.configureServerTitle': 'Configura server {{serverName}}',
+    'mcp.settings.configureServerTitle':
+      '{{serverName}} — impostazioni server MCP',
     'mcp.settings.edit': 'Modifica',
     'mcp.settings.editServerAriaLabel': 'Modifica {{serverName}}',
     'mcp.settings.enabled': 'Abilitato',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
@@ -139,11 +139,14 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.modalDescriptionDcr':
       'Questo server utilizza Dynamic Client Registration (DCR). I token vengono generati automaticamente utilizzando la tua identità Backstage — non è necessario alcun token manuale.',
     'mcp.settings.authenticationToken': 'Token di autenticazione',
+    'mcp.settings.modal.authenticationHeading': 'Autenticazione',
+    'mcp.settings.modal.credentialMode.organization':
+      'Usa il token predefinito dell\u2019organizzazione',
+    'mcp.settings.modal.credentialMode.organizationDescription':
+      'Usa il token configurato dal tuo amministratore.',
+    'mcp.settings.modal.credentialMode.personal': 'Usa token personale',
     'mcp.settings.modal.toolsHeading': 'Strumenti ({{count}})',
     'mcp.settings.modal.loadingTools': 'Caricamento strumenti...',
-    'mcp.settings.modal.loadingStatus': 'Disconnessione...',
-    'mcp.settings.modal.tokenRemovedWarning':
-      'Il token è stato rimosso. Per usare di nuovo questo server MCP, fornisci un nuovo token.',
     'mcp.settings.modal.noToolsAvailable': 'Nessuno strumento disponibile.',
     'mcp.settings.modal.toolsLoadFailed': 'Impossibile caricare gli strumenti.',
     'mcp.settings.modal.enabledDescription':
@@ -157,7 +160,6 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.personalAccessToken': 'Token di accesso personale',
     'mcp.settings.readOnlyAccess':
       "Disponi dell'accesso in sola lettura ai server MCP.",
-    'mcp.settings.removePersonalToken': 'Rimuovi token personale',
     'mcp.settings.savedToken': 'Token salvato',
     'mcp.settings.selectedCount':
       '{{selectedCount}} di {{totalCount}} selezionati',
@@ -182,8 +184,6 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.token.validating': 'Convalida del token in corso...',
     'mcp.settings.token.validationFailed':
       "Convalida non riuscita. Controlla l'URL del server e il token.",
-    'mcp.settings.usingAdminCredential':
-      "Sono in uso le credenziali fornite dall'amministratore. Inserisci un token personale per sovrascriverle per il tuo account.",
     'menu.newConversation': 'Nuova chat',
     'message.options.label': 'Opzioni',
     'modal.cancel': 'Cancella',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
@@ -138,6 +138,20 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
       "Le credenziali sono crittografate a riposo e associate al tuo profilo. L'assistente intelligente opererà con esattamente le tue autorizzazioni.",
     'mcp.settings.modalDescriptionDcr':
       'Questo server utilizza Dynamic Client Registration (DCR). I token vengono generati automaticamente utilizzando la tua identità Backstage — non è necessario alcun token manuale.',
+    'mcp.settings.authenticationToken': 'Token di autenticazione',
+    'mcp.settings.modal.toolsHeading': 'Strumenti ({{count}})',
+    'mcp.settings.modal.loadingTools': 'Caricamento strumenti...',
+    'mcp.settings.modal.loadingStatus': 'Disconnessione...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Il token è stato rimosso. Per usare di nuovo questo server MCP, fornisci un nuovo token.',
+    'mcp.settings.modal.noToolsAvailable': 'Nessuno strumento disponibile.',
+    'mcp.settings.modal.toolsLoadFailed': 'Impossibile caricare gli strumenti.',
+    'mcp.settings.modal.enabledDescription':
+      'Questo server è attivo e disponibile nella chat.',
+    'mcp.settings.modal.enabledDescriptionOff':
+      'Questo server è disabilitato e non disponibile nella chat.',
+    'mcp.settings.modal.enabledDescriptionTokenRequired':
+      'Questo server è attualmente disabilitato. Fornisci un token per abilitarlo.',
     'mcp.settings.name': 'Nome',
     'mcp.settings.noneAvailable': 'Nessun server MCP disponibile.',
     'mcp.settings.personalAccessToken': 'Token di accesso personale',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
@@ -147,6 +147,9 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': 'Usa token personale',
     'mcp.settings.modal.toolsHeading': 'Strumenti ({{count}})',
     'mcp.settings.modal.loadingTools': 'Caricamento strumenti...',
+    'mcp.settings.modal.loadingStatus': 'Disconnessione...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'Il token è stato rimosso. Per usare di nuovo questo server MCP, fornisci un nuovo token.',
     'mcp.settings.modal.noToolsAvailable': 'Nessuno strumento disponibile.',
     'mcp.settings.modal.toolsLoadFailed': 'Impossibile caricare gli strumenti.',
     'mcp.settings.modal.enabledDescription':
@@ -160,6 +163,7 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.personalAccessToken': 'Token di accesso personale',
     'mcp.settings.readOnlyAccess':
       "Disponi dell'accesso in sola lettura ai server MCP.",
+    'mcp.settings.removePersonalToken': 'Rimuovi token personale',
     'mcp.settings.savedToken': 'Token salvato',
     'mcp.settings.selectedCount':
       '{{selectedCount}} di {{totalCount}} selezionati',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
@@ -147,6 +147,7 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': 'Usa token personale',
     'mcp.settings.modal.toolsHeading': 'Strumenti ({{count}})',
     'mcp.settings.modal.loadingTools': 'Caricamento strumenti...',
+    'mcp.settings.modal.fetchingStatus': 'Recupero stato...',
     'mcp.settings.modal.loadingStatus': 'Disconnessione...',
     'mcp.settings.modal.tokenRemovedWarning':
       'Il token è stato rimosso. Per usare di nuovo questo server MCP, fornisci un nuovo token.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
@@ -125,7 +125,7 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'lcore.notConfigured.title': 'LLM に接続して始める',
     'mcp.settings.closeAriaLabel': 'MCP 設定を閉じる',
     'mcp.settings.closeConfigureModalAriaLabel': '設定モーダルを閉じる',
-    'mcp.settings.configureServerTitle': '{{serverName}} サーバーを設定',
+    'mcp.settings.configureServerTitle': '{{serverName}} MCP サーバー設定',
     'mcp.settings.edit': '編集',
     'mcp.settings.editServerAriaLabel': '{{serverName}} を編集',
     'mcp.settings.enabled': '有効',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
@@ -136,11 +136,14 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'mcp.settings.modalDescriptionDcr':
       'このサーバーは Dynamic Client Registration (DCR) を使用しています。トークンはあなたの Backstage ID を使用して自動的に発行されるため、手動でのトークン入力は不要です。',
     'mcp.settings.authenticationToken': '認証トークン',
+    'mcp.settings.modal.authenticationHeading': '認証',
+    'mcp.settings.modal.credentialMode.organization':
+      '組織のデフォルトトークンを使用',
+    'mcp.settings.modal.credentialMode.organizationDescription':
+      '管理者が設定したトークンを使用します。',
+    'mcp.settings.modal.credentialMode.personal': '個人トークンを使用',
     'mcp.settings.modal.toolsHeading': 'ツール ({{count}})',
     'mcp.settings.modal.loadingTools': 'ツールを読み込み中...',
-    'mcp.settings.modal.loadingStatus': '切断中...',
-    'mcp.settings.modal.tokenRemovedWarning':
-      'トークンが削除されました。この MCP サーバーを再度使用するには、新しいトークンを入力してください。',
     'mcp.settings.modal.noToolsAvailable': '利用可能なツールがありません。',
     'mcp.settings.modal.toolsLoadFailed': 'ツールの読み込みに失敗しました。',
     'mcp.settings.modal.enabledDescription':
@@ -154,7 +157,6 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'mcp.settings.personalAccessToken': '個人アクセストークン',
     'mcp.settings.readOnlyAccess':
       'MCP サーバーへのアクセスは読み取り専用です。',
-    'mcp.settings.removePersonalToken': '個人トークンを削除',
     'mcp.settings.savedToken': '保存済みトークン',
     'mcp.settings.selectedCount':
       '{{totalCount}} 件中 {{selectedCount}} 件を選択',
@@ -178,8 +180,6 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'mcp.settings.token.validating': 'トークンを検証中...',
     'mcp.settings.token.validationFailed':
       '検証に失敗しました。サーバー URL とトークンを確認してください。',
-    'mcp.settings.usingAdminCredential':
-      '管理者が提供した認証情報を使用しています。アカウント用に上書きするには個人トークンを入力してください。',
     'menu.newConversation': '新しいチャット',
     'message.options.label': 'オプション',
     'modal.cancel': 'キャンセル',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
@@ -135,6 +135,20 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
       '認証情報は保存時に暗号化され、あなたのプロファイルに限定されます。インテリジェントアシスタントはあなたの権限で動作します。',
     'mcp.settings.modalDescriptionDcr':
       'このサーバーは Dynamic Client Registration (DCR) を使用しています。トークンはあなたの Backstage ID を使用して自動的に発行されるため、手動でのトークン入力は不要です。',
+    'mcp.settings.authenticationToken': '認証トークン',
+    'mcp.settings.modal.toolsHeading': 'ツール ({{count}})',
+    'mcp.settings.modal.loadingTools': 'ツールを読み込み中...',
+    'mcp.settings.modal.loadingStatus': '切断中...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'トークンが削除されました。この MCP サーバーを再度使用するには、新しいトークンを入力してください。',
+    'mcp.settings.modal.noToolsAvailable': '利用可能なツールがありません。',
+    'mcp.settings.modal.toolsLoadFailed': 'ツールの読み込みに失敗しました。',
+    'mcp.settings.modal.enabledDescription':
+      'このサーバーはアクティブで、チャットで利用できます。',
+    'mcp.settings.modal.enabledDescriptionOff':
+      'このサーバーは無効になっており、チャットでは利用できません。',
+    'mcp.settings.modal.enabledDescriptionTokenRequired':
+      'このサーバーは現在無効です。有効にするにはトークンを入力してください。',
     'mcp.settings.name': '名前',
     'mcp.settings.noneAvailable': '利用可能な MCP サーバーはありません。',
     'mcp.settings.personalAccessToken': '個人アクセストークン',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
@@ -144,6 +144,9 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': '個人トークンを使用',
     'mcp.settings.modal.toolsHeading': 'ツール ({{count}})',
     'mcp.settings.modal.loadingTools': 'ツールを読み込み中...',
+    'mcp.settings.modal.loadingStatus': '切断中...',
+    'mcp.settings.modal.tokenRemovedWarning':
+      'トークンが削除されました。この MCP サーバーを再度使用するには、新しいトークンを入力してください。',
     'mcp.settings.modal.noToolsAvailable': '利用可能なツールがありません。',
     'mcp.settings.modal.toolsLoadFailed': 'ツールの読み込みに失敗しました。',
     'mcp.settings.modal.enabledDescription':
@@ -157,6 +160,7 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'mcp.settings.personalAccessToken': '個人アクセストークン',
     'mcp.settings.readOnlyAccess':
       'MCP サーバーへのアクセスは読み取り専用です。',
+    'mcp.settings.removePersonalToken': '個人トークンを削除',
     'mcp.settings.savedToken': '保存済みトークン',
     'mcp.settings.selectedCount':
       '{{totalCount}} 件中 {{selectedCount}} 件を選択',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
@@ -144,6 +144,7 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'mcp.settings.modal.credentialMode.personal': '個人トークンを使用',
     'mcp.settings.modal.toolsHeading': 'ツール ({{count}})',
     'mcp.settings.modal.loadingTools': 'ツールを読み込み中...',
+    'mcp.settings.modal.fetchingStatus': 'ステータスを取得中...',
     'mcp.settings.modal.loadingStatus': '切断中...',
     'mcp.settings.modal.tokenRemovedWarning':
       'トークンが削除されました。この MCP サーバーを再度使用するには、新しいトークンを入力してください。',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
@@ -349,10 +349,22 @@ export const intelligentAssistantMessages = {
     'This server uses Dynamic Client Registration (DCR). Tokens are minted automatically using your Backstage identity — no manual token is needed.',
   'mcp.settings.toggleServerAriaLabel': 'Toggle {{serverName}}',
   'mcp.settings.editServerAriaLabel': 'Edit {{serverName}}',
-  'mcp.settings.configureServerTitle': 'Configure {{serverName}} server',
+  'mcp.settings.configureServerTitle': '{{serverName}} MCP server settings',
   'mcp.settings.closeConfigureModalAriaLabel': 'Close configure modal',
   'mcp.settings.modalDescription':
-    'Credentials are encrypted at rest and scoped to your profile. The intelligent assistant will operate with your exact permissions.',
+    'Credentials are encrypted and operations use your exact permissions.',
+  'mcp.settings.authenticationToken': 'Authentication token',
+  'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
+  'mcp.settings.modal.loadingTools': 'Loading tools...',
+  'mcp.settings.modal.loadingStatus': 'Disconnecting...',
+  'mcp.settings.modal.tokenRemovedWarning':
+    'Token has been removed. To use this MCP server again, provide a new token.',
+  'mcp.settings.modal.noToolsAvailable': 'No tools available.',
+  'mcp.settings.modal.toolsLoadFailed': 'Failed to load tools.',
+  'mcp.settings.modal.enabledDescription':
+    'This server is active and available in chat.',
+  'mcp.settings.modal.enabledDescriptionOff':
+    'This server is disabled and unavailable in chat.',
   'mcp.settings.savedToken': 'Saved token',
   'mcp.settings.personalAccessToken': 'Personal Access Token',
   'mcp.settings.usingAdminCredential':

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
@@ -362,6 +362,9 @@ export const intelligentAssistantMessages = {
   'mcp.settings.modal.credentialMode.personal': 'Use personal token',
   'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
   'mcp.settings.modal.loadingTools': 'Loading tools...',
+  'mcp.settings.modal.loadingStatus': 'Disconnecting...',
+  'mcp.settings.modal.tokenRemovedWarning':
+    'Token has been removed. To use this MCP server again, provide a new token.',
   'mcp.settings.modal.noToolsAvailable': 'No tools available.',
   'mcp.settings.modal.toolsLoadFailed': 'Failed to load tools.',
   'mcp.settings.modal.enabledDescription':
@@ -373,6 +376,7 @@ export const intelligentAssistantMessages = {
   'mcp.settings.savedToken': 'Saved token',
   'mcp.settings.personalAccessToken': 'Personal Access Token',
   'mcp.settings.enterToken': 'Enter your token',
+  'mcp.settings.removePersonalToken': 'Remove personal token',
   'mcp.settings.token.clearAriaLabel': 'Clear token input',
   'mcp.settings.token.validating': 'Validating token...',
   'mcp.settings.token.savingAndValidating': 'Saving and validating token...',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
@@ -365,6 +365,8 @@ export const intelligentAssistantMessages = {
     'This server is active and available in chat.',
   'mcp.settings.modal.enabledDescriptionOff':
     'This server is disabled and unavailable in chat.',
+  'mcp.settings.modal.enabledDescriptionTokenRequired':
+    'This server is currently disabled. Provide a token to enable.',
   'mcp.settings.savedToken': 'Saved token',
   'mcp.settings.personalAccessToken': 'Personal Access Token',
   'mcp.settings.usingAdminCredential':

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
@@ -354,11 +354,14 @@ export const intelligentAssistantMessages = {
   'mcp.settings.modalDescription':
     'Credentials are encrypted and operations use your exact permissions.',
   'mcp.settings.authenticationToken': 'Authentication token',
+  'mcp.settings.modal.authenticationHeading': 'Authentication',
+  'mcp.settings.modal.credentialMode.organization':
+    'Use organization default token',
+  'mcp.settings.modal.credentialMode.organizationDescription':
+    'Uses the token configured by your administrator.',
+  'mcp.settings.modal.credentialMode.personal': 'Use personal token',
   'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
   'mcp.settings.modal.loadingTools': 'Loading tools...',
-  'mcp.settings.modal.loadingStatus': 'Disconnecting...',
-  'mcp.settings.modal.tokenRemovedWarning':
-    'Token has been removed. To use this MCP server again, provide a new token.',
   'mcp.settings.modal.noToolsAvailable': 'No tools available.',
   'mcp.settings.modal.toolsLoadFailed': 'Failed to load tools.',
   'mcp.settings.modal.enabledDescription':
@@ -369,10 +372,7 @@ export const intelligentAssistantMessages = {
     'This server is currently disabled. Provide a token to enable.',
   'mcp.settings.savedToken': 'Saved token',
   'mcp.settings.personalAccessToken': 'Personal Access Token',
-  'mcp.settings.usingAdminCredential':
-    'Using Administrator provided credential. Enter a personal token to override for your account.',
   'mcp.settings.enterToken': 'Enter your token',
-  'mcp.settings.removePersonalToken': 'Remove personal token',
   'mcp.settings.token.clearAriaLabel': 'Clear token input',
   'mcp.settings.token.validating': 'Validating token...',
   'mcp.settings.token.savingAndValidating': 'Saving and validating token...',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
@@ -362,6 +362,7 @@ export const intelligentAssistantMessages = {
   'mcp.settings.modal.credentialMode.personal': 'Use personal token',
   'mcp.settings.modal.toolsHeading': 'Tools ({{count}})',
   'mcp.settings.modal.loadingTools': 'Loading tools...',
+  'mcp.settings.modal.fetchingStatus': 'Fetching status...',
   'mcp.settings.modal.loadingStatus': 'Disconnecting...',
   'mcp.settings.modal.tokenRemovedWarning':
     'Token has been removed. To use this MCP server again, provide a new token.',

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -7355,32 +7355,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mswjs/cookies@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "@mswjs/cookies@npm:0.2.2"
-  dependencies:
-    "@types/set-cookie-parser": "npm:^2.4.0"
-    set-cookie-parser: "npm:^2.4.6"
-  checksum: 10c0/f950062538d431674d581309cf19884fc4d3f57e2a276164cac0c9a3250071d42464ba7825d13be14c703ca5a912d62a62626f4a068d8f36d1629dbb63bde740
-  languageName: node
-  linkType: hard
-
-"@mswjs/interceptors@npm:^0.17.10":
-  version: 0.17.10
-  resolution: "@mswjs/interceptors@npm:0.17.10"
-  dependencies:
-    "@open-draft/until": "npm:^1.0.3"
-    "@types/debug": "npm:^4.1.7"
-    "@xmldom/xmldom": "npm:^0.8.3"
-    debug: "npm:^4.3.3"
-    headers-polyfill: "npm:3.2.5"
-    outvariant: "npm:^1.2.1"
-    strict-event-emitter: "npm:^0.2.4"
-    web-encoding: "npm:^1.1.5"
-  checksum: 10c0/0343a93711b60c321c40733d6bf2720a736d8e0730f5d0d9916ee4a24abfcfca4a83d1e4b2e21c3affef4fc61f04588104be002fbc8258dc4b0d202c384ade33
-  languageName: node
-  linkType: hard
-
 "@mswjs/interceptors@npm:^0.41.3":
   version: 0.41.9
   resolution: "@mswjs/interceptors@npm:0.41.9"
@@ -8211,13 +8185,6 @@ __metadata:
     is-node-process: "npm:^1.2.0"
     outvariant: "npm:^1.4.0"
   checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
-  languageName: node
-  linkType: hard
-
-"@open-draft/until@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@open-draft/until@npm:1.0.3"
-  checksum: 10c0/f88bcd774b55359d14a4fa80f7bfe7d9d6d26a5995e94e823e43b211656daae3663e983f0a996937da286d22f6f5da2087b661845302f236ba27f8529dcd14fb
   languageName: node
   linkType: hard
 
@@ -9388,7 +9355,6 @@ __metadata:
     "@emotion/is-prop-valid": "npm:^1.3.1"
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.0"
     "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
     "@monaco-editor/react": "npm:^4.7.0"
     "@mui/icons-material": "npm:^6.1.8"
     "@mui/material": "npm:^5.12.2"
@@ -9407,12 +9373,10 @@ __metadata:
     "@testing-library/react": "npm:^15.0.0"
     "@testing-library/user-event": "npm:14.6.1"
     monaco-editor: "npm:^0.55.0"
-    msw: "npm:1.3.5"
     prettier: "npm:3.8.4"
     react: "npm:^18.0.0"
     react-dom: "npm:^18.0.0"
     react-dropzone: "npm:^14.4.0"
-    react-markdown: "npm:^9.0.1"
     react-router-dom: "npm:^6.0.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
@@ -12481,13 +12445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/cookie@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@types/cookie@npm:0.4.1"
-  checksum: 10c0/f96afe12bd51be1ec61410b0641243d93fa3a494702407c787a4c872b5c8bcd39b224471452055e44a9ce42af1a636e87d161994226eaf4c2be9c30f60418409
-  languageName: node
-  linkType: hard
-
 "@types/cookiejar@npm:^2.1.5":
   version: 2.1.5
   resolution: "@types/cookiejar@npm:2.1.5"
@@ -12504,7 +12461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.7":
+"@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
   dependencies:
@@ -12746,13 +12703,6 @@ __metadata:
   version: 2.2.7
   resolution: "@types/js-cookie@npm:2.2.7"
   checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
-  languageName: node
-  linkType: hard
-
-"@types/js-levenshtein@npm:^1.1.1":
-  version: 1.1.3
-  resolution: "@types/js-levenshtein@npm:1.1.3"
-  checksum: 10c0/025f2bd8d865cfa7a996799a1a2f2a77fa2fc74a28971aa035a103de35d7c1e3d949721a88f57fdb532815bbcb2bf7019196a608ed0a8bbd1023d64c52bb251b
   languageName: node
   linkType: hard
 
@@ -13132,7 +13082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/set-cookie-parser@npm:^2.4.0, @types/set-cookie-parser@npm:^2.4.10":
+"@types/set-cookie-parser@npm:^2.4.10":
   version: 2.4.10
   resolution: "@types/set-cookie-parser@npm:2.4.10"
   dependencies:
@@ -13907,13 +13857,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.3":
-  version: 0.8.13
-  resolution: "@xmldom/xmldom@npm:0.8.13"
-  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
-  languageName: node
-  linkType: hard
-
 "@xobotyi/scrollbar-width@npm:^1.9.5":
   version: 1.9.5
   resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
@@ -13970,13 +13913,6 @@ __metadata:
     js-yaml: "npm:^3.10.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/a0c340e13129643162423d7e666061c0b39b143bfad3fc5a74c7d92a30fd740f6665d41cd4e61832c20375889d793eea1d1d103cacb39ed68f7acd168add8c53
-  languageName: node
-  linkType: hard
-
-"@zxing/text-encoding@npm:0.9.0":
-  version: 0.9.0
-  resolution: "@zxing/text-encoding@npm:0.9.0"
-  checksum: 10c0/d15bff181d46c2ab709e7242801a8d40408aa8c19b44462e5f60e766bf59105b44957914ab6baab60d10d466a5e965f21fe890c67dfdb7d5c7f940df457b4d0d
   languageName: node
   linkType: hard
 
@@ -16796,13 +16732,6 @@ __metadata:
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
-  languageName: node
-  linkType: hard
-
-"cookie@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "cookie@npm:0.4.2"
-  checksum: 10c0/beab41fbd7c20175e3a2799ba948c1dcc71ef69f23fe14eeeff59fc09f50c517b0f77098db87dbb4c55da802f9d86ee86cdc1cd3efd87760341551838d53fca2
   languageName: node
   linkType: hard
 
@@ -20824,7 +20753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.0.0, graphql@npm:^16.13.2, graphql@npm:^16.8.1":
+"graphql@npm:^16.0.0, graphql@npm:^16.13.2":
   version: 16.14.2
   resolution: "graphql@npm:16.14.2"
   checksum: 10c0/a95a96961eaff55cc9fe9d31fae6f33499ac988b972d07ea5085024cb1333f515b902f376e7393a5489aa82200a8aff3eb96580e4d1b69d702ed19b6eb1ce97a
@@ -21201,13 +21130,6 @@ __metadata:
   bin:
     he: bin/he
   checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
-  languageName: node
-  linkType: hard
-
-"headers-polyfill@npm:3.2.5":
-  version: 3.2.5
-  resolution: "headers-polyfill@npm:3.2.5"
-  checksum: 10c0/10202f4ebfaecd6aa31305f29664f876ac01d9174a3fb8fcc5a0df3eaf9c1767fb0d6cf6f961484f2bfd2101b6768090976f146bd88aeedd07af4e741cb2dcb7
   languageName: node
   linkType: hard
 
@@ -23313,13 +23235,6 @@ __metadata:
   version: 0.4.12
   resolution: "js-file-download@npm:0.4.12"
   checksum: 10c0/3caec1491fa744214409e0bcb1fb18d76e3d56715c477ee033cb7d8becb5cf777803409dc1995c913bf1a2270dac98d78f07d83bba319b8e800bc7bf2a7266a7
-  languageName: node
-  linkType: hard
-
-"js-levenshtein@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "js-levenshtein@npm:1.1.6"
-  checksum: 10c0/14045735325ea1fd87f434a74b11d8a14380f090f154747e613529c7cff68b5ee607f5230fa40665d5fb6125a3791f4c223f73b9feca754f989b059f5c05864f
   languageName: node
   linkType: hard
 
@@ -26460,40 +26375,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:1.3.5":
-  version: 1.3.5
-  resolution: "msw@npm:1.3.5"
-  dependencies:
-    "@mswjs/cookies": "npm:^0.2.2"
-    "@mswjs/interceptors": "npm:^0.17.10"
-    "@open-draft/until": "npm:^1.0.3"
-    "@types/cookie": "npm:^0.4.1"
-    "@types/js-levenshtein": "npm:^1.1.1"
-    chalk: "npm:^4.1.1"
-    chokidar: "npm:^3.4.2"
-    cookie: "npm:^0.4.2"
-    graphql: "npm:^16.8.1"
-    headers-polyfill: "npm:3.2.5"
-    inquirer: "npm:^8.2.0"
-    is-node-process: "npm:^1.2.0"
-    js-levenshtein: "npm:^1.1.6"
-    node-fetch: "npm:^2.6.7"
-    outvariant: "npm:^1.4.0"
-    path-to-regexp: "npm:^6.3.0"
-    strict-event-emitter: "npm:^0.4.3"
-    type-fest: "npm:^2.19.0"
-    yargs: "npm:^17.3.1"
-  peerDependencies:
-    typescript: ">= 4.4.x"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    msw: cli/index.js
-  checksum: 10c0/bb0b3625b68f1750bfe90ade6e9e98c64f509138ce7b09c8a53af19f8f662ac79881dad64fbc74c9426247b725e3ec5e6d45eea2f6b71ddc02184e0ddf743e4d
-  languageName: node
-  linkType: hard
-
 "msw@npm:2.14.6":
   version: 2.14.6
   resolution: "msw@npm:2.14.6"
@@ -27505,7 +27386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"outvariant@npm:^1.2.1, outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
   checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
@@ -31453,13 +31334,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-cookie-parser@npm:^2.4.6":
-  version: 2.7.1
-  resolution: "set-cookie-parser@npm:2.7.1"
-  checksum: 10c0/060c198c4c92547ac15988256f445eae523f57f2ceefeccf52d30d75dedf6bff22b9c26f756bd44e8e560d44ff4ab2130b178bd2e52ef5571bf7be3bd7632d9a
-  languageName: node
-  linkType: hard
-
 "set-cookie-parser@npm:^3.0.1":
   version: 3.1.1
   resolution: "set-cookie-parser@npm:3.1.1"
@@ -32201,22 +32075,6 @@ __metadata:
     fast-fifo: "npm:^1.3.2"
     text-decoder: "npm:^1.1.0"
   checksum: 10c0/15708ce37818d588632fe1104e8febde573e33e8c0868bf583fce0703f3faf8d2a063c278e30df2270206811b69997f64eb78792099933a1fe757e786fbcbd44
-  languageName: node
-  linkType: hard
-
-"strict-event-emitter@npm:^0.2.4":
-  version: 0.2.8
-  resolution: "strict-event-emitter@npm:0.2.8"
-  dependencies:
-    events: "npm:^3.3.0"
-  checksum: 10c0/6891e19fea4f0289e4da2fe7050d85906eaca7f774aa38fe674f0e58fdece1b63b868614fa23974c4cb862aa99358caa987523b705fdfff4639231c62e384394
-  languageName: node
-  linkType: hard
-
-"strict-event-emitter@npm:^0.4.3":
-  version: 0.4.6
-  resolution: "strict-event-emitter@npm:0.4.6"
-  checksum: 10c0/d0231ef081cb1937b1445da59a1ec202d1c097d825c504f398600532490a4104e200b0dce4137467a8eaac5f8f9718d01c99869687afad78cad3b14c4b2e6a39
   languageName: node
   linkType: hard
 
@@ -34812,19 +34670,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-encoding@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "web-encoding@npm:1.1.5"
-  dependencies:
-    "@zxing/text-encoding": "npm:0.9.0"
-    util: "npm:^0.12.3"
-  dependenciesMeta:
-    "@zxing/text-encoding":
-      optional: true
-  checksum: 10c0/59d5413338ec0894c690006f5d8508b0c88cae1d8c78606c3f326e351c672196461ed808b849fe08d0900fa56a61fcacb9ff576499068d2ead0a7bc04afa7d34
-  languageName: node
-  linkType: hard
-
 "web-namespaces@npm:^2.0.0":
   version: 2.0.1
   resolution: "web-namespaces@npm:2.0.1"
@@ -35475,7 +35320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.1.1, yargs@npm:^17.3.1, yargs@npm:^17.7.2, yargs@npm:^17.7.3":
+"yargs@npm:^17.1.1, yargs@npm:^17.7.2, yargs@npm:^17.7.3":
   version: 17.7.3
   resolution: "yargs@npm:17.7.3"
   dependencies:

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -1946,6 +1946,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-plugin-api@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@backstage/backend-plugin-api@npm:1.9.3"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.3.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-auth-node": "npm:^0.7.3"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10c0/cf8547920e88bc94b812aae4b93a2d68dcf8e1cba0aa9065ca4530b795f6e89a9ec8e184a4e44ed342612ec2bb4fb25e195325a25b08edd1264b3e2de76208c2
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-test-utils@npm:^1.11.4":
   version: 1.11.4
   resolution: "@backstage/backend-test-utils@npm:1.11.4"
@@ -2028,6 +2049,16 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.24.5"
   checksum: 10c0/b83af32489662c1af7009d4a4965e5251cbe7e6bd12e5e14f2951e25d953872cba5802d9e6b780d0c93be95cdd9712e3ababeb2e97e34632b5cda6729f92a46d
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/cli-common@npm:0.3.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    cross-spawn: "npm:^7.0.3"
+  checksum: 10c0/c6ae3bf3697bf463e0043150c0e56e4075ff9fd516e786593845c02de47ee72c4dad64cc1cfd9f54685b11ba9ed075ffa11eb764cc65da58ca3367da18a5dca1
   languageName: node
   linkType: hard
 
@@ -3092,6 +3123,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@backstage/plugin-auth-node@npm:0.7.3"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10c0/faf274cc6d13193ef8aa6daa8dba33219ee8661029e603c6eb8e80f3ed7a35860a7b5603b2667c61b9c2df976a1ede836467ee3a94be08b4b31cb910fea10f90
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-react@npm:^0.1.28":
   version: 0.1.28
   resolution: "@backstage/plugin-auth-react@npm:0.1.28"
@@ -3625,11 +3679,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:^0.11.1":
-  version: 0.11.1
-  resolution: "@backstage/plugin-permission-node@npm:0.11.1"
+"@backstage/plugin-permission-node@npm:^0.11.1, @backstage/plugin-permission-node@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@backstage/plugin-permission-node@npm:0.11.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/plugin-permission-common": "npm:^0.9.9"
@@ -3638,7 +3692,7 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10c0/96efe0e8ccdecc4c640cf693d29988de226bd7cce9495e973d4e8ba7e26838bfa23678b47f668c2d33d1c1ea70b7613291a919bcbf67700cc507df316b637a8b
+  checksum: 10c0/70ac2494ff39fd55dfb82dad8f7be6fab91b0b21fdba3e978b2108b63cf4848f89f7bd38578629d71ddd072af7b3c4ad0c1d8916e20e4bdce88e8201c7e97d3d
   languageName: node
   linkType: hard
 

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -8307,17 +8307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:^6.1.0, @patternfly/react-icons@npm:^6.4.0, @patternfly/react-icons@npm:^6.5.0":
-  version: 6.5.1
-  resolution: "@patternfly/react-icons@npm:6.5.1"
-  peerDependencies:
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/32af8ca4be0fad74a056aec5bcd4f4748166a35016de958758041e6afa21dd65fb7349dd22ea78c92fe7a150c1433d08b4a59f5851d162695f6a05cc99a53a45
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-icons@npm:^6.6.0":
+"@patternfly/react-icons@npm:^6.1.0, @patternfly/react-icons@npm:^6.4.0, @patternfly/react-icons@npm:^6.5.0, @patternfly/react-icons@npm:^6.6.0":
   version: 6.6.0
   resolution: "@patternfly/react-icons@npm:6.6.0"
   dependencies:
@@ -8353,14 +8343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-tokens@npm:^6.4.0":
-  version: 6.5.1
-  resolution: "@patternfly/react-tokens@npm:6.5.1"
-  checksum: 10c0/3d38d92550d61cd34eea9c7b530b826af31cb929c1da28fd7f0649df12e40753ffdd5655a1ac2cf537d79866f635fcb71562e5ce3f55c32c81986a1f03b07cc2
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-tokens@npm:^6.6.0":
+"@patternfly/react-tokens@npm:^6.4.0, @patternfly/react-tokens@npm:^6.6.0":
   version: 6.6.0
   resolution: "@patternfly/react-tokens@npm:6.6.0"
   checksum: 10c0/3084a23e28e693163e68a8215a13eea036acf4c528dfbf794dd9b7f994e8e999a33a1874505cadb32c37e8e300d228b4eef3fc746acabae97f7be5ce8d65fd15

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -8290,24 +8290,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:6.5.1":
-  version: 6.5.1
-  resolution: "@patternfly/react-core@npm:6.5.1"
+"@patternfly/react-core@npm:6.6.0":
+  version: 6.6.0
+  resolution: "@patternfly/react-core@npm:6.6.0"
   dependencies:
-    "@patternfly/react-icons": "npm:^6.5.1"
-    "@patternfly/react-styles": "npm:^6.5.1"
-    "@patternfly/react-tokens": "npm:^6.5.1"
+    "@patternfly/react-icons": "npm:^6.6.0"
+    "@patternfly/react-styles": "npm:^6.6.0"
+    "@patternfly/react-tokens": "npm:^6.6.0"
     focus-trap: "npm:7.6.6"
     react-dropzone: "npm:^14.3.5"
     tslib: "npm:^2.8.1"
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/a19cb6e7e286618b62883f0e15876563df8c3b64e5246b9253de40ee7c84b230cb344694a55641dca6a6dd087d331ab05bd0a7554fe160b5c8a1d52c10713ac6
+  checksum: 10c0/7042f6b8fd9bdc0ddea5bd5206144216ebd0819486ad903e5052ca5bb6a433c5981a4f1d694d48e12ab4717b3139ccdf5c8344c27543a5e8c1644d994e7bbb3a
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:^6.1.0, @patternfly/react-icons@npm:^6.4.0, @patternfly/react-icons@npm:^6.5.0, @patternfly/react-icons@npm:^6.5.1":
+"@patternfly/react-icons@npm:^6.1.0, @patternfly/react-icons@npm:^6.4.0, @patternfly/react-icons@npm:^6.5.0":
   version: 6.5.1
   resolution: "@patternfly/react-icons@npm:6.5.1"
   peerDependencies:
@@ -8317,7 +8317,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-styles@npm:^6.1.0, @patternfly/react-styles@npm:^6.4.0, @patternfly/react-styles@npm:^6.5.1":
+"@patternfly/react-icons@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "@patternfly/react-icons@npm:6.6.0"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  peerDependencies:
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10c0/55ce255ce1acedc0405c3ceb22c4ac1843b2e19d9c2953bfe3cdd76561b402490bf233ad51b8aa3904616173131da78ab7792c46c9a5d0d859bded3c8dccbc73
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-styles@npm:^6.1.0, @patternfly/react-styles@npm:^6.4.0, @patternfly/react-styles@npm:^6.6.0":
   version: 6.6.0
   resolution: "@patternfly/react-styles@npm:6.6.0"
   checksum: 10c0/067fe58534605b37775fcc1ea0ce5ee69d73c449286bd8e980ca0fa82edf3d0e1ec3f8603d07c69617ab0090fe58dd6f4ed443f1c199675f58623b1a2d82e837
@@ -8341,10 +8353,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-tokens@npm:^6.4.0, @patternfly/react-tokens@npm:^6.5.1":
+"@patternfly/react-tokens@npm:^6.4.0":
   version: 6.5.1
   resolution: "@patternfly/react-tokens@npm:6.5.1"
   checksum: 10c0/3d38d92550d61cd34eea9c7b530b826af31cb929c1da28fd7f0649df12e40753ffdd5655a1ac2cf537d79866f635fcb71562e5ce3f55c32c81986a1f03b07cc2
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-tokens@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "@patternfly/react-tokens@npm:6.6.0"
+  checksum: 10c0/3084a23e28e693163e68a8215a13eea036acf4c528dfbf794dd9b7f994e8e999a33a1874505cadb32c37e8e300d228b4eef3fc746acabae97f7be5ce8d65fd15
   languageName: node
   linkType: hard
 

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -1925,28 +1925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.9.2":
-  version: 1.9.2
-  resolution: "@backstage/backend-plugin-api@npm:1.9.2"
-  dependencies:
-    "@backstage/cli-common": "npm:^0.2.2"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-auth-node": "npm:^0.7.2"
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-permission-node": "npm:^0.11.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/express": "npm:^4.17.6"
-    "@types/json-schema": "npm:^7.0.6"
-    "@types/luxon": "npm:^3.0.0"
-    knex: "npm:^3.0.0"
-    luxon: "npm:^3.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10c0/4ece1a7a599d558954cb5f97d1fd5840a5c8691a4006ebacbbed471588df133535c206cf972c29f4324d41a22b3826379a05149225dcef0e3a864ad7b98d264d
-  languageName: node
-  linkType: hard
-
-"@backstage/backend-plugin-api@npm:^1.9.3":
+"@backstage/backend-plugin-api@npm:^1.9.2, @backstage/backend-plugin-api@npm:^1.9.3":
   version: 1.9.3
   resolution: "@backstage/backend-plugin-api@npm:1.9.3"
   dependencies:
@@ -3100,30 +3079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:^0.7.2":
-  version: 0.7.2
-  resolution: "@backstage/plugin-auth-node@npm:0.7.2"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
-    "@backstage/catalog-client": "npm:^1.16.0"
-    "@backstage/catalog-model": "npm:^1.9.0"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/express": "npm:^4.17.6"
-    "@types/passport": "npm:^1.0.3"
-    express: "npm:^4.22.0"
-    jose: "npm:^5.0.0"
-    lodash: "npm:^4.17.21"
-    passport: "npm:^0.7.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10c0/f03cae9a92db961db544af75852df16ed97a427cdd849b5112d0157551b4444082076821145cc4bc4dce59a7c433c24ea3f65d903dd089447cd554f0a8f5a3bc
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-auth-node@npm:^0.7.3":
+"@backstage/plugin-auth-node@npm:^0.7.2, @backstage/plugin-auth-node@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/plugin-auth-node@npm:0.7.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For [RHIDP-14843](https://redhat.atlassian.net/browse/RHIDP-14843)

Refactor the MCP server configure modal with PatternFly layout and improved credential management:

- Add **Use organization default token** / **Use personal token** radio selectors when an app-config default token is available, replacing the remove-personal-token flow
- Show server status, tools list, and enabled toggle with local draft state applied on Save
- Hide the tools section when the server is disabled; keep status consistent while drafting an unverified personal token
- Disable Save after a failed token validation until the input changes
- Auto-enable the server after a successful personal token save
- Add sortable **Name** and **Status** columns to the MCP servers table, with always-visible sort icons (gray when inactive, directional when active)
- Keep the DCR configure modal aligned with personal-token servers (status, tools, enabled toggle, and Save/Cancel) with an additional DCR info alert and no token input
- Show **Fetching status...** in the Status section while server tools/status are loading
- Bump `@patternfly/react-core` to 6.6.0 and add translations for new modal strings (de, es, fr, it, ja)

The backend now exposes `hasOrgToken` on MCP server list and patch responses so the UI can distinguish organization default tokens from personal-only servers.

Behavior confirmation: ~~[Intelligent-assistant MCP config modal details alignment](https://docs.google.com/document/d/19LSi9GWJ6GmkKWKvBiD6HgDDev7Ik-dbzGXlPsWlfpM/edit?usp=sharing)~~

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

#### Test steps:
[Test steps for Intelligent-assistant plugin](https://docs.google.com/document/d/1RfFFSgLhih1uXnxmwb2r0UUHlR1lMgrlxCZuDRKN_48/edit?usp=sharing)


screen recording(updated on 7/13)

https://github.com/user-attachments/assets/7d87d639-1f4d-447b-a582-7be2942dae7f


