### PR TITLE
fix(fullsend): bump reusable dispatch workflow

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -50,7 +50,7 @@ jobs:
           || github.event.comment.author_association == 'COLLABORATOR'
         )
       )
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@32f73a4f93301493d2c31be3970aa4c51a26acc7 # v0
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@e22a1eff69ae1e1a4ac1b19927b5c8d4660b0ae7 # v0.29.0
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo


### PR DESCRIPTION
## Description

This updates the Fullsend reusable dispatch workflow pin in `.github/workflows/fullsend.yaml` to a newer released Fullsend commit.

The previous fix added `allowed_remote_resources` to `.fullsend/config.yaml`, but the repository workflow was still pinned to an older `reusable-dispatch.yml` revision that predates the per-repo config loading fixes. As a result, rerunning Fullsend triage could still fail with the same `allowed_remote_resources` error even after the config change merged.

## Changes

- bump `fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml` from `32f73a4f93301493d2c31be3970aa4c51a26acc7` to `e22a1eff69ae1e1a4ac1b19927b5c8d4660b0ae7` (`v0.29.0`)

## Testing

- [ ] Tested locally
- [x] Not tested locally, because this is a GitHub Actions workflow pin change

## Checklist

- [x] Added/updated tests if needed, or explained why not needed
- [x] This PR is not a docs-only change
- [x] This change is scoped to fixing the still-failing Fullsend triage workflow


Made with [Cursor](https://cursor.com)