### PR TITLE
chore(intelligent-assistant): skip versioning private packages

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/config.json
+++ b/workspaces/intelligent-assistant/.changeset/config.json
@@ -6,5 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "tag": false,
+    "version": false
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `privatePackages` configuration to the intelligent-assistant changeset config to prevent changesets from tagging or versioning private packages (e.g. `app`, `backend` dev packages)

## Test plan
- [ ] Verify `yarn changeset version` no longer bumps versions or creates tags for private packages
- [ ] Confirm public packages are still versioned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)