### PR TITLE
fix(fullsend): allow upstream remote harness resources

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -4,3 +4,6 @@ roles:
   - coder
   - review
   - fix
+allowed_remote_resources:
+  - https://raw.githubusercontent.com/fullsend-ai/fullsend/
+  - https://raw.githubusercontent.com/fullsend-ai/agents/


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add the missing `allowed_remote_resources` entries to `.fullsend/config.yaml` so per-repo fullsend runs can resolve remote harness resources from upstream `fullsend-ai/fullsend` and `fullsend-ai/agents`.

## Why this started failing

The failure appears to be caused by upstream Fullsend behavior changes interacting with an older repo-local `.fullsend/config.yaml`.

### Root cause

The triage workflow now resolves the triage harness from `fullsend-ai/agents@v0`, and that harness pulls its pre-script from:

- `https://raw.githubusercontent.com/fullsend-ai/agents/v0/scripts/pre-triage.sh`

Fullsend validates remote harness resources against `allowed_remote_resources` in the repo's `.fullsend/config.yaml`. This repository's config did not include the required raw GitHub prefixes, so harness loading failed with:

> URL is not in `allowed_remote_resources`

### Why it started failing recently

This repo uses floating upstream refs (`v0`), so it picked up recent Fullsend changes without any local config update.

Relevant upstream changes:

- [`fullsend-ai/fullsend@9a39f2ec`](https://github.com/fullsend-ai/fullsend/commit/9a39f2ec1888d71d091057109c1025f9f60640ad)
  `feat(run): add runtime agent resolution from config (ADR 0058 Phase 3)`

- [`fullsend-ai/fullsend@f5cb1490`](https://github.com/fullsend-ai/fullsend/commit/f5cb1490a969b97333285195746132686b655285)
  `fix: load per-repo config.yaml in fullsend run and reusable workflows`

- [`fullsend-ai/agents@c362e3f6`](https://github.com/fullsend-ai/agents/commit/c362e3f6eeb2e78490e58745e4daf652f2abc402)
  Current `v0` tag target at the time of failure

These changes mean Fullsend now actually loads and enforces the per-repo config during runtime agent resolution. That exposed a latent config drift in this repo.

### What drifted

Upstream Fullsend's current config defaults include these allowed remote resource prefixes:

- `https://raw.githubusercontent.com/fullsend-ai/fullsend/`
- `https://raw.githubusercontent.com/fullsend-ai/agents/`

This repo's `.fullsend/config.yaml` did not include them, so remote harness resources from `fullsend-ai/agents` were blocked.

### Proposed fix

Add the missing upstream allowlist entries to `.fullsend/config.yaml`:

```yaml
allowed_remote_resources:
  - https://raw.githubusercontent.com/fullsend-ai/fullsend/
  - https://raw.githubusercontent.com/fullsend-ai/agents/
```

### Summary

This was not caused by a change in the local workflow itself. It was caused by:

1. floating `v0` references pulling in newer upstream Fullsend behavior,
2. newer runtime loading/enforcement of per-repo config,
3. an outdated repo-local `.fullsend/config.yaml` missing the now-required `allowed_remote_resources` entries.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

Made with [Cursor](https://cursor.com)