### PR TITLE
fix(orchestrator): drop Alpha module from translationResources

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-orchestrator-translation-module.md
+++ b/workspaces/orchestrator/.changeset/fix-orchestrator-translation-module.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix intermittent page load failures in dynamic plugin mode by loading translation resources from the PluginRoot Scalprum module instead of Alpha, avoiding a module initialization race on the Alpha default export.

--- a/workspaces/orchestrator/.changeset/fix-orchestrator-translation-module.md
+++ b/workspaces/orchestrator/.changeset/fix-orchestrator-translation-module.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-orchestrator': patch
 ---
 
-Fix intermittent page load failures in dynamic plugin mode by loading translation resources from the PluginRoot Scalprum module instead of Alpha, avoiding a module initialization race on the Alpha default export.
+Fix intermittent page load failures in dynamic plugin mode by removing the explicit Alpha module from translationResources, letting RHDH default to PluginRoot and avoiding a module initialization race on the Alpha default export.

--- a/workspaces/orchestrator/plugins/orchestrator/app-config.yaml
+++ b/workspaces/orchestrator/plugins/orchestrator/app-config.yaml
@@ -3,7 +3,6 @@ dynamicPlugins:
     red-hat-developer-hub.backstage-plugin-orchestrator:
       translationResources:
         - importName: orchestratorTranslations
-          module: PluginRoot
           ref: orchestratorTranslationRef
       appIcons:
         - name: orchestratorIcon

--- a/workspaces/orchestrator/plugins/orchestrator/app-config.yaml
+++ b/workspaces/orchestrator/plugins/orchestrator/app-config.yaml
@@ -3,7 +3,7 @@ dynamicPlugins:
     red-hat-developer-hub.backstage-plugin-orchestrator:
       translationResources:
         - importName: orchestratorTranslations
-          module: Alpha
+          module: PluginRoot
           ref: orchestratorTranslationRef
       appIcons:
         - name: orchestratorIcon


### PR DESCRIPTION
## Summary
- Remove the explicit `module: Alpha` from Orchestrator `translationResources` in the plugin `app-config.yaml`
- RHDH defaults to `PluginRoot` when `module` is omitted, which avoids loading the Alpha Scalprum bundle and the related module initialization race

## Context
Loading translations from the Alpha module can cause intermittent page load failures (`Cannot access 'U' before initialization`) because the host loader initializes the Alpha bundle, which also exports the NFS plugin as its `default` export. This can happen even with NFS disabled.

## Test plan
- [ ] Upgrade to RHDH/IDH 1.10 with Orchestrator dynamic plugin enabled and verify the app loads consistently (no stuck spinner)
- [ ] Confirm Orchestrator translations still load correctly in legacy/dynamic plugin mode
- [ ] Confirm NFS apps importing from `/alpha` are unaffected