### PR TITLE
chore: RHIDP-15485: fix renovate config validator

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -14,6 +14,8 @@ jobs:
     name: Renovate Config Validator
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Validate config
         # See https://docs.renovatebot.com/config-validation/
         env:

--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Renovate Config Validator
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Validate config
         # See https://docs.renovatebot.com/config-validation/
+        env:
+          GITHUB_COM_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
         run: |
-          npx --yes --package renovate -- renovate-config-validator --strict .github/renovate.json
+          npx --yes --package renovate@43 -- renovate-config-validator --strict .github/renovate.json

--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -8,6 +8,9 @@ on:
     # https://docs.renovatebot.com/configuration-options/
     branches: [ 'main' ]
 
+permissions:
+  contents: read
+
 jobs:
   renovate-config-validator:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
Fixes: https://redhat.atlassian.net/browse/RHIDP-15485
-   Update actions/checkout to v6
-   Configured a GH token in the validator to avoid rate limits
-   Pinned Renovate to current supported major version (v43) to force upgrading the deprecated cached version

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
