### PR TITLE
test(orchestrator-form-widgets): expand unit coverage for fetch and templating

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.test.tsx
@@ -36,7 +36,7 @@ describe('FormWidgetsApi', () => {
 
   it('returns undefined review component by default', () => {
     const api = new FormWidgetsApi();
-    expect(api.getReviewComponent()).toBeUndefined();
+    expect(api.getReviewComponent?.()).toBeUndefined();
   });
 
   it('decorates form component with widgets and context props', () => {
@@ -49,7 +49,9 @@ describe('FormWidgetsApi', () => {
     };
 
     const decorator = api.getFormDecorator();
-    const Decorated = decorator(DummyForm as ComponentType<any>);
+    const Decorated = decorator(
+      DummyForm as ComponentType<any>,
+    ) as ComponentType<any>;
 
     render(
       <Decorated

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormWidgetsApi.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentType } from 'react';
+import { render } from '@testing-library/react';
+import { FormWidgetsApi } from './FormWidgetsApi';
+import * as utils from './utils';
+
+jest.mock('./utils', () => {
+  const actual = jest.requireActual('./utils');
+  return {
+    ...actual,
+    useGetExtraErrors: jest.fn(),
+  };
+});
+
+const mockedUseGetExtraErrors = utils.useGetExtraErrors as jest.Mock;
+
+describe('FormWidgetsApi', () => {
+  beforeEach(() => {
+    mockedUseGetExtraErrors.mockReset();
+    mockedUseGetExtraErrors.mockReturnValue(jest.fn());
+  });
+
+  it('returns undefined review component by default', () => {
+    const api = new FormWidgetsApi();
+    expect(api.getReviewComponent()).toBeUndefined();
+  });
+
+  it('decorates form component with widgets and context props', () => {
+    const api = new FormWidgetsApi();
+    const receivedProps: Record<string, unknown>[] = [];
+
+    const DummyForm = (props: Record<string, unknown>) => {
+      receivedProps.push(props);
+      return <div data-testid="dummy-form" />;
+    };
+
+    const decorator = api.getFormDecorator();
+    const Decorated = decorator(DummyForm as ComponentType<any>);
+
+    render(
+      <Decorated
+        formData={{ current: { step: {} } }}
+        getIsChangedByUser={() => false}
+        setIsChangedByUser={() => {}}
+      />,
+    );
+
+    expect(receivedProps).toHaveLength(1);
+    expect(receivedProps[0].widgets).toEqual(
+      expect.objectContaining({
+        SchemaUpdater: expect.any(Function),
+        ActiveTextInput: expect.any(Function),
+        ActiveText: expect.any(Function),
+        ActiveDropdown: expect.any(Function),
+        ActiveMultiSelect: expect.any(Function),
+      }),
+    );
+    expect(receivedProps[0].customValidate).toEqual(expect.any(Function));
+    expect(receivedProps[0].getExtraErrors).toEqual(expect.any(Function));
+    expect(receivedProps[0].formContext).toEqual(
+      expect.objectContaining({
+        formData: expect.any(Object),
+        getIsChangedByUser: expect.any(Function),
+        setIsChangedByUser: expect.any(Function),
+      }),
+    );
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetch.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetch.test.ts
@@ -129,7 +129,7 @@ describe('useFetch', () => {
       },
     });
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       useFetch(
         {} as any,
         { 'fetch:url': 'https://example.test/fetch' } as any,

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetch.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useFetch.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useFetch } from './useFetch';
+import { useRequestInit } from './useRequestInit';
+import { useEvaluateTemplate } from './evaluateTemplate';
+import { fetchWithRetry } from './retry';
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  fetchApiRef: { id: 'fetch' },
+  useApi: jest.fn(),
+}));
+
+jest.mock('./useRequestInit', () => ({
+  useRequestInit: jest.fn(),
+}));
+
+jest.mock('./evaluateTemplate', () => ({
+  useEvaluateTemplate: jest.fn(),
+}));
+
+jest.mock('./retry', () => ({
+  fetchWithRetry: jest.fn(),
+}));
+
+const mockedUseApi = jest.requireMock('@backstage/core-plugin-api')
+  .useApi as jest.Mock;
+const mockedUseRequestInit = useRequestInit as jest.Mock;
+const mockedUseEvaluateTemplate = useEvaluateTemplate as jest.Mock;
+const mockedFetchWithRetry = fetchWithRetry as jest.Mock;
+
+describe('useFetch', () => {
+  const fetchApi = {
+    fetch: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockedUseApi.mockReturnValue(fetchApi);
+    mockedUseRequestInit.mockReturnValue({ method: 'GET' });
+    mockedUseEvaluateTemplate.mockReturnValue('https://example.test/fetch');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns loading=false when fetch inputs are missing', async () => {
+    const { result } = renderHook(() =>
+      useFetch({} as any, {} as any, undefined as any),
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('sets error when evaluated fetch URL is not a string', async () => {
+    mockedUseEvaluateTemplate.mockReturnValue({ unexpected: true });
+
+    const { result } = renderHook(() =>
+      useFetch(
+        {} as any,
+        { 'fetch:url': 'https://example.test/fetch' } as any,
+        ['ready'],
+      ),
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toContain(
+        'fetch:url is not evaluated to a string',
+      );
+    });
+  });
+
+  it('suppresses errors when fetch:error:ignoreUnready is enabled and deps are empty', async () => {
+    mockedFetchWithRetry.mockRejectedValue(new Error('request failed'));
+
+    const { result } = renderHook(() =>
+      useFetch(
+        {} as any,
+        {
+          'fetch:url': 'https://example.test/fetch',
+          'fetch:error:ignoreUnready': true,
+        } as any,
+        [''],
+      ),
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(mockedFetchWithRetry).toHaveBeenCalled();
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('calls onSamlSsoError when response indicates expired SSO', async () => {
+    const onSamlSsoError = jest.fn();
+    mockedFetchWithRetry.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: {
+        get: () => 'required; url=https://github.com/orgs/example/sso',
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useFetch(
+        {} as any,
+        { 'fetch:url': 'https://example.test/fetch' } as any,
+        ['ready'],
+        onSamlSsoError,
+      ),
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(onSamlSsoError).toHaveBeenCalled();
+    });
+    expect(onSamlSsoError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('Re-authorize at'),
+      }),
+    );
+  });
+
+  it('stores response data for successful fetch', async () => {
+    mockedFetchWithRetry.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: 'ok' }),
+    });
+
+    const { result } = renderHook(() =>
+      useFetch(
+        {} as any,
+        { 'fetch:url': 'https://example.test/fetch' } as any,
+        ['ready'],
+      ),
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ value: 'ok' });
+    });
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { useTemplateUnitEvaluator } from './useTemplateUnitEvaluator';
+import { applySelectorString } from './applySelector';
+
+jest.mock('./applySelector', () => ({
+  applySelectorString: jest.fn(),
+}));
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const refs = {
+    configApiRef: { id: 'config' },
+    identityApiRef: { id: 'identity' },
+    githubAuthApiRef: { id: 'github' },
+    atlassianAuthApiRef: { id: 'atlassian' },
+    googleAuthApiRef: { id: 'google' },
+    microsoftAuthApiRef: { id: 'microsoft' },
+    gitlabAuthApiRef: { id: 'gitlab' },
+  };
+
+  return {
+    ...refs,
+    useApp: jest.fn(),
+    useApiHolder: jest.fn(),
+    useApi: jest.fn(),
+  };
+});
+
+const corePluginApi = jest.requireMock('@backstage/core-plugin-api');
+const mockedUseApi = corePluginApi.useApi as jest.Mock;
+const mockedUseApp = corePluginApi.useApp as jest.Mock;
+const mockedUseApiHolder = corePluginApi.useApiHolder as jest.Mock;
+const mockedApplySelectorString = applySelectorString as jest.Mock;
+
+describe('useTemplateUnitEvaluator', () => {
+  const configApi = {
+    getString: jest.fn(() => 'http://backend.local'),
+    getOptionalString: jest.fn(() => 'from-config'),
+  };
+
+  const identityApi = {
+    getCredentials: jest.fn(async () => ({ token: 'identity-token' })),
+    getBackstageIdentity: jest.fn(async () => ({
+      userEntityRef: 'user:default/dev',
+    })),
+    getProfileInfo: jest.fn(async () => ({
+      email: 'dev@example.com',
+      displayName: 'Dev User',
+    })),
+  };
+
+  const oauthApi = {
+    getAccessToken: jest.fn(async () => 'oauth-token'),
+    getProfile: jest.fn(async () => ({
+      email: 'oauth@example.com',
+      displayName: 'OAuth User',
+    })),
+  };
+
+  const openIdApi = {
+    ...oauthApi,
+    getIdToken: jest.fn(async () => 'openid-token'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedUseApp.mockReturnValue({
+      getPlugins: () => [],
+    });
+
+    mockedUseApiHolder.mockReturnValue({
+      get: jest.fn(),
+      apis: new Map(),
+    });
+
+    mockedUseApi.mockImplementation((ref: { id: string }) => {
+      switch (ref.id) {
+        case 'config':
+          return configApi;
+        case 'identity':
+          return identityApi;
+        case 'github':
+        case 'atlassian':
+          return oauthApi;
+        case 'google':
+        case 'microsoft':
+        case 'gitlab':
+          return openIdApi;
+        default:
+          return {};
+      }
+    });
+  });
+
+  it('evaluates current.*, backend.*, and identityApi.* units', async () => {
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('current.user.name', { user: { name: 'Ada' } } as any),
+    ).resolves.toBe('Ada');
+    await expect(result.current('backend.baseUrl', {} as any)).resolves.toBe(
+      'http://backend.local',
+    );
+    await expect(result.current('identityApi.token', {} as any)).resolves.toBe(
+      'identity-token',
+    );
+  });
+
+  it('evaluates fetch response selector units', async () => {
+    mockedApplySelectorString.mockResolvedValue('resolved-value');
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current(
+        'fetch:response:value',
+        {} as any,
+        { data: [{ id: 'a' }] } as any,
+        { 'fetch:response:value': '$.data[0].id' } as any,
+      ),
+    ).resolves.toBe('resolved-value');
+
+    expect(mockedApplySelectorString).toHaveBeenCalledWith(
+      { data: [{ id: 'a' }] },
+      '$.data[0].id',
+    );
+  });
+
+  it('errors when fetch response unit is requested without schema selector', async () => {
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current(
+        'fetch:response:value',
+        {} as any,
+        { data: [] } as any,
+        {} as any,
+      ),
+    ).rejects.toThrow("ui property 'fetch:response:value' does not exist");
+  });
+
+  it('errors for unknown custom auth provider api id', async () => {
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('customAuthApi.my.custom.provider.token', {} as any),
+    ).rejects.toThrow('Unknown custom auth provider API');
+  });
+
+  it('errors for unknown template units', async () => {
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(result.current('mystery.unit', {} as any)).rejects.toThrow(
+      'Unknown template unit',
+    );
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveDropdown.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { ActiveDropdown } from './ActiveDropdown';
+import * as utils from '../utils';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    useTemplateUnitEvaluator: jest.fn(),
+    useRetriggerEvaluate: jest.fn(),
+    useFetch: jest.fn(),
+    useProcessingState: jest.fn(),
+    useClearOnRetrigger: jest.fn(),
+  };
+});
+
+const mockedUseTemplateUnitEvaluator =
+  utils.useTemplateUnitEvaluator as jest.Mock;
+const mockedUseRetriggerEvaluate = utils.useRetriggerEvaluate as jest.Mock;
+const mockedUseFetch = utils.useFetch as jest.Mock;
+const mockedUseProcessingState = utils.useProcessingState as jest.Mock;
+
+describe('ActiveDropdown', () => {
+  beforeEach(() => {
+    mockedUseTemplateUnitEvaluator.mockReturnValue(() => undefined);
+    mockedUseRetriggerEvaluate.mockReturnValue([]);
+    mockedUseFetch.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: false,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+  });
+
+  it('shows error when required selectors are missing', () => {
+    render(
+      <ActiveDropdown
+        id="ad"
+        name="ad"
+        label="Dropdown"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value=""
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByTestId('ad-error-text')).toHaveTextContent(
+      'fetch:response:label and fetch:response:value',
+    );
+  });
+
+  it('suppresses fetch errors and renders disabled select fallback', () => {
+    mockedUseFetch.mockReturnValue({
+      data: undefined,
+      error: 'network failed',
+      loading: false,
+    });
+
+    render(
+      <ActiveDropdown
+        id="ad"
+        name="ad"
+        label="Dropdown"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{
+          props: {
+            'fetch:response:label': '$.labels',
+            'fetch:response:value': '$.values',
+            'fetch:error:silent': true,
+          },
+        }}
+        value=""
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(screen.queryByTestId('ad-error-text')).not.toBeInTheDocument();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveText.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveText.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { ActiveText } from './ActiveText';
+import * as utils from '../utils';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    useFetchAndEvaluate: jest.fn(),
+  };
+});
+
+const mockedUseFetchAndEvaluate = utils.useFetchAndEvaluate as jest.Mock;
+
+describe('ActiveText', () => {
+  beforeEach(() => {
+    mockedUseFetchAndEvaluate.mockReturnValue({
+      text: 'resolved markdown',
+      error: undefined,
+      fetchError: undefined,
+      loading: false,
+      waitingForRetrigger: false,
+    });
+  });
+
+  it('renders configuration error when ui:text is missing', () => {
+    render(
+      <ActiveText
+        id="at"
+        name="at"
+        label="AT"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value={undefined}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={{ formData: {} } as any}
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByTestId('at-error-text')).toHaveTextContent(
+      "doesn't contain property ui:text",
+    );
+  });
+
+  it('renders fetch/evaluation error', () => {
+    mockedUseFetchAndEvaluate.mockReturnValue({
+      text: '',
+      error: 'template error',
+      fetchError: undefined,
+      loading: false,
+      waitingForRetrigger: false,
+    });
+
+    render(
+      <ActiveText
+        id="at"
+        name="at"
+        label="AT"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: { 'ui:text': 'hello' } }}
+        value={undefined}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={{ formData: {} } as any}
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByTestId('at-error-text')).toHaveTextContent(
+      'template error',
+    );
+  });
+
+  it('renders evaluated markdown content', () => {
+    render(
+      <ActiveText
+        id="at"
+        name="at"
+        label="AT"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: { 'ui:text': 'hello' } }}
+        value={undefined}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={{ formData: {} } as any}
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByTestId('at')).toHaveTextContent('resolved markdown');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ActiveTextInput } from './ActiveTextInput';
+import * as utils from '../utils';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    useTemplateUnitEvaluator: jest.fn(),
+    useRetriggerEvaluate: jest.fn(),
+    useFetch: jest.fn(),
+    useProcessingState: jest.fn(),
+    useClearOnRetrigger: jest.fn(),
+  };
+});
+
+const mockedUseTemplateUnitEvaluator =
+  utils.useTemplateUnitEvaluator as jest.Mock;
+const mockedUseRetriggerEvaluate = utils.useRetriggerEvaluate as jest.Mock;
+const mockedUseFetch = utils.useFetch as jest.Mock;
+const mockedUseProcessingState = utils.useProcessingState as jest.Mock;
+
+describe('ActiveTextInput', () => {
+  beforeEach(() => {
+    mockedUseTemplateUnitEvaluator.mockReturnValue(() => undefined);
+    mockedUseRetriggerEvaluate.mockReturnValue([]);
+    mockedUseFetch.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: false,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+  });
+
+  it('shows config error when fetch:url is provided without selectors', () => {
+    render(
+      <ActiveTextInput
+        id="ati"
+        name="ati"
+        label="ATI"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: { 'fetch:url': 'https://example.test/api' } }}
+        value=""
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByTestId('ati-error-text')).toHaveTextContent(
+      'fetch:response:value or fetch:response:default',
+    );
+  });
+
+  it('shows spinner while complete loading and no static default', () => {
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: true,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+
+    const { container } = render(
+      <ActiveTextInput
+        id="ati"
+        name="ati"
+        label="ATI"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value=""
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('marks field as user-changed and forwards text input value', () => {
+    const onChange = jest.fn();
+    const setIsChangedByUser = jest.fn();
+
+    render(
+      <ActiveTextInput
+        id="ati"
+        name="ati"
+        label="ATI"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value=""
+        onChange={onChange}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser,
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    const input = screen.getByTestId('ati-textfield').querySelector('input');
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input!, {
+      target: { value: 'new value' },
+    });
+
+    expect(setIsChangedByUser).toHaveBeenCalledWith('ati', true);
+    expect(onChange).toHaveBeenCalledWith('new value');
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/SchemaUpdater.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/SchemaUpdater.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { SchemaUpdater } from './SchemaUpdater';
+import * as utils from '../utils';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    useTemplateUnitEvaluator: jest.fn(),
+    useRetriggerEvaluate: jest.fn(),
+    useFetch: jest.fn(),
+    useProcessingState: jest.fn(),
+    evaluateFetchResponseSelectorTemplate: jest.fn(),
+    applySelectorObject: jest.fn(),
+  };
+});
+
+const mockedUseTemplateUnitEvaluator =
+  utils.useTemplateUnitEvaluator as jest.Mock;
+const mockedUseRetriggerEvaluate = utils.useRetriggerEvaluate as jest.Mock;
+const mockedUseFetch = utils.useFetch as jest.Mock;
+const mockedUseProcessingState = utils.useProcessingState as jest.Mock;
+const mockedEvaluateFetchResponseSelectorTemplate =
+  utils.evaluateFetchResponseSelectorTemplate as jest.Mock;
+const mockedApplySelectorObject = utils.applySelectorObject as jest.Mock;
+
+describe('SchemaUpdater', () => {
+  beforeEach(() => {
+    mockedUseTemplateUnitEvaluator.mockReturnValue(() => undefined);
+    mockedUseRetriggerEvaluate.mockReturnValue([]);
+    mockedUseFetch.mockReturnValue({
+      data: { nextStep: { type: 'string' } },
+      error: undefined,
+      loading: false,
+    });
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: false,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+    mockedEvaluateFetchResponseSelectorTemplate.mockResolvedValue(
+      '$.next.schema.chunks',
+    );
+    mockedApplySelectorObject.mockResolvedValue({
+      nextStep: { type: 'string' },
+    });
+  });
+
+  it('shows error when updateSchema is missing from form context', async () => {
+    render(
+      <SchemaUpdater
+        id="su"
+        name="su"
+        label="SchemaUpdater"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value={undefined}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={{ formData: {} } as any}
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('su-error-text')).toHaveTextContent(
+        'Missing the updateSchema() function',
+      );
+    });
+  });
+
+  it('applies selector result and calls updateSchema', async () => {
+    const updateSchema = jest.fn();
+
+    render(
+      <SchemaUpdater
+        id="su"
+        name="su"
+        label="SchemaUpdater"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'string' }}
+        uiSchema={{}}
+        options={{ props: { 'fetch:response:value': '$.foo' } }}
+        value={undefined}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={{ formData: {}, updateSchema } as any}
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockedEvaluateFetchResponseSelectorTemplate).toHaveBeenCalled();
+      expect(mockedApplySelectorObject).toHaveBeenCalled();
+      expect(updateSchema).toHaveBeenCalledWith(
+        { nextStep: { type: 'string' } },
+        'su',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds unit tests for form API wiring, widget behavior, fetch error/retry flows, and template unit evaluation branches to strengthen coverage in orchestrator-form-widgets.

Closes [RHIDP-9860](https://redhat.atlassian.net/browse/RHIDP-9860)

