### PR TITLE
feat(lightspeed)!: remove OFS re-exports from main entry point [RHIDP-15153]

### DIFF
--- a/workspaces/lightspeed/.changeset/bright-waves-flow.md
+++ b/workspaces/lightspeed/.changeset/bright-waves-flow.md
@@ -1,7 +1,14 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-lightspeed': minor
+'@red-hat-developer-hub/backstage-plugin-lightspeed': major
 ---
 
-Graduate the New Frontend System (NFS) plugin from the `./alpha` export to the primary `./` entry point. Legacy (OFS) component exports are still available from the main path (deprecated, will be removed in a future release) and also accessible at `./legacy`. Translations remain at `./alpha`.
+**Breaking:** Legacy (OFS) component exports have been removed from the main `./` entry point and are now exclusively available at the `./legacy` subpath. OFS consumers must update their imports:
 
-Existing OFS dynamic plugin configurations continue to work without changes — `module: Legacy` is advised but not mandatory.
+```diff
+- import { LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-lightspeed';
++ import { LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-lightspeed/legacy';
+```
+
+**New:** Graduate the New Frontend System (NFS) plugin from `./alpha` to the primary `./` entry point.
+
+Translations remain at `./alpha`. Existing OFS dynamic plugin configurations using `module: Legacy` continue to work unchanged.

--- a/workspaces/lightspeed/packages/app-legacy/src/components/Root/Root.tsx
+++ b/workspaces/lightspeed/packages/app-legacy/src/components/Root/Root.tsx
@@ -46,7 +46,7 @@ import {
   LightspeedChatContainer,
   LightspeedDrawerStateExposer,
   LightspeedFAB,
-} from '@red-hat-developer-hub/backstage-plugin-lightspeed';
+} from '@red-hat-developer-hub/backstage-plugin-lightspeed/legacy';
 import { Administration } from '@backstage-community/plugin-rbac';
 import { ApplicationDrawer } from './ApplicationDrawer';
 import LogoFull from './LogoFull';

--- a/workspaces/lightspeed/plugins/lightspeed/README.md
+++ b/workspaces/lightspeed/plugins/lightspeed/README.md
@@ -14,7 +14,7 @@ This plugin supports two frontend systems:
 | `./legacy`     | **OFS** (Old Frontend System) | `@red-hat-developer-hub/backstage-plugin-lightspeed/legacy` |
 | `./alpha`      | Translations only             | `@red-hat-developer-hub/backstage-plugin-lightspeed/alpha`  |
 
-NFS is the primary and recommended mode. OFS is preserved for community consumers until Backstage 2.x drops OFS support.
+NFS is the primary and recommended mode. OFS is available exclusively at the `./legacy` subpath for community consumers until Backstage 2.x drops OFS support.
 
 ## For administrators
 
@@ -261,7 +261,7 @@ Expected: entries for `LightspeedFABModule` and `LightspeedTranslationsModule`.
 
 ### OFS Mode (Scalprum / Legacy)
 
-OFS mode uses Scalprum for dynamic plugin loading. Legacy exports are also available from the default module (PluginRoot), but it is advisable to add `module: Legacy` for clarity. Translation resources require `module: Alpha`:
+OFS mode uses Scalprum for dynamic plugin loading. Legacy exports require `module: Legacy`. Translation resources require `module: Alpha`:
 
 ```yaml
 plugins:
@@ -335,32 +335,32 @@ import { lightspeedFABModule } from '@red-hat-developer-hub/backstage-plugin-lig
 
 ### Legacy / OFS consumers
 
-Legacy component imports from the main package path still work for backwards compatibility, but are deprecated and will be removed in a future release. New OFS consumers should use the `./legacy` subpath:
+Legacy component imports have been **removed from the main package path**. OFS consumers must update imports to use the `./legacy` subpath:
 
 ```ts
-// Still works (deprecated — will be removed in a future release)
+// Before (no longer works)
 import { LightspeedPage, LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-lightspeed';
 
-// Recommended for new OFS consumers
+// After (required)
 import { LightspeedPage, LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-lightspeed/legacy';
 ```
 
 ### Dynamic plugin configuration (OFS)
 
-Legacy exports are available from the default module (PluginRoot), but it is advisable to add `module: Legacy` for clarity:
+Legacy exports are available exclusively from the `Legacy` module. Use `module: Legacy` in your dynamic plugin configuration:
 
 ```yaml
 dynamicRoutes:
   - path: /intelligent-assistant
     importName: LightspeedPage
-    module: Legacy # advisable for clarity, but not mandatory
+    module: Legacy
 ```
 
 ### Dynamic plugin module name change
 
 The `LightspeedPlugin` scalprum module has been removed. Configurations that previously used `module: LightspeedPlugin` should be updated:
 
-- **OFS/Legacy** — omit `module` (defaults to PluginRoot which has legacy exports) or use `module: Legacy` for clarity
+- **OFS/Legacy** — use `module: Legacy` (required since legacy exports are no longer on the default module)
 - **NFS** — use the default `module: PluginRoot` (or omit `module` entirely)
 
 ```yaml
@@ -370,9 +370,9 @@ dynamicRoutes:
     importName: LightspeedPage
     module: LightspeedPlugin
 
-# After (OFS — either works)
+# After (OFS)
 dynamicRoutes:
   - path: /intelligent-assistant
     importName: LightspeedPage
-    module: Legacy  # or omit module entirely
+    module: Legacy
 ```

--- a/workspaces/lightspeed/plugins/lightspeed/app-config.dynamic.yaml
+++ b/workspaces/lightspeed/plugins/lightspeed/app-config.dynamic.yaml
@@ -16,8 +16,7 @@ dynamicPlugins:
 
       # OFS (Old Frontend System) deployment configuration:
 
-      # Note: Legacy exports are also available from the default module (PluginRoot),
-      # but it is advisable to add `module: Legacy` for clarity.
+      # Legacy exports require `module: Legacy` — they are not available on the default module.
       translationResources:
         - importName: lightspeedTranslations
           module: Alpha
@@ -25,15 +24,20 @@ dynamicPlugins:
       dynamicRoutes:
         - path: /intelligent-assistant
           importName: LightspeedPage
+          module: Legacy
       mountPoints:
         - mountPoint: application/listener
           importName: LightspeedFAB
+          module: Legacy
         - mountPoint: application/provider
           importName: LightspeedDrawerProvider
+          module: Legacy
         - mountPoint: application/internal/drawer-state
           importName: LightspeedDrawerStateExposer
+          module: Legacy
         - mountPoint: application/internal/drawer-content
           importName: LightspeedChatContainer
+          module: Legacy
           config:
             id: lightspeed
             priority: 100

--- a/workspaces/lightspeed/plugins/lightspeed/report.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report.api.md
@@ -7,7 +7,6 @@ import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { AppDrawerContent } from '@red-hat-developer-hub/backstage-plugin-app-react';
-import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
@@ -15,15 +14,10 @@ import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendModule } from '@backstage/frontend-plugin-api';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
-import { JSX as JSX_3 } from 'react/jsx-runtime';
 import { OverridableExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
-import { PathParams } from '@backstage/core-plugin-api';
-import { PropsWithChildren } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
-import { RouteRef as RouteRef_2 } from '@backstage/core-plugin-api';
 import { SubRouteRef } from '@backstage/frontend-plugin-api';
-import { SubRouteRef as SubRouteRef_2 } from '@backstage/core-plugin-api';
 
 // @public
 const _default: OverridableFrontendPlugin<
@@ -168,56 +162,8 @@ const _default: OverridableFrontendPlugin<
 >;
 export default _default;
 
-// @public
-export type DrawerState = {
-  id: string;
-  isDrawerOpen: boolean;
-  drawerWidth: number;
-  setDrawerWidth: (width: number) => void;
-  closeDrawer: () => void;
-};
-
-// @public
-export type DrawerStateExposerProps = {
-  onStateChange: (state: DrawerState) => void;
-};
-
-// @public (undocumented)
-export const LightspeedChatContainer: () => JSX_3.Element;
-
-// @public
-export const LightspeedDrawerProvider: React.ComponentType<PropsWithChildren>;
-
-// @public
-export const LightspeedDrawerStateExposer: (
-  input: DrawerStateExposerProps,
-) => null;
-
-// @public
-export const LightspeedFAB: () => JSX_3.Element | null;
-
 // @public (undocumented)
 export const lightspeedFABModule: FrontendModule;
-
-// @public
-export const LightspeedIcon: () => JSX_3.Element;
-
-// @public
-export const LightspeedPage: () => JSX_3.Element;
-
-// @public
-export const lightspeedPlugin: BackstagePlugin<
-  {
-    root: RouteRef_2<undefined>;
-    lightspeedConversation: SubRouteRef_2<
-      PathParams<'/conversation/:conversationId'>
-    >;
-    lightspeedNotebooks: SubRouteRef_2<undefined>;
-    lightspeedNotebookView: SubRouteRef_2<PathParams<'/notebooks/:notebookId'>>;
-  },
-  {},
-  {}
->;
 
 // @public (undocumented)
 export const lightspeedRedirectModule: FrontendModule;

--- a/workspaces/lightspeed/plugins/lightspeed/src/index.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/index.tsx
@@ -202,16 +202,3 @@ export default createFrontendPlugin({
     lightspeedConversation: nfsConversationRouteRef,
   },
 });
-
-// Legacy (OFS) re-exports for backwards compatibility.
-// Deprecated — will be removed in a future release. Use './legacy' subpath for new OFS consumers.
-export {
-  lightspeedPlugin,
-  LightspeedPage,
-  LightspeedDrawerProvider,
-  LightspeedIcon,
-  LightspeedFAB,
-  LightspeedChatContainer,
-  LightspeedDrawerStateExposer,
-} from './legacy';
-export type { DrawerStateExposerProps, DrawerState } from './legacy';


### PR DESCRIPTION
## Description

Remove legacy (OFS) component re-exports from the main `./` entry point of `@red-hat-developer-hub/backstage-plugin-lightspeed`. OFS consumers must now import from the `./legacy` subpath exclusively. This is a breaking change that graduates the New Frontend System (NFS) plugin to the primary entry point while keeping OFS available at `./legacy` for community consumers until Backstage 2.x drops OFS support.

Updates documentation (README, `app-config.dynamic.yaml`) to reflect that `module: Legacy` is now required for all OFS dynamic plugin configurations, and bumps the changeset to `major`.

## Fixed
- [RHIDP-15153](https://redhat.atlassian.net/browse/RHIDP-15153) — [Lightspeed] Remove legacy OFS re-exports from main entry point

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)