### PR TITLE
chore(ai-integrations): add openspec for RHIDP-15200 KFMR client code removal

### DIFF
--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/.openspec.yaml
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-07-09
+status: draft

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/design.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/design.md
@@ -143,7 +143,7 @@ After all changes:
 1. `yarn tsc` passes with no errors
 2. `yarn build:all` succeeds
 3. `yarn test:all` passes (existing tests in the workspace)
-4. No remaining imports or references to `Kfmr` in any `.ts` file under `kserve-kubeflow-connector-backend/src/`
+4. No remaining imports or references to `Kfmr` in any `.ts` file under `plugins/kserve-kubeflow-connector-backend/src/`
 5. No remaining references to `KFMRClient`, `kfmrClients`, `kfmrRoutes`, `setupKFMR`, `loopOverKFMR`, `processKFMR`, or `KubeflowNormalizer`
 6. `PropertyKeys` is importable from `types.ts` and `KServe.ts` compiles using the new import
 7. `getModelCard()` is callable from the relocated catalog module and the `CatalogModel` type is available from `types.ts`

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/design.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/design.md
@@ -1,0 +1,122 @@
+# Design: Remove KubeFlow Model Registry (KFMR) Client Code
+
+## Canonical Touchpoints
+
+- Parent design: `openspec/changes/transition-oai-connector-to-kserve-plugin/design.md` — Decision 4
+- Jira: [RHIDP-15200](https://redhat.atlassian.net/browse/RHIDP-15200)
+
+## Context
+
+The `kserve-kubeflow-connector-backend` plugin was ported from a golang model-catalog-bridge that supported two data paths:
+
+1. **KServe path** — K8s Informer watches `InferenceService` CRs, `KServe.ts` converts them to `ModelCatalog` JSON
+2. **KFMR path** — REST client calls KubeFlow Model Registry APIs to fetch `RegisteredModel`, `ModelVersion`, `ModelArtifact`, and `KFMRInferenceService` data, `Kfmr.ts` converts them to `ModelCatalog` JSON
+
+RHDHPLAN-404 scopes in only KServe + KubeFlow Model Catalog. The KFMR path must be removed.
+
+The complication is that `Kfmr.ts` is not purely KFMR client code — it also contains shared utilities (`PropertyKeys`, `NormalizerFormat`, `getTagsFromCustomProps`, `getStringPropVal`, `sanitizeName`, `sanitizeModelVersion`) and re-exports model types (`ModelCatalog`, `Model`, `ModelServer`, `API`, `APIType`) that are consumed by `KServe.ts` and `InformerService.ts`. These must be relocated before deletion.
+
+### Current dependency graph
+
+```
+InformerService.ts
+  ├── imports from Kfmr.ts: setupKFMR, loopOverKFMR, callBackstagePrinters,
+  │    getKubeFlowInferenceServicesForModelVersion, sanitizeName (as kfmrSanitizeName),
+  │    KFMRClient, KFMRInferenceService
+  ├── imports from KServe.ts: callBackstagePrinters (as callKServeBackstagePrinters)
+  └── imports from types.ts: ReconcilerConfig, InferenceService, etc.
+
+KServe.ts
+  └── imports from Kfmr.ts: PropertyKeys
+
+Kfmr.ts
+  └── imports from types.ts: ReconcilerConfig, Route, RegisteredModel, etc.
+  └── re-exports: ModelCatalog, Model, ModelServer, API, APIType (from types.ts)
+```
+
+### Target dependency graph (after removal)
+
+```
+InformerService.ts
+  ├── imports from KServe.ts: callBackstagePrinters
+  └── imports from types.ts: ReconcilerConfig, InferenceService, PropertyKeys,
+       NormalizerFormat, sanitizeName, etc.
+
+KServe.ts
+  └── imports from types.ts: PropertyKeys, getStringPropVal, getTagsFromCustomProps, etc.
+
+(Kfmr.ts — deleted)
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Delete `Kfmr.ts` entirely
+- Remove all KFMR-specific types from `types.ts`
+- Remove all KFMR logic from `InformerService.ts` (imports, `processKFMR`, label constants, `KubeflowNormalizer`)
+- Relocate shared utilities so `KServe.ts` and `InformerService.ts` continue to compile
+- Remove KFMR fields from `ReconcilerConfig`
+- Maintain all KServe + KubeFlow Model Catalog functionality unchanged
+- `yarn build:all`, `yarn tsc`, and existing tests pass after removal
+
+**Non-Goals:**
+
+- Refactoring InformerService beyond KFMR removal (console.log migration, concurrency patterns — separate tasks)
+- Adding new unit tests (separate Jira)
+- Changing the connector's REST API routes
+- Removing KubeFlow Model Catalog API support (that stays)
+
+## Decisions
+
+### D1 — Relocate shared utilities to `types.ts`
+
+**Choice:** Move `PropertyKeys`, `NormalizerFormat`, `getTagsFromCustomProps`, `getStringPropVal`, `sanitizeName`, `sanitizeModelVersion`, and the model type re-exports (`ModelCatalog`, `Model`, `ModelServer`, `API`, `APIType`) from `Kfmr.ts` into `types.ts`.
+
+**Rationale:** `types.ts` already serves as the shared type/constant module for the connector (its header comment says "Shared types and constants to avoid circular dependencies between InformerService.ts and Kfmr.ts"). With Kfmr.ts gone, it becomes the natural home. Creating a new `constants.ts` would add a file for content that fits in the existing module.
+
+**Alternative considered:** Create a new `shared.ts` or `constants.ts`. Rejected because `types.ts` already plays this role and the additional file adds no benefit for this amount of code.
+
+### D2 — Remove `processKFMR` and KFMR reconciliation entirely
+
+**Choice:** Delete the `processKFMR` function (~180 lines), all KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`), the `KubeflowNormalizer` enum value, and the `ProcessKFMRResult` interface from `InformerService.ts`. Remove the KFMR branch from the reconcile callbacks (the code that checks whether a KServe InferenceService maps to a KFMR registered model via labels).
+
+**Rationale:** Without the KFMR client, there is nothing to call. The label-based mapping between KServe InferenceServices and KFMR registered models serves no purpose. The reconcile callbacks should only call the KServe path (`callKServeBackstagePrinters`).
+
+### D3 — Simplify `ReconcilerConfig`
+
+**Choice:** Remove `kfmrClients`, `kfmrRoutes`, and `kfmrCatalogRoute` fields from the `ReconcilerConfig` interface. Remove `KFMRClient` and related KFMR types that were only used by the KFMR client.
+
+**Rationale:** These fields are only populated by `setupKFMR` and consumed by `processKFMR`, both of which are being deleted.
+
+### D4 — Remove the `tlsSkipAgent` and KFMR-specific `undici` import
+
+**Choice:** Remove the TLS-skipping `Agent` from `Kfmr.ts`. If `undici` is not used elsewhere in the connector, remove it from `package.json` dependencies.
+
+**Rationale:** The TLS skip agent was only used by the KFMR REST client's `getFromModelRegistry` function. With that function deleted, the agent and import are unused. This also resolves the recurring fullsend review finding about disabled TLS verification.
+
+### D5 — Remove `@ts-ignore` suppressed unused constants
+
+**Choice:** The URI constants (`GET_REG_MODEL_URI`, `LIST_VERSIONS_OFF_REG_MODELS_URI`, etc.) that were annotated with `@ts-ignore` because they were defined but unused are deleted with `Kfmr.ts`. No need to move them.
+
+**Rationale:** These were ported from golang but never wired into the TypeScript client. Their deletion resolves another recurring fullsend review finding.
+
+## Risks / Trade-offs
+
+| Risk                                                                   | Mitigation                                                                                                                                      |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared utilities relocated incorrectly, breaking KServe path           | Run `yarn tsc` and `yarn build:all` after relocation, before any KFMR deletion                                                                  |
+| Removing KFMR code breaks model card resolution on RHOAI               | Model card resolution via KubeFlow Model Catalog API is separate from KFMR — verify the catalog REST path in `InformerService.ts` is unaffected |
+| `InformerService.ts` reconcile callbacks have subtle KFMR dependencies | Trace every `processKFMR` call site and verify the KServe-only path produces the same entity output for KServe-only InferenceServices           |
+| `undici` removal breaks other code                                     | Grep for `undici` imports across the plugin before removing from `package.json`                                                                 |
+
+## Verification
+
+After all changes:
+
+1. `yarn tsc` passes with no errors
+2. `yarn build:all` succeeds
+3. `yarn test:all` passes (existing tests in the workspace)
+4. No remaining imports or references to `Kfmr` in any `.ts` file under `kserve-kubeflow-connector-backend/src/`
+5. No remaining references to `KFMRClient`, `kfmrClients`, `kfmrRoutes`, `setupKFMR`, `loopOverKFMR`, `processKFMR`, or `KubeflowNormalizer`
+6. `PropertyKeys` is importable from `types.ts` and `KServe.ts` compiles using the new import

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/design.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/design.md
@@ -11,10 +11,15 @@ The `kserve-kubeflow-connector-backend` plugin was ported from a golang model-ca
 
 1. **KServe path** — K8s Informer watches `InferenceService` CRs, `KServe.ts` converts them to `ModelCatalog` JSON
 2. **KFMR path** — REST client calls KubeFlow Model Registry APIs to fetch `RegisteredModel`, `ModelVersion`, `ModelArtifact`, and `KFMRInferenceService` data, `Kfmr.ts` converts them to `ModelCatalog` JSON
+3. **Model Catalog path** — REST client calls KubeFlow Model Catalog APIs (`/api/model_catalog/v1alpha1`) to fetch `CatalogModel`/model card data; currently embedded in `Kfmr.ts` and invoked from `processKFMR`
 
-RHDHPLAN-404 scopes in only KServe + KubeFlow Model Catalog. The KFMR path must be removed.
+RHDHPLAN-404 scopes in KServe + KubeFlow Model Catalog. Only the **KFMR (Model Registry) path** must be removed. The **Model Catalog path** must be preserved — it will be enhanced in later Jiras to support inference-service-driven catalog lookup and full catalog polling.
 
-The complication is that `Kfmr.ts` is not purely KFMR client code — it also contains shared utilities (`PropertyKeys`, `NormalizerFormat`, `getTagsFromCustomProps`, `getStringPropVal`, `sanitizeName`, `sanitizeModelVersion`) and re-exports model types (`ModelCatalog`, `Model`, `ModelServer`, `API`, `APIType`) that are consumed by `KServe.ts` and `InformerService.ts`. These must be relocated before deletion.
+The complication is that `Kfmr.ts` contains three categories of code that must be handled differently:
+
+1. **KFMR-only code** (delete) — registry route setup, `listRegisteredModels`, `listInferenceServices`, `listModelVersions`, `listModelArtifacts`, `getServingEnvironment`, `getModelVersion`, `loopOverKFMR`, KFMR-specific `callBackstagePrinters`/`generateModelCatalog`
+2. **Model Catalog code** (preserve/relocate) — catalog route discovery (`kfmrCatalogRoute`), `rootCatalogURL` construction, `getModelCard()`, `KFMR_CATALOG_BASE_URI`, `GET_CATALOG_MODEL_URI`, `CatalogModel` type
+3. **Shared utilities** (relocate) — `PropertyKeys`, `NormalizerFormat`, `getTagsFromCustomProps`, `getStringPropVal`, `sanitizeName`, `sanitizeModelVersion`, re-exported model types
 
 ### Current dependency graph
 
@@ -39,11 +44,15 @@ Kfmr.ts
 ```
 InformerService.ts
   ├── imports from KServe.ts: callBackstagePrinters
-  └── imports from types.ts: ReconcilerConfig, InferenceService, PropertyKeys,
-       NormalizerFormat, sanitizeName, etc.
+  ├── imports from types.ts: ReconcilerConfig, InferenceService, PropertyKeys,
+  │    NormalizerFormat, sanitizeName, CatalogModel, etc.
+  └── imports from Catalog.ts (or types.ts): getModelCard, setupCatalogRoute
 
 KServe.ts
   └── imports from types.ts: PropertyKeys, getStringPropVal, getTagsFromCustomProps, etc.
+
+Catalog.ts (new, or inlined into types.ts)
+  └── catalog route discovery, getModelCard(), CATALOG_BASE_URI, GET_CATALOG_MODEL_URI
 
 (Kfmr.ts — deleted)
 ```
@@ -52,11 +61,12 @@ KServe.ts
 
 **Goals:**
 
-- Delete `Kfmr.ts` entirely
-- Remove all KFMR-specific types from `types.ts`
-- Remove all KFMR logic from `InformerService.ts` (imports, `processKFMR`, label constants, `KubeflowNormalizer`)
+- Delete `Kfmr.ts` after relocating catalog and shared code
+- Remove all KFMR-specific (Model Registry) types from `types.ts`
+- Remove KFMR-only logic from `InformerService.ts` (registry imports, KFMR label constants, `KubeflowNormalizer`, registry reconciliation in `processKFMR`)
 - Relocate shared utilities so `KServe.ts` and `InformerService.ts` continue to compile
-- Remove KFMR fields from `ReconcilerConfig`
+- Relocate Model Catalog code (catalog route discovery, `getModelCard()`, `CatalogModel`) so it remains functional
+- Remove KFMR-only fields from `ReconcilerConfig` (`kfmrClients`, `kfmrRoutes`); rename `kfmrCatalogRoute` to `catalogRoute`
 - Maintain all KServe + KubeFlow Model Catalog functionality unchanged
 - `yarn build:all`, `yarn tsc`, and existing tests pass after removal
 
@@ -77,17 +87,17 @@ KServe.ts
 
 **Alternative considered:** Create a new `shared.ts` or `constants.ts`. Rejected because `types.ts` already plays this role and the additional file adds no benefit for this amount of code.
 
-### D2 — Remove `processKFMR` and KFMR reconciliation entirely
+### D2 — Remove KFMR-only reconciliation from `processKFMR`; preserve model card fetching
 
-**Choice:** Delete the `processKFMR` function (~180 lines), all KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`), the `KubeflowNormalizer` enum value, and the `ProcessKFMRResult` interface from `InformerService.ts`. Remove the KFMR branch from the reconcile callbacks (the code that checks whether a KServe InferenceService maps to a KFMR registered model via labels).
+**Choice:** Remove the KFMR-specific parts of `processKFMR`: registered model listing, model version matching, KFMR inference service correlation, and KFMR-specific `callBackstagePrinters` calls. Remove KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`), the `KubeflowNormalizer` enum value, and the `ProcessKFMRResult` interface. **Preserve** the model card fetching logic (lines 421-444) which calls `kfmr.getModelCard()` — this uses the **Model Catalog API**, not the Model Registry, and must be relocated so it can be called from the KServe reconciliation path.
 
-**Rationale:** Without the KFMR client, there is nothing to call. The label-based mapping between KServe InferenceServices and KFMR registered models serves no purpose. The reconcile callbacks should only call the KServe path (`callKServeBackstagePrinters`).
+**Rationale:** Without the KFMR client, the registry-specific logic (registered model listing, label matching, KFMR inference service correlation) has nothing to call. However, the model card fetching via `getModelCard()` calls the separate Model Catalog API (`/api/model_catalog/v1alpha1`) and is valuable for enriching KServe InferenceService entities with catalog metadata. This catalog interaction must be preserved for future enhancement.
 
-### D3 — Simplify `ReconcilerConfig`
+### D3 — Simplify `ReconcilerConfig`; keep catalog route
 
-**Choice:** Remove `kfmrClients`, `kfmrRoutes`, and `kfmrCatalogRoute` fields from the `ReconcilerConfig` interface. Remove `KFMRClient` and related KFMR types that were only used by the KFMR client.
+**Choice:** Remove `kfmrClients` and `kfmrRoutes` fields from the `ReconcilerConfig` interface. **Rename** `kfmrCatalogRoute` to `catalogRoute` — this field stores the discovered OpenShift route for the Model Catalog service and is needed for catalog API calls. Remove `KFMRClient` interface; extract a smaller `CatalogClient` interface (or standalone function) that retains only `rootCatalogURL` and `getModelCard()`.
 
-**Rationale:** These fields are only populated by `setupKFMR` and consumed by `processKFMR`, both of which are being deleted.
+**Rationale:** `kfmrClients` and `kfmrRoutes` are only populated by `setupKFMR` for registry routes and consumed by `processKFMR` for registry operations — both being deleted. However, `kfmrCatalogRoute` stores the catalog service route discovered during setup; this is needed for the Model Catalog API and is renamed to remove the misleading "kfmr" prefix.
 
 ### D4 — Remove the `tlsSkipAgent` and KFMR-specific `undici` import
 
@@ -101,14 +111,30 @@ KServe.ts
 
 **Rationale:** These were ported from golang but never wired into the TypeScript client. Their deletion resolves another recurring fullsend review finding.
 
+### D6 — Preserve and relocate Model Catalog code from `Kfmr.ts`
+
+**Choice:** Extract the Model Catalog client code from `Kfmr.ts` into a dedicated module (e.g., `Catalog.ts`) or inline it into `types.ts`. This includes:
+
+- `KFMR_CATALOG_BASE_URI` (renamed to `CATALOG_BASE_URI`)
+- `GET_CATALOG_MODEL_URI`
+- Catalog route discovery logic (the `route.metadata.name.includes('catalog')` branch in `setupKFMR`)
+- `rootCatalogURL` construction from catalog route ingress
+- `getModelCard()` function
+- `CatalogModel` interface (already in `types.ts`)
+
+**Rationale:** The Model Catalog API (`/api/model_catalog/v1alpha1`) is a separate KubeFlow service from the Model Registry. The current code in `Kfmr.ts` that discovers the catalog route and calls `getModelCard()` is catalog integration, not registry integration. Deleting it with the registry code would remove Model Catalog support, which is explicitly in-scope for RHDHPLAN-404. Relocating it allows future Jiras to enhance catalog integration (inference-service-driven lookup, full catalog polling) without reimplementing route discovery and model card fetching from scratch.
+
+**Alternative considered:** Delete all catalog code now and reimplement later. Rejected because the catalog route discovery and model card fetching are already working and tested; deleting and reimplementing would be unnecessary churn.
+
 ## Risks / Trade-offs
 
-| Risk                                                                   | Mitigation                                                                                                                                      |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Shared utilities relocated incorrectly, breaking KServe path           | Run `yarn tsc` and `yarn build:all` after relocation, before any KFMR deletion                                                                  |
-| Removing KFMR code breaks model card resolution on RHOAI               | Model card resolution via KubeFlow Model Catalog API is separate from KFMR — verify the catalog REST path in `InformerService.ts` is unaffected |
-| `InformerService.ts` reconcile callbacks have subtle KFMR dependencies | Trace every `processKFMR` call site and verify the KServe-only path produces the same entity output for KServe-only InferenceServices           |
-| `undici` removal breaks other code                                     | Grep for `undici` imports across the plugin before removing from `package.json`                                                                 |
+| Risk                                                                   | Mitigation                                                                                                                                                    |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared utilities relocated incorrectly, breaking KServe path           | Run `yarn tsc` and `yarn build:all` after relocation, before any KFMR deletion                                                                                |
+| Catalog code accidentally deleted with registry code                   | Catalog code (route discovery, `getModelCard()`, `CatalogModel`) is explicitly tracked and relocated first; verify catalog API calls compile after relocation |
+| Model card fetching broken after `processKFMR` removal                 | Model card fetching logic is extracted and re-wired to be callable from the KServe reconciliation path; verify `getModelCard()` remains functional            |
+| `InformerService.ts` reconcile callbacks have subtle KFMR dependencies | Trace every `processKFMR` call site and verify the KServe-only path produces the same entity output for KServe-only InferenceServices                         |
+| `undici` removal breaks catalog client                                 | Check if `getModelCard()` / catalog fetch uses `undici` — if so, `undici` must stay until catalog client is refactored to use a different HTTP client         |
 
 ## Verification
 
@@ -120,3 +146,15 @@ After all changes:
 4. No remaining imports or references to `Kfmr` in any `.ts` file under `kserve-kubeflow-connector-backend/src/`
 5. No remaining references to `KFMRClient`, `kfmrClients`, `kfmrRoutes`, `setupKFMR`, `loopOverKFMR`, `processKFMR`, or `KubeflowNormalizer`
 6. `PropertyKeys` is importable from `types.ts` and `KServe.ts` compiles using the new import
+7. `getModelCard()` is callable from the relocated catalog module and the `CatalogModel` type is available from `types.ts`
+8. `catalogRoute` (renamed from `kfmrCatalogRoute`) is present on `ReconcilerConfig`
+
+## Future Work (Deferred to Later Jiras)
+
+The Model Catalog integration preserved in this change is a foundation for two planned enhancements under RHDHPLAN-404:
+
+1. **Inference-service-driven catalog lookup**: Call the Model Catalog API using metadata stored in KServe InferenceService CRs (labels/annotations containing catalog source and model references) to retrieve model cards and catalog metadata. This enriches KServe-discovered models with catalog descriptions, readmes, and provenance data.
+
+2. **Full catalog polling via REST API**: Poll all Model Catalog `CatalogSource` entries via the REST API and match them to discovered KServe InferenceServices. This enables bidirectional discovery — models known to the catalog can be correlated with running inference services even when the InferenceService doesn't carry catalog metadata.
+
+Both approaches build on the catalog route discovery (`catalogRoute` on `ReconcilerConfig`) and `getModelCard()` infrastructure preserved in this change. The current `getModelCard()` signature (`sourceId`, `modelName`) supports approach 1 directly; approach 2 will require additional catalog API methods (e.g., `listCatalogSources`).

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/proposal.md
@@ -19,30 +19,48 @@ The connector plugin was merged in PR #3705 on branch `kserve-kubeflow-connector
 
 ## What Changes
 
-- **Delete `Kfmr.ts`**: Remove the entire KFMR REST client module
+- **Delete KFMR-only code from `Kfmr.ts`**: Remove the Model Registry REST client (`setupKFMR` registry route handling, `listRegisteredModels`, `listInferenceServices`, `listModelVersions`, `listModelArtifacts`, `getServingEnvironment`, `getModelVersion`), the `loopOverKFMR` function, and the KFMR-specific `callBackstagePrinters`/`generateModelCatalog` functions
+- **Preserve and relocate Model Catalog code**: The catalog route discovery (`kfmrCatalogRoute`), `rootCatalogURL` construction, `getModelCard()` method, `KFMR_CATALOG_BASE_URI`, and `GET_CATALOG_MODEL_URI` currently live in `Kfmr.ts` but belong to the **Model Catalog API**, not the Model Registry. These must be relocated (to `types.ts` or a new `Catalog.ts` module), not deleted
 - **Relocate shared utilities**: Move `PropertyKeys`, `NormalizerFormat`, `getTagsFromCustomProps`, `sanitizeName`, `sanitizeModelVersion`, and re-exported model types (`ModelCatalog`, `Model`, `ModelServer`, `API`, `APIType`) from `Kfmr.ts` to `types.ts` or a new shared constants module
-- **Clean `types.ts`**: Remove `KFMRClient`, `KFMRInferenceService`, `InferenceServiceList`, `LoopOverKFMRResult`, and KFMR fields from `ReconcilerConfig`
-- **Clean `InformerService.ts`**: Remove `processKFMR` function, KFMR imports, KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`), `KubeflowNormalizer` enum value, and all KFMR cross-reference logic in the reconcile callbacks
+- **Clean `types.ts`**: Remove KFMR-only types (`KFMRInferenceService`, `InferenceServiceList`, `LoopOverKFMRResult`) and KFMR-only fields from `ReconcilerConfig` (`kfmrClients`, `kfmrRoutes`). **Keep** `CatalogModel`, `kfmrCatalogRoute` (rename to `catalogRoute`), and the `getModelCard`/`rootCatalogURL` signature (relocate to a catalog-focused interface)
+- **Clean `InformerService.ts`**: Remove KFMR-specific reconciliation (`processKFMR` registry matching logic, KFMR label constants, `KubeflowNormalizer` enum value). **Preserve** the model card fetching logic (lines 421-444 of `processKFMR`) by relocating it to a catalog utility that can be called from the KServe path
+- **Delete `Kfmr.ts`**: After all catalog and shared code has been relocated, the remainder of `Kfmr.ts` (now purely registry code) can be deleted
 - **Update `KServe.ts` import**: Change `import { PropertyKeys } from './Kfmr'` to import from the new location
 
 ## Capabilities
 
 ### Removed Capabilities
 
-- `kfmr-rest-client`: KFMR REST client for Model Registry APIs (route setup, registered model listing, model version/artifact fetching, inference service listing, serving environment lookup, catalog model/model card retrieval)
+- `kfmr-rest-client`: KFMR REST client for Model Registry APIs (route setup, registered model listing, model version/artifact fetching, inference service listing, serving environment lookup)
 - `kfmr-reconciliation`: KFMR-specific reconciliation logic in InformerService that maps KServe InferenceServices to KFMR registered models via label matching
+- `kfmr-normalizer`: The `KubeflowNormalizer` enum value and KFMR-specific `callBackstagePrinters`/`generateModelCatalog` functions
+
+### Preserved Capabilities
+
+- `model-catalog-client`: KubeFlow Model Catalog API support — catalog route discovery, `getModelCard()` for fetching model cards from the Catalog API (`/api/model_catalog/v1alpha1`), `CatalogModel` type, catalog-related `PropertyKeys` entries. This code is relocated from `Kfmr.ts` to a catalog-focused module
+- `catalog-route-config`: `kfmrCatalogRoute` on `ReconcilerConfig` (renamed to `catalogRoute`) — stores the discovered OpenShift route for the Model Catalog service
 
 ### Modified Capabilities
 
-- `kserve-reconciliation`: InformerService reconciliation simplified — KServe-only path remains, KFMR cross-referencing removed
+- `kserve-reconciliation`: InformerService reconciliation simplified — KServe-only path remains, KFMR cross-referencing removed. Model card fetching via Model Catalog API is preserved and can be called from the KServe path
 - `shared-utilities`: `PropertyKeys`, `NormalizerFormat`, model types relocated from `Kfmr.ts` to shared module
 
 ## Non-goals
 
-- Removing KubeFlow Model Catalog API support (this is in-scope for RHDHPLAN-404 and stays)
+- Removing KubeFlow Model Catalog API support — Model Catalog integration is in-scope for RHDHPLAN-404 and stays. Catalog route discovery, `getModelCard()`, `CatalogModel`, and catalog-related `PropertyKeys` are preserved
 - Refactoring InformerService beyond KFMR removal (e.g., console.log → LoggerService migration is a separate task)
 - Adding unit tests for InformerService (separate Jira)
 - Changing the connector's REST API surface (routes remain the same)
+- Enhancing Model Catalog integration (deferred to later Jiras — see Future Work)
+
+## Future Work
+
+In later RHDHPLAN-404 Jiras, the Model Catalog integration will be enhanced beyond its current form:
+
+1. **Inference-service-driven catalog lookup**: Call the Model Catalog API using metadata stored in KServe InferenceService CRs (labels/annotations) to retrieve model cards and catalog metadata for models that have catalog entries
+2. **Full catalog polling**: Use the Model Catalog REST API to poll all `CatalogSource` entries and match them to KServe InferenceServices, enabling discovery of catalog metadata even when InferenceServices don't carry catalog references
+
+These enhancements build on the catalog route discovery and `getModelCard()` infrastructure that is preserved in this change.
 
 ## Canonical Touchpoints
 
@@ -54,8 +72,9 @@ The connector plugin was merged in PR #3705 on branch `kserve-kubeflow-connector
 
 ## Impact
 
-- `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts` — deleted
-- `plugins/kserve-kubeflow-connector-backend/src/services/types.ts` — KFMR types removed, shared utilities added
-- `plugins/kserve-kubeflow-connector-backend/src/services/InformerService.ts` — ~200+ lines of KFMR logic removed
+- `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts` — deleted (after catalog code relocated)
+- `plugins/kserve-kubeflow-connector-backend/src/services/types.ts` — KFMR-only types removed, shared utilities added, `kfmrCatalogRoute` renamed to `catalogRoute`
+- `plugins/kserve-kubeflow-connector-backend/src/services/InformerService.ts` — ~150+ lines of KFMR-only logic removed, model card fetching logic preserved
 - `plugins/kserve-kubeflow-connector-backend/src/services/KServe.ts` — import path updated
-- Net reduction: ~1000+ lines removed
+- New or modified: catalog client module (relocated from `Kfmr.ts`) containing `getModelCard()`, catalog route setup, `CatalogModel` type
+- Net reduction: ~700+ lines removed (less than original estimate because catalog code is preserved)

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/proposal.md
@@ -14,7 +14,7 @@ The connector plugin was merged in PR #3705 on branch `kserve-kubeflow-connector
 
 - `Kfmr.ts` (837 lines) — full KFMR REST client, route setup, model registry data fetching, `callBackstagePrinters` for KFMR normalizer, `loopOverKFMR`, `getKubeFlowInferenceServicesForModelVersion`. Also contains shared utilities (`PropertyKeys`, `NormalizerFormat`, `getStringPropVal`, `getTagsFromCustomProps`, `sanitizeName`) that are used by `KServe.ts`
 - `types.ts` (425 lines) — contains KFMR-specific interfaces (`KFMRClient`, `KFMRInferenceService`, `InferenceServiceList`, `LoopOverKFMRResult`) and KFMR fields on `ReconcilerConfig` (`kfmrClients`, `kfmrRoutes`, `kfmrCatalogRoute`)
-- `InformerService.ts` (1406 lines) — imports and calls KFMR functions (`setupKFMR`, `loopOverKFMR`, `callBackstagePrinters`, `getKubeFlowInferenceServicesForModelVersion`), contains `processKFMR` function (~180 lines), KFMR label constants, `KubeflowNormalizer` enum value
+- `InformerService.ts` (1406 lines) — imports and calls KFMR functions (`setupKFMR`, `loopOverKFMR`, `callBackstagePrinters`, `getKubeFlowInferenceServicesForModelVersion`), contains `processKFMR` function (~340 lines, lines 287-625), KFMR label constants, `KubeflowNormalizer` enum value
 - `KServe.ts` (311 lines) — imports `PropertyKeys` from `Kfmr.ts` (must be relocated)
 
 ## What Changes

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: Remove KubeFlow Model Registry (KFMR) Client Code
+
+## Why
+
+The `kserve-kubeflow-connector-backend` plugin contains ~837 lines of KubeFlow Model Registry (KFMR) REST client code (`Kfmr.ts`) plus ~300 lines of KFMR-specific types and cross-references in `types.ts` and `InformerService.ts`. This code was included because the prototype was a direct golang conversion of the model-catalog-bridge, which supported both KServe and KFMR integration paths.
+
+RHDHPLAN-404 explicitly scopes out Model Registry integration. The KFMR code increases the connector's surface area, introduces unused dependencies on KFMR REST APIs, and confuses automated reviewers and human reviewers alike — the recently merged PR #3705 received repeated fullsend review findings about KFMR code quality issues that were all deferred because the code is being removed.
+
+Removing KFMR code now reduces the connector to its intended scope: KServe API (K8s Informer on `InferenceService` CRs) and KubeFlow Model Catalog API (REST client for `CatalogSource`, `CatalogModel`/`ModelCard`). This is Design Decision 4 from the parent `transition-oai-connector-to-kserve-plugin` openspec.
+
+## Starting Point
+
+The connector plugin was merged in PR #3705 on branch `kserve-kubeflow-connector` with the full KFMR code intact. The current state of the affected files:
+
+- `Kfmr.ts` (837 lines) — full KFMR REST client, route setup, model registry data fetching, `callBackstagePrinters` for KFMR normalizer, `loopOverKFMR`, `getKubeFlowInferenceServicesForModelVersion`. Also contains shared utilities (`PropertyKeys`, `NormalizerFormat`, `getStringPropVal`, `getTagsFromCustomProps`, `sanitizeName`) that are used by `KServe.ts`
+- `types.ts` (425 lines) — contains KFMR-specific interfaces (`KFMRClient`, `KFMRInferenceService`, `InferenceServiceList`, `LoopOverKFMRResult`) and KFMR fields on `ReconcilerConfig` (`kfmrClients`, `kfmrRoutes`, `kfmrCatalogRoute`)
+- `InformerService.ts` (1406 lines) — imports and calls KFMR functions (`setupKFMR`, `loopOverKFMR`, `callBackstagePrinters`, `getKubeFlowInferenceServicesForModelVersion`), contains `processKFMR` function (~180 lines), KFMR label constants, `KubeflowNormalizer` enum value
+- `KServe.ts` (311 lines) — imports `PropertyKeys` from `Kfmr.ts` (must be relocated)
+
+## What Changes
+
+- **Delete `Kfmr.ts`**: Remove the entire KFMR REST client module
+- **Relocate shared utilities**: Move `PropertyKeys`, `NormalizerFormat`, `getTagsFromCustomProps`, `sanitizeName`, `sanitizeModelVersion`, and re-exported model types (`ModelCatalog`, `Model`, `ModelServer`, `API`, `APIType`) from `Kfmr.ts` to `types.ts` or a new shared constants module
+- **Clean `types.ts`**: Remove `KFMRClient`, `KFMRInferenceService`, `InferenceServiceList`, `LoopOverKFMRResult`, and KFMR fields from `ReconcilerConfig`
+- **Clean `InformerService.ts`**: Remove `processKFMR` function, KFMR imports, KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`), `KubeflowNormalizer` enum value, and all KFMR cross-reference logic in the reconcile callbacks
+- **Update `KServe.ts` import**: Change `import { PropertyKeys } from './Kfmr'` to import from the new location
+
+## Capabilities
+
+### Removed Capabilities
+
+- `kfmr-rest-client`: KFMR REST client for Model Registry APIs (route setup, registered model listing, model version/artifact fetching, inference service listing, serving environment lookup, catalog model/model card retrieval)
+- `kfmr-reconciliation`: KFMR-specific reconciliation logic in InformerService that maps KServe InferenceServices to KFMR registered models via label matching
+
+### Modified Capabilities
+
+- `kserve-reconciliation`: InformerService reconciliation simplified — KServe-only path remains, KFMR cross-referencing removed
+- `shared-utilities`: `PropertyKeys`, `NormalizerFormat`, model types relocated from `Kfmr.ts` to shared module
+
+## Non-goals
+
+- Removing KubeFlow Model Catalog API support (this is in-scope for RHDHPLAN-404 and stays)
+- Refactoring InformerService beyond KFMR removal (e.g., console.log → LoggerService migration is a separate task)
+- Adding unit tests for InformerService (separate Jira)
+- Changing the connector's REST API surface (routes remain the same)
+
+## Canonical Touchpoints
+
+- **Parent openspec**: `openspec/changes/transition-oai-connector-to-kserve-plugin/` — Design Decision 4
+- **Jira**: [RHIDP-15200](https://redhat.atlassian.net/browse/RHIDP-15200)
+- **Plan**: RHDHPLAN-404
+
+**Change type**: refactor
+
+## Impact
+
+- `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts` — deleted
+- `plugins/kserve-kubeflow-connector-backend/src/services/types.ts` — KFMR types removed, shared utilities added
+- `plugins/kserve-kubeflow-connector-backend/src/services/InformerService.ts` — ~200+ lines of KFMR logic removed
+- `plugins/kserve-kubeflow-connector-backend/src/services/KServe.ts` — import path updated
+- Net reduction: ~1000+ lines removed

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/specs/post-removal-verification/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/specs/post-removal-verification/spec.md
@@ -1,0 +1,83 @@
+## REMOVED Capabilities
+
+### Requirement: No KFMR client code remains in the connector
+
+After removal, the connector plugin SHALL contain zero references to KubeFlow Model Registry client code, types, or configuration.
+
+#### Scenario: No KFMR source file exists
+
+- **WHEN** the connector plugin source directory is inspected
+- **THEN** no file named `Kfmr.ts` or containing KFMR client logic exists under `kserve-kubeflow-connector-backend/src/`
+
+#### Scenario: No KFMR imports remain
+
+- **WHEN** all TypeScript files under `kserve-kubeflow-connector-backend/src/` are searched for import statements
+- **THEN** no import references `./Kfmr` or any KFMR-specific symbol (`KFMRClient`, `setupKFMR`, `loopOverKFMR`, `processKFMR`, `getKubeFlowInferenceServicesForModelVersion`)
+
+#### Scenario: No KFMR types remain in types.ts
+
+- **WHEN** `types.ts` is inspected
+- **THEN** the interfaces `KFMRClient`, `KFMRInferenceService`, `InferenceServiceList`, and `LoopOverKFMRResult` do not exist
+- **AND** `ReconcilerConfig` does not contain fields `kfmrClients`, `kfmrRoutes`, or `kfmrCatalogRoute`
+
+#### Scenario: No KFMR label constants remain
+
+- **WHEN** `InformerService.ts` is inspected
+- **THEN** the constants `INF_SVC_RM_ID_LABEL` and `INF_SVC_MV_ID_LABEL` do not exist
+- **AND** no code references `modelregistry.opendatahub.io/registered-model-id` or `modelregistry.opendatahub.io/model-version-id`
+
+---
+
+## PRESERVED Capabilities
+
+### Requirement: Shared utilities remain functional after relocation
+
+Shared utilities previously exported from `Kfmr.ts` SHALL be available from `types.ts` with identical behavior.
+
+#### Scenario: PropertyKeys importable from types.ts
+
+- **WHEN** `KServe.ts` imports `PropertyKeys` from `./types`
+- **THEN** the import resolves and all property key references compile without errors
+
+#### Scenario: Model types importable from types.ts
+
+- **WHEN** any module imports `ModelCatalog`, `Model`, `ModelServer`, `API`, or `APIType`
+- **THEN** the import resolves from `./types` and the types match their original definitions
+
+---
+
+### Requirement: KServe reconciliation path unchanged
+
+The KServe-only reconciliation path SHALL continue to produce identical entity output after KFMR removal.
+
+#### Scenario: KServe InferenceService produces ModelCatalog entity
+
+- **WHEN** a KServe `InferenceService` CR is observed by the Informer
+- **THEN** the reconcile callback calls the KServe `callBackstagePrinters` function
+- **AND** the resulting `ModelCatalog` JSON is served via the connector's REST API
+
+#### Scenario: KServe path does not reference KFMR
+
+- **WHEN** a KServe `InferenceService` CR is reconciled
+- **THEN** no KFMR client calls, label checks, or registered model lookups occur
+
+---
+
+### Requirement: Build and type-check pass
+
+The connector plugin SHALL compile and type-check cleanly after all changes.
+
+#### Scenario: TypeScript compilation succeeds
+
+- **WHEN** `yarn tsc` is run from the workspace root
+- **THEN** it completes with zero errors
+
+#### Scenario: Full build succeeds
+
+- **WHEN** `yarn build:all` is run from the workspace root
+- **THEN** it completes with zero errors
+
+#### Scenario: Existing tests pass
+
+- **WHEN** `yarn test:all` is run from the workspace root
+- **THEN** all existing tests pass

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/specs/post-removal-verification/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/specs/post-removal-verification/spec.md
@@ -7,11 +7,11 @@ After removal, the connector plugin SHALL contain zero references to KubeFlow Mo
 #### Scenario: No KFMR source file exists
 
 - **WHEN** the connector plugin source directory is inspected
-- **THEN** no file named `Kfmr.ts` or containing KFMR client logic exists under `kserve-kubeflow-connector-backend/src/`
+- **THEN** no file named `Kfmr.ts` or containing KFMR client logic exists under `plugins/kserve-kubeflow-connector-backend/src/`
 
 #### Scenario: No KFMR imports remain
 
-- **WHEN** all TypeScript files under `kserve-kubeflow-connector-backend/src/` are searched for import statements
+- **WHEN** all TypeScript files under `plugins/kserve-kubeflow-connector-backend/src/` are searched for import statements
 - **THEN** no import references `./Kfmr` or any KFMR-specific symbol (`KFMRClient`, `setupKFMR`, `loopOverKFMR`, `processKFMR`, `getKubeFlowInferenceServicesForModelVersion`)
 
 #### Scenario: No KFMR-only types remain in types.ts

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/specs/post-removal-verification/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/specs/post-removal-verification/spec.md
@@ -14,11 +14,13 @@ After removal, the connector plugin SHALL contain zero references to KubeFlow Mo
 - **WHEN** all TypeScript files under `kserve-kubeflow-connector-backend/src/` are searched for import statements
 - **THEN** no import references `./Kfmr` or any KFMR-specific symbol (`KFMRClient`, `setupKFMR`, `loopOverKFMR`, `processKFMR`, `getKubeFlowInferenceServicesForModelVersion`)
 
-#### Scenario: No KFMR types remain in types.ts
+#### Scenario: No KFMR-only types remain in types.ts
 
 - **WHEN** `types.ts` is inspected
 - **THEN** the interfaces `KFMRClient`, `KFMRInferenceService`, `InferenceServiceList`, and `LoopOverKFMRResult` do not exist
-- **AND** `ReconcilerConfig` does not contain fields `kfmrClients`, `kfmrRoutes`, or `kfmrCatalogRoute`
+- **AND** `ReconcilerConfig` does not contain fields `kfmrClients` or `kfmrRoutes`
+- **AND** `ReconcilerConfig` contains `catalogRoute` (renamed from `kfmrCatalogRoute`) for Model Catalog route storage
+- **AND** `CatalogModel` interface is preserved (it is a Model Catalog type, not a registry type)
 
 #### Scenario: No KFMR label constants remain
 
@@ -43,6 +45,35 @@ Shared utilities previously exported from `Kfmr.ts` SHALL be available from `typ
 
 - **WHEN** any module imports `ModelCatalog`, `Model`, `ModelServer`, `API`, or `APIType`
 - **THEN** the import resolves from `./types` and the types match their original definitions
+
+---
+
+### Requirement: Model Catalog integration preserved
+
+The KubeFlow Model Catalog API support SHALL remain functional after KFMR removal. Catalog route discovery, model card fetching, and catalog types are relocated, not deleted.
+
+#### Scenario: Catalog route discovery is functional
+
+- **WHEN** the connector starts and discovers OpenShift routes managed by `model-registry-operator`
+- **THEN** routes with `catalog` in the name are stored on `ReconcilerConfig.catalogRoute`
+- **AND** the catalog route's ingress host is used to construct the catalog base URL
+
+#### Scenario: getModelCard is callable
+
+- **WHEN** a `sourceId` and `modelName` are provided to the relocated `getModelCard()` function
+- **AND** the catalog route has been discovered
+- **THEN** a GET request is made to the Model Catalog API at `/api/model_catalog/v1alpha1/sources/{sourceId}/models/{modelName}`
+- **AND** the `readme` field of the returned `CatalogModel` is returned
+
+#### Scenario: CatalogModel type is available
+
+- **WHEN** code imports `CatalogModel` from `types.ts`
+- **THEN** the import resolves and the type includes `id`, `name`, `description`, `readme`, `sourceId`, and `repositoryName` fields
+
+#### Scenario: Catalog PropertyKeys are preserved
+
+- **WHEN** `PropertyKeys` is inspected
+- **THEN** catalog-related keys (`RHOAIModelCatalogSourceModelVersion`, `RHOAIModelCatalogSourceModelKey`, `RHOAIModelCatalogRegisteredFromKey`, `RHOAIModelCatalogProviderKey`) are present
 
 ---
 

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/tasks.md
@@ -49,7 +49,7 @@
 
 - [ ] 5.1 Verify all catalog code and shared utilities have been relocated (tasks 1.x and 2.x complete)
 - [ ] 5.2 Delete `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts`
-- [ ] 5.3 Verify no remaining imports reference `./Kfmr` in any file under `kserve-kubeflow-connector-backend/src/`
+- [ ] 5.3 Verify no remaining imports reference `./Kfmr` in any file under `plugins/kserve-kubeflow-connector-backend/src/`
 
 ## 6. Clean Up Dependencies
 
@@ -62,7 +62,7 @@
 - [ ] 7.1 `yarn tsc` passes with no errors
 - [ ] 7.2 `yarn build:all` succeeds
 - [ ] 7.3 `yarn test:all` passes (existing workspace tests)
-- [ ] 7.4 `grep -rn 'loopOverKFMR\|setupKFMR\|KFMRClient\|KFMRInferenceService\|processKFMR\|KubeflowNormalizer\|kfmrClients\|kfmrRoutes' --include='*.ts' kserve-kubeflow-connector-backend/src/` returns zero results (note: `kfmrCatalogRoute` renamed to `catalogRoute`, so "kfmr" should not appear except in comments explaining the rename)
+- [ ] 7.4 `grep -rn 'loopOverKFMR\|setupKFMR\|KFMRClient\|KFMRInferenceService\|processKFMR\|KubeflowNormalizer\|kfmrClients\|kfmrRoutes' --include='*.ts' plugins/kserve-kubeflow-connector-backend/src/` returns zero results (note: `kfmrCatalogRoute` renamed to `catalogRoute`, so "kfmr" should not appear except in comments explaining the rename)
 - [ ] 7.5 `PropertyKeys` is importable from `./types` and `KServe.ts` compiles correctly
 - [ ] 7.6 `getModelCard()` is importable from the relocated catalog module and compiles correctly
 - [ ] 7.7 `CatalogModel` type is available from `types.ts`

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Remove KubeFlow Model Registry (KFMR) Client Code
+
+## 1. Relocate Shared Utilities from Kfmr.ts
+
+- [ ] 1.1 Move `PropertyKeys` constant object from `Kfmr.ts` to `types.ts`
+- [ ] 1.2 Move `NormalizerFormat` enum from `Kfmr.ts` to `types.ts`
+- [ ] 1.3 Move `getTagsFromCustomProps` function from `Kfmr.ts` to `types.ts`
+- [ ] 1.4 Move `getStringPropVal` function from `Kfmr.ts` to `types.ts`
+- [ ] 1.5 Move `sanitizeName` and `sanitizeModelVersion` functions from `Kfmr.ts` to `types.ts`
+- [ ] 1.6 Ensure `ModelCatalog`, `Model`, `ModelServer`, `API`, `APIType` are exported from `types.ts` (they are currently re-exported via `Kfmr.ts`)
+- [ ] 1.7 Update `KServe.ts` to import `PropertyKeys` from `./types` instead of `./Kfmr`
+- [ ] 1.8 Verify `yarn tsc` passes after relocation (before any deletions)
+
+## 2. Remove KFMR Types from types.ts
+
+- [ ] 2.1 Remove `KFMRClient` interface
+- [ ] 2.2 Remove `KFMRInferenceService` interface and `InferenceServiceList` interface
+- [ ] 2.3 Remove `LoopOverKFMRResult` interface
+- [ ] 2.4 Remove `kfmrClients`, `kfmrRoutes`, and `kfmrCatalogRoute` fields from `ReconcilerConfig` interface
+- [ ] 2.5 Remove any KFMR-specific enums (`RegisteredModelState`, `ModelVersionState`, `InferenceServiceState`) if they are not used by KServe path — verify before deleting
+- [ ] 2.6 Remove KFMR-specific model interfaces (`RegisteredModel`, `RegisteredModelList`, `ModelVersion`, `ModelVersionList`, `ModelArtifact`, `ModelArtifactList`, `ServingEnvironment`, `CatalogModel`) if not used by KServe path — verify before deleting
+- [ ] 2.7 Clean up the `types.ts` header comment (currently references "avoid circular dependencies between InformerService.ts and Kfmr.ts")
+
+## 3. Remove KFMR Logic from InformerService.ts
+
+- [ ] 3.1 Remove all imports from `./Kfmr` (`setupKFMR`, `loopOverKFMR`, `callBackstagePrinters`, `getKubeFlowInferenceServicesForModelVersion`, `sanitizeName as kfmrSanitizeName`)
+- [ ] 3.2 Remove KFMR type imports (`KFMRClient`, `KFMRInferenceService`)
+- [ ] 3.3 Remove KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`, commented `INF_SVC_INF_SVC_ID_LABEL`)
+- [ ] 3.4 Remove `KubeflowNormalizer` value from `NormalizerType` enum (keep `KServeNormalizer` only)
+- [ ] 3.5 Remove `ProcessKFMRResult` interface
+- [ ] 3.6 Delete the `processKFMR` function entirely (~lines 285-465)
+- [ ] 3.7 Remove the helper function that checks if a KServe InferenceService maps to a KFMR model (the function using `INF_SVC_RM_ID_LABEL`/`INF_SVC_MV_ID_LABEL`, ~lines 249-283)
+- [ ] 3.8 Remove `setupKFMR(config)` call from `innerStart` function
+- [ ] 3.9 Remove `processKFMR` call sites from reconcile callbacks — simplify to call only the KServe path
+- [ ] 3.10 Remove any KFMR-related `console.log` statements that reference KFMR processing
+- [ ] 3.11 Update remaining imports to source shared utilities from `./types` instead of `./Kfmr`
+
+## 4. Delete Kfmr.ts
+
+- [ ] 4.1 Delete `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts`
+- [ ] 4.2 Verify no remaining imports reference `./Kfmr` in any file under `kserve-kubeflow-connector-backend/src/`
+
+## 5. Clean Up Dependencies
+
+- [ ] 5.1 Check if `undici` is imported anywhere other than `Kfmr.ts` — if not, remove from `package.json` dependencies
+- [ ] 5.2 Check if `MODEL_REGISTRY_ROUTE_ENV_VAR` or `MODEL_REGISTRY_TOKEN_ENV_VAR` are referenced outside `Kfmr.ts` — if not, confirm they are gone with the file deletion
+- [ ] 5.3 Remove any KFMR-related environment variable documentation or comments in `plugin.ts`, `router.ts`, or config files
+
+## 6. Verification
+
+- [ ] 6.1 `yarn tsc` passes with no errors
+- [ ] 6.2 `yarn build:all` succeeds
+- [ ] 6.3 `yarn test:all` passes (existing workspace tests)
+- [ ] 6.4 `grep -rn 'Kfmr\|kfmr\|KFMR\|loopOverKFMR\|setupKFMR\|KFMRClient\|KFMRInferenceService\|processKFMR\|KubeflowNormalizer' --include='*.ts' kserve-kubeflow-connector-backend/src/` returns zero results
+- [ ] 6.5 `PropertyKeys` is importable from `./types` and `KServe.ts` compiles correctly
+- [ ] 6.6 Connector plugin starts without errors in dev environment (KServe path exercised, no KFMR errors)

--- a/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/remove-kfmr-client-code/tasks.md
@@ -11,46 +11,60 @@
 - [ ] 1.7 Update `KServe.ts` to import `PropertyKeys` from `./types` instead of `./Kfmr`
 - [ ] 1.8 Verify `yarn tsc` passes after relocation (before any deletions)
 
-## 2. Remove KFMR Types from types.ts
+## 2. Relocate Model Catalog Code from Kfmr.ts
 
-- [ ] 2.1 Remove `KFMRClient` interface
-- [ ] 2.2 Remove `KFMRInferenceService` interface and `InferenceServiceList` interface
-- [ ] 2.3 Remove `LoopOverKFMRResult` interface
-- [ ] 2.4 Remove `kfmrClients`, `kfmrRoutes`, and `kfmrCatalogRoute` fields from `ReconcilerConfig` interface
-- [ ] 2.5 Remove any KFMR-specific enums (`RegisteredModelState`, `ModelVersionState`, `InferenceServiceState`) if they are not used by KServe path — verify before deleting
-- [ ] 2.6 Remove KFMR-specific model interfaces (`RegisteredModel`, `RegisteredModelList`, `ModelVersion`, `ModelVersionList`, `ModelArtifact`, `ModelArtifactList`, `ServingEnvironment`, `CatalogModel`) if not used by KServe path — verify before deleting
-- [ ] 2.7 Clean up the `types.ts` header comment (currently references "avoid circular dependencies between InformerService.ts and Kfmr.ts")
+- [ ] 2.1 Extract catalog route discovery logic (the `route.metadata.name.includes('catalog')` branch from `setupKFMR`) into a standalone `setupCatalogRoute` function or similar
+- [ ] 2.2 Extract `KFMR_CATALOG_BASE_URI` (rename to `CATALOG_BASE_URI`) and `GET_CATALOG_MODEL_URI` constants
+- [ ] 2.3 Extract `rootCatalogURL` construction from catalog route ingress
+- [ ] 2.4 Extract `getModelCard()` function
+- [ ] 2.5 Place the above in a new `Catalog.ts` module or inline into `types.ts`
+- [ ] 2.6 Verify `getModelCard()` compiles and is callable after relocation
 
-## 3. Remove KFMR Logic from InformerService.ts
+## 3. Remove KFMR-Only Types from types.ts
 
-- [ ] 3.1 Remove all imports from `./Kfmr` (`setupKFMR`, `loopOverKFMR`, `callBackstagePrinters`, `getKubeFlowInferenceServicesForModelVersion`, `sanitizeName as kfmrSanitizeName`)
-- [ ] 3.2 Remove KFMR type imports (`KFMRClient`, `KFMRInferenceService`)
-- [ ] 3.3 Remove KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`, commented `INF_SVC_INF_SVC_ID_LABEL`)
-- [ ] 3.4 Remove `KubeflowNormalizer` value from `NormalizerType` enum (keep `KServeNormalizer` only)
-- [ ] 3.5 Remove `ProcessKFMRResult` interface
-- [ ] 3.6 Delete the `processKFMR` function entirely (~lines 285-465)
-- [ ] 3.7 Remove the helper function that checks if a KServe InferenceService maps to a KFMR model (the function using `INF_SVC_RM_ID_LABEL`/`INF_SVC_MV_ID_LABEL`, ~lines 249-283)
-- [ ] 3.8 Remove `setupKFMR(config)` call from `innerStart` function
-- [ ] 3.9 Remove `processKFMR` call sites from reconcile callbacks — simplify to call only the KServe path
-- [ ] 3.10 Remove any KFMR-related `console.log` statements that reference KFMR processing
-- [ ] 3.11 Update remaining imports to source shared utilities from `./types` instead of `./Kfmr`
+- [ ] 3.1 Remove `KFMRClient` interface (replace with a smaller `CatalogClient` interface if needed, retaining only `rootCatalogURL` and `getModelCard`)
+- [ ] 3.2 Remove `KFMRInferenceService` interface and `InferenceServiceList` interface
+- [ ] 3.3 Remove `LoopOverKFMRResult` interface
+- [ ] 3.4 Remove `kfmrClients` and `kfmrRoutes` fields from `ReconcilerConfig` interface
+- [ ] 3.5 Rename `kfmrCatalogRoute` to `catalogRoute` on `ReconcilerConfig` (this is Model Catalog, not Model Registry)
+- [ ] 3.6 Remove KFMR-specific enums (`RegisteredModelState`, `ModelVersionState`, `InferenceServiceState`) if they are not used by KServe or Catalog path — verify before deleting
+- [ ] 3.7 Remove KFMR-specific model interfaces (`RegisteredModel`, `RegisteredModelList`, `ModelVersion`, `ModelVersionList`, `ModelArtifact`, `ModelArtifactList`, `ServingEnvironment`) if not used by KServe or Catalog path — verify before deleting. **Keep** `CatalogModel` (it is a Model Catalog type, not a registry type)
+- [ ] 3.8 Clean up the `types.ts` header comment (currently references "avoid circular dependencies between InformerService.ts and Kfmr.ts")
 
-## 4. Delete Kfmr.ts
+## 4. Remove KFMR-Only Logic from InformerService.ts
 
-- [ ] 4.1 Delete `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts`
-- [ ] 4.2 Verify no remaining imports reference `./Kfmr` in any file under `kserve-kubeflow-connector-backend/src/`
+- [ ] 4.1 Remove KFMR-only imports from `./Kfmr` (`setupKFMR`, `loopOverKFMR`, `callBackstagePrinters`, `getKubeFlowInferenceServicesForModelVersion`, `sanitizeName as kfmrSanitizeName`)
+- [ ] 4.2 Remove KFMR type imports (`KFMRClient`, `KFMRInferenceService`)
+- [ ] 4.3 Remove KFMR label constants (`INF_SVC_RM_ID_LABEL`, `INF_SVC_MV_ID_LABEL`, commented `INF_SVC_INF_SVC_ID_LABEL`)
+- [ ] 4.4 Remove `KubeflowNormalizer` value from `NormalizerType` enum (keep `KServeNormalizer` only)
+- [ ] 4.5 Remove `ProcessKFMRResult` interface
+- [ ] 4.6 Remove KFMR-only logic from `processKFMR`: registered model listing, model version matching, KFMR inference service correlation, and KFMR-specific `callBackstagePrinters` calls. **Preserve** the model card fetching logic (lines 421-444) — relocate it to a utility that can be called from the KServe reconciliation path
+- [ ] 4.7 Remove the helper function that checks if a KServe InferenceService maps to a KFMR model (the function using `INF_SVC_RM_ID_LABEL`/`INF_SVC_MV_ID_LABEL`, ~lines 249-283)
+- [ ] 4.8 Remove `setupKFMR(config)` call from `innerStart` function. Replace with a catalog-only setup call that discovers the catalog route (preserving the `route.metadata.name.includes('catalog')` logic)
+- [ ] 4.9 Remove `processKFMR` call sites from reconcile callbacks — simplify to call only the KServe path
+- [ ] 4.10 Remove any KFMR-related `console.log` statements that reference KFMR processing
+- [ ] 4.11 Update remaining imports to source shared utilities from `./types` (and catalog utilities from the new location) instead of `./Kfmr`
 
-## 5. Clean Up Dependencies
+## 5. Delete Kfmr.ts
 
-- [ ] 5.1 Check if `undici` is imported anywhere other than `Kfmr.ts` — if not, remove from `package.json` dependencies
-- [ ] 5.2 Check if `MODEL_REGISTRY_ROUTE_ENV_VAR` or `MODEL_REGISTRY_TOKEN_ENV_VAR` are referenced outside `Kfmr.ts` — if not, confirm they are gone with the file deletion
-- [ ] 5.3 Remove any KFMR-related environment variable documentation or comments in `plugin.ts`, `router.ts`, or config files
+- [ ] 5.1 Verify all catalog code and shared utilities have been relocated (tasks 1.x and 2.x complete)
+- [ ] 5.2 Delete `plugins/kserve-kubeflow-connector-backend/src/services/Kfmr.ts`
+- [ ] 5.3 Verify no remaining imports reference `./Kfmr` in any file under `kserve-kubeflow-connector-backend/src/`
 
-## 6. Verification
+## 6. Clean Up Dependencies
 
-- [ ] 6.1 `yarn tsc` passes with no errors
-- [ ] 6.2 `yarn build:all` succeeds
-- [ ] 6.3 `yarn test:all` passes (existing workspace tests)
-- [ ] 6.4 `grep -rn 'Kfmr\|kfmr\|KFMR\|loopOverKFMR\|setupKFMR\|KFMRClient\|KFMRInferenceService\|processKFMR\|KubeflowNormalizer' --include='*.ts' kserve-kubeflow-connector-backend/src/` returns zero results
-- [ ] 6.5 `PropertyKeys` is importable from `./types` and `KServe.ts` compiles correctly
-- [ ] 6.6 Connector plugin starts without errors in dev environment (KServe path exercised, no KFMR errors)
+- [ ] 6.1 Check if `undici` is imported anywhere other than `Kfmr.ts` — if not, check whether the relocated catalog client (`getModelCard`) uses `undici` (via `getFromModelRegistry`). If catalog code still needs it, keep `undici`; otherwise remove from `package.json`
+- [ ] 6.2 Check if `MODEL_REGISTRY_ROUTE_ENV_VAR` or `MODEL_REGISTRY_TOKEN_ENV_VAR` are referenced outside `Kfmr.ts` — if not, confirm they are gone with the file deletion
+- [ ] 6.3 Remove any KFMR-related environment variable documentation or comments in `plugin.ts`, `router.ts`, or config files
+
+## 7. Verification
+
+- [ ] 7.1 `yarn tsc` passes with no errors
+- [ ] 7.2 `yarn build:all` succeeds
+- [ ] 7.3 `yarn test:all` passes (existing workspace tests)
+- [ ] 7.4 `grep -rn 'loopOverKFMR\|setupKFMR\|KFMRClient\|KFMRInferenceService\|processKFMR\|KubeflowNormalizer\|kfmrClients\|kfmrRoutes' --include='*.ts' kserve-kubeflow-connector-backend/src/` returns zero results (note: `kfmrCatalogRoute` renamed to `catalogRoute`, so "kfmr" should not appear except in comments explaining the rename)
+- [ ] 7.5 `PropertyKeys` is importable from `./types` and `KServe.ts` compiles correctly
+- [ ] 7.6 `getModelCard()` is importable from the relocated catalog module and compiles correctly
+- [ ] 7.7 `CatalogModel` type is available from `types.ts`
+- [ ] 7.8 `catalogRoute` (formerly `kfmrCatalogRoute`) is present on `ReconcilerConfig`
+- [ ] 7.9 Connector plugin starts without errors in dev environment (KServe path exercised, no KFMR errors, catalog route discovery still functional)


### PR DESCRIPTION
Adds proposal, design, tasks, and post-removal verification spec for removing KubeFlow Model Registry client code from the kserve-kubeflow-connector-backend plugin per RHDHPLAN-404 Decision 4.

Key design insight: shared utilities (PropertyKeys, NormalizerFormat, helper functions) must be relocated from Kfmr.ts to types.ts before deletion since KServe.ts depends on them.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [n/a] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [/] Added or Updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [/] Screenshots attached (for UI changes)
