### PR TITLE
fix(intelligent-assistant): correct changeset breaking change format and import path

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/bright-waves-flow.md
+++ b/workspaces/intelligent-assistant/.changeset/bright-waves-flow.md
@@ -2,11 +2,11 @@
 '@red-hat-developer-hub/backstage-plugin-intelligent-assistant': major
 ---
 
-**Breaking:** Legacy (OFS) component exports have been removed from the main `./` entry point and are now exclusively available at the `./legacy` subpath. OFS consumers must update their imports:
+BREAKING CHANGE: Legacy (OFS) component exports have been removed from the main `./` entry point and are now exclusively available at the `./legacy` subpath. OFS consumers must update their imports:
 
 ```diff
 - import { LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-lightspeed';
-+ import { LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-lightspeed/legacy';
++ import { LightspeedDrawerProvider } from '@red-hat-developer-hub/backstage-plugin-intelligent-assistant/legacy';
 ```
 
 **New:** Graduate the New Frontend System (NFS) plugin from `./alpha` to the primary `./` entry point.


### PR DESCRIPTION
## Summary
- Use `BREAKING CHANGE:` prefix instead of `**Breaking:**` for proper changeset formatting
- Fix the legacy import path example: `lightspeed` -> `intelligent-assistant` to match the renamed package

Just to alignt the release notes of #3772

<img width="1110" height="738" alt="image" src="https://github.com/user-attachments/assets/2d1adb68-4c32-43e5-aaec-b94942712227" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)