### PR TITLE
fix(x2a): copy gitignored files in job script instead of only warning

### DIFF
--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -151,9 +151,10 @@ copy_changed_files() {
   done < <(git ls-files --others --ignored --exclude-standard)
 
   if [[ ${#ignored_files[@]} -gt 0 ]]; then
-    echo "  WARNING: ${#ignored_files[@]} file(s) created by x2a but blocked by .gitignore:"
+    echo "  WARNING: ${#ignored_files[@]} file(s) created by x2a matched .gitignore — including them anyway:"
     for file in "${ignored_files[@]}"; do
       echo "    - $file"
+      changed_files+=("$file")
     done
   fi
 


### PR DESCRIPTION
## Summary

`copy_changed_files()` in the x2a job script detects files created by x2a that match the source repo's `.gitignore` but only logs a warning — it never actually copies them to the project output directory.

When `generated-project-metadata.json` (or any other x2a output) is matched by the source repo's `.gitignore`, the file is silently excluded from the copy. This causes the init phase to crash at:

```bash
METADATA=$(cat ${PROJECT_PATH}/generated-project-metadata.json)
```

Under `set -eo pipefail`, this exits the script with code 1. The K8s Job retries up to `backoffLimit=3` (4 pods total), all fail, and the project state becomes `failed`.

## Root cause

Commit f2b9c97f added detection of gitignored files and a WARNING log, but did not merge them into the `changed_files` array that drives the actual copy loop.

## Fix

Append each ignored file to `changed_files` inside the warning loop, so they are copied alongside other x2a-generated output. The warning is preserved (with updated wording) for visibility.

## How to reproduce

1. Create an x2a project targeting a Chef cookbook repo whose `.gitignore` matches `*.json` or `generated-project-metadata.json`
2. Run the init phase
3. Observe: all K8s pods for the init job end in Error state; project state = failed
4. Pod logs show `cat: .../generated-project-metadata.json: No such file or directory`

## Test plan

- [ ] Run init phase against a cookbook with `.gitignore` matching `*.json` — verify `generated-project-metadata.json` is copied and init succeeds
- [ ] Run init phase against a cookbook with no matching `.gitignore` — verify behavior is unchanged
- [ ] Check pod logs: WARNING line should now say "including them anyway" and the file should appear in the copied count
