### PR TITLE
feat(orchestrator-form): enable backward navigation in multi-step stepper

### DIFF
--- a/workspaces/orchestrator/.changeset/orchestrator-multi-step-stepper-back-nav.md
+++ b/workspaces/orchestrator/.changeset/orchestrator-multi-step-stepper-back-nav.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Enable backward navigation in multi-step workflow forms by clicking completed stepper steps, while keeping the current and future steps display-only.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormStepper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormStepper.tsx
@@ -16,12 +16,14 @@
 
 import Button from '@mui/material/Button';
 import Step from '@mui/material/Step';
+import StepButton from '@mui/material/StepButton';
 import StepLabel from '@mui/material/StepLabel';
 import Stepper from '@mui/material/Stepper';
 import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { isBackwardStepNavigable } from '../utils/isBackwardStepNavigable';
 import { useStepperContext } from '../utils/StepperContext';
 import SubmitButton from './SubmitButton';
 
@@ -45,6 +47,10 @@ const useStyles = makeStyles()(theme => ({
   formWrapper: {
     padding: theme.spacing(2),
   },
+  stepper: {
+    overflowX: 'auto',
+    overflowY: 'hidden',
+  },
 }));
 
 export type OrchestratorFormStep = {
@@ -60,7 +66,7 @@ const OrchestratorFormStepper = ({
 }) => {
   const { t } = useTranslation();
   const { classes } = useStyles();
-  const { activeStep, reviewStep } = useStepperContext();
+  const { activeStep, goToStep, reviewStep } = useStepperContext();
   const stepsWithReview = [
     ...steps,
     { content: reviewStep, title: t('common.review'), key: 'review' },
@@ -71,22 +77,37 @@ const OrchestratorFormStepper = ({
       <Stepper
         activeStep={activeStep}
         variant="elevation"
-        style={{ overflowX: 'auto' }}
+        className={classes.stepper}
         alternativeLabel
       >
-        {stepsWithReview?.map((step, index) => (
-          <Step key={step.key} className={classes.step}>
-            <StepLabel
-              aria-label={`Step ${index + 1} ${step.title}`}
-              aria-disabled="false"
-              tabIndex={0}
+        {stepsWithReview?.map((step, index) => {
+          const canNavigateBack = isBackwardStepNavigable(index, activeStep);
+          const stepLabel = (
+            <Typography variant="h6" component="h2">
+              {step.title}
+            </Typography>
+          );
+          const ariaLabel = `Step ${index + 1} ${step.title}`;
+
+          return (
+            <Step
+              key={step.key}
+              className={classes.step}
+              completed={canNavigateBack}
             >
-              <Typography variant="h6" component="h2">
-                {step.title}
-              </Typography>
-            </StepLabel>
-          </Step>
-        ))}
+              {canNavigateBack ? (
+                <StepButton
+                  onClick={() => goToStep(index)}
+                  aria-label={ariaLabel}
+                >
+                  {stepLabel}
+                </StepButton>
+              ) : (
+                <StepLabel aria-label={ariaLabel}>{stepLabel}</StepLabel>
+              )}
+            </Step>
+          );
+        })}
       </Stepper>
       <div className={classes.formWrapper}>
         {stepsWithReview[activeStep].content}

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorFormWrapper.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { ErrorPanel } from '@backstage/core-components';
 import { JsonObject } from '@backstage/types';
@@ -38,6 +38,7 @@ import {
   rjsfIdToFieldPath,
 } from '../utils/clearExtraErrorAtPath';
 import { getActiveStepKey } from '../utils/getSortedStepEntries';
+import { normalizeErrorSchema } from '../utils/resolveStepErrorSchema';
 import { useStepperContext } from '../utils/StepperContext';
 import { toRootExtraErrors } from '../utils/toRootExtraErrors';
 import useValidator from '../utils/useValidator';
@@ -58,11 +59,26 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
   >();
   const numStepsInMultiStepSchema = formContext?.numStepsInMultiStepSchema;
   const isMultiStep = numStepsInMultiStepSchema !== undefined;
-  const { handleNext, activeStep, handleValidateStarted, handleValidateEnded } =
-    useStepperContext();
+  const {
+    handleNext,
+    activeStep,
+    handleValidateStarted,
+    handleValidateEnded,
+    clearFormErrorsRef,
+  } = useStepperContext();
   const [validationError, setValidationError] = useState<Error | undefined>();
   const validator = useValidator(isMultiStep);
   const { t } = useTranslation();
+
+  useEffect(() => {
+    clearFormErrorsRef.current = () => {
+      setExtraErrors(undefined);
+      setValidationError(undefined);
+    };
+    return () => {
+      clearFormErrorsRef.current = undefined;
+    };
+  }, [clearFormErrorsRef]);
 
   if (!formContext) {
     return <div>{t('formDecorator.error')}</div>;
@@ -107,7 +123,9 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
           extraErrorsUiSchema,
         );
 
-        setExtraErrors(toRootExtraErrors(activeKey, _extraErrors));
+        setExtraErrors(
+          normalizeErrorSchema(toRootExtraErrors(activeKey, _extraErrors)),
+        );
       } catch (err) {
         _validationError = err as Error;
       } finally {
@@ -166,7 +184,7 @@ const FormComponent = (decoratorProps: FormDecoratorProps) => {
           formData={formData}
           formContext={formContext}
           noHtml5Validate
-          extraErrors={extraErrors}
+          extraErrors={normalizeErrorSchema(extraErrors)}
           onSubmit={e => onSubmit(e.formData || {})}
           onChange={onChange}
         >

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/StepperObjectField.tsx
@@ -23,6 +23,8 @@ import type { JSONSchema7 } from 'json-schema';
 
 import { useTranslation } from '../hooks/useTranslation';
 import { getSortedStepEntries } from '../utils/getSortedStepEntries';
+import { resolveStepErrorSchema } from '../utils/resolveStepErrorSchema';
+import { useStepperContext } from '../utils/StepperContext';
 import OrchestratorFormStepper, {
   OrchestratorFormStep,
   OrchestratorFormToolbar,
@@ -39,6 +41,7 @@ const StepperObjectField = ({
   ...props
 }: FieldProps<JsonObject, JSONSchema7>) => {
   const { t } = useTranslation();
+  const { activeStep } = useStepperContext();
 
   const sortedStepEntries = useMemo(
     () => getSortedStepEntries(schema, formData),
@@ -47,6 +50,8 @@ const StepperObjectField = ({
   if (sortedStepEntries === undefined) {
     throw new Error(t('stepperObjectField.error'));
   }
+
+  const activeStepKey = sortedStepEntries[activeStep]?.[0];
 
   const steps = sortedStepEntries.reduce<OrchestratorFormStep[]>(
     (prev, [key, subSchema]) => {
@@ -75,7 +80,11 @@ const StepperObjectField = ({
                     ObjectField: ObjectField, // undo override of objectfield
                   },
                 }}
-                errorSchema={errorSchema?.[key] as ErrorSchema<JsonObject>}
+                errorSchema={resolveStepErrorSchema(
+                  errorSchema as ErrorSchema<JsonObject>,
+                  key,
+                  activeStepKey,
+                )}
               />
               <OrchestratorFormToolbar />
             </>

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/StepperContext.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/StepperContext.tsx
@@ -14,14 +14,25 @@
  * limitations under the License.
  */
 
-import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  MutableRefObject,
+  ReactNode,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { TranslationFunction } from '../hooks/useTranslation';
+import { isBackwardStepNavigable } from './isBackwardStepNavigable';
 
 export type StepperContext = {
   activeStep: number;
   handleNext: () => void;
   handleBack: () => void;
+  goToStep: (step: number) => void;
+  clearFormErrorsRef: MutableRefObject<(() => void) | undefined>;
   reviewStep: ReactNode;
   isValidating: boolean;
   handleValidateStarted: () => void;
@@ -54,14 +65,30 @@ export const StepperContextProvider = ({
   const [activeStep, setActiveStep] = useState<number>(0);
   const [isValidating, setIsValidating] = useState<boolean>(false);
   const [fetchingCount, setFetchingCount] = useState<number>(0);
+  const clearFormErrorsRef = useRef<(() => void) | undefined>();
 
   const contextData = useMemo(() => {
+    const clearFormErrors = () => clearFormErrorsRef.current?.();
+
     return {
       activeStep,
+      clearFormErrorsRef,
       handleNext: () => {
         setActiveStep(curActiveStep => curActiveStep + 1);
       },
-      handleBack: () => setActiveStep(curActiveStep => curActiveStep - 1),
+      handleBack: () => {
+        clearFormErrors();
+        setActiveStep(curActiveStep => curActiveStep - 1);
+      },
+      goToStep: (step: number) => {
+        setActiveStep(curActiveStep => {
+          if (!isBackwardStepNavigable(step, curActiveStep)) {
+            return curActiveStep;
+          }
+          clearFormErrors();
+          return step;
+        });
+      },
       reviewStep,
       isValidating,
       handleValidateStarted: () => setIsValidating(true),
@@ -80,6 +107,7 @@ export const StepperContextProvider = ({
     setIsValidating,
     fetchingCount,
     setFetchingCount,
+    clearFormErrorsRef,
   ]);
   return <context.Provider value={contextData}>{children}</context.Provider>;
 };

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/isBackwardStepNavigable.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/isBackwardStepNavigable.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isBackwardStepNavigable } from './isBackwardStepNavigable';
+
+describe('isBackwardStepNavigable', () => {
+  it('allows navigating to any step before the active step', () => {
+    expect(isBackwardStepNavigable(0, 2)).toBe(true);
+    expect(isBackwardStepNavigable(1, 2)).toBe(true);
+  });
+
+  it('disallows the active step and future steps', () => {
+    expect(isBackwardStepNavigable(2, 2)).toBe(false);
+    expect(isBackwardStepNavigable(3, 2)).toBe(false);
+  });
+
+  it('disallows negative step indices', () => {
+    expect(isBackwardStepNavigable(-1, 2)).toBe(false);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/isBackwardStepNavigable.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/isBackwardStepNavigable.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** True when the user may jump to `targetStep` from `activeStep` (backward only). */
+export const isBackwardStepNavigable = (
+  targetStep: number,
+  activeStep: number,
+): boolean => targetStep >= 0 && targetStep < activeStep;

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/resolveStepErrorSchema.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/resolveStepErrorSchema.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ERRORS_KEY } from '@rjsf/utils';
+
+import {
+  isFieldErrorSchema,
+  normalizeErrorSchema,
+  resolveStepErrorSchema,
+} from './resolveStepErrorSchema';
+
+describe('resolveStepErrorSchema', () => {
+  it('returns the nested slice when the root error schema is keyed by step', () => {
+    const stepErrors = { fieldA: { [ERRORS_KEY]: ['required'] } };
+    const tree = { stepOne: stepErrors };
+
+    expect(resolveStepErrorSchema(tree, 'stepOne', 'stepOne')).toStrictEqual(
+      stepErrors,
+    );
+  });
+
+  it('returns the root error schema when it is already scoped to the active step', () => {
+    const slice = { fieldA: { [ERRORS_KEY]: ['required'] } };
+
+    expect(resolveStepErrorSchema(slice, 'stepOne', 'stepOne')).toStrictEqual(
+      slice,
+    );
+  });
+
+  it('returns undefined for non-active steps without a nested slice', () => {
+    const slice = { fieldA: { [ERRORS_KEY]: ['required'] } };
+
+    expect(resolveStepErrorSchema(slice, 'stepTwo', 'stepOne')).toBeUndefined();
+  });
+});
+
+describe('normalizeErrorSchema', () => {
+  it('coerces string __errors values to arrays', () => {
+    expect(normalizeErrorSchema({ [ERRORS_KEY]: 'invalid' } as any)).toEqual({
+      [ERRORS_KEY]: ['invalid'],
+    });
+  });
+
+  it('normalizes nested error trees', () => {
+    expect(
+      normalizeErrorSchema({
+        stepOne: { fieldA: { [ERRORS_KEY]: 'required' } },
+      } as any),
+    ).toEqual({
+      stepOne: { fieldA: { [ERRORS_KEY]: ['required'] } },
+    });
+  });
+});
+
+describe('isFieldErrorSchema', () => {
+  it('detects field-level error objects', () => {
+    expect(isFieldErrorSchema({ [ERRORS_KEY]: ['msg'] })).toBe(true);
+  });
+
+  it('rejects non-array __errors values', () => {
+    expect(isFieldErrorSchema({ [ERRORS_KEY]: 'msg' })).toBe(false);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/resolveStepErrorSchema.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/resolveStepErrorSchema.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import { ERRORS_KEY, ErrorSchema } from '@rjsf/utils';
+
+/**
+ * RJSF expects every `__errors` entry to be an array. Coerce invalid values.
+ */
+export function normalizeErrorSchema(
+  errorSchema: ErrorSchema<JsonObject> | undefined,
+): ErrorSchema<JsonObject> | undefined {
+  if (!errorSchema || typeof errorSchema !== 'object') {
+    return undefined;
+  }
+
+  const normalized = { ...errorSchema } as JsonObject;
+  const rootErrors = normalized[ERRORS_KEY];
+
+  if (rootErrors !== undefined) {
+    normalized[ERRORS_KEY] = Array.isArray(rootErrors)
+      ? rootErrors
+      : [String(rootErrors)];
+  }
+
+  for (const key of Object.keys(normalized)) {
+    if (key === ERRORS_KEY) {
+      continue;
+    }
+    const child = normalizeErrorSchema(
+      normalized[key] as ErrorSchema<JsonObject>,
+    );
+    if (child === undefined) {
+      delete normalized[key];
+    } else {
+      normalized[key] = child;
+    }
+  }
+
+  return normalized as ErrorSchema<JsonObject>;
+}
+
+/**
+ * Resolves the RJSF error schema for one wizard step. The root form may pass
+ * either a full multi-step tree or a slice scoped to the active step only.
+ */
+export function resolveStepErrorSchema(
+  errorSchema: ErrorSchema<JsonObject> | undefined,
+  stepKey: string,
+  activeStepKey: string | undefined,
+): ErrorSchema<JsonObject> | undefined {
+  if (!errorSchema) {
+    return undefined;
+  }
+
+  const nested = errorSchema[stepKey] as ErrorSchema<JsonObject> | undefined;
+  if (nested !== undefined) {
+    return normalizeErrorSchema(nested);
+  }
+
+  if (stepKey === activeStepKey) {
+    return normalizeErrorSchema(errorSchema);
+  }
+
+  return undefined;
+}
+
+/** True when `node` is a field-level error object (has an `__errors` array). */
+export function isFieldErrorSchema(node: unknown): boolean {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    Array.isArray((node as JsonObject)[ERRORS_KEY])
+  );
+}

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/useValidator.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/useValidator.ts
@@ -31,6 +31,7 @@ import _validator from '@rjsf/validator-ajv8';
 import type { JSONSchema7 } from 'json-schema';
 
 import { getActiveStepKey } from './getSortedStepEntries';
+import { normalizeErrorSchema } from './resolveStepErrorSchema';
 import { useStepperContext } from './StepperContext';
 
 // add the activeStep to the validator to force rjsf form to rerender when activeStep changes. This doesn't happen because it assumes function are equal.
@@ -74,7 +75,10 @@ const useValidator = (isMultiStepSchema: boolean) => {
         errors: validationData.errors.filter(err =>
           err.property?.startsWith(`.${activeKey}.`),
         ),
-        errorSchema: validationData.errorSchema[activeKey] || {},
+        errorSchema:
+          normalizeErrorSchema(
+            validationData.errorSchema[activeKey] as ErrorSchema<JsonObject>,
+          ) || {},
       };
     },
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useGetExtraErrors.ts
@@ -101,7 +101,9 @@ export const useGetExtraErrors = () => {
               evaluatedValidateUrl,
             });
             safeSet(errors, path, {
-              [ERRORS_KEY]: `The validate:url is not evaluated to a string: "${validateUrl}"`,
+              [ERRORS_KEY]: [
+                `The validate:url is not evaluated to a string: "${validateUrl}"`,
+              ],
             });
           } else {
             const evaluatedRequestInit = await getRequestInit(
@@ -119,7 +121,9 @@ export const useGetExtraErrors = () => {
               const data = await parseValidationErrorBody(response);
               if (!data || Object.keys(data).length === 0) {
                 safeSet(errors, path, {
-                  [ERRORS_KEY]: `Validation request failed with status ${response.status}`,
+                  [ERRORS_KEY]: [
+                    `Validation request failed with status ${response.status}`,
+                  ],
                 });
                 return;
               }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Story - https://redhat.atlassian.net/browse/RHIDP-15114

## Summary

- Allow users to click completed stepper steps in multi-step workflow forms to jump back to earlier steps
- Clear stale async validation errors when navigating backward (Back or stepper click)
- Resolve per-step error schemas correctly when jumping between steps
- Fix `useGetExtraErrors` to set RJSF `__errors` as arrays (prevents crashes when `validate:url` fails)


https://github.com/user-attachments/assets/5192de11-7862-4eae-84cf-b147b09596ef



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
