### PR TITLE
fix(fullsend): clear agent field to use default claude agent type

### DIFF
--- a/.fullsend/harness/code.yaml
+++ b/.fullsend/harness/code.yaml
@@ -1,3 +1,4 @@
+agent: ""
 base: https://raw.githubusercontent.com/fullsend-ai/fullsend/807037ff09a6b5d18fbc339d06e57752af9cd522/internal/scaffold/fullsend-repo/harness/code.yaml#sha256=adba903da2cbb861205a75e906dca341eb6dd67560224421c3ed5975c4e00ca1
 image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 host_files:

--- a/.fullsend/harness/fix.yaml
+++ b/.fullsend/harness/fix.yaml
@@ -1,3 +1,4 @@
+agent: ""
 base: https://raw.githubusercontent.com/fullsend-ai/fullsend/807037ff09a6b5d18fbc339d06e57752af9cd522/internal/scaffold/fullsend-repo/harness/fix.yaml#sha256=490f90febfcf879df52856b3bf582dd7a059dd38353e9957b6aa3aaa72180c0e
 image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 host_files:


### PR DESCRIPTION
## Summary

- Add `agent: ""` to both `harness/code.yaml` and `harness/fix.yaml` to prevent inheriting `agent: agents/code.md` / `agents/fix.md` from the upstream base
- The custom agent types lack Bash access in the sandbox, causing the agent to waste ~15 minutes and $6 discovering workarounds via subagent spawning before actually working
- Matches the pattern used in rhdh-agentic (`agent: ""` on code.yaml)

**Root cause:** with `base:` composition, omitting a field means you inherit it from upstream. The upstream base sets `agent: agents/code.md`, which runs the sandbox as a custom "code" agent type. That type doesn't have Bash enabled. Setting `agent: ""` clears the inherited value and uses the default agent type (which has full tool access).

Discovered during smoke test of #3717 on issue #3720 — see run transcript analysis in the issue.

## Test plan

- [ ] Trigger `/fs-code` on a test issue — agent should have Bash at the top level (no subagent spawning)
- [ ] Run should complete in ~15 min instead of ~35 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)