### PR TITLE
fix(fullsend): register local code/fix agent harnesses

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -4,6 +4,15 @@ roles:
   - coder
   - review
   - fix
+# Prefer the repo-local customized code/fix harnesses over the transitional
+# fullsend-ai/agents fallback. Without this, v0.29+ resolves those agents from
+# the agents repo (stock image/policy) and skips .fullsend/customized/, which
+# breaks yarn install in the rhdh-plugins monorepo sandbox.
+agents:
+  # Paths are relative to .fullsend/. Point at customized/ directly so the
+  # files exist in git before prepare-workspace overlays them onto harness/.
+  - source: customized/harness/code.yaml
+  - source: customized/harness/fix.yaml
 allowed_remote_resources:
   - https://raw.githubusercontent.com/fullsend-ai/fullsend/
   - https://raw.githubusercontent.com/fullsend-ai/agents/

--- a/.fullsend/customized/harness/code.yaml
+++ b/.fullsend/customized/harness/code.yaml
@@ -1,6 +1,6 @@
-# forked-from: fullsend v0.17.0 scaffold
-# last-synced: 2026-06-16
-# harness/code.yaml — code agent with pre/post script pipeline.
+# forked-from: fullsend v0.17.0 scaffold / agents harness
+# last-synced: 2026-07-08
+# harness/code.yaml — RHDH-customized code agent.
 #
 # Flow: pre_script → sandbox (agent) → post_script
 #   pre_script  : validates inputs on the runner BEFORE sandbox creation
@@ -10,12 +10,14 @@
 # The agent NEVER pushes or creates PRs (disallowedTools enforces this).
 # Only the post-script, running on the runner with PUSH_TOKEN, can write.
 #
-# Customizations over upstream code.yaml:
+# Customizations over upstream agents harness:
 #   - image: rhdh custom image with yarn/corepack pre-installed
-#   - policy: custom code policy with repo.yarnpkg.com for corepack downloads
-#   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
-#   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
+#   - policy: custom code policy with allow_encoded_slash + repo.yarnpkg.com
+#   - host_files: rhdh-toolchain.env (COREPACK_HOME) + yarn-proxy.env
+#   - skills: rhdh-workspace for monorepo workspace routing
+#   - timeout_minutes: 45 (monorepo yarn install needs headroom)
 role: coder
+slug: fullsend-ai-coder
 agent: agents/code.md
 doc: docs/agents/code.md
 model: opus
@@ -49,6 +51,11 @@ skills:
 plugins:
   - plugins/gopls-lsp
 
+validation_loop:
+  script: scripts/validate-output-schema.sh
+  schema: schemas/code-result.schema.json
+  max_iterations: 2
+
 # Environment variables available to post_script on the runner.
 # These are expanded from the runner environment and NEVER enter the sandbox.
 runner_env:
@@ -58,5 +65,17 @@ runner_env:
   ISSUE_NUMBER: "${ISSUE_NUMBER}"
   REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"
   TARGET_BRANCH: "${TARGET_BRANCH}"
+  FULLSEND_OUTPUT_FILE: code-result.json
 
 timeout_minutes: 45
+
+forge:
+  github:
+    pre_script: scripts/pre-code.sh
+    post_script: scripts/post-code.sh
+    runner_env:
+      PUSH_TOKEN: "${PUSH_TOKEN}"
+      PUSH_TOKEN_SOURCE: "${PUSH_TOKEN_SOURCE}"
+      REPO_FULL_NAME: "${REPO_FULL_NAME}"
+      ISSUE_NUMBER: "${ISSUE_NUMBER}"
+      REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"

--- a/.fullsend/customized/harness/fix.yaml
+++ b/.fullsend/customized/harness/fix.yaml
@@ -1,24 +1,21 @@
-# forked-from: fullsend v0.17.0 scaffold
-# last-synced: 2026-06-16
-# harness/fix.yaml — fix agent with yarn sandbox workaround.
-#
-# Based on upstream fix.yaml. The fix agent handles
-# automated fixes triggered by /fs-fix commands on issues or PRs.
+# forked-from: fullsend v0.17.0 scaffold / agents harness
+# last-synced: 2026-07-08
+# harness/fix.yaml — RHDH-customized fix agent with yarn sandbox workaround.
 #
 # Flow: pre_script → sandbox (agent) → validation_loop → post_script
-#   pre_script       : validates inputs, checks iteration cap
+#   pre_script       : validates inputs, checks iteration cap, rebases onto target
 #   agent            : reads pre-fetched review body, fixes code, tests, scans, commits
 #   validation_loop  : validates output schema (max 2 iterations)
 #   post_script      : push commit, post summary comment on PR
 #
-# Customizations over upstream fix.yaml:
+# Customizations over upstream agents harness:
 #   - pre_script: wraps upstream pre-fix.sh with auto-rebase onto target branch
 #   - image: rhdh custom image with yarn/corepack pre-installed
-#   - host_files: rhdh-toolchain.env sets COREPACK_HOME to writable /tmp/corepack
-#   - host_files: yarn-proxy.env maps OpenShell's HTTP_PROXY to YARN_HTTP_PROXY
+#   - host_files: rhdh-toolchain.env + yarn-proxy.env
 #   - skills: adds rhdh-workspace for workspace navigation + test scoping
-#   - policy: custom fix policy with yarn registry + pnpm binary allowlist
+#   - policy: custom fix policy with yarn registry + allow_encoded_slash
 role: fix
+slug: fullsend-ai-coder
 agent: agents/fix.md
 doc: docs/agents/fix.md
 model: opus
@@ -26,12 +23,12 @@ image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 policy: policies/fix.yaml
 
 pre_script: scripts/pre-fix-rebase.sh
+post_script: scripts/post-fix.sh
 
 validation_loop:
   script: scripts/validate-output-schema.sh
+  schema: schemas/fix-result.schema.json
   max_iterations: 2
-
-post_script: scripts/post-fix.sh
 
 host_files:
   - src: env/gcp-vertex.env
@@ -68,7 +65,29 @@ runner_env:
   FIX_ITERATION: "${FIX_ITERATION}"
   REVIEW_BODY_FILE: "${REVIEW_BODY_FILE}"
   PRE_AGENT_HEAD: "${PRE_AGENT_HEAD}"
-  FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/fix-result.schema.json
   FULLSEND_OUTPUT_FILE: fix-result.json
 
 timeout_minutes: 90
+
+forge:
+  github:
+    pre_script: scripts/pre-fix-rebase.sh
+    post_script: scripts/post-fix.sh
+    env:
+      runner:
+        PUSH_TOKEN: "${PUSH_TOKEN}"
+        PUSH_TOKEN_SOURCE: "${PUSH_TOKEN_SOURCE}"
+        REPO_FULL_NAME: "${REPO_FULL_NAME}"
+        PR_NUMBER: "${PR_NUMBER}"
+        REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"
+      sandbox:
+        PR_NUMBER: "${PR_NUMBER}"
+        REPO_FULL_NAME: "${REPO_FULL_NAME}"
+        TRIGGER_SOURCE: "${TRIGGER_SOURCE}"
+        HUMAN_INSTRUCTION: "${HUMAN_INSTRUCTION}"
+        FIX_ITERATION: "${FIX_ITERATION}"
+        GH_TOKEN: "${GH_TOKEN}"
+        GIT_AUTHOR_NAME: "fullsend-fix"
+        GIT_AUTHOR_EMAIL: "${GIT_BOT_EMAIL}"
+        GIT_COMMITTER_NAME: "fullsend-fix"
+        GIT_COMMITTER_EMAIL: "${GIT_BOT_EMAIL}"


### PR DESCRIPTION
## Description

After #3702 bumped the Fullsend reusable dispatch workflow to v0.29, unconfigured agents fall back to `fullsend-ai/agents`. That stock harness uses `ghcr.io/fullsend-ai/fullsend-code:latest` and a policy without `allow_encoded_slash`, so the repo-local `.fullsend/customized/` RHDH image, yarn policy, and toolchain env never load.

That caused `/fs-code` on #3694 to report success while producing no PR: the agent timed out during `yarn install` (`yarn: command not found`, `corepack` EACCES under `/usr`, repeated `registry.npmjs.org` `%2F` denials), then the post-script exited with `No changed files in agent's commit(s) — nothing to do`.

This PR registers the local customized `code`/`fix` harnesses in `.fullsend/config.yaml` so config resolution beats the agents-repo fallback, and updates those harnesses for the current Fullsend schema while keeping the RHDH image and yarn sandbox customizations.

## Changes

- add `agents:` entries for `customized/harness/code.yaml` and `customized/harness/fix.yaml`
- modernize local code/fix harnesses (`role`/`slug`, `validation_loop.schema`, `forge.github`) while retaining:
  - `ghcr.io/redhat-developer/rhdh-fullsend-code:latest`
  - custom policies with `allow_encoded_slash` / `repo.yarnpkg.com`
  - `rhdh-toolchain.env` + `yarn-proxy.env`
  - `rhdh-workspace` skill

## Testing

- [ ] Tested locally
- [x] Not tested locally, because this is Fullsend harness/config wiring validated against the failed #3694 code-run artifact (`fullsend-code` from run 28977719758)

## Checklist

- [x] Added/updated tests if needed, or explained why not needed
- [x] This PR is not a docs-only change
- [x] After merge, re-run `/fs-code` on #3694 and confirm the run log uses the RHDH image and does not say `Fetching agent code from fullsend-ai/agents`


Made with [Cursor](https://cursor.com)