### PR TITLE
feat(boost): extensible browse filters via NFS (RHIDP-15449)

### DIFF
--- a/workspaces/boost/app-config.yaml
+++ b/workspaces/boost/app-config.yaml
@@ -8,6 +8,8 @@ app:
           redirects:
             - from: /
               to: /ai-catalog
+    # Example: disable a built-in filter
+    # - ai-catalog-filter:boost/owner: false
 
 organization:
   name: Red Hat

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/design.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/design.md
@@ -51,17 +51,19 @@ BUI (`@backstage/ui`) is the component library for all new UI. MUI v5 as fallbac
 
 Permission checks for `ai-catalog.asset.read.usage-docs` default to allow when the permission is not yet registered (RHDHPLAN-1508 not built). Content is shown, and enforcement activates automatically when RBAC lands.
 
-### Decision 8: Extensible browse filters via AiCatalogFilterBlueprint
+### Decision 8: Extensible browse filters via data-driven FilterDefinition
 
-The browse page filter sidebar becomes NFS-extensible. Each filter is an extension of a custom `AiCatalogFilterBlueprint` (kind: `ai-catalog-filter`) that attaches to the AI Catalog page's `filters` input.
+The browse page filter sidebar becomes NFS-extensible using a **data-driven** approach. Filters are plain objects (`FilterDefinition`), not per-filter React components. The `FilterSidebar` renders a generic `<Select>` for each registered filter — the same pattern already used for all 4 current filters.
 
 **Architecture:**
 
-- The `aiCatalogPage` PageBlueprint is upgraded via `makeWithOverrides` to declare a `filters` input accepting `ai-catalog-filter` extensions
-- Each filter extension provides three things: a React component (sidebar UI), a `filterFn` (entity predicate for client-side filtering), and a `urlParam` name (for URL state persistence)
-- Built-in filters (category, provider, owner, tags) become default `ai-catalog-filter` extensions registered by the plugin
-- The `FilterSidebar` renders child filter extensions in priority order instead of hardcoding filter components
-- `useUrlFilters` and `applyEntityFilters` become dynamic — they read the registered filter set instead of a fixed field list
+- A `FilterDefinition` interface defines each filter: `urlParam`, `label`, `getOptions(entities)`, `matchEntity(entity, values)`, `priority`
+- `AiCatalogFilterBlueprint` wraps a `FilterDefinition` as an NFS extension (kind: `ai-catalog-filter`) with a single custom `createExtensionDataRef`
+- Built-in filters are plain objects in `src/filters/builtinFilters.ts`, registered as Blueprint extensions in `plugin.tsx`
+- The `aiCatalogPage` PageBlueprint uses `makeWithOverrides` to declare a `filters` input, resolves `FilterDefinition[]`, sorts by priority, and passes to the page component
+- `FilterSidebar` maps over the array and renders `<Select>` for each — no per-filter component files
+- `useUrlFilters` reads/writes URL params dynamically from the definition array
+- `applyEntityFilters` loops over active definitions calling `matchEntity` in AND logic
 
 **Deployer customization (app-config.yaml):**
 
@@ -70,10 +72,6 @@ app:
   extensions:
     # Disable a built-in filter
     - ai-catalog-filter:boost/owner: false
-    # Configure a filter
-    - ai-catalog-filter:boost/category:
-        config:
-          collapsed: true
     # Custom filter from a third-party module (just enable it)
     - ai-catalog-filter:my-plugin/team-filter: {}
 ```
@@ -81,7 +79,6 @@ app:
 **Third-party filter contribution:**
 
 ```typescript
-// In a third-party plugin or module
 createFrontendModule({
   pluginId: 'boost',
   extensions: [
@@ -89,16 +86,19 @@ createFrontendModule({
       name: 'team-filter',
       params: {
         urlParam: 'team',
-        filterFn: (entity, values) =>
-          values.some(v => entity.spec?.owner?.includes(v)),
-        loader: () => import('./TeamFilter').then(m => <m.TeamFilter />),
+        label: 'Team',
+        getOptions: entities =>
+          [...new Set(entities.map(e => e.spec?.team).filter(Boolean))]
+            .sort()
+            .map(t => ({ id: t, label: t })),
+        matchEntity: (entity, values) =>
+          values.some(v => v === entity.spec?.team),
+        priority: 200,
       },
     }),
   ],
 });
 ```
-
-This follows the same pattern as upstream `CatalogFilterBlueprint` and the in-repo `GlobalHeaderComponentBlueprint` / `ScorecardLayoutBlueprint`.
 
 ## Entity Model
 

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/design.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/design.md
@@ -16,7 +16,6 @@ Boost has a backend with 30+ API routes and 9 plugin packages but no frontend. T
 
 - Chat UI, admin panels, or agent gallery (future domains)
 - Custom entity detail pages (use existing catalog pages)
-- RHDH dynamic plugin packaging (Scalprum/export-dynamic deferred)
 - Custom search collator for global search (rely on default catalog indexing)
 
 ## Decisions
@@ -51,6 +50,55 @@ BUI (`@backstage/ui`) is the component library for all new UI. MUI v5 as fallbac
 ### Decision 7: RBAC graceful degradation
 
 Permission checks for `ai-catalog.asset.read.usage-docs` default to allow when the permission is not yet registered (RHDHPLAN-1508 not built). Content is shown, and enforcement activates automatically when RBAC lands.
+
+### Decision 8: Extensible browse filters via AiCatalogFilterBlueprint
+
+The browse page filter sidebar becomes NFS-extensible. Each filter is an extension of a custom `AiCatalogFilterBlueprint` (kind: `ai-catalog-filter`) that attaches to the AI Catalog page's `filters` input.
+
+**Architecture:**
+
+- The `aiCatalogPage` PageBlueprint is upgraded via `makeWithOverrides` to declare a `filters` input accepting `ai-catalog-filter` extensions
+- Each filter extension provides three things: a React component (sidebar UI), a `filterFn` (entity predicate for client-side filtering), and a `urlParam` name (for URL state persistence)
+- Built-in filters (category, provider, owner, tags) become default `ai-catalog-filter` extensions registered by the plugin
+- The `FilterSidebar` renders child filter extensions in priority order instead of hardcoding filter components
+- `useUrlFilters` and `applyEntityFilters` become dynamic — they read the registered filter set instead of a fixed field list
+
+**Deployer customization (app-config.yaml):**
+
+```yaml
+app:
+  extensions:
+    # Disable a built-in filter
+    - ai-catalog-filter:boost/owner: false
+    # Configure a filter
+    - ai-catalog-filter:boost/category:
+        config:
+          collapsed: true
+    # Custom filter from a third-party module (just enable it)
+    - ai-catalog-filter:my-plugin/team-filter: {}
+```
+
+**Third-party filter contribution:**
+
+```typescript
+// In a third-party plugin or module
+createFrontendModule({
+  pluginId: 'boost',
+  extensions: [
+    AiCatalogFilterBlueprint.make({
+      name: 'team-filter',
+      params: {
+        urlParam: 'team',
+        filterFn: (entity, values) =>
+          values.some(v => entity.spec?.owner?.includes(v)),
+        loader: () => import('./TeamFilter').then(m => <m.TeamFilter />),
+      },
+    }),
+  ],
+});
+```
+
+This follows the same pattern as upstream `CatalogFilterBlueprint` and the in-repo `GlobalHeaderComponentBlueprint` / `ScorecardLayoutBlueprint`.
 
 ## Entity Model
 

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/dynamic-plugin-export/spec.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/dynamic-plugin-export/spec.md
@@ -1,0 +1,119 @@
+# Dynamic Plugin Export
+
+> **Status: Draft** — Pre-implementation specification. Subject to change during implementation.
+
+Package the AI Catalog frontend plugin for RHDH dynamic plugin deployment and register it in the overlays repo for OCI image builds. Boost is NFS-only (`createFrontendPlugin` as default export) — no Scalprum, no `./alpha`, no legacy entry point.
+
+## Requirements
+
+### Requirement: Plugin Export Configuration
+
+The plugin is configured for `rhdh-cli plugin export`.
+
+#### Scenario: export-dynamic script exists
+
+- **GIVEN** the `plugins/boost/package.json`
+- **WHEN** a developer runs `yarn export-dynamic`
+- **THEN** `rhdh-cli plugin export` runs and produces output in `dist-dynamic/`
+
+#### Scenario: dist-dynamic included in package files
+
+- **GIVEN** the plugin's `package.json` `files` array
+- **THEN** it includes `dist-dynamic/*.*` and `dist-dynamic/dist/**`
+- **AND** the published package contains the dynamic plugin bundle
+
+### Requirement: Default Extension Configuration
+
+A default `app-config.dynamic.yaml` provides sensible extension defaults for deployers.
+
+#### Scenario: Page route configured
+
+- **GIVEN** the `app-config.dynamic.yaml` in `plugins/boost/`
+- **THEN** it configures `page:boost/ai-catalog` with the `/ai-catalog` path
+
+#### Scenario: Entity cards configured
+
+- **GIVEN** the `app-config.dynamic.yaml`
+- **THEN** it lists `entity-card:boost/summary`, `entity-card:boost/adoption`, and `entity-card:boost/version-list` under `app.extensions`
+- **AND** each card has a default entity filter matching AI asset kinds
+
+#### Scenario: Entity tab configured
+
+- **GIVEN** the `app-config.dynamic.yaml`
+- **THEN** it lists `entity-content:boost/usage` under `app.extensions`
+- **AND** the tab has a default title and group assignment
+
+### Requirement: Overlay Registration
+
+The plugin is registered in the overlays repo for automated OCI image builds.
+
+#### Scenario: Plugin added to rhdh-plugin-export-overlays
+
+- **GIVEN** the `redhat-developer/rhdh-plugin-export-overlays` repository
+- **WHEN** a PR adds the boost frontend plugin entry
+- **THEN** the CI pipeline builds an OCI image for the plugin
+- **AND** the image is published to the configured registry
+
+#### Scenario: Image reference updated in workspace
+
+- **GIVEN** the OCI image is published
+- **WHEN** the workspace `dynamic-plugins-image-reference.yaml` is updated
+- **THEN** it contains the OCI image reference for the boost frontend plugin
+- **AND** the reference follows the same format as existing backend plugin entries
+
+### Requirement: Plugin Loads in RHDH
+
+The OCI-packaged plugin loads correctly in an RHDH deployment.
+
+#### Scenario: Plugin loads with Module Federation
+
+- **GIVEN** an RHDH deployment with `ENABLE_STANDARD_MODULE_FEDERATION=true`
+- **AND** the boost frontend dynamic plugin is installed via `dynamic-plugins.yaml` with `enabled: true`
+- **WHEN** a user navigates to the RHDH instance
+- **THEN** the "AI Catalog" nav item appears in the sidebar
+- **AND** navigating to `/ai-catalog` renders the browse page
+
+#### Scenario: Entity page extensions mount
+
+- **GIVEN** the boost frontend dynamic plugin is installed
+- **WHEN** a user navigates to a catalog entity page for an AI asset
+- **THEN** the AI Asset Summary Card, Download/Adopt Card, and Version List Card render on the overview
+- **AND** the Usage tab appears in the entity page tabs
+
+#### Scenario: Extensions absent on non-AI entities
+
+- **GIVEN** the boost frontend dynamic plugin is installed
+- **WHEN** a user navigates to a catalog entity page for a non-AI entity (e.g., a regular Component)
+- **THEN** no boost entity cards or tabs are rendered
+
+### Requirement: Adopter Overrides
+
+Deployers can customize the plugin via `app.extensions` in `app-config.yaml`.
+
+#### Scenario: Disable an entity card
+
+- **GIVEN** the deployer sets `entity-card:boost/adoption: false` in `app.extensions`
+- **WHEN** a user views an AI asset entity page
+- **THEN** the Download/Adopt Card is not rendered
+- **AND** other boost cards still render
+
+#### Scenario: Rename a tab
+
+- **GIVEN** the deployer sets `entity-content:boost/usage` with `config.title: "How to Use"`
+- **WHEN** a user views an AI asset entity page
+- **THEN** the tab label reads "How to Use" instead of the default
+
+#### Scenario: Change entity filter on a card
+
+- **GIVEN** the deployer sets `entity-card:boost/summary` with `config.filter` restricting to `kind: component`
+- **WHEN** a user views an AiResource entity page
+- **THEN** the summary card is not rendered (filter excludes AiResource)
+- **WHEN** a user views a Component/ai-agent entity page
+- **THEN** the summary card renders
+
+#### Scenario: Disable the page
+
+- **GIVEN** the deployer sets `page:boost/ai-catalog: false` in `app.extensions`
+- **WHEN** a user views the RHDH sidebar
+- **THEN** the "AI Catalog" nav item is not present
+- **AND** navigating to `/ai-catalog` shows a 404 or redirects

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/e2e-tests/spec.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/e2e-tests/spec.md
@@ -1,0 +1,131 @@
+# E2E Tests
+
+> **Status: Draft** — Pre-implementation specification. Subject to change during implementation.
+
+Playwright end-to-end tests for the AI Catalog frontend plugin. Boost is NFS-only (no legacy app), so no `APP_MODE` dual testing. Tests use translation keys instead of hardcoded strings and include axe-core accessibility audits.
+
+## Requirements
+
+### Requirement: Playwright Infrastructure
+
+The workspace has a working Playwright setup following rhdh-plugins conventions.
+
+#### Scenario: Playwright config exists
+
+- **GIVEN** the boost workspace
+- **WHEN** a developer runs `yarn test:e2e`
+- **THEN** Playwright starts the dev app via `yarn start`, waits for readiness, and runs tests from `e2e-tests/`
+
+#### Scenario: Multi-locale test projects
+
+- **GIVEN** the Playwright config defines projects for at least `en` and one non-English locale (e.g., `ja`)
+- **WHEN** the full e2e suite runs
+- **THEN** tests execute against both locales
+- **AND** per-locale `app-config-e2e-*.yaml` overrides configure separate ports so projects can run in parallel
+
+#### Scenario: CI integration
+
+- **GIVEN** CI runs `yarn playwright test` in the boost workspace
+- **WHEN** the test suite completes
+- **THEN** test reports are generated in `e2e-test-report/`
+- **AND** test artifacts (screenshots, traces on failure) are stored in `e2e-test-results/`
+
+### Requirement: Browse Page Tests
+
+The AI Catalog browse page is tested end-to-end.
+
+#### Scenario: Card grid renders with fixture data
+
+- **WHEN** the e2e test navigates to `/ai-catalog`
+- **THEN** AI asset cards are visible on the page
+- **AND** cards display translated text (using translation keys, not hardcoded English)
+
+#### Scenario: Search filters cards
+
+- **GIVEN** the browse page has loaded with AI assets
+- **WHEN** the test types a keyword in the search bar
+- **THEN** the visible cards are filtered to match the keyword
+- **AND** the URL updates with `?q=<keyword>`
+
+#### Scenario: Sidebar filters narrow results
+
+- **GIVEN** the browse page has loaded
+- **WHEN** the test selects a category filter (e.g., "skill")
+- **THEN** only cards matching that category are shown
+- **AND** the URL updates with the filter param
+
+#### Scenario: Multiple filters combine as AND
+
+- **GIVEN** the browse page has loaded
+- **WHEN** the test selects category "skill" AND a specific tag
+- **THEN** only cards matching both criteria are shown
+
+#### Scenario: Clear filters resets the view
+
+- **GIVEN** filters are active and the card grid is narrowed
+- **WHEN** the test clicks the clear-filters action
+- **THEN** all filter URL params are removed
+- **AND** the full card grid is restored
+
+#### Scenario: Card click navigates to entity detail
+
+- **GIVEN** AI asset cards are visible
+- **WHEN** the test clicks on a card
+- **THEN** the browser navigates to the catalog entity detail page for that asset
+
+### Requirement: State and Error Handling Tests
+
+Edge cases are covered by e2e tests.
+
+#### Scenario: Empty state when no assets match
+
+- **GIVEN** the browse page has loaded
+- **WHEN** the test applies filters that match no assets
+- **THEN** the empty state message is displayed (verified via translation key)
+- **AND** the clear-filters action is visible
+
+#### Scenario: Pagination controls work
+
+- **GIVEN** the catalog has more assets than one page
+- **WHEN** the test clicks the next-page control
+- **THEN** the card grid updates to show the next page of results
+- **AND** the URL updates with the page param
+
+#### Scenario: Sort control changes order
+
+- **GIVEN** the browse page has loaded
+- **WHEN** the test changes the sort to "last updated"
+- **THEN** the card order updates accordingly
+
+### Requirement: Accessibility Audits
+
+Every tested page passes automated accessibility checks.
+
+#### Scenario: Browse page passes axe audit
+
+- **WHEN** the browse page has loaded
+- **THEN** an axe-core scan with WCAG 2.1 AA rules reports zero violations
+- **AND** violations (if any) are attached to the test report for debugging
+
+#### Scenario: Filtered state passes axe audit
+
+- **GIVEN** filters are active on the browse page
+- **WHEN** an axe-core scan runs
+- **THEN** zero WCAG 2.1 AA violations are reported (focus management, aria-labels intact)
+
+### Requirement: Translation Key Usage
+
+Tests do not hardcode English strings.
+
+#### Scenario: UI text verified via translation keys
+
+- **GIVEN** the test needs to verify a UI label
+- **WHEN** it locates the element
+- **THEN** it uses the translated string from the plugin's translation module for the current locale
+- **AND** the same test code works for `en`, `de`, `es`, `fr`, `it`, `ja` without modification
+
+#### Scenario: Translation helper utility exists
+
+- **GIVEN** a `getTranslations(locale)` utility exists in `e2e-tests/utils/`
+- **WHEN** a test calls it
+- **THEN** it returns the message map for that locale loaded from the plugin's translation modules

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/filter-customization/spec.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/filter-customization/spec.md
@@ -1,0 +1,170 @@
+# Filter Customization
+
+> **Status: Draft** — Pre-implementation specification. Subject to change during implementation.
+
+The AI Catalog browse page filter sidebar becomes extensible via the Backstage New Frontend System (NFS). Deployers can enable/disable built-in filters and third-party plugins can contribute new filters — all without modifying boost source code.
+
+## Requirements
+
+### Requirement: AiCatalogFilterBlueprint
+
+A custom Blueprint defines the contract for browse page filters.
+
+#### Scenario: Filter extension provides required params
+
+- **GIVEN** a filter extension created via `AiCatalogFilterBlueprint.make`
+- **THEN** it provides a `urlParam` (string) for URL state persistence
+- **AND** it provides a `filterFn(entity, selectedValues) => boolean` for client-side filtering
+- **AND** it provides a `loader` returning a React component for the sidebar UI
+- **AND** optionally provides a `priority` (number) controlling render order in the sidebar
+
+#### Scenario: Filter extension receives standardized props
+
+- **WHEN** the filter sidebar renders a filter extension
+- **THEN** the extension component receives `entities` (all unfiltered AI assets for option derivation)
+- **AND** receives `selectedValues` (current selections from URL state)
+- **AND** receives `onChange(values: string[])` callback to update the filter
+
+### Requirement: Built-in Filters as Extensions
+
+Existing hardcoded filters are converted to default Blueprint extensions.
+
+#### Scenario: Default filter set matches current behavior
+
+- **WHEN** no app-config overrides are present
+- **THEN** the browse page renders the same four filters as before: category (type), provider, owner, tags
+- **AND** filter behavior (AND logic, URL params, dynamic options) is unchanged
+
+#### Scenario: Lifecycle filter added as built-in
+
+- **WHEN** no app-config overrides are present
+- **THEN** a lifecycle filter (`spec.lifecycle`) is available in the sidebar
+- **AND** options are dynamically derived from loaded entities (e.g., production, experimental, deprecated)
+- **AND** the URL param is `lifecycle`
+
+### Requirement: Disable Filters via app-config
+
+Deployers can disable any built-in filter.
+
+#### Scenario: Disable a single filter
+
+- **GIVEN** the deployer sets `ai-catalog-filter:boost/owner: false` in `app.extensions`
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** the owner filter is not rendered in the sidebar
+- **AND** the `owner` URL param has no effect on filtering
+- **AND** the remaining filters (category, provider, tags, lifecycle) work normally
+
+#### Scenario: Disable multiple filters
+
+- **GIVEN** the deployer disables both `ai-catalog-filter:boost/tags` and `ai-catalog-filter:boost/lifecycle`
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** neither filter appears in the sidebar
+- **AND** the category, provider, and owner filters render normally
+
+#### Scenario: Disable all filters
+
+- **GIVEN** the deployer disables all filter extensions
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** the filter sidebar is not rendered
+- **AND** the search bar still works
+- **AND** the card grid shows all AI assets
+
+### Requirement: Configure Filters via app-config
+
+Deployers can configure built-in filter behavior.
+
+#### Scenario: Collapse a filter by default
+
+- **GIVEN** the deployer sets `ai-catalog-filter:boost/tags` with `config.collapsed: true`
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** the tags filter section is rendered in collapsed state
+- **AND** clicking it expands to show the filter options
+
+#### Scenario: Reorder filters via priority
+
+- **GIVEN** the deployer configures `ai-catalog-filter:boost/owner` with a lower priority number than `ai-catalog-filter:boost/category`
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** the owner filter renders above the category filter in the sidebar
+
+### Requirement: Add Custom Filters via NFS Module
+
+Third-party plugins can contribute new filters.
+
+#### Scenario: Third-party filter appears in sidebar
+
+- **GIVEN** a third-party plugin registers a filter via `createFrontendModule({ pluginId: 'boost' })` using `AiCatalogFilterBlueprint.make`
+- **AND** the filter provides `urlParam: 'team'`, a `filterFn`, and a sidebar component
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** the custom "team" filter appears in the sidebar alongside built-in filters
+- **AND** selecting a value in the custom filter narrows the card grid using the provided `filterFn`
+- **AND** the `team` URL param persists the selection
+
+#### Scenario: Custom filter participates in AND logic
+
+- **GIVEN** a custom filter is active with a selected value
+- **AND** the built-in category filter also has a selected value
+- **WHEN** the card grid is filtered
+- **THEN** only entities matching both the custom filter AND the category filter are shown
+
+#### Scenario: Custom filter state in URL
+
+- **GIVEN** a custom filter has a selection
+- **WHEN** the URL is copied and opened in a new tab
+- **THEN** the custom filter selection is restored from the URL
+- **AND** the card grid shows the same filtered results
+
+#### Scenario: Custom filter disabled by deployer
+
+- **GIVEN** a third-party plugin registers `ai-catalog-filter:my-plugin/team-filter`
+- **AND** the deployer sets `ai-catalog-filter:my-plugin/team-filter: false` in `app.extensions`
+- **WHEN** the developer navigates to `/ai-catalog`
+- **THEN** the custom team filter is not rendered
+
+### Requirement: Dynamic Filter Architecture
+
+The filter pipeline adapts to the registered filter set.
+
+#### Scenario: useUrlFilters reads registered filters
+
+- **WHEN** the page initializes
+- **THEN** `useUrlFilters` reads URL params for all registered filter extensions (not a hardcoded list)
+- **AND** unrecognized URL params from disabled or removed filters are ignored (not cleared)
+
+#### Scenario: applyEntityFilters uses registered filterFns
+
+- **WHEN** the card grid is filtered
+- **THEN** `applyEntityFilters` iterates over all registered filter extensions' `filterFn` functions
+- **AND** applies them in AND logic
+- **AND** does not reference hardcoded filter field names
+
+#### Scenario: Clear filters resets all registered filters
+
+- **WHEN** the developer clicks "Clear filters"
+- **THEN** all registered filter URL params are cleared
+- **AND** custom filter params are also cleared
+- **AND** the full unfiltered card grid is restored
+
+#### Scenario: Active filter detection includes custom filters
+
+- **WHEN** only a custom filter has a selection (no built-in filters active)
+- **THEN** the "has active filters" indicator is shown
+- **AND** the empty state shows "Clear filters" when results are empty
+
+### Requirement: Page Extension Input
+
+The AI Catalog page declares a filters input for child extensions.
+
+#### Scenario: Page collects filter extensions
+
+- **GIVEN** the `aiCatalogPage` extension is defined with `PageBlueprint.makeWithOverrides`
+- **AND** it declares a `filters` input of kind `ai-catalog-filter`
+- **WHEN** the page renders
+- **THEN** it receives all enabled `ai-catalog-filter` extensions as resolved inputs
+- **AND** passes them to the filter sidebar and filter pipeline
+
+#### Scenario: No filters input graceful fallback
+
+- **WHEN** zero filter extensions are registered (all disabled)
+- **THEN** the page renders without a filter sidebar
+- **AND** search still works
+- **AND** the page does not crash

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/filter-customization/spec.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/filter-customization/spec.md
@@ -4,30 +4,45 @@
 
 The AI Catalog browse page filter sidebar becomes extensible via the Backstage New Frontend System (NFS). Deployers can enable/disable built-in filters and third-party plugins can contribute new filters — all without modifying boost source code.
 
+## Design Approach
+
+Filters are **data, not components**. Each filter is a `FilterDefinition` — a plain object with a URL param name, a label, a function to extract options from entities, and a function to match an entity against selected values. The `FilterSidebar` renders a generic `<Select>` for each definition. No per-filter React components, no lazy loading, no custom data refs per field.
+
+The NFS extension system handles enable/disable/add via `app.extensions`. The `AiCatalogFilterBlueprint` wraps a `FilterDefinition` in an extension. A single custom `createExtensionDataRef` carries the whole definition object. No `config` schema — deployers control filter visibility via NFS disable (`ai-catalog-filter:boost/owner: false`) and filter render order via `priority` in params.
+
 ## Requirements
 
-### Requirement: AiCatalogFilterBlueprint
+### Requirement: FilterDefinition and AiCatalogFilterBlueprint
 
-A custom Blueprint defines the contract for browse page filters.
+A `FilterDefinition` interface defines the contract. A Blueprint wraps it as an NFS extension.
 
-#### Scenario: Filter extension provides required params
+#### Scenario: FilterDefinition provides required fields
 
-- **GIVEN** a filter extension created via `AiCatalogFilterBlueprint.make`
-- **THEN** it provides a `urlParam` (string) for URL state persistence
-- **AND** it provides a `filterFn(entity, selectedValues) => boolean` for client-side filtering
-- **AND** it provides a `loader` returning a React component for the sidebar UI
-- **AND** optionally provides a `priority` (number) controlling render order in the sidebar
+- **GIVEN** a `FilterDefinition` object
+- **THEN** it has `urlParam` (string) for URL state persistence
+- **AND** it has `label` (string) for the sidebar heading (i18n key or plain text)
+- **AND** it has `getOptions(entities) => { id, label }[]` for deriving select options from loaded entities
+- **AND** it has `matchEntity(entity, selectedValues) => boolean` for client-side filtering
+- **AND** it has `priority` (number) controlling render order in the sidebar
 
-#### Scenario: Filter extension receives standardized props
+#### Scenario: Blueprint wraps FilterDefinition as NFS extension
 
-- **WHEN** the filter sidebar renders a filter extension
-- **THEN** the extension component receives `entities` (all unfiltered AI assets for option derivation)
-- **AND** receives `selectedValues` (current selections from URL state)
-- **AND** receives `onChange(values: string[])` callback to update the filter
+- **GIVEN** a filter created via `AiCatalogFilterBlueprint.make`
+- **THEN** it outputs a `FilterDefinition` via a single extension data ref
+- **AND** the extension kind is `ai-catalog-filter`
+- **AND** the extension attaches to `page:boost/ai-catalog` input `filters`
+- **AND** the Blueprint has no `config` schema (no deployer YAML config per filter)
+
+#### Scenario: FilterSidebar renders generic Select for each filter
+
+- **WHEN** the filter sidebar renders
+- **THEN** it maps over resolved `FilterDefinition[]` and renders a `<Select>` for each
+- **AND** each `<Select>` uses `getOptions(allEntities)` for its options list
+- **AND** each `<Select>` binds to URL state via `urlParam`
 
 ### Requirement: Built-in Filters as Extensions
 
-Existing hardcoded filters are converted to default Blueprint extensions.
+Existing hardcoded filters are converted to `FilterDefinition` objects registered as default Blueprint extensions.
 
 #### Scenario: Default filter set matches current behavior
 
@@ -35,16 +50,16 @@ Existing hardcoded filters are converted to default Blueprint extensions.
 - **THEN** the browse page renders the same four filters as before: category (type), provider, owner, tags
 - **AND** filter behavior (AND logic, URL params, dynamic options) is unchanged
 
-#### Scenario: Lifecycle filter added as built-in
+#### Scenario: Built-in filters are plain objects
 
-- **WHEN** no app-config overrides are present
-- **THEN** a lifecycle filter (`spec.lifecycle`) is available in the sidebar
-- **AND** options are dynamically derived from loaded entities (e.g., production, experimental, deprecated)
-- **AND** the URL param is `lifecycle`
+- **GIVEN** the 4 built-in filter definitions (category, provider, owner, tags)
+- **THEN** each is a plain object in `src/filters/builtinFilters.ts`
+- **AND** no filter has its own React component file
+- **AND** all share the same generic `<Select>` rendering in `FilterSidebar`
 
 ### Requirement: Disable Filters via app-config
 
-Deployers can disable any built-in filter.
+Deployers can disable any built-in filter using NFS extension disable.
 
 #### Scenario: Disable a single filter
 
@@ -52,11 +67,11 @@ Deployers can disable any built-in filter.
 - **WHEN** the developer navigates to `/ai-catalog`
 - **THEN** the owner filter is not rendered in the sidebar
 - **AND** the `owner` URL param has no effect on filtering
-- **AND** the remaining filters (category, provider, tags, lifecycle) work normally
+- **AND** the remaining filters (category, provider, tags) work normally
 
 #### Scenario: Disable multiple filters
 
-- **GIVEN** the deployer disables both `ai-catalog-filter:boost/tags` and `ai-catalog-filter:boost/lifecycle`
+- **GIVEN** the deployer disables both `ai-catalog-filter:boost/tags` and `ai-catalog-filter:boost/owner`
 - **WHEN** the developer navigates to `/ai-catalog`
 - **THEN** neither filter appears in the sidebar
 - **AND** the category, provider, and owner filters render normally
@@ -69,34 +84,17 @@ Deployers can disable any built-in filter.
 - **AND** the search bar still works
 - **AND** the card grid shows all AI assets
 
-### Requirement: Configure Filters via app-config
-
-Deployers can configure built-in filter behavior.
-
-#### Scenario: Collapse a filter by default
-
-- **GIVEN** the deployer sets `ai-catalog-filter:boost/tags` with `config.collapsed: true`
-- **WHEN** the developer navigates to `/ai-catalog`
-- **THEN** the tags filter section is rendered in collapsed state
-- **AND** clicking it expands to show the filter options
-
-#### Scenario: Reorder filters via priority
-
-- **GIVEN** the deployer configures `ai-catalog-filter:boost/owner` with a lower priority number than `ai-catalog-filter:boost/category`
-- **WHEN** the developer navigates to `/ai-catalog`
-- **THEN** the owner filter renders above the category filter in the sidebar
-
 ### Requirement: Add Custom Filters via NFS Module
 
-Third-party plugins can contribute new filters.
+Third-party plugins can contribute new filters by providing a `FilterDefinition`.
 
 #### Scenario: Third-party filter appears in sidebar
 
 - **GIVEN** a third-party plugin registers a filter via `createFrontendModule({ pluginId: 'boost' })` using `AiCatalogFilterBlueprint.make`
-- **AND** the filter provides `urlParam: 'team'`, a `filterFn`, and a sidebar component
+- **AND** the filter provides a `FilterDefinition` with `urlParam: 'team'`, `getOptions`, and `matchEntity`
 - **WHEN** the developer navigates to `/ai-catalog`
-- **THEN** the custom "team" filter appears in the sidebar alongside built-in filters
-- **AND** selecting a value in the custom filter narrows the card grid using the provided `filterFn`
+- **THEN** the custom "team" filter appears as a `<Select>` in the sidebar alongside built-in filters
+- **AND** selecting a value narrows the card grid using the provided `matchEntity`
 - **AND** the `team` URL param persists the selection
 
 #### Scenario: Custom filter participates in AND logic
@@ -124,24 +122,27 @@ Third-party plugins can contribute new filters.
 
 The filter pipeline adapts to the registered filter set.
 
-#### Scenario: useUrlFilters reads registered filters
+#### Scenario: useUrlFilters reads registered filters dynamically
 
+- **GIVEN** the page receives a resolved `FilterDefinition[]`
 - **WHEN** the page initializes
-- **THEN** `useUrlFilters` reads URL params for all registered filter extensions (not a hardcoded list)
+- **THEN** `useUrlFilters` reads URL params for each definition's `urlParam` (not a hardcoded list)
 - **AND** unrecognized URL params from disabled or removed filters are ignored (not cleared)
 
-#### Scenario: applyEntityFilters uses registered filterFns
+#### Scenario: applyEntityFilters uses registered matchEntity functions
 
 - **WHEN** the card grid is filtered
-- **THEN** `applyEntityFilters` iterates over all registered filter extensions' `filterFn` functions
-- **AND** applies them in AND logic
+- **THEN** `applyEntityFilters` iterates over all active `FilterDefinition` entries
+- **AND** for each with selected values, calls `matchEntity(entity, values)`
+- **AND** applies all in AND logic
 - **AND** does not reference hardcoded filter field names
 
-#### Scenario: Clear filters resets all registered filters
+#### Scenario: Clear filters resets registered filters and search only
 
 - **WHEN** the developer clicks "Clear filters"
 - **THEN** all registered filter URL params are cleared
-- **AND** custom filter params are also cleared
+- **AND** the search param (`q`) is cleared
+- **AND** view mode (`view`) and page size (`pageSize`) are preserved
 - **AND** the full unfiltered card grid is restored
 
 #### Scenario: Active filter detection includes custom filters
@@ -156,11 +157,12 @@ The AI Catalog page declares a filters input for child extensions.
 
 #### Scenario: Page collects filter extensions
 
-- **GIVEN** the `aiCatalogPage` extension is defined with `PageBlueprint.makeWithOverrides`
+- **GIVEN** the `aiCatalogPage` extension is defined with `PageBlueprint.makeWithOverrides` and `name: 'ai-catalog'`
 - **AND** it declares a `filters` input of kind `ai-catalog-filter`
 - **WHEN** the page renders
-- **THEN** it receives all enabled `ai-catalog-filter` extensions as resolved inputs
-- **AND** passes them to the filter sidebar and filter pipeline
+- **THEN** it receives all enabled `ai-catalog-filter` extensions as resolved `FilterDefinition[]`
+- **AND** sorts them by priority
+- **AND** passes the sorted array to the filter sidebar and filter pipeline
 
 #### Scenario: No filters input graceful fallback
 

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/translations/spec.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/specs/translations/spec.md
@@ -1,0 +1,96 @@
+# Translations
+
+> **Status: Draft** — Pre-implementation specification. Subject to change during implementation.
+
+Add non-English translation files for the AI Catalog plugin, covering all 5 languages supported across rhdh-plugins. The i18n scaffold (TranslationBlueprint, `createTranslationRef`, English `ref.ts`) is already in place from Story 1.
+
+## Requirements
+
+### Requirement: Translation Files for Supported Languages
+
+Each supported language has a complete translation file following the standard rhdh-plugins pattern.
+
+#### Scenario: Translation files exist for all 5 languages
+
+- **GIVEN** the plugin has English strings in `src/translations/ref.ts`
+- **WHEN** the translation story is complete
+- **THEN** `src/translations/` contains `de.ts`, `es.ts`, `fr.ts`, `it.ts`, `ja.ts`
+- **AND** each file uses `createTranslationMessages` referencing the `boostTranslationRef`
+
+#### Scenario: Translation resource registers all locales
+
+- **GIVEN** all 5 locale files exist
+- **WHEN** the `createTranslationResource` in `src/translations/index.ts` is configured
+- **THEN** it lazy-imports all 5 locales (`de: () => import('./de')`, etc.)
+- **AND** each locale is only loaded when the user selects that language
+
+#### Scenario: Translation module auto-discovery for dynamic plugins
+
+- **GIVEN** the plugin is deployed as a dynamic plugin in RHDH
+- **WHEN** the translation module needs to be auto-discovered
+- **THEN** a separate entry point re-exports `boostTranslationsModule` as default (e.g., `./boost-translations-module` in `package.json` exports)
+- **AND** RHDH auto-discovers the module without explicit `features` array registration
+
+### Requirement: Complete String Coverage
+
+Every user-facing string in the plugin is translated.
+
+#### Scenario: All browse page strings translated
+
+- **GIVEN** a user switches their RHDH locale to German
+- **WHEN** they navigate to `/ai-catalog`
+- **THEN** the page title, search placeholder, filter labels, empty state message, error state message, pagination labels, and sort options are all in German
+
+#### Scenario: All filter strings translated
+
+- **GIVEN** a user is viewing the AI Catalog in Japanese
+- **WHEN** the filter sidebar is visible
+- **THEN** filter section headings (type, provider, owner, tags), clear-filters action text, and "has active filters" indicators are in Japanese
+
+#### Scenario: All entity extension strings translated
+
+- **GIVEN** a user views an AI asset entity page in French
+- **WHEN** entity cards and tabs from the boost plugin render
+- **THEN** card titles (summary, download/adopt, version list), tab labels (usage), download button text, copy button text, docker/podman labels, and "Contact owner" fallback text are all in French
+
+#### Scenario: Error and empty state strings translated
+
+- **GIVEN** a user is viewing the AI Catalog in Spanish
+- **WHEN** no assets match the current filters
+- **THEN** the empty state message and clear-filters button text are in Spanish
+- **WHEN** the catalog API is unreachable
+- **THEN** the error message and retry button text are in Spanish
+
+### Requirement: Translation Quality
+
+Translations are accurate and consistent with RHDH conventions.
+
+#### Scenario: Translation keys use dot-notation
+
+- **GIVEN** the English source in `ref.ts` uses nested objects for message keys
+- **WHEN** locale files are created
+- **THEN** they use flattened dot-notation keys (e.g., `'catalog.filter.type': 'Typ'`)
+- **AND** keys match the structure in `ref.ts` exactly
+
+#### Scenario: Placeholder interpolation preserved
+
+- **GIVEN** an English string contains interpolation placeholders (e.g., `{{count}} assets`)
+- **WHEN** the string is translated
+- **THEN** the same placeholders appear in the translated string
+- **AND** the interpolation works correctly at runtime
+
+### Requirement: Verification
+
+Translations render correctly in the dev app.
+
+#### Scenario: Locale switching in dev app
+
+- **GIVEN** the dev app is running
+- **WHEN** a developer switches the locale via RHDH Settings
+- **THEN** all AI Catalog strings update to the selected language without a page reload
+
+#### Scenario: Fallback to English for missing keys
+
+- **GIVEN** a translation file is missing a key that exists in `ref.ts`
+- **WHEN** the UI renders that string
+- **THEN** the English fallback is shown (not a raw key or empty string)

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/tasks.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/tasks.md
@@ -49,3 +49,78 @@
 - [ ] 3.8 i18n: all user-facing strings via translation resources
 - [ ] 3.9 WCAG 2.1 AA for all interactive elements
 - [ ] 3.10 Unit tests for each card/tab, RBAC-gated rendering, download/copy behavior
+
+## 4. Extensible Browse Filters via NFS (RHIDP-15449)
+
+- [ ] 4.1 Create `AiCatalogFilterBlueprint` via `createExtensionBlueprint` (kind: `ai-catalog-filter`). Params: `urlParam` (string), `filterFn` (entity predicate), `loader` (React.lazy component), optional `priority` (number, default 100). Config schema: optional `collapsed` (boolean, default false).
+- [ ] 4.2 Define `AiCatalogFilterProps` interface — `entities: Entity[]`, `selectedValues: string[]`, `onChange: (values: string[]) => void`
+- [ ] 4.3 Upgrade `aiCatalogPage` to `PageBlueprint.makeWithOverrides` — declare `filters` input via `createExtensionInput` accepting `ai-catalog-filter` extensions
+- [ ] 4.4 Convert category filter to `AiCatalogFilterBlueprint.make({ name: 'category', params: { urlParam: 'type', filterFn, loader } })` — options from `getAllCategories()`, multi-select
+- [ ] 4.5 Convert provider filter to `AiCatalogFilterBlueprint.make({ name: 'provider', params: { urlParam: 'provider', filterFn, loader } })` — options from `rhdh.io/ai-asset-source` annotation
+- [ ] 4.6 Convert owner filter to `AiCatalogFilterBlueprint.make({ name: 'owner', params: { urlParam: 'owner', filterFn, loader } })` — options from `spec.owner`
+- [ ] 4.7 Convert tags filter to `AiCatalogFilterBlueprint.make({ name: 'tags', params: { urlParam: 'tag', filterFn, loader } })` — options from `metadata.tags`
+- [ ] 4.8 Add lifecycle filter as new built-in: `AiCatalogFilterBlueprint.make({ name: 'lifecycle', params: { urlParam: 'lifecycle', filterFn, loader } })` — options from `spec.lifecycle`
+- [ ] 4.9 Refactor `FilterSidebar` — iterate over resolved filter extension inputs instead of hardcoded `<Select>` components. Render each filter's loaded component, passing standardized props. Respect priority ordering and `collapsed` config.
+- [ ] 4.10 Refactor `useUrlFilters` — read/write URL params dynamically from the registered filter set (array of `urlParam` strings) instead of hardcoded param names. Keep search (`q`), view mode, pagination as built-in.
+- [ ] 4.11 Refactor `applyEntityFilters` — iterate over registered `filterFn` functions in AND logic instead of checking hardcoded field names. The search filter remains built-in (not a Blueprint extension).
+- [ ] 4.12 Update `clearFilters` to reset all registered filter URL params (including custom ones) and search
+- [ ] 4.13 Update `hasActiveFilters` detection to check all registered filter URL params
+- [ ] 4.14 Export `AiCatalogFilterBlueprint` and `AiCatalogFilterProps` from plugin public API (`src/index.ts`) so third-party modules can import them
+- [ ] 4.15 Add dev app example: a sample custom filter module (`packages/app/src/modules/sampleFilter.ts`) using `createFrontendModule({ pluginId: 'boost' })` to demonstrate third-party filter contribution
+- [ ] 4.16 Add app-config example in dev app showing filter disable (`ai-catalog-filter:boost/owner: false`) and configuration (`collapsed: true`)
+- [ ] 4.17 i18n: all filter labels and accessibility strings via translation resources
+- [ ] 4.18 WCAG 2.1 AA: keyboard navigation through dynamically rendered filters, aria-labels
+- [ ] 4.19 Unit tests: Blueprint creation, filter registration, enable/disable via config, custom filter rendering, filterFn AND logic, URL param sync for dynamic filters, clearFilters with custom params, priority ordering, collapsed state
+
+## 5. Add Translations for Supported Languages (RHIDP-15479)
+
+- [ ] 5.1 Create `src/translations/de.ts` — German translations using `createTranslationMessages` referencing `boostTranslationRef`, flattened dot-notation keys
+- [ ] 5.2 Create `src/translations/es.ts` — Spanish translations
+- [ ] 5.3 Create `src/translations/fr.ts` — French translations
+- [ ] 5.4 Create `src/translations/it.ts` — Italian translations
+- [ ] 5.5 Create `src/translations/ja.ts` — Japanese translations
+- [ ] 5.6 Update `src/translations/index.ts` — register all 5 locales in `createTranslationResource` with lazy imports (`de: () => import('./de')`, etc.)
+- [ ] 5.7 Audit all user-facing strings in browse page, filter sidebar, entity cards, entity tabs, empty/error/loading states — ensure every string uses `useTranslationRef` with a key in `ref.ts`
+- [ ] 5.8 Add missing keys to `ref.ts` if any strings are found not externalized
+- [ ] 5.9 Ensure interpolation placeholders (e.g., `{{count}}`) are preserved in all locale files
+- [ ] 5.10 Add separate entry point for translation module auto-discovery — re-export `boostTranslationsModule` as default from a dedicated file, add entry to `package.json` `exports`
+- [ ] 5.11 Verify locale switching in dev app — switch locale via Settings, confirm all AI Catalog strings update without page reload
+- [ ] 5.12 Verify English fallback — if a key is missing from a locale file, English is shown (not a raw key or empty string)
+
+## 6. E2E Tests with Playwright (RHIDP-15480)
+
+- [ ] 6.1 Install `@playwright/test` and `@backstage/e2e-test-utils` as devDependencies
+- [ ] 6.2 Create `playwright.config.ts` at workspace root — `webServer` starts `yarn start`, `testDir: 'e2e-tests'`, NFS-only (no `APP_MODE`)
+- [ ] 6.3 Add Playwright projects for at least `en` and one non-English locale (e.g., `ja`) with separate ports
+- [ ] 6.4 Create `e2e-tests/test_yamls/` with per-locale `app-config-e2e-*.yaml` overrides (baseUrl, backend port, CORS)
+- [ ] 6.5 Add `package.json` scripts: `test:e2e` → `playwright test`, `playwright` → forwarding script
+- [ ] 6.6 Create `e2e-tests/utils/translations.ts` — `getTranslations(locale)` helper loading messages from plugin translation modules
+- [ ] 6.7 Create `e2e-tests/utils/accessibility.ts` — axe-core audit helper with WCAG 2.1 AA tags, attaches results to `TestInfo`
+- [ ] 6.8 Test: browse page renders card grid with fixture data — verify cards visible using translation keys
+- [ ] 6.9 Test: search filters cards by keyword — type in search, verify URL updates, cards filtered
+- [ ] 6.10 Test: sidebar filter narrows results — select category, verify only matching cards shown
+- [ ] 6.11 Test: multiple filters combine as AND — select category + tag, verify intersection
+- [ ] 6.12 Test: clear filters resets view — click clear, verify URL params removed, full grid restored
+- [ ] 6.13 Test: card click navigates to entity detail — click card, verify URL changes to catalog entity page
+- [ ] 6.14 Test: empty state when no matches — apply impossible filter combination, verify empty state message
+- [ ] 6.15 Test: pagination controls — navigate pages, verify card grid updates
+- [ ] 6.16 Test: sort control — change sort order, verify card reordering
+- [ ] 6.17 Accessibility: axe-core audit on browse page (unfiltered)
+- [ ] 6.18 Accessibility: axe-core audit on browse page (with active filters)
+- [ ] 6.19 Verify same tests pass for non-English locale project
+
+## 7. Dynamic Plugin Export and Overlay Registration (RHIDP-15481)
+
+- [ ] 7.1 Add `"export-dynamic": "rhdh-cli plugin export"` script to `plugins/boost/package.json`
+- [ ] 7.2 Add `"dist-dynamic/*.*"` and `"dist-dynamic/dist/**"` to `files` array in `plugins/boost/package.json`
+- [ ] 7.3 Run `yarn export-dynamic` and verify `dist-dynamic/` is produced without errors
+- [ ] 7.4 Create `plugins/boost/app-config.dynamic.yaml` with default `app.extensions` config:
+  - `page:boost/ai-catalog` at `/ai-catalog`
+  - `entity-card:boost/summary`, `entity-card:boost/adoption`, `entity-card:boost/version-list` with AI asset filter
+  - `entity-content:boost/usage` tab with title and group
+- [ ] 7.5 Add boost frontend plugin entry to `redhat-developer/rhdh-plugin-export-overlays` — PR with overlay config for OCI image build
+- [ ] 7.6 Update workspace `dynamic-plugins-image-reference.yaml` with the published OCI image ref for the frontend plugin
+- [ ] 7.7 Verify plugin loads in RHDH with `ENABLE_STANDARD_MODULE_FEDERATION=true` — AI Catalog nav item appears, browse page renders
+- [ ] 7.8 Verify entity page extensions mount on AI asset entities and are absent on non-AI entities
+- [ ] 7.9 Verify adopter overrides via `app.extensions` — disable a card, rename a tab, change entity filter
+- [ ] 7.10 Verify `page:boost/ai-catalog: false` removes the nav item and page

--- a/workspaces/boost/openspec/changes/ai-catalog-frontend/tasks.md
+++ b/workspaces/boost/openspec/changes/ai-catalog-frontend/tasks.md
@@ -52,25 +52,26 @@
 
 ## 4. Extensible Browse Filters via NFS (RHIDP-15449)
 
-- [ ] 4.1 Create `AiCatalogFilterBlueprint` via `createExtensionBlueprint` (kind: `ai-catalog-filter`). Params: `urlParam` (string), `filterFn` (entity predicate), `loader` (React.lazy component), optional `priority` (number, default 100). Config schema: optional `collapsed` (boolean, default false).
-- [ ] 4.2 Define `AiCatalogFilterProps` interface — `entities: Entity[]`, `selectedValues: string[]`, `onChange: (values: string[]) => void`
-- [ ] 4.3 Upgrade `aiCatalogPage` to `PageBlueprint.makeWithOverrides` — declare `filters` input via `createExtensionInput` accepting `ai-catalog-filter` extensions
-- [ ] 4.4 Convert category filter to `AiCatalogFilterBlueprint.make({ name: 'category', params: { urlParam: 'type', filterFn, loader } })` — options from `getAllCategories()`, multi-select
-- [ ] 4.5 Convert provider filter to `AiCatalogFilterBlueprint.make({ name: 'provider', params: { urlParam: 'provider', filterFn, loader } })` — options from `rhdh.io/ai-asset-source` annotation
-- [ ] 4.6 Convert owner filter to `AiCatalogFilterBlueprint.make({ name: 'owner', params: { urlParam: 'owner', filterFn, loader } })` — options from `spec.owner`
-- [ ] 4.7 Convert tags filter to `AiCatalogFilterBlueprint.make({ name: 'tags', params: { urlParam: 'tag', filterFn, loader } })` — options from `metadata.tags`
-- [ ] 4.8 Add lifecycle filter as new built-in: `AiCatalogFilterBlueprint.make({ name: 'lifecycle', params: { urlParam: 'lifecycle', filterFn, loader } })` — options from `spec.lifecycle`
-- [ ] 4.9 Refactor `FilterSidebar` — iterate over resolved filter extension inputs instead of hardcoded `<Select>` components. Render each filter's loaded component, passing standardized props. Respect priority ordering and `collapsed` config.
-- [ ] 4.10 Refactor `useUrlFilters` — read/write URL params dynamically from the registered filter set (array of `urlParam` strings) instead of hardcoded param names. Keep search (`q`), view mode, pagination as built-in.
-- [ ] 4.11 Refactor `applyEntityFilters` — iterate over registered `filterFn` functions in AND logic instead of checking hardcoded field names. The search filter remains built-in (not a Blueprint extension).
-- [ ] 4.12 Update `clearFilters` to reset all registered filter URL params (including custom ones) and search
-- [ ] 4.13 Update `hasActiveFilters` detection to check all registered filter URL params
-- [ ] 4.14 Export `AiCatalogFilterBlueprint` and `AiCatalogFilterProps` from plugin public API (`src/index.ts`) so third-party modules can import them
-- [ ] 4.15 Add dev app example: a sample custom filter module (`packages/app/src/modules/sampleFilter.ts`) using `createFrontendModule({ pluginId: 'boost' })` to demonstrate third-party filter contribution
-- [ ] 4.16 Add app-config example in dev app showing filter disable (`ai-catalog-filter:boost/owner: false`) and configuration (`collapsed: true`)
-- [ ] 4.17 i18n: all filter labels and accessibility strings via translation resources
-- [ ] 4.18 WCAG 2.1 AA: keyboard navigation through dynamically rendered filters, aria-labels
-- [ ] 4.19 Unit tests: Blueprint creation, filter registration, enable/disable via config, custom filter rendering, filterFn AND logic, URL param sync for dynamic filters, clearFilters with custom params, priority ordering, collapsed state
+- [ ] 4.1 Define `FilterDefinition` interface in `src/blueprints/AiCatalogFilterBlueprint.ts` — fields: `urlParam` (string), `label` (string), `getOptions(entities) => {id, label}[]`, `matchEntity(entity, values) => boolean`, `priority` (number)
+- [ ] 4.2 Create single `filterDefinitionDataRef` via `createExtensionDataRef<FilterDefinition>` in same file
+- [ ] 4.3 Create `AiCatalogFilterBlueprint` via `createExtensionBlueprint` — kind `ai-catalog-filter`, attaches to `page:boost/ai-catalog` input `filters`, params are `FilterDefinition` fields, no config schema. Factory outputs the `FilterDefinition` via the single data ref.
+- [ ] 4.4 Create `src/filters/builtinFilters.ts` with 4 plain `FilterDefinition` objects:
+  - `categoryFilter` — urlParam `type`, getOptions from `getAllCategories()`, matchEntity checks `spec.type`, priority 100
+  - `providerFilter` — urlParam `provider`, getOptions from `rhdh.io/ai-asset-source` annotation, priority 200
+  - `ownerFilter` — urlParam `owner`, getOptions from `spec.owner`, priority 300
+  - `tagsFilter` — urlParam `tag`, getOptions from `metadata.tags`, priority 400
+- [ ] 4.5 Register 5 built-in filters as `AiCatalogFilterBlueprint.make(...)` extensions in `plugin.tsx`, add to `createFrontendPlugin({ extensions: [...] })`
+- [ ] 4.6 Upgrade `aiCatalogPage` to `PageBlueprint.makeWithOverrides` with `name: 'ai-catalog'` — declare `filters` input via `createExtensionInput` accepting `ai-catalog-filter` extensions. Factory resolves `FilterDefinition[]`, sorts by priority, passes to page component as prop.
+- [ ] 4.7 Refactor `FilterSidebar` — receive `FilterDefinition[]` + URL values. Map over definitions, render `<Select>` for each using `getOptions(allEntities)`. Return `null` when array is empty.
+- [ ] 4.8 Refactor `useUrlFilters` — accept `urlParam[]` from resolved definitions instead of hardcoded param names. Replace `setCategory`/`setProvider`/`setOwner`/`setTag` with generic `setFilter(urlParam, values)`. Keep `setSearch`, `setViewMode`, `setPage`, `setPageSize` unchanged. `clearFilters` resets registered filter params + search only (preserves view/pageSize).
+- [ ] 4.9 Refactor `applyEntityFilters` in `entityHelpers.ts` — replace 5 hardcoded `if` blocks with one loop: for each `FilterDefinition` with active values, call `matchEntity(entity, values)`. AND logic. Search filter stays built-in. Remove old `EntityFilters` interface.
+- [ ] 4.10 Update `AiCatalogPage.tsx` — receive `FilterDefinition[]` from page factory, pass to `FilterSidebar` and `useUrlFilters`. `hasActiveFilters` checks all registered urlParams dynamically.
+- [ ] 4.11 Export `AiCatalogFilterBlueprint` and `FilterDefinition` from `src/index.ts`
+- [ ] 4.12 Add dev app example: `packages/app/src/modules/sampleFilter/` — a lifecycle filter via `createFrontendModule({ pluginId: 'boost' })` demonstrating third-party contribution (lifecycle is not built-in, shown as custom filter example)
+- [ ] 4.13 Add app-config example showing filter disable (`ai-catalog-filter:boost/owner: false`)
+- [ ] 4.14 Add lifecycle filter label to `ref.ts` translation keys
+- [ ] 4.15 WCAG 2.1 AA: keyboard navigation through dynamically rendered filters, aria-labels on each `<Select>`
+- [ ] 4.16 Unit tests: `builtinFilters` (getOptions returns correct options, matchEntity matches correctly), `FilterSidebar` (renders N selects from definitions, returns null when empty), `useUrlFilters` (dynamic param read/write, setFilter, clearFilters preserves view/pageSize), `applyEntityFilters` (AND loop with matchEntity, search + filters combined), priority ordering
 
 ## 5. Add Translations for Supported Languages (RHIDP-15479)
 

--- a/workspaces/boost/packages/app/src/App.tsx
+++ b/workspaces/boost/packages/app/src/App.tsx
@@ -18,8 +18,9 @@ import { createApp } from '@backstage/frontend-defaults';
 import { rhdhThemeModule } from '@red-hat-developer-hub/backstage-plugin-theme/alpha';
 
 import { navModule } from './modules/nav';
+import { sampleFilterModule } from './modules/sampleFilter';
 import { signInModule } from './modules/signIn';
 
 export default createApp({
-  features: [rhdhThemeModule, signInModule, navModule],
+  features: [rhdhThemeModule, signInModule, navModule, sampleFilterModule],
 });

--- a/workspaces/boost/packages/app/src/modules/sampleFilter/index.ts
+++ b/workspaces/boost/packages/app/src/modules/sampleFilter/index.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import type { Entity } from '@backstage/catalog-model';
+
+import { AiCatalogFilterBlueprint } from '@red-hat-developer-hub/backstage-plugin-boost';
+
+function uniqueSorted(
+  items: (string | undefined)[],
+): { id: string; label: string }[] {
+  const set = new Set<string>();
+  for (const item of items) {
+    if (item) set.add(item);
+  }
+  return Array.from(set)
+    .sort((a, b) => a.localeCompare(b))
+    .map(v => ({ id: v, label: v }));
+}
+
+/**
+ * Example module demonstrating how a third-party plugin contributes
+ * a custom filter to the AI Catalog browse page.
+ *
+ * Lifecycle is not a built-in filter — it's added here via the
+ * extension system to show how deployers and third-party plugins
+ * can extend the filter sidebar.
+ */
+const lifecycleFilterExt = AiCatalogFilterBlueprint.make({
+  name: 'lifecycle',
+  params: {
+    urlParam: 'lifecycle',
+    label: 'Lifecycle',
+    getOptions: (entities: Entity[]) =>
+      uniqueSorted(
+        entities.map(
+          e =>
+            (e.spec as Record<string, unknown> | undefined)?.lifecycle as
+              | string
+              | undefined,
+        ),
+      ),
+    matchEntity: (entity: Entity, values: string[]) => {
+      const lifecycle = (entity.spec as Record<string, unknown> | undefined)
+        ?.lifecycle as string | undefined;
+      return (
+        lifecycle !== undefined &&
+        values.some(v => v.toLowerCase() === lifecycle.toLowerCase())
+      );
+    },
+    priority: 500,
+  },
+});
+
+export const sampleFilterModule = createFrontendModule({
+  pluginId: 'boost',
+  extensions: [lifecycleFilterExt],
+});

--- a/workspaces/boost/plugins/boost/report.api.md
+++ b/workspaces/boost/plugins/boost/report.api.md
@@ -7,6 +7,7 @@ import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
+import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FilterPredicate } from '@backstage/filter-predicates';
@@ -22,12 +23,152 @@ import { TranslationRef } from '@backstage/frontend-plugin-api';
 import { TranslationResource } from '@backstage/frontend-plugin-api';
 
 // @public
+export const AiCatalogFilterBlueprint: ExtensionBlueprint<{
+  kind: 'ai-catalog-filter';
+  params: {
+    urlParam: string;
+    label: string;
+    getOptions: (entities: Entity[]) => {
+      id: string;
+      label: string;
+    }[];
+    matchEntity: (entity: Entity, values: string[]) => boolean;
+    priority?: number;
+  };
+  output: ExtensionDataRef<
+    FilterDefinition,
+    'ai-catalog-filter.definition',
+    {}
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
+    filterDefinition: ConfigurableExtensionDataRef<
+      FilterDefinition,
+      'ai-catalog-filter.definition',
+      {}
+    >;
+  };
+}>;
+
+// @public
 const boostPlugin: OverridableFrontendPlugin<
   {
     root: RouteRef<undefined>;
   },
   {},
   {
+    'ai-catalog-filter:boost/category': OverridableExtensionDefinition<{
+      kind: 'ai-catalog-filter';
+      name: 'category';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        FilterDefinition,
+        'ai-catalog-filter.definition',
+        {}
+      >;
+      inputs: {};
+      params: {
+        urlParam: string;
+        label: string;
+        getOptions: (entities: Entity[]) => {
+          id: string;
+          label: string;
+        }[];
+        matchEntity: (entity: Entity, values: string[]) => boolean;
+        priority?: number;
+      };
+    }>;
+    'ai-catalog-filter:boost/lifecycle': OverridableExtensionDefinition<{
+      kind: 'ai-catalog-filter';
+      name: 'lifecycle';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        FilterDefinition,
+        'ai-catalog-filter.definition',
+        {}
+      >;
+      inputs: {};
+      params: {
+        urlParam: string;
+        label: string;
+        getOptions: (entities: Entity[]) => {
+          id: string;
+          label: string;
+        }[];
+        matchEntity: (entity: Entity, values: string[]) => boolean;
+        priority?: number;
+      };
+    }>;
+    'ai-catalog-filter:boost/owner': OverridableExtensionDefinition<{
+      kind: 'ai-catalog-filter';
+      name: 'owner';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        FilterDefinition,
+        'ai-catalog-filter.definition',
+        {}
+      >;
+      inputs: {};
+      params: {
+        urlParam: string;
+        label: string;
+        getOptions: (entities: Entity[]) => {
+          id: string;
+          label: string;
+        }[];
+        matchEntity: (entity: Entity, values: string[]) => boolean;
+        priority?: number;
+      };
+    }>;
+    'ai-catalog-filter:boost/provider': OverridableExtensionDefinition<{
+      kind: 'ai-catalog-filter';
+      name: 'provider';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        FilterDefinition,
+        'ai-catalog-filter.definition',
+        {}
+      >;
+      inputs: {};
+      params: {
+        urlParam: string;
+        label: string;
+        getOptions: (entities: Entity[]) => {
+          id: string;
+          label: string;
+        }[];
+        matchEntity: (entity: Entity, values: string[]) => boolean;
+        priority?: number;
+      };
+    }>;
+    'ai-catalog-filter:boost/tags': OverridableExtensionDefinition<{
+      kind: 'ai-catalog-filter';
+      name: 'tags';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        FilterDefinition,
+        'ai-catalog-filter.definition',
+        {}
+      >;
+      inputs: {};
+      params: {
+        urlParam: string;
+        label: string;
+        getOptions: (entities: Entity[]) => {
+          id: string;
+          label: string;
+        }[];
+        matchEntity: (entity: Entity, values: string[]) => boolean;
+        priority?: number;
+      };
+    }>;
     'entity-card:boost/adoption': OverridableExtensionDefinition<{
       kind: 'entity-card';
       name: 'adoption';
@@ -169,6 +310,7 @@ const boostPlugin: OverridableFrontendPlugin<
         icon?: string | undefined;
       };
       output:
+        | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
         | ExtensionDataRef<string, 'core.routing.path', {}>
         | ExtensionDataRef<
             RouteRef<AnyRouteRefParams>,
@@ -177,7 +319,6 @@ const boostPlugin: OverridableFrontendPlugin<
               optional: true;
             }
           >
-        | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
         | ExtensionDataRef<
             (entity: Entity) => boolean,
             'catalog.entity-filter-function',
@@ -216,10 +357,10 @@ const boostPlugin: OverridableFrontendPlugin<
         defaultGroup?: [Error: `Use the 'group' param instead`];
         group?:
           | (
-              | 'overview'
-              | 'documentation'
               | 'development'
               | 'deployment'
+              | 'overview'
+              | 'documentation'
               | 'operation'
               | 'observability'
             )
@@ -230,20 +371,18 @@ const boostPlugin: OverridableFrontendPlugin<
         filter?: string | FilterPredicate | ((entity: Entity) => boolean);
       };
     }>;
-    'page:boost': OverridableExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
+    'page:boost/ai-catalog': OverridableExtensionDefinition<{
       config: {
         path: string | undefined;
         title: string | undefined;
       };
       configInput: {
-        path?: string | undefined;
-        title?: string | undefined;
+        path?: string | undefined | undefined;
+        title?: string | undefined | undefined;
       };
       output:
-        | ExtensionDataRef<string, 'core.routing.path', {}>
         | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ExtensionDataRef<string, 'core.routing.path', {}>
         | ExtensionDataRef<
             RouteRef<AnyRouteRefParams>,
             'core.routing.ref',
@@ -296,7 +435,21 @@ const boostPlugin: OverridableFrontendPlugin<
             internal: false;
           }
         >;
+        filters: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            FilterDefinition,
+            'ai-catalog-filter.definition',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+            internal: false;
+          }
+        >;
       };
+      kind: 'page';
+      name: 'ai-catalog';
       params: {
         path: string;
         title?: string;
@@ -315,39 +468,40 @@ export const boostTranslationRef: TranslationRef<
   'plugin.boost',
   {
     readonly 'nav.aiCatalog': string;
-    readonly 'catalog.table.name': string;
-    readonly 'catalog.table.type': string;
-    readonly 'catalog.table.description': string;
-    readonly 'catalog.table.provider': string;
-    readonly 'catalog.table.owner': string;
     readonly 'catalog.filter.type': string;
-    readonly 'catalog.filter.provider': string;
-    readonly 'catalog.filter.owner': string;
     readonly 'catalog.filter.tag': string;
-    readonly 'catalog.page.title': string;
-    readonly 'catalog.page.subtitle': string;
+    readonly 'catalog.filter.lifecycle': string;
+    readonly 'catalog.filter.owner': string;
+    readonly 'catalog.filter.provider': string;
     readonly 'catalog.error.title': string;
     readonly 'catalog.error.description': string;
     readonly 'catalog.error.retry': string;
+    readonly 'catalog.page.title': string;
+    readonly 'catalog.page.subtitle': string;
+    readonly 'catalog.table.name': string;
+    readonly 'catalog.table.type': string;
+    readonly 'catalog.table.description': string;
+    readonly 'catalog.table.owner': string;
+    readonly 'catalog.table.provider': string;
+    readonly 'catalog.empty.title': string;
+    readonly 'catalog.empty.description': string;
+    readonly 'catalog.empty.learnMore': string;
+    readonly 'catalog.toolbar.search': string;
+    readonly 'catalog.toolbar.allPrefix': string;
+    readonly 'catalog.toolbar.viewGrid': string;
+    readonly 'catalog.toolbar.viewTable': string;
     readonly 'catalog.tab.usageTitle': string;
     readonly 'catalog.tab.usageDocumentation': string;
     readonly 'catalog.tab.usageViewTechDocs': string;
     readonly 'catalog.tab.usageExternalLinks': string;
     readonly 'catalog.tab.usageNoDocumentation': string;
-    readonly 'catalog.toolbar.search': string;
-    readonly 'catalog.toolbar.allPrefix': string;
-    readonly 'catalog.toolbar.viewGrid': string;
-    readonly 'catalog.toolbar.viewTable': string;
+    readonly 'catalog.card.copied': string;
     readonly 'catalog.card.summaryTitle': string;
     readonly 'catalog.card.adoptionTitle': string;
     readonly 'catalog.card.versionTitle': string;
     readonly 'catalog.card.versionCurrent': string;
     readonly 'catalog.card.copyCommand': string;
-    readonly 'catalog.card.copied': string;
     readonly 'catalog.card.copyAriaLabel': string;
-    readonly 'catalog.empty.title': string;
-    readonly 'catalog.empty.description': string;
-    readonly 'catalog.empty.learnMore': string;
     readonly 'catalog.emptyFiltered.title': string;
     readonly 'catalog.emptyFiltered.description': string;
     readonly 'catalog.emptyFiltered.clearFilters': string;
@@ -359,4 +513,23 @@ export const boostTranslations: TranslationResource<'plugin.boost'>;
 
 // @public
 export const boostTranslationsModule: FrontendModule;
+
+// @public
+export interface FilterDefinition {
+  getOptions: (entities: Entity[]) => {
+    id: string;
+    label: string;
+  }[];
+  label: string;
+  matchEntity: (entity: Entity, values: string[]) => boolean;
+  priority: number;
+  urlParam: string;
+}
+
+// @public
+export const filterDefinitionDataRef: ConfigurableExtensionDataRef<
+  FilterDefinition,
+  'ai-catalog-filter.definition',
+  {}
+>;
 ```

--- a/workspaces/boost/plugins/boost/src/blueprints/AiCatalogFilterBlueprint.ts
+++ b/workspaces/boost/plugins/boost/src/blueprints/AiCatalogFilterBlueprint.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createExtensionBlueprint,
+  createExtensionDataRef,
+} from '@backstage/frontend-plugin-api';
+import type { Entity } from '@backstage/catalog-model';
+
+/**
+ * Describes a single filter in the AI Catalog browse sidebar.
+ * Filters are data — the FilterSidebar renders a generic Select for each.
+ *
+ * @public
+ */
+export interface FilterDefinition {
+  /** URL query parameter name (e.g., 'type', 'owner', 'tag'). */
+  urlParam: string;
+  /** Plain text label for the filter heading. Used when `labelKey` is not set. */
+  label: string;
+  /** Translation key resolved via boostTranslationRef. Takes precedence over `label`. */
+  labelKey?: string;
+  /** Derive select options from the full set of loaded entities. */
+  getOptions: (entities: Entity[]) => { id: string; label: string }[];
+  /** Return true if the entity matches any of the selected values. */
+  matchEntity: (entity: Entity, values: string[]) => boolean;
+  /** Render order in the sidebar. Lower numbers render first. */
+  priority: number;
+}
+
+/**
+ * Extension data ref carrying a FilterDefinition from a filter extension
+ * to the AI Catalog page.
+ *
+ * @public
+ */
+export const filterDefinitionDataRef =
+  createExtensionDataRef<FilterDefinition>().with({
+    id: 'ai-catalog-filter.definition',
+  });
+
+/**
+ * Blueprint for contributing a filter to the AI Catalog browse sidebar.
+ *
+ * Each filter is a plain FilterDefinition — no per-filter React component
+ * needed. The FilterSidebar renders a generic Select for each definition.
+ *
+ * @example
+ * ```
+ * const myFilter = AiCatalogFilterBlueprint.make({
+ *   name: 'namespace',
+ *   params: {
+ *     urlParam: 'ns',
+ *     label: 'Namespace',
+ *     getOptions: entities =>
+ *       uniqueSorted(entities.map(e => e.metadata.namespace ?? 'default')),
+ *     matchEntity: (entity, values) =>
+ *       values.includes(entity.metadata.namespace ?? 'default'),
+ *   },
+ * });
+ * ```
+ *
+ * Deployers can disable filters via app-config:
+ * ```yaml
+ * app:
+ *   extensions:
+ *     - ai-catalog-filter:boost/owner: false
+ * ```
+ *
+ * @public
+ */
+export const AiCatalogFilterBlueprint = createExtensionBlueprint({
+  kind: 'ai-catalog-filter',
+  attachTo: { id: 'page:boost/ai-catalog', input: 'filters' },
+  output: [filterDefinitionDataRef],
+  dataRefs: {
+    filterDefinition: filterDefinitionDataRef,
+  },
+  *factory(params: {
+    urlParam: string;
+    label: string;
+    labelKey?: string;
+    getOptions: (entities: Entity[]) => { id: string; label: string }[];
+    matchEntity: (entity: Entity, values: string[]) => boolean;
+    priority?: number;
+  }) {
+    yield filterDefinitionDataRef({
+      urlParam: params.urlParam,
+      label: params.label,
+      labelKey: params.labelKey,
+      getOptions: params.getOptions,
+      matchEntity: params.matchEntity,
+      priority: params.priority ?? 100,
+    });
+  },
+});

--- a/workspaces/boost/plugins/boost/src/components/catalog/AiCatalogPage.test.tsx
+++ b/workspaces/boost/plugins/boost/src/components/catalog/AiCatalogPage.test.tsx
@@ -20,10 +20,23 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { screen, waitFor } from '@testing-library/react';
 
+import {
+  categoryFilterDefinition,
+  providerFilterDefinition,
+  ownerFilterDefinition,
+  tagsFilterDefinition,
+} from '../../filters/builtInFilterDefinitions';
 import { boostMessages } from '../../translations/ref';
 import { AiCatalogPage } from './AiCatalogPage';
 
 const { catalog: msg } = boostMessages;
+
+const defaultFilters = [
+  categoryFilterDefinition,
+  providerFilterDefinition,
+  ownerFilterDefinition,
+  tagsFilterDefinition,
+];
 
 const mockEntities: Entity[] = [
   {
@@ -65,7 +78,7 @@ function renderPage() {
     <TestApiProvider
       apis={[[catalogApiRef, mockCatalogApi as unknown as CatalogApi]]}
     >
-      <AiCatalogPage />
+      <AiCatalogPage filters={defaultFilters} />
     </TestApiProvider>,
   );
 }

--- a/workspaces/boost/plugins/boost/src/components/catalog/AiCatalogPage.tsx
+++ b/workspaces/boost/plugins/boost/src/components/catalog/AiCatalogPage.tsx
@@ -28,6 +28,7 @@ import {
 import GridViewOutlined from '@mui/icons-material/GridViewOutlined';
 import ViewListOutlined from '@mui/icons-material/ViewListOutlined';
 
+import type { FilterDefinition } from '../../blueprints/AiCatalogFilterBlueprint';
 import { useAiAssets } from '../../hooks/useAiAssets';
 import { useUrlFilters } from '../../hooks/useUrlFilters';
 import { useTranslation } from '../../hooks/useTranslation';
@@ -42,17 +43,25 @@ import { ErrorBoundary } from './ErrorBoundary';
 import { FilterSidebar } from './FilterSidebar';
 import styles from './AiCatalogPage.module.css';
 
-const AiCatalogPageContent = () => {
+interface AiCatalogPageProps {
+  filters: FilterDefinition[];
+}
+
+const AiCatalogPageContent = ({ filters }: AiCatalogPageProps) => {
   const { t } = useTranslation();
-  const urlState = useUrlFilters();
+
+  const filterParams = useMemo(() => filters.map(f => f.urlParam), [filters]);
+  const categoryUrlParam = filters.find(f => f.urlParam === 'type')?.urlParam;
+  const urlState = useUrlFilters(filterParams);
   const {
-    filters,
+    search,
     searchInputValue,
+    filterValues,
     viewMode,
     page,
     pageSize,
     setSearch,
-    setCategory,
+    setFilter,
     setViewMode,
     setPage,
     setPageSize,
@@ -65,7 +74,7 @@ const AiCatalogPageContent = () => {
     loading,
     error,
     retry,
-  } = useAiAssets(filters);
+  } = useAiAssets(search || undefined, filters, filterValues);
 
   const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor | null>(
     null,
@@ -104,12 +113,7 @@ const AiCatalogPageContent = () => {
   if (loading) return <LoadingState />;
   if (error) return <ErrorState onRetry={retry} />;
 
-  const hasActiveFilters =
-    filters.search ||
-    filters.category?.length ||
-    filters.provider?.length ||
-    filters.tags?.length ||
-    filters.owner?.length;
+  const hasActiveFilters = search || filterValues.size > 0;
 
   if (allEntities.length === 0 && !hasActiveFilters) {
     return <EmptyState />;
@@ -118,9 +122,10 @@ const AiCatalogPageContent = () => {
   return (
     <Flex gap="6" p="4" align="start" className={styles.layout}>
       <FilterSidebar
+        filters={filters}
         entities={allEntities}
-        state={{ filters }}
-        actions={urlState}
+        values={filterValues}
+        onFilterChange={setFilter}
       />
       <Flex direction="column" grow={1} className={styles.content}>
         <Flex align="center" justify="between" gap="4" mb="4">
@@ -170,7 +175,11 @@ const AiCatalogPageContent = () => {
               <Grid.Item key={entity.metadata.uid ?? entity.metadata.name}>
                 <AiAssetCard
                   entity={entity}
-                  onCategoryClick={cat => setCategory([cat])}
+                  onCategoryClick={
+                    categoryUrlParam
+                      ? cat => setFilter(categoryUrlParam, [cat])
+                      : undefined
+                  }
                 />
               </Grid.Item>
             ))}
@@ -201,14 +210,14 @@ const AiCatalogPageContent = () => {
   );
 };
 
-export const AiCatalogPage = () => {
+export const AiCatalogPage = ({ filters }: AiCatalogPageProps) => {
   const { t } = useTranslation();
   return (
     <ErrorBoundary
       title={t('catalog.error.title')}
       retryLabel={t('catalog.error.retry')}
     >
-      <AiCatalogPageContent />
+      <AiCatalogPageContent filters={filters} />
     </ErrorBoundary>
   );
 };

--- a/workspaces/boost/plugins/boost/src/components/catalog/FilterSidebar.tsx
+++ b/workspaces/boost/plugins/boost/src/components/catalog/FilterSidebar.tsx
@@ -19,110 +19,76 @@ import type { Entity } from '@backstage/catalog-model';
 import { Select } from '@backstage/ui';
 import type { Key } from 'react-aria-components';
 
+import type { FilterDefinition } from '../../blueprints/AiCatalogFilterBlueprint';
 import { useTranslation } from '../../hooks/useTranslation';
-import { getAllCategories } from '../../utils/categoryMeta';
-import { getSpecField } from '../../utils/entityHelpers';
-import type {
-  UrlFilterActions,
-  UrlFilterState,
-} from '../../hooks/useUrlFilters';
 import styles from './FilterSidebar.module.css';
 
+type TranslationKey = Parameters<ReturnType<typeof useTranslation>['t']>[0];
+
 interface FilterSidebarProps {
+  filters: FilterDefinition[];
   entities: Entity[];
-  state: Pick<UrlFilterState, 'filters'>;
-  actions: Pick<
-    UrlFilterActions,
-    'setCategory' | 'setProvider' | 'setOwner' | 'setTag'
-  >;
+  values: Map<string, string[]>;
+  onFilterChange: (urlParam: string, values: string[]) => void;
 }
 
-function uniqueOptions(
-  items: (string | undefined)[],
-): { id: string; label: string }[] {
-  const set = new Set<string>();
-  for (const item of items) {
-    if (item) set.add(item);
-  }
-  return Array.from(set)
-    .sort((a, b) => a.localeCompare(b))
-    .map(v => ({ id: v, label: v }));
-}
-
-export const FilterSidebar = ({
+function FilterSelect({
+  filter,
   entities,
-  state,
-  actions: { setCategory, setProvider, setOwner, setTag },
-}: FilterSidebarProps) => {
+  selected,
+  onChange,
+}: {
+  filter: FilterDefinition;
+  entities: Entity[];
+  selected: string[];
+  onChange: (values: string[]) => void;
+}) {
   const { t } = useTranslation();
-
-  const categoryOptions = useMemo(() => getAllCategories(), []);
-
-  const providerOptions = useMemo(
-    () =>
-      uniqueOptions(
-        entities.map(e => e.metadata.annotations?.['rhdh.io/ai-asset-source']),
-      ),
-    [entities],
+  const label = filter.labelKey
+    ? t(filter.labelKey as TranslationKey)
+    : filter.label;
+  const options = useMemo(
+    () => filter.getOptions(entities),
+    [filter, entities],
   );
 
-  const ownerOptions = useMemo(
-    () => uniqueOptions(entities.map(e => getSpecField(e, 'owner'))),
-    [entities],
-  );
-
-  const tagOptions = useMemo(
-    () => uniqueOptions(entities.flatMap(e => e.metadata.tags ?? [])),
-    [entities],
-  );
-
-  const onCategoryChange = useCallback(
-    (value: Key[]) => setCategory(value as string[]),
-    [setCategory],
-  );
-  const onProviderChange = useCallback(
-    (value: Key[]) => setProvider(value as string[]),
-    [setProvider],
-  );
-  const onOwnerChange = useCallback(
-    (value: Key[]) => setOwner(value as string[]),
-    [setOwner],
-  );
-  const onTagChange = useCallback(
-    (value: Key[]) => setTag(value as string[]),
-    [setTag],
+  const handleChange = useCallback(
+    (keys: Key[]) => onChange(keys as string[]),
+    [onChange],
   );
 
   return (
+    <Select
+      label={label}
+      selectionMode="multiple"
+      options={options}
+      value={selected}
+      onChange={handleChange}
+    />
+  );
+}
+
+export const FilterSidebar = ({
+  filters,
+  entities,
+  values,
+  onFilterChange,
+}: FilterSidebarProps) => {
+  const { t } = useTranslation();
+
+  if (filters.length === 0) return null;
+
+  return (
     <nav className={styles.sidebar} aria-label={t('catalog.page.title')}>
-      <Select
-        label={t('catalog.filter.type')}
-        selectionMode="multiple"
-        options={categoryOptions}
-        value={state.filters.category ?? []}
-        onChange={onCategoryChange}
-      />
-      <Select
-        label={t('catalog.filter.provider')}
-        selectionMode="multiple"
-        options={providerOptions}
-        value={state.filters.provider ?? []}
-        onChange={onProviderChange}
-      />
-      <Select
-        label={t('catalog.filter.owner')}
-        selectionMode="multiple"
-        options={ownerOptions}
-        value={state.filters.owner ?? []}
-        onChange={onOwnerChange}
-      />
-      <Select
-        label={t('catalog.filter.tag')}
-        selectionMode="multiple"
-        options={tagOptions}
-        value={state.filters.tags ?? []}
-        onChange={onTagChange}
-      />
+      {filters.map(filter => (
+        <FilterSelect
+          key={filter.urlParam}
+          filter={filter}
+          entities={entities}
+          selected={values.get(filter.urlParam) ?? []}
+          onChange={vals => onFilterChange(filter.urlParam, vals)}
+        />
+      ))}
     </nav>
   );
 };

--- a/workspaces/boost/plugins/boost/src/filters/builtInFilterDefinitions.test.ts
+++ b/workspaces/boost/plugins/boost/src/filters/builtInFilterDefinitions.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Entity } from '@backstage/catalog-model';
+
+import {
+  categoryFilterDefinition,
+  providerFilterDefinition,
+  ownerFilterDefinition,
+  tagsFilterDefinition,
+} from './builtInFilterDefinitions';
+
+const skill: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'AiResource',
+  metadata: {
+    name: 'code-review',
+    namespace: 'default',
+    tags: ['security', 'quality'],
+    annotations: { 'rhdh.io/ai-asset-source': 'github' },
+  },
+  spec: { type: 'skill', lifecycle: 'production', owner: 'team-ai' },
+};
+
+const agent: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'dev-assistant',
+    namespace: 'default',
+    tags: ['agent'],
+    annotations: { 'rhdh.io/ai-asset-source': 'kagenti' },
+  },
+  spec: { type: 'ai-agent', lifecycle: 'experimental', owner: 'team-ml' },
+};
+
+const entities = [skill, agent];
+
+describe('builtinFilters', () => {
+  describe('categoryFilterDefinition', () => {
+    it('returns all category options', () => {
+      const options = categoryFilterDefinition.getOptions(entities);
+      expect(options.length).toBeGreaterThanOrEqual(5);
+      expect(options.find(o => o.id === 'skill')).toBeDefined();
+      expect(options.find(o => o.id === 'ai-agent')).toBeDefined();
+    });
+
+    it('matches entity by spec.type', () => {
+      expect(categoryFilterDefinition.matchEntity(skill, ['skill'])).toBe(true);
+      expect(categoryFilterDefinition.matchEntity(skill, ['ai-agent'])).toBe(
+        false,
+      );
+      expect(categoryFilterDefinition.matchEntity(agent, ['ai-agent'])).toBe(
+        true,
+      );
+    });
+
+    it('matches case-insensitively', () => {
+      expect(categoryFilterDefinition.matchEntity(skill, ['SKILL'])).toBe(true);
+    });
+
+    it('has correct urlParam and priority', () => {
+      expect(categoryFilterDefinition.urlParam).toBe('type');
+      expect(categoryFilterDefinition.priority).toBe(100);
+    });
+  });
+
+  describe('providerFilterDefinition', () => {
+    it('returns unique sorted provider options', () => {
+      const options = providerFilterDefinition.getOptions(entities);
+      expect(options).toEqual([
+        { id: 'github', label: 'github' },
+        { id: 'kagenti', label: 'kagenti' },
+      ]);
+    });
+
+    it('matches entity by annotation', () => {
+      expect(providerFilterDefinition.matchEntity(skill, ['github'])).toBe(
+        true,
+      );
+      expect(providerFilterDefinition.matchEntity(skill, ['kagenti'])).toBe(
+        false,
+      );
+      expect(providerFilterDefinition.matchEntity(agent, ['kagenti'])).toBe(
+        true,
+      );
+    });
+
+    it('has correct urlParam', () => {
+      expect(providerFilterDefinition.urlParam).toBe('provider');
+    });
+  });
+
+  describe('ownerFilterDefinition', () => {
+    it('returns unique sorted owner options', () => {
+      const options = ownerFilterDefinition.getOptions(entities);
+      expect(options).toEqual([
+        { id: 'team-ai', label: 'team-ai' },
+        { id: 'team-ml', label: 'team-ml' },
+      ]);
+    });
+
+    it('matches entity by spec.owner', () => {
+      expect(ownerFilterDefinition.matchEntity(skill, ['team-ai'])).toBe(true);
+      expect(ownerFilterDefinition.matchEntity(skill, ['team-ml'])).toBe(false);
+    });
+
+    it('has correct urlParam', () => {
+      expect(ownerFilterDefinition.urlParam).toBe('owner');
+    });
+  });
+
+  describe('tagsFilterDefinition', () => {
+    it('returns unique sorted tag options', () => {
+      const options = tagsFilterDefinition.getOptions(entities);
+      expect(options).toEqual([
+        { id: 'agent', label: 'agent' },
+        { id: 'quality', label: 'quality' },
+        { id: 'security', label: 'security' },
+      ]);
+    });
+
+    it('matches entity when any tag matches', () => {
+      expect(tagsFilterDefinition.matchEntity(skill, ['security'])).toBe(true);
+      expect(tagsFilterDefinition.matchEntity(skill, ['agent'])).toBe(false);
+      expect(tagsFilterDefinition.matchEntity(agent, ['agent'])).toBe(true);
+    });
+
+    it('matches case-insensitively', () => {
+      expect(tagsFilterDefinition.matchEntity(skill, ['SECURITY'])).toBe(true);
+    });
+
+    it('has correct urlParam', () => {
+      expect(tagsFilterDefinition.urlParam).toBe('tag');
+    });
+  });
+
+  describe('priority ordering', () => {
+    it('built-in filters have ascending priorities', () => {
+      const priorities = [
+        categoryFilterDefinition.priority,
+        providerFilterDefinition.priority,
+        ownerFilterDefinition.priority,
+        tagsFilterDefinition.priority,
+      ];
+      for (let i = 1; i < priorities.length; i++) {
+        expect(priorities[i]).toBeGreaterThan(priorities[i - 1]);
+      }
+    });
+  });
+});

--- a/workspaces/boost/plugins/boost/src/filters/builtInFilterDefinitions.ts
+++ b/workspaces/boost/plugins/boost/src/filters/builtInFilterDefinitions.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Entity } from '@backstage/catalog-model';
+
+import type { FilterDefinition } from '../blueprints/AiCatalogFilterBlueprint';
+import { getAllCategories } from '../utils/categoryMeta';
+import { getSpecField } from '../utils/entityHelpers';
+
+function uniqueSorted(
+  items: (string | undefined)[],
+): { id: string; label: string }[] {
+  const set = new Set<string>();
+  for (const item of items) {
+    if (item) set.add(item);
+  }
+  return Array.from(set)
+    .sort((a, b) => a.localeCompare(b))
+    .map(v => ({ id: v, label: v }));
+}
+
+function matchesCaseInsensitive(
+  value: string | undefined,
+  selected: string[],
+): boolean {
+  return (
+    value !== undefined &&
+    selected.some(s => s.toLowerCase() === value.toLowerCase())
+  );
+}
+
+export const categoryFilterDefinition: FilterDefinition = {
+  urlParam: 'type',
+  label: 'Type',
+  labelKey: 'catalog.filter.type',
+  getOptions: (_entities: Entity[]) => getAllCategories(),
+  matchEntity: (entity: Entity, values: string[]) =>
+    matchesCaseInsensitive(getSpecField(entity, 'type'), values),
+  priority: 100,
+};
+
+export const providerFilterDefinition: FilterDefinition = {
+  urlParam: 'provider',
+  label: 'Provider',
+  labelKey: 'catalog.filter.provider',
+  getOptions: (entities: Entity[]) =>
+    uniqueSorted(
+      entities.map(e => e.metadata.annotations?.['rhdh.io/ai-asset-source']),
+    ),
+  matchEntity: (entity: Entity, values: string[]) =>
+    matchesCaseInsensitive(
+      entity.metadata.annotations?.['rhdh.io/ai-asset-source'],
+      values,
+    ),
+  priority: 200,
+};
+
+export const ownerFilterDefinition: FilterDefinition = {
+  urlParam: 'owner',
+  label: 'Owner',
+  labelKey: 'catalog.filter.owner',
+  getOptions: (entities: Entity[]) =>
+    uniqueSorted(entities.map(e => getSpecField(e, 'owner'))),
+  matchEntity: (entity: Entity, values: string[]) =>
+    matchesCaseInsensitive(getSpecField(entity, 'owner'), values),
+  priority: 300,
+};
+
+export const tagsFilterDefinition: FilterDefinition = {
+  urlParam: 'tag',
+  label: 'Tag',
+  labelKey: 'catalog.filter.tag',
+  getOptions: (entities: Entity[]) =>
+    uniqueSorted(entities.flatMap(e => e.metadata.tags ?? [])),
+  matchEntity: (entity: Entity, values: string[]) => {
+    const tagSet = new Set(values.map(t => t.toLowerCase()));
+    return (entity.metadata.tags ?? []).some(t => tagSet.has(t.toLowerCase()));
+  },
+  priority: 400,
+};

--- a/workspaces/boost/plugins/boost/src/hooks/useAiAssets.test.ts
+++ b/workspaces/boost/plugins/boost/src/hooks/useAiAssets.test.ts
@@ -23,6 +23,11 @@ import { TestApiProvider } from '@backstage/test-utils';
 import { renderHook, waitFor } from '@testing-library/react';
 import { type ReactNode, createElement } from 'react';
 
+import type { FilterDefinition } from '../blueprints/AiCatalogFilterBlueprint';
+import {
+  categoryFilterDefinition,
+  tagsFilterDefinition,
+} from '../filters/builtInFilterDefinitions';
 import { useAiAssets } from './useAiAssets';
 
 const aiSkill: Entity = {
@@ -60,6 +65,9 @@ const mockCatalogApi: Pick<jest.Mocked<CatalogApi>, 'getEntities'> = {
   getEntities: jest.fn(),
 };
 
+const emptyFilters: FilterDefinition[] = [];
+const emptyValues = new Map<string, string[]>();
+
 function wrapper({ children }: { children: ReactNode }) {
   return createElement(
     TestApiProvider,
@@ -77,7 +85,10 @@ describe('useAiAssets', () => {
 
   it('returns loading true initially', () => {
     mockCatalogApi.getEntities.mockReturnValue(new Promise(() => {}));
-    const { result } = renderHook(() => useAiAssets(), { wrapper });
+    const { result } = renderHook(
+      () => useAiAssets(undefined, emptyFilters, emptyValues),
+      { wrapper },
+    );
     expect(result.current.loading).toBe(true);
     expect(result.current.entities).toEqual([]);
   });
@@ -87,7 +98,10 @@ describe('useAiAssets', () => {
       items: [aiSkill, aiAgent, nonAiComponent],
     });
 
-    const { result } = renderHook(() => useAiAssets(), { wrapper });
+    const { result } = renderHook(
+      () => useAiAssets(undefined, emptyFilters, emptyValues),
+      { wrapper },
+    );
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -106,7 +120,7 @@ describe('useAiAssets', () => {
     });
 
     const { result } = renderHook(
-      () => useAiAssets({ search: 'code review' }),
+      () => useAiAssets('code review', emptyFilters, emptyValues),
       { wrapper },
     );
 
@@ -118,14 +132,18 @@ describe('useAiAssets', () => {
     expect(result.current.entities[0].metadata.name).toBe('test-skill');
   });
 
-  it('filters by tags', async () => {
+  it('filters by tags via FilterDefinition', async () => {
     mockCatalogApi.getEntities.mockResolvedValue({
       items: [aiSkill, aiAgent],
     });
 
-    const { result } = renderHook(() => useAiAssets({ tags: ['agent'] }), {
-      wrapper,
-    });
+    const filters = [tagsFilterDefinition];
+    const values = new Map([['tag', ['agent']]]);
+
+    const { result } = renderHook(
+      () => useAiAssets(undefined, filters, values),
+      { wrapper },
+    );
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -135,14 +153,18 @@ describe('useAiAssets', () => {
     expect(result.current.entities[0].metadata.name).toBe('test-agent');
   });
 
-  it('filters by category (spec.type)', async () => {
+  it('filters by category via FilterDefinition', async () => {
     mockCatalogApi.getEntities.mockResolvedValue({
       items: [aiSkill, aiAgent],
     });
 
-    const { result } = renderHook(() => useAiAssets({ category: ['skill'] }), {
-      wrapper,
-    });
+    const filters = [categoryFilterDefinition];
+    const values = new Map([['type', ['skill']]]);
+
+    const { result } = renderHook(
+      () => useAiAssets(undefined, filters, values),
+      { wrapper },
+    );
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -155,7 +177,10 @@ describe('useAiAssets', () => {
   it('sets error on fetch failure', async () => {
     mockCatalogApi.getEntities.mockRejectedValue(new Error('Network error'));
 
-    const { result } = renderHook(() => useAiAssets(), { wrapper });
+    const { result } = renderHook(
+      () => useAiAssets(undefined, emptyFilters, emptyValues),
+      { wrapper },
+    );
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -172,8 +197,15 @@ describe('useAiAssets', () => {
     });
 
     const { result, rerender } = renderHook(
-      ({ filters }) => useAiAssets(filters),
-      { wrapper, initialProps: { filters: {} } },
+      ({ search, filters, values }) => useAiAssets(search, filters, values),
+      {
+        wrapper,
+        initialProps: {
+          search: undefined as string | undefined,
+          filters: emptyFilters,
+          values: emptyValues,
+        },
+      },
     );
 
     await waitFor(() => {
@@ -182,7 +214,7 @@ describe('useAiAssets', () => {
 
     expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
 
-    rerender({ filters: { search: 'skill' } });
+    rerender({ search: 'skill', filters: emptyFilters, values: emptyValues });
 
     expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
     expect(result.current.entities).toHaveLength(1);

--- a/workspaces/boost/plugins/boost/src/hooks/useAiAssets.ts
+++ b/workspaces/boost/plugins/boost/src/hooks/useAiAssets.ts
@@ -18,10 +18,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { type EntityFilters, applyEntityFilters } from '../utils/entityHelpers';
+import type { FilterDefinition } from '../blueprints/AiCatalogFilterBlueprint';
+import { applyEntityFilters } from '../utils/entityHelpers';
 import { buildCatalogFilter, isAiAsset } from '../utils/isAiAsset';
-
-export type AiAssetFilters = EntityFilters;
 
 export interface UseAiAssetsResult {
   /** Entities after all client-side filters. */
@@ -37,15 +36,12 @@ export interface UseAiAssetsResult {
  * Fetches all AI asset entities from the catalog and applies filters
  * client-side. The catalog API is called once on mount (and on retry);
  * all filtering is a pure memo over the cached result.
- *
- * Callers must pass a memoized `filters` object (e.g. from useMemo or
- * useUrlFilters) — an inline object literal will defeat the memo and
- * recompute on every render.
- *
- * When catalogs grow beyond ~500 assets, the internals can switch to
- * cursor-based queryEntities without changing the consumer API.
  */
-export function useAiAssets(filters: AiAssetFilters = {}): UseAiAssetsResult {
+export function useAiAssets(
+  search: string | undefined,
+  filters: FilterDefinition[],
+  filterValues: Map<string, string[]>,
+): UseAiAssetsResult {
   const catalogApi = useApi(catalogApiRef);
   const [allEntities, setAllEntities] = useState<Entity[]>([]);
   const [loading, setLoading] = useState(true);
@@ -90,8 +86,8 @@ export function useAiAssets(filters: AiAssetFilters = {}): UseAiAssetsResult {
   }, [catalogApi, retryCount]);
 
   const entities = useMemo(
-    () => applyEntityFilters(allEntities, filters),
-    [allEntities, filters],
+    () => applyEntityFilters(allEntities, search, filters, filterValues),
+    [allEntities, search, filters, filterValues],
   );
 
   return { entities, allEntities, loading, error, retry };

--- a/workspaces/boost/plugins/boost/src/hooks/useUrlFilters.ts
+++ b/workspaces/boost/plugins/boost/src/hooks/useUrlFilters.ts
@@ -17,15 +17,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import type { AiAssetFilters } from './useAiAssets';
-
 export type ViewMode = 'grid' | 'table';
 
 export interface UrlFilterState {
-  /** Debounced filters passed to useAiAssets. */
-  filters: AiAssetFilters;
-  /** Current search input value (not debounced) — bind to SearchField. */
+  search: string;
   searchInputValue: string;
+  filterValues: Map<string, string[]>;
   viewMode: ViewMode;
   page: number;
   pageSize: number;
@@ -33,10 +30,7 @@ export interface UrlFilterState {
 
 export interface UrlFilterActions {
   setSearch: (value: string) => void;
-  setCategory: (values: string[]) => void;
-  setProvider: (values: string[]) => void;
-  setOwner: (values: string[]) => void;
-  setTag: (values: string[]) => void;
+  setFilter: (urlParam: string, values: string[]) => void;
   setViewMode: (mode: ViewMode) => void;
   setPage: (page: number) => void;
   setPageSize: (size: number) => void;
@@ -48,46 +42,36 @@ function readArray(params: URLSearchParams, key: string): string[] {
   return val ? val.split(',').filter(Boolean) : [];
 }
 
-function writeArray(
-  params: URLSearchParams,
-  key: string,
-  values: string[],
-): void {
-  if (values.length > 0) {
-    params.set(key, values.join(','));
-  } else {
-    params.delete(key);
-  }
-}
-
 const SEARCH_DEBOUNCE_MS = 300;
 
 /**
  * Synchronizes filter, search, pagination, and view mode state
- * with URL query parameters. Search is debounced at 300ms so
- * the SearchField responds instantly while the data query
- * waits for the user to stop typing.
+ * with URL query parameters. Accepts dynamic filter param names
+ * from the registered FilterDefinition set.
  */
-export function useUrlFilters(): UrlFilterState & UrlFilterActions {
+export function useUrlFilters(
+  filterParams: string[],
+): UrlFilterState & UrlFilterActions {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const rawSearch = searchParams.get('q') ?? '';
-  const category = useMemo(
-    () => readArray(searchParams, 'type'),
-    [searchParams],
-  );
-  const provider = useMemo(
-    () => readArray(searchParams, 'provider'),
-    [searchParams],
-  );
-  const owner = useMemo(() => readArray(searchParams, 'owner'), [searchParams]);
-  const tag = useMemo(() => readArray(searchParams, 'tag'), [searchParams]);
   const viewMode = (searchParams.get('view') as ViewMode) || 'grid';
   const page = Math.max(0, parseInt(searchParams.get('page') ?? '0', 10) || 0);
   const pageSize = Math.min(
     100,
     Math.max(1, parseInt(searchParams.get('pageSize') ?? '20', 10) || 20),
   );
+
+  const filterValues = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const param of filterParams) {
+      const vals = readArray(searchParams, param);
+      if (vals.length > 0) {
+        map.set(param, vals);
+      }
+    }
+    return map;
+  }, [searchParams, filterParams]);
 
   const [searchInputValue, setSearchInputValue] = useState(rawSearch);
   const [debouncedSearch, setDebouncedSearch] = useState(rawSearch);
@@ -123,118 +107,91 @@ export function useUrlFilters(): UrlFilterState & UrlFilterActions {
     return () => clearTimeout(timerRef.current);
   }, [searchInputValue, setSearchParams]);
 
-  const update = useCallback(
-    (updater: (params: URLSearchParams) => void) => {
+  const setSearch = useCallback((value: string) => {
+    setSearchInputValue(value);
+  }, []);
+
+  const setFilter = useCallback(
+    (urlParam: string, values: string[]) => {
       setSearchParams(prev => {
         const next = new URLSearchParams(prev);
-        updater(next);
+        if (values.length > 0) {
+          next.set(urlParam, values.join(','));
+        } else {
+          next.delete(urlParam);
+        }
+        next.delete('page');
         return next;
       });
     },
     [setSearchParams],
   );
 
-  const setSearch = useCallback((value: string) => {
-    setSearchInputValue(value);
-  }, []);
-
-  const setCategory = useCallback(
-    (values: string[]) =>
-      update(p => {
-        writeArray(p, 'type', values);
-        p.delete('page');
-      }),
-    [update],
-  );
-
-  const setProvider = useCallback(
-    (values: string[]) =>
-      update(p => {
-        writeArray(p, 'provider', values);
-        p.delete('page');
-      }),
-    [update],
-  );
-
-  const setOwner = useCallback(
-    (values: string[]) =>
-      update(p => {
-        writeArray(p, 'owner', values);
-        p.delete('page');
-      }),
-    [update],
-  );
-
-  const setTag = useCallback(
-    (values: string[]) =>
-      update(p => {
-        writeArray(p, 'tag', values);
-        p.delete('page');
-      }),
-    [update],
-  );
-
   const setViewMode = useCallback(
-    (mode: ViewMode) =>
-      update(p => {
+    (mode: ViewMode) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev);
         if (mode === 'grid') {
-          p.delete('view');
+          next.delete('view');
         } else {
-          p.set('view', mode);
+          next.set('view', mode);
         }
-      }),
-    [update],
+        return next;
+      });
+    },
+    [setSearchParams],
   );
 
   const setPage = useCallback(
-    (p: number) =>
-      update(params => {
+    (p: number) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev);
         if (p === 0) {
-          params.delete('page');
+          next.delete('page');
         } else {
-          params.set('page', String(p));
+          next.set('page', String(p));
         }
-      }),
-    [update],
+        return next;
+      });
+    },
+    [setSearchParams],
   );
 
   const setPageSize = useCallback(
-    (size: number) =>
-      update(p => {
-        p.set('pageSize', String(size));
-        p.delete('page');
-      }),
-    [update],
+    (size: number) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev);
+        next.set('pageSize', String(size));
+        next.delete('page');
+        return next;
+      });
+    },
+    [setSearchParams],
   );
 
   const clearFilters = useCallback(() => {
-    setSearchParams(new URLSearchParams());
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      next.delete('q');
+      next.delete('page');
+      for (const param of filterParams) {
+        next.delete(param);
+      }
+      return next;
+    });
     setSearchInputValue('');
     setDebouncedSearch('');
-  }, [setSearchParams]);
-
-  const filters: AiAssetFilters = useMemo(
-    () => ({
-      search: debouncedSearch || undefined,
-      category: category.length > 0 ? category : undefined,
-      provider: provider.length > 0 ? provider : undefined,
-      tags: tag.length > 0 ? tag : undefined,
-      owner: owner.length > 0 ? owner : undefined,
-    }),
-    [debouncedSearch, category, provider, tag, owner],
-  );
+  }, [setSearchParams, filterParams]);
 
   return {
-    filters,
+    search: debouncedSearch,
     searchInputValue,
+    filterValues,
     viewMode,
     page,
     pageSize,
     setSearch,
-    setCategory,
-    setProvider,
-    setOwner,
-    setTag,
+    setFilter,
     setViewMode,
     setPage,
     setPageSize,

--- a/workspaces/boost/plugins/boost/src/index.ts
+++ b/workspaces/boost/plugins/boost/src/index.ts
@@ -25,3 +25,10 @@
 export { boostPlugin as default, boostTranslationsModule } from './plugin';
 /** @public */
 export { boostTranslationRef, boostTranslations } from './translations';
+/** @public */
+export {
+  AiCatalogFilterBlueprint,
+  filterDefinitionDataRef,
+} from './blueprints/AiCatalogFilterBlueprint';
+/** @public */
+export type { FilterDefinition } from './blueprints/AiCatalogFilterBlueprint';

--- a/workspaces/boost/plugins/boost/src/plugin.tsx
+++ b/workspaces/boost/plugins/boost/src/plugin.tsx
@@ -15,6 +15,7 @@
  */
 
 import {
+  createExtensionInput,
   createFrontendModule,
   createFrontendPlugin,
   PageBlueprint,
@@ -25,19 +26,62 @@ import {
   EntityContentBlueprint,
 } from '@backstage/plugin-catalog-react/alpha';
 
+import {
+  AiCatalogFilterBlueprint,
+  filterDefinitionDataRef,
+} from './blueprints/AiCatalogFilterBlueprint';
+import {
+  categoryFilterDefinition,
+  providerFilterDefinition,
+  ownerFilterDefinition,
+  tagsFilterDefinition,
+} from './filters/builtInFilterDefinitions';
 import { rootRouteRef } from './routes';
 import { boostTranslations } from './translations';
 import { isAiAsset } from './utils/isAiAsset';
 
 // ---------------------------------------------------------------------------
-// Page Blueprint — Browse page at /ai-catalog
+// Built-in filter extensions
 // ---------------------------------------------------------------------------
-const aiCatalogPage = PageBlueprint.make({
-  params: {
-    path: '/ai-catalog',
-    routeRef: rootRouteRef,
-    title: 'AI Catalog',
-    loader: () => import('./components/catalog').then(m => <m.AiCatalogPage />),
+const categoryFilter = AiCatalogFilterBlueprint.make({
+  name: 'category',
+  params: categoryFilterDefinition,
+});
+const providerFilter = AiCatalogFilterBlueprint.make({
+  name: 'provider',
+  params: providerFilterDefinition,
+});
+const ownerFilter = AiCatalogFilterBlueprint.make({
+  name: 'owner',
+  params: ownerFilterDefinition,
+});
+const tagsFilter = AiCatalogFilterBlueprint.make({
+  name: 'tags',
+  params: tagsFilterDefinition,
+});
+
+// ---------------------------------------------------------------------------
+// Page Blueprint — Browse page at /ai-catalog with extensible filter input
+// ---------------------------------------------------------------------------
+const aiCatalogPage = PageBlueprint.makeWithOverrides({
+  name: 'ai-catalog',
+  inputs: {
+    filters: createExtensionInput([filterDefinitionDataRef]),
+  },
+  factory(originalFactory, { inputs }) {
+    const filterDefs = inputs.filters
+      .map(f => f.get(filterDefinitionDataRef))
+      .sort((a, b) => a.priority - b.priority);
+
+    return originalFactory({
+      path: '/ai-catalog',
+      routeRef: rootRouteRef,
+      title: 'AI Catalog',
+      loader: () =>
+        import('./components/catalog').then(m => (
+          <m.AiCatalogPage filters={filterDefs} />
+        )),
+    });
   },
 });
 
@@ -113,6 +157,10 @@ export const boostPlugin = createFrontendPlugin({
   pluginId: 'boost',
   extensions: [
     aiCatalogPage,
+    categoryFilter,
+    providerFilter,
+    ownerFilter,
+    tagsFilter,
     summaryCard,
     adoptionCard,
     versionListCard,

--- a/workspaces/boost/plugins/boost/src/utils/entityHelpers.test.ts
+++ b/workspaces/boost/plugins/boost/src/utils/entityHelpers.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Entity } from '@backstage/catalog-model';
+
+import type { FilterDefinition } from '../blueprints/AiCatalogFilterBlueprint';
+import { applyEntityFilters } from './entityHelpers';
+
+const skill: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'AiResource',
+  metadata: {
+    name: 'code-review',
+    namespace: 'default',
+    description: 'Automated code review skill',
+    tags: ['security'],
+  },
+  spec: { type: 'skill', lifecycle: 'production', owner: 'team-ai' },
+};
+
+const agent: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'dev-assistant',
+    namespace: 'default',
+    description: 'AI developer assistant',
+    tags: ['agent'],
+  },
+  spec: { type: 'ai-agent', lifecycle: 'experimental', owner: 'team-ml' },
+};
+
+const entities = [skill, agent];
+
+const typeFilter: FilterDefinition = {
+  urlParam: 'type',
+  label: 'Type',
+  getOptions: () => [],
+  matchEntity: (e, vals) => {
+    const t = (e.spec as Record<string, unknown>)?.type as string | undefined;
+    return (
+      t !== undefined && vals.some(v => v.toLowerCase() === t.toLowerCase())
+    );
+  },
+  priority: 100,
+};
+
+const ownerFilter: FilterDefinition = {
+  urlParam: 'owner',
+  label: 'Owner',
+  getOptions: () => [],
+  matchEntity: (e, vals) => {
+    const o = (e.spec as Record<string, unknown>)?.owner as string | undefined;
+    return (
+      o !== undefined && vals.some(v => v.toLowerCase() === o.toLowerCase())
+    );
+  },
+  priority: 200,
+};
+
+describe('applyEntityFilters', () => {
+  it('returns all entities when no search or filters active', () => {
+    const result = applyEntityFilters(entities, undefined, [], new Map());
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by search term in name', () => {
+    const result = applyEntityFilters(entities, 'code-review', [], new Map());
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('code-review');
+  });
+
+  it('filters by search term in description', () => {
+    const result = applyEntityFilters(
+      entities,
+      'developer assistant',
+      [],
+      new Map(),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('dev-assistant');
+  });
+
+  it('filters by search term in tags', () => {
+    const result = applyEntityFilters(entities, 'security', [], new Map());
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('code-review');
+  });
+
+  it('applies single filter via matchEntity', () => {
+    const values = new Map([['type', ['skill']]]);
+    const result = applyEntityFilters(
+      entities,
+      undefined,
+      [typeFilter],
+      values,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('code-review');
+  });
+
+  it('applies multiple filters in AND logic', () => {
+    const values = new Map([
+      ['type', ['skill']],
+      ['owner', ['team-ml']],
+    ]);
+    const result = applyEntityFilters(
+      entities,
+      undefined,
+      [typeFilter, ownerFilter],
+      values,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('combines search with filters in AND logic', () => {
+    const values = new Map([['type', ['skill']]]);
+    const result = applyEntityFilters(entities, 'code', [typeFilter], values);
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('code-review');
+  });
+
+  it('skips filters with no active values', () => {
+    const values = new Map<string, string[]>();
+    const result = applyEntityFilters(
+      entities,
+      undefined,
+      [typeFilter, ownerFilter],
+      values,
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it('search is case-insensitive', () => {
+    const result = applyEntityFilters(entities, 'CODE-REVIEW', [], new Map());
+    expect(result).toHaveLength(1);
+  });
+});

--- a/workspaces/boost/plugins/boost/src/utils/entityHelpers.ts
+++ b/workspaces/boost/plugins/boost/src/utils/entityHelpers.ts
@@ -16,6 +16,7 @@
 
 import type { Entity } from '@backstage/catalog-model';
 
+import type { FilterDefinition } from '../blueprints/AiCatalogFilterBlueprint';
 import { getCategoryMeta } from './categoryMeta';
 
 export function entityHref(entity: Entity): string {
@@ -34,22 +35,21 @@ export function getSpecField(
     | undefined;
 }
 
-export interface EntityFilters {
-  search?: string;
-  category?: string[];
-  tags?: string[];
-  owner?: string[];
-  provider?: string[];
-}
-
+/**
+ * Apply search + registered filter definitions in AND logic.
+ * Search is built-in (not a FilterDefinition). Each FilterDefinition
+ * with active values must match for the entity to be included.
+ */
 export function applyEntityFilters(
   items: Entity[],
-  filters: EntityFilters,
+  search: string | undefined,
+  filters: FilterDefinition[],
+  filterValues: Map<string, string[]>,
 ): Entity[] {
   let results = items;
 
-  if (filters.search) {
-    const term = filters.search.toLowerCase();
+  if (search) {
+    const term = search.toLowerCase();
     results = results.filter(
       e =>
         e.metadata.name.toLowerCase().includes(term) ||
@@ -59,36 +59,11 @@ export function applyEntityFilters(
     );
   }
 
-  if (filters.tags?.length) {
-    const tagSet = new Set(filters.tags.map(t => t.toLowerCase()));
-    results = results.filter(e =>
-      (e.metadata.tags ?? []).some(t => tagSet.has(t.toLowerCase())),
-    );
-  }
-
-  if (filters.category?.length) {
-    const cats = new Set(filters.category.map(c => c.toLowerCase()));
-    results = results.filter(e => {
-      const specType = getSpecField(e, 'type');
-      return specType !== undefined && cats.has(specType.toLowerCase());
-    });
-  }
-
-  if (filters.provider?.length) {
-    const providers = new Set(filters.provider.map(v => v.toLowerCase()));
-    results = results.filter(e => {
-      const src =
-        e.metadata.annotations?.['rhdh.io/ai-asset-source']?.toLowerCase();
-      return src !== undefined && providers.has(src);
-    });
-  }
-
-  if (filters.owner?.length) {
-    const owners = new Set(filters.owner.map(v => v.toLowerCase()));
-    results = results.filter(e => {
-      const o = getSpecField(e, 'owner');
-      return o !== undefined && owners.has(o.toLowerCase());
-    });
+  for (const filter of filters) {
+    const values = filterValues.get(filter.urlParam);
+    if (values && values.length > 0) {
+      results = results.filter(e => filter.matchEntity(e, values));
+    }
   }
 
   return results;

--- a/workspaces/boost/specifications/boost-frontend-architecture.md
+++ b/workspaces/boost/specifications/boost-frontend-architecture.md
@@ -257,18 +257,18 @@ The AI Catalog is the first domain. Here is how future capabilities map to surfa
 
 ## Technology Stack
 
-| Layer             | Technology                                                                                                      |
-| ----------------- | --------------------------------------------------------------------------------------------------------------- |
-| Component library | BUI (`@backstage/ui`) for new components, MUI v5 fallback where BUI lacks coverage, `@mui/icons-material` icons |
-| Chat UI           | `@patternfly/chatbot` for conversational interfaces                                                             |
-| Styling           | CSS Modules with `--bui-*` CSS variables                                                                        |
-| Frontend system   | NFS Blueprints (`createFrontendPlugin`, `PageBlueprint`, `EntityCardBlueprint`, etc.)                           |
-| State             | React hooks + URL params for filters; streaming reducer for chat events                                         |
-| API               | `catalogApiRef` for entity queries; `BoostApiClient` for `/api/boost` routes; `fetchApi` for auth               |
-| Testing           | `TestApiProvider` + `renderInTestApp` from `@backstage/test-utils`                                              |
-| i18n              | `TranslationBlueprint` + `useTranslationRef` (English-only initially)                                           |
-| Dynamic plugins   | Scalprum federation, `dist-scalprum` build                                                                      |
-| Accessibility     | WCAG 2.1 AA, keyboard navigation, screen reader support                                                         |
+| Layer             | Technology                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| Component library | BUI (`@backstage/ui`) for new components, MUI v5 fallback where BUI lacks coverage, `@remixicon/react` icons |
+| Chat UI           | `@patternfly/chatbot` for conversational interfaces                                                          |
+| Styling           | CSS Modules with `--bui-*` CSS variables                                                                     |
+| Frontend system   | NFS Blueprints (`createFrontendPlugin`, `PageBlueprint`, `EntityCardBlueprint`, etc.)                        |
+| State             | React hooks + URL params for filters; streaming reducer for chat events                                      |
+| API               | `catalogApiRef` for entity queries; `BoostApiClient` for `/api/boost` routes; `fetchApi` for auth            |
+| Testing           | Unit: `TestApiProvider` + `renderInTestApp`; E2E: Playwright with multi-locale projects and axe-core          |
+| i18n              | `TranslationBlueprint` + `useTranslationRef`; 5 locales planned (de, es, fr, it, ja)                         |
+| Dynamic plugins   | NFS Module Federation via `rhdh-cli plugin export`; no Scalprum (NFS-only plugin)                            |
+| Accessibility     | WCAG 2.1 AA, keyboard navigation, screen reader support                                                      |
 
 ---
 


### PR DESCRIPTION
## Summary

- Introduces `AiCatalogFilterBlueprint` — an NFS extension blueprint that lets deployers disable built-in filters and third-party plugins add new filters to the AI Catalog browse sidebar, all via `app-config.yaml`
- Replaces hardcoded `FilterSidebar` with a data-driven approach: each filter is a plain `FilterDefinition` object (urlParam, label, getOptions, matchEntity, priority) rendered by a generic `<Select>`
- Adds specs, design decisions, and tasks for 3 additional stories under RHIDP-15164: translations, E2E tests, and dynamic plugin export

## Changes

**New files:**
- `src/blueprints/AiCatalogFilterBlueprint.ts` — `FilterDefinition` interface, `filterDefinitionDataRef`, `AiCatalogFilterBlueprint`
- `src/filters/builtInFilterDefinitions.ts` — 4 built-in definitions (category, provider, owner, tags)
- `packages/app/src/modules/sampleFilter/` — dev app lifecycle filter demonstrating third-party contribution
- `specs/filter-customization/spec.md`, `specs/translations/spec.md`, `specs/e2e-tests/spec.md`, `specs/dynamic-plugin-export/spec.md`

**Refactored:**
- `plugin.tsx` — page `makeWithOverrides` with `name: 'ai-catalog'` and `filters` input; 4 filter extensions registered
- `FilterSidebar` — generic `<Select>` per `FilterDefinition`, `label`/`labelKey` i18n pattern
- `useUrlFilters` — dynamic `filterParams[]`, generic `setFilter()`, `clearFilters` preserves view/pageSize
- `applyEntityFilters` — AND loop over `matchEntity`, no hardcoded field names
- `useAiAssets` — new signature `(search, filters, filterValues)`

**Public API:** `AiCatalogFilterBlueprint`, `filterDefinitionDataRef`, `FilterDefinition` exported from `index.ts`

## Test plan

- [x] `yarn tsc --noEmit` — 0 errors
- [x] `yarn build:api-reports:only` — report updated with `page:boost/ai-catalog` and new exports
- [x] `yarn test --no-watch` — 51 suites, 526 tests passing
- [ ] Smoke test: `yarn start` → verify 4 filters + lifecycle sample filter render at `/ai-catalog`
- [ ] Verify `ai-catalog-filter:boost/owner: false` in app-config disables the owner filter
- [ ] Verify card category click filters when category filter is enabled, no-ops when disabled


Made with [Cursor](https://cursor.com)