### PR TITLE
fix(orchestrator): remove hardcoded "at" from workflow status translations

### DIFF
--- a/workspaces/orchestrator/.changeset/humble-language-fix.md
+++ b/workspaces/orchestrator/.changeset/humble-language-fix.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix hardcoded English "at" in workflow status time translations - now each language uses its own grammatically correct preposition

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -163,7 +163,7 @@ const ResultMessage = ({
       );
       return [formattedDate, matchingMessage ?? ''];
     }
-    return [`at ${formattedDate}`];
+    return [formattedDate];
   };
 
   const getAbortTimeAgo = (): string => {

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/de.ts
@@ -116,11 +116,11 @@ const orchestratorTranslationDe = createTranslationMessages({
     'run.status.aborted': 'Der Lauf wurde vor {{time}} abgebrochen.',
     'run.status.abortedWithoutTime': 'Der Lauf wurde abgebrochen.',
     'run.status.completed': 'Lauf abgeschlossen',
-    'run.status.completedAt': 'Lauf abgeschlossen {{time}}',
+    'run.status.completedAt': 'Lauf abgeschlossen am {{time}}',
     'run.status.completedWithMessage':
-      'Lauf abgeschlossen {{time}} mit folgender Nachricht',
-    'run.status.failed': 'Der Lauf ist fehlgeschlagen {{time}}',
-    'run.status.failedAt': 'Der Lauf ist fehlgeschlagen {{time}}',
+      'Lauf abgeschlossen am {{time}} mit folgender Nachricht',
+    'run.status.failed': 'Der Lauf ist fehlgeschlagen am {{time}}',
+    'run.status.failedAt': 'Der Lauf ist fehlgeschlagen am {{time}}',
     'run.status.noAdditionalInfo':
       'Der Workflow lieferte keine weiteren Informationen zum Status.',
     'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/es.ts
@@ -117,21 +117,21 @@ const orchestratorTranslationEs = createTranslationMessages({
     'run.status.aborted': 'La ejecución se canceló hace {{time}}.',
     'run.status.abortedWithoutTime': 'La ejecución se canceló.',
     'run.status.completed': 'Ejecución completada',
-    'run.status.completedAt': 'Ejecución completada {{time}}',
+    'run.status.completedAt': 'Ejecución completada el {{time}}',
     'run.status.completedWithMessage':
-      'Ejecución completada {{time}} con mensaje',
-    'run.status.failed': 'La ejecución falló {{time}}',
-    'run.status.failedAt': 'La ejecución falló {{time}}',
+      'Ejecución completada el {{time}} con mensaje',
+    'run.status.failed': 'La ejecución falló el {{time}}',
+    'run.status.failedAt': 'La ejecución falló el {{time}}',
     'run.status.noAdditionalInfo':
       'El flujo de trabajo no proporcionó información adicional sobre el estado.',
     'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete':
       'Los resultados se mostrarán aquí una vez que se complete la ejecución.',
     'run.status.running':
-      'El flujo de trabajo está en ejecución. Comenzó {{time}}',
+      'El flujo de trabajo está en ejecución. Comenzó el {{time}}',
     'run.status.runningWaitingAtNode':
       'El flujo de trabajo está en ejecución; esperando en el nodo {{node}} desde {{formattedTime}}',
     'run.status.workflowIsRunning':
-      'El flujo de trabajo está en ejecución. Comenzó {{time}}',
+      'El flujo de trabajo está en ejecución. Comenzó el {{time}}',
     'run.suggestedNextWorkflow': 'Próximo flujo de trabajo sugerido',
     'run.suggestedNextWorkflows': 'Próximos flujos de trabajo sugeridos',
     'run.title': 'Ejecutar flujo de trabajo',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/fr.ts
@@ -117,11 +117,11 @@ const orchestratorTranslationFr = createTranslationMessages({
     'run.status.aborted': "L'exécution a été interrompue il y a {{time}}.",
     'run.status.abortedWithoutTime': "L'exécution a été interrompue.",
     'run.status.completed': 'Exécution terminée',
-    'run.status.completedAt': 'Exécution terminée {{time}}',
+    'run.status.completedAt': 'Exécution terminée le {{time}}',
     'run.status.completedWithMessage':
-      'Exécution terminée {{time}} avec le message',
-    'run.status.failed': "L'exécution a échoué {{time}}",
-    'run.status.failedAt': "L'exécution a échoué {{time}}",
+      'Exécution terminée le {{time}} avec le message',
+    'run.status.failed': "L'exécution a échoué le {{time}}",
+    'run.status.failedAt': "L'exécution a échoué le {{time}}",
     'run.status.noAdditionalInfo':
       "Le flux de travail n'a fourni aucune information supplémentaire concernant l'état.",
     'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete':

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/it.ts
@@ -117,21 +117,21 @@ const orchestratorTranslationIt = createTranslationMessages({
     'run.status.aborted': "L'esecuzione è stata interrotta {{time}} fa.",
     'run.status.abortedWithoutTime': "L'esecuzione è stata interrotta.",
     'run.status.completed': 'Esecuzione completata',
-    'run.status.completedAt': 'Esecuzione completata {{time}}',
+    'run.status.completedAt': 'Esecuzione completata il {{time}}',
     'run.status.completedWithMessage':
-      'Esecuzione completata {{time}} con messaggio',
-    'run.status.failed': "L'esecuzione non è riuscita {{time}}",
-    'run.status.failedAt': "L'esecuzione non è riuscita {{time}}",
+      'Esecuzione completata il {{time}} con messaggio',
+    'run.status.failed': "L'esecuzione non è riuscita il {{time}}",
+    'run.status.failedAt': "L'esecuzione non è riuscita il {{time}}",
     'run.status.noAdditionalInfo':
       'Il flusso di lavoro non forniva ulteriori informazioni sullo stato.',
     'run.status.resultsWillBeDisplayedHereOnceTheRunIsComplete':
       "I risultati verranno visualizzati qui al termine dell'esecuzione.",
     'run.status.running':
-      'Il flusso di lavoro è in esecuzione. Iniziata {{time}}',
+      'Il flusso di lavoro è in esecuzione. Iniziata il {{time}}',
     'run.status.runningWaitingAtNode':
       'Il flusso di lavoro è in esecuzione - in attesa al nodo {{node}} da {{formattedTime}}',
     'run.status.workflowIsRunning':
-      'Il flusso di lavoro è in esecuzione. Iniziata {{time}}',
+      'Il flusso di lavoro è in esecuzione. Iniziata il {{time}}',
     'run.suggestedNextWorkflow': 'Flusso di lavoro successivo suggerito',
     'run.suggestedNextWorkflows': 'Flussi di lavoro successivi suggeriti',
     'run.title': 'Esegui flusso di lavoro',

--- a/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/translations/ref.ts
@@ -167,16 +167,16 @@ export const orchestratorMessages = {
     },
     status: {
       completed: 'Run completed',
-      failed: 'Run has failed {{time}}',
+      failed: 'Run has failed at {{time}}',
       aborted: 'Run was aborted {{time}} ago.',
       abortedWithoutTime: 'Run was aborted.',
-      completedWithMessage: 'Run completed {{time}} with message',
-      failedAt: 'Run has failed {{time}}',
-      completedAt: 'Run completed {{time}}',
-      running: 'Workflow is running. Started {{time}}',
+      completedWithMessage: 'Run completed at {{time}} with message',
+      failedAt: 'Run has failed at {{time}}',
+      completedAt: 'Run completed at {{time}}',
+      running: 'Workflow is running. Started at {{time}}',
       runningWaitingAtNode:
         'Workflow is running - waiting at node {{node}} since {{formattedTime}}',
-      workflowIsRunning: 'Workflow is running. Started {{time}}',
+      workflowIsRunning: 'Workflow is running. Started at {{time}}',
       noAdditionalInfo:
         'The workflow provided no additional info about the status.',
       resultsWillBeDisplayedHereOnceTheRunIsComplete:


### PR DESCRIPTION
## Description

Fixed a translation bug where the English word "at" was hardcoded in the workflow status time formatting code. This caused Japanese and other language translations to display incorrectly with mixed English/native text (e.g., "実行は at 10/07/2026, 16:05:27 に完了しました").

The fix removes the hardcoded "at" from `WorkflowResult.tsx` and adds language-appropriate time prepositions to all translation files (English: "at", Japanese: "に", Spanish: "el", German: "am", French: "le", Italian: "il").

## Fixed
- [RHDHBUGS-3406](https://redhat.atlassian.net/browse/RHDHBUGS-3406)

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)