### PR TITLE
chore(orchestrator): add output links to the catalog entity and the workflow list in the Orchestrator

### DIFF
--- a/workspaces/orchestrator/.changeset/fuzzy-plants-swim.md
+++ b/workspaces/orchestrator/.changeset/fuzzy-plants-swim.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator': patch
+---
+
+add output links to the catalog entity and the workflow list in the Orchestrator

--- a/workspaces/orchestrator/entities/yamlgreet.yaml
+++ b/workspaces/orchestrator/entities/yamlgreet.yaml
@@ -55,3 +55,7 @@ spec:
     links:
       - title: Open workflow run
         url: ${{ steps.runWorkflow.output.instanceUrl }}
+      - title: Open Workflows Tab
+        url: ${{ steps.runWorkflow.output.catalogEntityUrl }}
+      - title: View in Orchestrator
+        url: ${{ steps.runWorkflow.output.orchestratorWorkflowsUrl }}

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
@@ -109,7 +109,7 @@ describe('createRunWorkflowAction', () => {
     expect(mockApi.executeWorkflow).not.toHaveBeenCalled();
   });
 
-  it('executes the workflow and outputs the instance url derived from the template entity', async () => {
+  it('executes the workflow and outputs orchestrator, catalog, and instance urls', async () => {
     mockApi.executeWorkflow.mockResolvedValue({
       data: {
         id: 'instance-123',
@@ -140,6 +140,14 @@ describe('createRunWorkflowAction', () => {
         targetEntity: 'component:default/sample-service',
       },
       reqConfigOption,
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'orchestratorWorkflowsUrl',
+      '/orchestrator/workflows',
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'catalogEntityUrl',
+      '/catalog/default/component/sample-service/workflows',
     );
     expect(ctx.output).toHaveBeenCalledWith(
       'instanceUrl',
@@ -176,6 +184,14 @@ describe('createRunWorkflowAction', () => {
         targetEntity: 'resource:prod/database',
       }),
       reqConfigOption,
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'orchestratorWorkflowsUrl',
+      '/orchestrator/workflows',
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'catalogEntityUrl',
+      '/catalog/prod/resource/database/workflows',
     );
     expect(ctx.output).toHaveBeenCalledWith(
       'instanceUrl',

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.ts
@@ -77,6 +77,14 @@ export function createRunWorkflowAction(
           },
           reqConfigOption,
         );
+        // Link to the orchestrator workflows page
+        ctx.output('orchestratorWorkflowsUrl', `/orchestrator/workflows`);
+        // Direct link to the catalog entity
+        ctx.output(
+          'catalogEntityUrl',
+          `/catalog/${targetEntityNamespace}/${targetEntityKind}/${targetEntityName}/workflows`,
+        );
+        // Keeping this for backwards compatibility
         ctx.output(
           'instanceUrl',
           `/orchestrator/entity/${targetEntityNamespace}/${targetEntityKind}/${targetEntityName}/${ctx.input.workflow_id}/${data.id}`,


### PR DESCRIPTION

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This updates the `runWorkflow` function of the orchestartor backend scaffolder and makes links available for the workflows tab associated with the entity in the catalog.

This also makes another link available that will direct the user to the list of workflows in the orchestrator admin


These new links can be used in the workflows in the output section, for example:

```
  output:
    links:
      - title: Open workflow run
        url: ${{ steps.runWorkflow.output.instanceUrl }}
      - title: Open Workflows Tab
        url: ${{ steps.runWorkflow.output.catalogEntityUrl }}
      - title: View in Orchestrator
        url: ${{ steps.runWorkflow.output.orchestratorWorkflowsUrl }}
```

https://github.com/user-attachments/assets/d3075846-d746-490a-8c52-c9fde142c5fe

This fixes https://redhat.atlassian.net/browse/RHIDP-14341


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
