### PR TITLE
RHIDP-9859 add orchestrator-common unit coverage

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-common/src/QueryParams.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/QueryParams.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QUERY_PARAM_INSTANCE_ID } from './QueryParams';
+
+describe('QueryParams constants', () => {
+  it('exports the expected instance id query parameter', () => {
+    expect(QUERY_PARAM_INSTANCE_ID).toBe('instanceId');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/auth/index.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/auth/index.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as auth from './index';
+
+describe('auth barrel exports', () => {
+  it('can be imported as a valid module surface', () => {
+    expect(auth).toBeDefined();
+    expect(typeof auth).toBe('object');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/constants.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/constants.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DEFAULT_SONATAFLOW_BASE_URL,
+  DEFAULT_SONATAFLOW_CONTAINER_IMAGE,
+  DEFAULT_SONATAFLOW_PERSISTENCE_PATH,
+  DEFAULT_WORKFLOWS_PATH,
+} from './constants';
+
+describe('orchestrator common constants', () => {
+  it('exports expected sonataflow defaults', () => {
+    expect(DEFAULT_SONATAFLOW_CONTAINER_IMAGE).toContain('sonataflow');
+    expect(DEFAULT_SONATAFLOW_PERSISTENCE_PATH).toBe(
+      '/home/kogito/persistence',
+    );
+    expect(DEFAULT_SONATAFLOW_BASE_URL).toBe('http://localhost');
+  });
+
+  it('exports the default workflows path', () => {
+    expect(DEFAULT_WORKFLOWS_PATH).toBe('workflows');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/index.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/index.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as orchestratorCommon from './index';
+
+describe('root barrel exports', () => {
+  it('re-exports constants and utilities', () => {
+    expect(orchestratorCommon.QUERY_PARAM_INSTANCE_ID).toBe('instanceId');
+    expect(orchestratorCommon.DEFAULT_WORKFLOWS_PATH).toBe('workflows');
+    expect(orchestratorCommon.capitalize('mIXed')).toBe('Mixed');
+  });
+
+  it('re-exports workflow helpers', () => {
+    expect(orchestratorCommon.extractWorkflowFormat('{"id":"wf"}')).toBe(
+      'json',
+    );
+  });
+
+  it('re-exports orchestrator permissions', () => {
+    expect(orchestratorCommon.orchestratorWorkflowPermission).toMatchObject({
+      name: 'orchestrator.workflow',
+      attributes: { action: 'read' },
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/permissions.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/permissions.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  orchestratorAdminViewPermission,
+  orchestratorInstanceAdminViewPermission,
+  orchestratorPermissions,
+  orchestratorWorkflowPermission,
+  orchestratorWorkflowSpecificPermission,
+  orchestratorWorkflowUsePermission,
+  orchestratorWorkflowUseSpecificPermission,
+} from './permissions';
+
+describe('orchestrator permissions', () => {
+  it('exports the expected base permissions', () => {
+    expect(orchestratorWorkflowPermission).toMatchObject({
+      name: 'orchestrator.workflow',
+      attributes: { action: 'read' },
+    });
+
+    expect(orchestratorWorkflowUsePermission).toMatchObject({
+      name: 'orchestrator.workflow.use',
+      attributes: { action: 'update' },
+    });
+
+    expect(orchestratorAdminViewPermission).toMatchObject({
+      name: 'orchestrator.workflowAdminView',
+      attributes: { action: 'read' },
+    });
+
+    expect(orchestratorInstanceAdminViewPermission).toMatchObject({
+      name: 'orchestrator.instanceAdminView',
+      attributes: { action: 'read' },
+    });
+  });
+
+  it('builds workflow-specific read permission', () => {
+    expect(orchestratorWorkflowSpecificPermission('my-workflow')).toMatchObject(
+      {
+        name: 'orchestrator.workflow.my-workflow',
+        attributes: { action: 'read' },
+      },
+    );
+  });
+
+  it('builds workflow-specific use permission', () => {
+    expect(
+      orchestratorWorkflowUseSpecificPermission('my-workflow'),
+    ).toMatchObject({
+      name: 'orchestrator.workflow.use.my-workflow',
+      attributes: { action: 'update' },
+    });
+  });
+
+  it('includes all base permissions in orchestratorPermissions list', () => {
+    expect(orchestratorPermissions).toEqual([
+      orchestratorWorkflowPermission,
+      orchestratorWorkflowUsePermission,
+      orchestratorAdminViewPermission,
+      orchestratorInstanceAdminViewPermission,
+    ]);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/utils/StringUtils.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/utils/StringUtils.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { capitalize, ellipsis } from './StringUtils';
+
+describe('capitalize', () => {
+  it('capitalizes mixed-case text', () => {
+    expect(capitalize('wOrKfLoW')).toBe('Workflow');
+  });
+
+  it('keeps an already capitalized word unchanged', () => {
+    expect(capitalize('Workflow')).toBe('Workflow');
+  });
+
+  it('capitalizes a single character', () => {
+    expect(capitalize('a')).toBe('A');
+  });
+
+  it('throws for empty input', () => {
+    expect(() => capitalize('')).toThrow();
+  });
+});
+
+describe('ellipsis', () => {
+  it('uses default prefix length', () => {
+    expect(ellipsis('1234567890')).toBe('12345678...');
+  });
+
+  it('uses custom prefix length', () => {
+    expect(ellipsis('1234567890', 4)).toBe('1234...');
+  });
+
+  it('returns full short text plus ellipsis', () => {
+    expect(ellipsis('abc', 8)).toBe('abc...');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/utils/index.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/utils/index.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { capitalize, ellipsis, isJsonObject } from './index';
+
+describe('utils barrel exports', () => {
+  it('re-exports capitalize', () => {
+    expect(capitalize('hELLo')).toBe('Hello');
+  });
+
+  it('re-exports ellipsis', () => {
+    expect(ellipsis('abcdefghi')).toBe('abcdefgh...');
+  });
+
+  it('re-exports isJsonObject', () => {
+    expect(isJsonObject({ a: 1 })).toBe(true);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-common/src/utils/isJsonObject.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/src/utils/isJsonObject.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonValue } from '@backstage/types';
+
+import { isJsonObject } from './isJsonObject';
+
+describe('isJsonObject', () => {
+  it('returns true for plain objects', () => {
+    expect(isJsonObject({ key: 'value' })).toBe(true);
+  });
+
+  it('returns false for arrays', () => {
+    expect(isJsonObject(['a', 'b'] as unknown as JsonValue)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isJsonObject(null)).toBe(false);
+  });
+
+  it('returns false for primitives', () => {
+    expect(isJsonObject('value')).toBe(false);
+    expect(isJsonObject(10)).toBe(false);
+    expect(isJsonObject(true)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isJsonObject(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Add focused unit tests for orchestrator-common utilities, constants, permissions, and barrel exports to raise package coverage and align with the phased coverage strategy used in recent orchestrator test tickets.

Closes https://redhat.atlassian.net/browse/RHIDP-9859