### PR TITLE
test(orchestrator): expand backend unit test coverage (RHIDP-15513)

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-backend-module-loki/src/workflowLogsProviders/LokiProvider.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend-module-loki/src/workflowLogsProviders/LokiProvider.test.ts
@@ -323,7 +323,7 @@ describe('LokiProvider', () => {
       it('rejects baseUrl when the resolved URL has no hostname', () => {
         const OriginalURL = globalThis.URL;
         globalThis.URL = class URLWithEmptyHostname extends OriginalURL {
-          get hostname(): string {
+          get hostname() {
             return '';
           }
         };
@@ -860,12 +860,12 @@ describe('LokiProvider', () => {
         nodes: [],
       };
 
-      const urlToFetch =
-        'http://localhost:3100/loki/api/v1/query_range?query=%7Bopenshift_log_type%3D%22application%22%7D+%7C%3D%2212345%22&start=2025-12-05T16%3A30%3A13.621Z&end=2026-01-03T16%3A35%3A13.621Z&limit=50';
-
       await provider.fetchWorkflowLogsByInstance(workflowInstance);
-      const parsedURLToFetch = new URL(urlToFetch);
-      expect(parsedURLToFetch.searchParams.get('limit')).toEqual('50');
+
+      const calls = jest.mocked(undiciFetch).mock.calls;
+      expect(calls).toHaveLength(1);
+      const actualURL = new URL(calls[0][0] as string);
+      expect(actualURL.searchParams.get('limit')).toEqual('50');
     });
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/queryBuilder.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/helpers/queryBuilder.test.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+import { FilterClause } from '../types/filterClause';
 import { Pagination } from '../types/pagination';
-import { buildGraphQlQuery } from './queryBuilder';
+import {
+  buildGraphQlQuery,
+  buildOrderByVariables,
+  buildPaginationVariables,
+  buildQueryParamVariable,
+} from './queryBuilder';
 
 describe('buildGraphQlQuery', () => {
   const defaultTestParams = {
@@ -61,7 +67,9 @@ describe('buildGraphQlQuery', () => {
       expectedResult: `query ($paginationInfo: Pagination, $orderByInfo: ${defaultTestParams.type.slice(0, -1)}OrderBy){${defaultTestParams.type} (where: {${defaultTestParams.whereClause}}, orderBy: $orderByInfo, pagination: $paginationInfo) {${defaultTestParams.queryBody} } }`,
     },
     {
-      name: 'should build a query with pagination',
+      // The query string always contains $paginationInfo/$orderByInfo variable refs
+      // regardless of pagination values — actual values are passed via buildQueryParamVariable.
+      name: 'should build the same query structure with or without pagination values',
       params: {
         type: defaultTestParams.type,
         queryBody: defaultTestParams.queryBody,
@@ -88,5 +96,125 @@ describe('buildGraphQlQuery', () => {
       const result = buildGraphQlQuery(params);
       expect(result).toBe(expectedResult);
     });
+  });
+});
+
+describe('buildOrderByVariables', () => {
+  it('returns empty object when no pagination is provided', () => {
+    expect(buildOrderByVariables(undefined)).toEqual({});
+  });
+
+  it('returns empty object when pagination has no sortField', () => {
+    expect(buildOrderByVariables({ limit: 10, offset: 0 })).toEqual({});
+  });
+
+  it('returns orderBy object with ASC as default when no order is provided', () => {
+    expect(buildOrderByVariables({ sortField: 'name' })).toEqual({
+      name: 'ASC',
+    });
+  });
+
+  it('returns orderBy object with the specified order uppercased', () => {
+    expect(
+      buildOrderByVariables({ sortField: 'lastUpdated', order: 'desc' }),
+    ).toEqual({ lastUpdated: 'DESC' });
+  });
+
+  it('returns orderBy object with DESC when order is DESC', () => {
+    expect(
+      buildOrderByVariables({ sortField: 'start', order: 'DESC' }),
+    ).toEqual({ start: 'DESC' });
+  });
+});
+
+describe('buildPaginationVariables', () => {
+  it('returns empty object when no pagination is provided', () => {
+    expect(buildPaginationVariables(undefined)).toEqual({});
+  });
+
+  it('returns empty object when pagination has neither limit nor offset', () => {
+    expect(
+      buildPaginationVariables({ order: 'ASC', sortField: 'name' }),
+    ).toEqual({});
+  });
+
+  it('includes only limit when only limit is defined', () => {
+    expect(buildPaginationVariables({ limit: 20 })).toEqual({ limit: 20 });
+  });
+
+  it('includes only offset when only offset is defined', () => {
+    expect(buildPaginationVariables({ offset: 5 })).toEqual({ offset: 5 });
+  });
+
+  it('includes both limit and offset when both are defined', () => {
+    expect(buildPaginationVariables({ limit: 10, offset: 0 })).toEqual({
+      limit: 10,
+      offset: 0,
+    });
+  });
+});
+
+describe('buildQueryParamVariable', () => {
+  it('returns paginationInfo and orderByInfo with empty objects when no args provided', () => {
+    const result = buildQueryParamVariable(undefined, undefined);
+    expect(result).toEqual({
+      paginationInfo: {},
+      orderByInfo: {},
+    });
+  });
+
+  it('includes pagination values in paginationInfo and orderByInfo', () => {
+    const pagination: Pagination = {
+      limit: 10,
+      offset: 5,
+      sortField: 'name',
+      order: 'ASC',
+    };
+    const result = buildQueryParamVariable(pagination, undefined);
+    expect(result).toEqual({
+      paginationInfo: { limit: 10, offset: 5 },
+      orderByInfo: { name: 'ASC' },
+    });
+  });
+
+  it('merges filter clause variables alongside pagination info', () => {
+    const pagination: Pagination = { limit: 5 };
+    const filterCondition: FilterClause = {
+      clause: 'processId: {equal: $processId}',
+      clauseVariable: [
+        {
+          clauseVariableName: 'processId',
+          clauseVariableType: 'StringArgument',
+          formattedValue: 'my-workflow',
+        },
+      ],
+    };
+    const result = buildQueryParamVariable(pagination, filterCondition);
+    expect(result).toEqual({
+      paginationInfo: { limit: 5 },
+      orderByInfo: {},
+      processId: 'my-workflow',
+    });
+  });
+
+  it('supports multiple filter clause variables', () => {
+    const filterCondition: FilterClause = {
+      clause: 'id: {equal: $id}, status: {equal: $status}',
+      clauseVariable: [
+        {
+          clauseVariableName: 'id',
+          clauseVariableType: 'StringArgument',
+          formattedValue: 'wf-123',
+        },
+        {
+          clauseVariableName: 'status',
+          clauseVariableType: 'StringArgument',
+          formattedValue: 'ACTIVE',
+        },
+      ],
+    };
+    const result = buildQueryParamVariable(undefined, filterCondition);
+    expect(result.id).toBe('wf-123');
+    expect(result.status).toBe('ACTIVE');
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DataIndexService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DataIndexService.test.ts
@@ -21,6 +21,7 @@ import { Client, OperationResult } from '@urql/core';
 import {
   FieldFilter,
   FieldFilterOperatorEnum,
+  fromWorkflowSource,
   LogicalFilter,
   NodeInstance,
   ProcessInstance,
@@ -62,8 +63,22 @@ jest.mock('@urql/core', () => {
     Client: jest.fn().mockImplementation(() => ({
       query: jest.fn(),
     })),
+    // gql is used as a tagged template literal in DataIndexService methods;
+    // return the concatenated string so client.query receives a non-null value.
+    gql: (strings: TemplateStringsArray, ...values: any[]) =>
+      strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), ''),
   };
 });
+
+jest.mock(
+  '@red-hat-developer-hub/backstage-plugin-orchestrator-common',
+  () => ({
+    ...jest.requireActual(
+      '@red-hat-developer-hub/backstage-plugin-orchestrator-common',
+    ),
+    fromWorkflowSource: jest.fn(),
+  }),
+);
 
 const mockOperationResult = <T>(data: T, error?: any): OperationResult<T> => ({
   data,
@@ -916,3 +931,475 @@ function createNodeObject(suffix: string): NodeInstance {
     retrigger: false,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Helpers shared across new describe blocks
+// ---------------------------------------------------------------------------
+
+function createMockSetup() {
+  const loggerMock: LoggerService = {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    child: jest.fn(),
+  };
+  const mockClient: jest.Mocked<Pick<Client, 'query'>> = { query: jest.fn() };
+  (Client as jest.Mock).mockImplementation(() => mockClient);
+  const dataIndexService = new DataIndexService('fakeUrl', loggerMock);
+  return { loggerMock, mockClient, dataIndexService };
+}
+
+// ---------------------------------------------------------------------------
+// fetchWorkflowInfo
+// ---------------------------------------------------------------------------
+
+describe('fetchWorkflowInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the first matching workflow info', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const wfInfo: WorkflowInfo = { id: 'wf1', name: 'Workflow One' };
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessDefinitions: [wfInfo] }),
+    );
+
+    const result = await dataIndexService.fetchWorkflowInfo('wf1');
+
+    expect(result).toEqual(wfInfo);
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when no definition is found', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessDefinitions: [] }),
+    );
+
+    const result = await dataIndexService.fetchWorkflowInfo('unknown');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('GraphQL error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(dataIndexService.fetchWorkflowInfo('wf1')).rejects.toThrow(
+      'GraphQL error',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWorkflowServiceUrls
+// ---------------------------------------------------------------------------
+
+describe('fetchWorkflowServiceUrls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a record mapping definition ids to service urls, filtering missing urls', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({
+        ProcessDefinitions: [
+          { id: 'wf1', serviceUrl: 'http://svc1' },
+          { id: 'wf2', serviceUrl: 'http://svc2' },
+          { id: 'wf3' }, // no serviceUrl → filtered out
+        ],
+      }),
+    );
+
+    const result = await dataIndexService.fetchWorkflowServiceUrls();
+
+    expect(result).toEqual({ wf1: 'http://svc1', wf2: 'http://svc2' });
+  });
+
+  it('returns an empty record when no definitions have a service url', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessDefinitions: [] }),
+    );
+
+    const result = await dataIndexService.fetchWorkflowServiceUrls();
+
+    expect(result).toEqual({});
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('Network error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(dataIndexService.fetchWorkflowServiceUrls()).rejects.toThrow(
+      'Network error',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWorkflowSource
+// ---------------------------------------------------------------------------
+
+describe('fetchWorkflowSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the source string for the given definition id', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({
+        ProcessDefinitions: [{ id: 'wf1', source: 'yaml content here' }],
+      }),
+    );
+
+    const result = await dataIndexService.fetchWorkflowSource('wf1');
+
+    expect(result).toBe('yaml content here');
+  });
+
+  it('returns undefined when no definition is found', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessDefinitions: [] }),
+    );
+
+    const result = await dataIndexService.fetchWorkflowSource('unknown');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('GraphQL error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(dataIndexService.fetchWorkflowSource('wf1')).rejects.toThrow(
+      'GraphQL error',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchInstanceVariables
+// ---------------------------------------------------------------------------
+
+describe('fetchInstanceVariables', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the parsed variables for the given instance id', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const variables = { greeting: 'hello', count: 3 };
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({
+        ProcessInstances: [{ variables }],
+      }),
+    );
+
+    const result = await dataIndexService.fetchInstanceVariables('inst1');
+
+    expect(result).toEqual(variables);
+  });
+
+  it('returns undefined when no instance is found', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [] }),
+    );
+
+    const result = await dataIndexService.fetchInstanceVariables('missing');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('Query failed');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(
+      dataIndexService.fetchInstanceVariables('inst1'),
+    ).rejects.toThrow('Query failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDefinitionIdByInstanceId
+// ---------------------------------------------------------------------------
+
+describe('fetchDefinitionIdByInstanceId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the processId for the given instance id', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({
+        ProcessInstances: [{ processId: 'wf1' }],
+      }),
+    );
+
+    const result = await dataIndexService.fetchDefinitionIdByInstanceId('i1');
+
+    expect(result).toBe('wf1');
+  });
+
+  it('returns undefined when no instance is found', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [] }),
+    );
+
+    const result =
+      await dataIndexService.fetchDefinitionIdByInstanceId('missing');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('Query error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(
+      dataIndexService.fetchDefinitionIdByInstanceId('i1'),
+    ).rejects.toThrow('Query error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDefinitionIdsFromInstances
+// ---------------------------------------------------------------------------
+
+describe('fetchDefinitionIdsFromInstances', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns distinct processIds from matching instances', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+
+    // First call: introspection for ProcessInstance argument types
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult(mockProcessInstanceArguments),
+    );
+    // Second call: actual data query
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({
+        ProcessInstances: [
+          { processId: 'wf1' },
+          { processId: 'wf1' }, // duplicate — should appear once
+          { processId: 'wf2' },
+        ],
+      }),
+    );
+
+    const result = await dataIndexService.fetchDefinitionIdsFromInstances({
+      targetEntity: 'component:default/my-service',
+    });
+
+    expect(result).toEqual(['wf1', 'wf2']);
+  });
+
+  it('returns an empty array when no instances match', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult(mockProcessInstanceArguments),
+    );
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [] }),
+    );
+
+    const result = await dataIndexService.fetchDefinitionIdsFromInstances({
+      targetEntity: 'component:default/unknown',
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('throws when the client returns an error on the data query', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult(mockProcessInstanceArguments),
+    );
+    const error = new Error('Data fetch error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(
+      dataIndexService.fetchDefinitionIdsFromInstances({
+        targetEntity: 'component:default/my-service',
+      }),
+    ).rejects.toThrow('Data fetch error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchInstancesByDefinitionId
+// ---------------------------------------------------------------------------
+
+describe('fetchInstancesByDefinitionId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns process instances for the given definition id', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const instances: ProcessInstance[] = [
+      {
+        id: 'inst1',
+        processId: 'wf1',
+        nodes: [],
+        state: 'COMPLETED' as any,
+        start: '2024-01-01T00:00:00.000Z',
+        endpoint: '',
+      },
+    ];
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: instances }),
+    );
+
+    const result = await dataIndexService.fetchInstancesByDefinitionId({
+      definitionId: 'wf1',
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result).toEqual(instances);
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes targetEntity variable when provided', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [] }),
+    );
+
+    await dataIndexService.fetchInstancesByDefinitionId({
+      definitionId: 'wf1',
+      limit: 5,
+      offset: 0,
+      targetEntity: 'component:default/my-svc',
+    });
+
+    const [, variables] = mockClient.query.mock.calls[0];
+    expect(variables).toMatchObject({
+      definitionId: 'wf1',
+      targetEntity: 'component:default/my-svc',
+    });
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('Query error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(
+      dataIndexService.fetchInstancesByDefinitionId({
+        definitionId: 'wf1',
+        limit: 10,
+        offset: 0,
+      }),
+    ).rejects.toThrow('Query error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchInstance
+// ---------------------------------------------------------------------------
+
+describe('fetchInstance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(fromWorkflowSource)
+      .mockReturnValue({ id: 'wf1', description: 'Mocked description' } as any);
+  });
+
+  it('returns the process instance enriched with workflow description', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const instance: ProcessInstance = {
+      id: 'inst1',
+      processId: 'wf1',
+      nodes: [createNodeObject('A')],
+      endpoint: '',
+    };
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [instance] }),
+    );
+    jest
+      .spyOn(dataIndexService, 'fetchWorkflowInfo')
+      .mockResolvedValue({ id: 'wf1', source: 'id: wf1' });
+
+    const result = await dataIndexService.fetchInstance('inst1');
+
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('inst1');
+    expect(result!.description).toBe('Mocked description');
+  });
+
+  it('returns undefined when no instance is found', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [] }),
+    );
+
+    const result = await dataIndexService.fetchInstance('missing');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws when the workflow source is missing', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const instance: ProcessInstance = {
+      id: 'inst1',
+      processId: 'wf1',
+      nodes: [],
+      endpoint: '',
+    };
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({ ProcessInstances: [instance] }),
+    );
+    jest
+      .spyOn(dataIndexService, 'fetchWorkflowInfo')
+      .mockResolvedValue(undefined);
+
+    await expect(dataIndexService.fetchInstance('inst1')).rejects.toThrow(
+      'Workflow definition is required to fetch instance inst1',
+    );
+  });
+
+  it('throws when the client returns an error', async () => {
+    const { mockClient, dataIndexService } = createMockSetup();
+    const error = new Error('Client error');
+    mockClient.query.mockResolvedValueOnce(
+      mockOperationResult({} as any, error),
+    );
+
+    await expect(dataIndexService.fetchInstance('inst1')).rejects.toThrow(
+      'Client error',
+    );
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DevModeService.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/DevModeService.test.ts
@@ -477,5 +477,76 @@ describe('DevModeService', () => {
 
       await launchPromise;
     });
+
+    it('should log an error when the child process emits an error event', async () => {
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      const spawnError = new Error('spawn docker ENOENT');
+      mockProcess.emit('error', spawnError);
+
+      await flushPromises();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('SonataFlow process error'),
+      );
+
+      await launchPromise;
+    });
+
+    it('should log when the child process exits with a non-zero code', async () => {
+      mockConfig.getOptionalString.mockImplementation((key: string) => {
+        if (key === 'orchestrator.sonataFlowService.baseUrl')
+          return 'http://localhost';
+        if (key === 'orchestrator.sonataFlowService.workflowsSource.localPath')
+          return '/test/workflows';
+        if (key === 'orchestrator.sonataFlowService.runtime') return 'docker';
+        return undefined;
+      });
+      mockConfig.getOptionalNumber.mockReturnValue(8080);
+
+      const mockProcess = new EventEmitter() as any;
+      mockSpawn.mockReturnValue(mockProcess);
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValue({ ok: true });
+
+      const service = new DevModeService(mockConfig, mockLogger);
+      const launchPromise = service.launchDevMode();
+
+      await flushPromises();
+
+      mockProcess.emit('exit', 1);
+
+      await flushPromises();
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('SonataFlow process exited with code 1'),
+      );
+
+      await launchPromise;
+    });
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/mapping/V2Mappings.test.ts
@@ -72,11 +72,7 @@ describe('scenarios to verify mapToWorkflowOverviewDTO', () => {
     expect(result.format).toBe(overview.format);
     expect(result.lastTriggeredMs).toBe(overview.lastTriggeredMs);
 
-    expect(result.lastRunStatus).toBe(
-      overview.lastRunStatus
-        ? getProcessInstancesStatusDTOFromString(overview.lastRunStatus)
-        : undefined,
-    );
+    expect(result.lastRunStatus).toBe(ProcessInstanceStatusDTO.Completed);
     expect(result.description).toBe(overview.description);
   });
 
@@ -119,11 +115,7 @@ describe('scenarios to verify mapToProcessInstanceDTO', () => {
     expect(result.end).toBeUndefined();
     expect(result.duration).toBeUndefined();
     expect(result.state).toBeDefined();
-    expect(result.state).toEqual(
-      getProcessInstancesStatusDTOFromString(
-        result.state as ProcessInstanceStatusDTO,
-      ),
-    );
+    expect(result.state).toBe(ProcessInstanceStatusDTO.Active);
     expect(result.description).toEqual(processInstanceV1.description);
     expect(result.workflowdata).toEqual(
       // @ts-ignore
@@ -154,18 +146,9 @@ describe('scenarios to verify mapToProcessInstanceDTO', () => {
     expect(result.duration).toEqual(duration);
 
     expect(result).toBeDefined();
-    if (!result.state) {
-      throw new Error('result.state should be defined');
-    }
-    expect(result.state).toEqual(
-      getProcessInstancesStatusDTOFromString(result.state),
-    );
+    expect(result.state).toBeDefined();
+    expect(result.state).toBe(ProcessInstanceStatusDTO.Active);
     expect(processIntanceV1.state).toBeDefined();
-    expect(result.state).toEqual(
-      getProcessInstancesStatusDTOFromString(
-        processIntanceV1.state as ProcessInstanceStatusDTO,
-      ),
-    );
     expect(result.end).toEqual(processIntanceV1.end);
     expect(result.duration).toEqual(duration);
     expect(result.description).toEqual(processIntanceV1.description);
@@ -187,5 +170,50 @@ describe('scenarios to verify mapToWorkflowRunStatusDTO', () => {
     expect(mappedValue.value).toBeDefined();
     expect(mappedValue.key).toEqual('Active');
     expect(mappedValue.value).toEqual('ACTIVE');
+  });
+});
+
+describe('scenarios to verify getProcessInstancesStatusDTOFromString', () => {
+  it('maps ACTIVE state to ProcessInstanceStatusDTO.Active', () => {
+    const result = getProcessInstancesStatusDTOFromString(
+      ProcessInstanceState.Active,
+    );
+    expect(result).toBe(ProcessInstanceStatusDTO.Active);
+  });
+
+  it('maps ERROR state to ProcessInstanceStatusDTO.Error', () => {
+    const result = getProcessInstancesStatusDTOFromString(
+      ProcessInstanceState.Error,
+    );
+    expect(result).toBe(ProcessInstanceStatusDTO.Error);
+  });
+
+  it('maps COMPLETED state to ProcessInstanceStatusDTO.Completed', () => {
+    const result = getProcessInstancesStatusDTOFromString(
+      ProcessInstanceState.Completed,
+    );
+    expect(result).toBe(ProcessInstanceStatusDTO.Completed);
+  });
+
+  it('maps ABORTED state to ProcessInstanceStatusDTO.Aborted', () => {
+    const result = getProcessInstancesStatusDTOFromString(
+      ProcessInstanceState.Aborted,
+    );
+    expect(result).toBe(ProcessInstanceStatusDTO.Aborted);
+  });
+
+  it('maps SUSPENDED state to ProcessInstanceStatusDTO.Suspended', () => {
+    const result = getProcessInstancesStatusDTOFromString(
+      ProcessInstanceState.Suspended,
+    );
+    expect(result).toBe(ProcessInstanceStatusDTO.Suspended);
+  });
+
+  it('throws for an invalid state string', () => {
+    expect(() => {
+      getProcessInstancesStatusDTOFromString('INVALID_STATE');
+    }).toThrow(
+      'state INVALID_STATE is not one of the values of type ProcessInstanceStatusDTO',
+    );
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/v2.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/service/api/v2.test.ts
@@ -254,9 +254,13 @@ describe('getWorkflowOverview', () => {
     // Act
     const result: WorkflowOverviewListResultDTO = await v2.getWorkflowsOverview(
       buildPaginationTmp(mockRequest.paginationInfo),
+      mockRequest.filters,
     );
 
     // Assert
+    expect(mockOrchestratorService.fetchWorkflowOverviews).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: mockRequest.filters }),
+    );
     expect(result).toEqual({
       overviews: mockOverviewsV1.items.map((item: WorkflowOverview) =>
         mapToWorkflowOverviewDTO(item),
@@ -289,25 +293,16 @@ describe('getWorkflowOverviewById', () => {
     jest.clearAllMocks();
   });
 
-  it('0 items in workflow overview list', async () => {
+  it('not found - throws when overview is undefined', async () => {
     // Arrange
-    const mockOverviewsV1 = {
-      items: [],
-    };
     (
       mockOrchestratorService.fetchWorkflowOverview as jest.Mock
-    ).mockResolvedValue(mockOverviewsV1.items);
-    // Act
-    const overviewV2 = await v2.getWorkflowOverviewById('test_workflowId');
+    ).mockResolvedValue(undefined);
 
-    // Assert
-    expect(overviewV2).toBeDefined();
-    expect(overviewV2.workflowId).toBeUndefined();
-    expect(overviewV2.name).toBeUndefined();
-    expect(overviewV2.format).toBeUndefined();
-    expect(overviewV2.lastTriggeredMs).toBeUndefined();
-    expect(overviewV2.lastRunStatus).toBeUndefined();
-    expect(overviewV2.description).toBeUndefined();
+    // Act & Assert
+    await expect(v2.getWorkflowOverviewById('test_workflowId')).rejects.toThrow(
+      "Couldn't fetch workflow overview for test_workflowId",
+    );
   });
 
   it('1 item in workflow overview list', async () => {
@@ -510,24 +505,17 @@ describe('executeWorkflow as event type', () => {
       customAttrib: 'My customAttrib',
       isEvent: true,
     };
-    // Act
-    try {
-      await v2.executeWorkflow(
-        {
-          inputData: workflowData,
-          targetEntity: 'someEntity',
-        },
+    // Act & Assert
+    await expect(
+      v2.executeWorkflow(
+        { inputData: workflowData, targetEntity: 'someEntity' },
         workflowInfo.id,
         'someUserEntity',
         'someToken',
-      );
-    } catch (err) {
-      // Assert
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err.message).toEqual(
-        'Error executing workflow with id test_workflowId, No States that match the start state',
-      );
-    }
+      ),
+    ).rejects.toThrow(
+      'Error executing workflow with id test_workflowId, No States that match the start state',
+    );
   });
 
   it('executes a given workflow: event type, no start.stateName error', async () => {
@@ -542,24 +530,17 @@ describe('executeWorkflow as event type', () => {
       customAttrib: 'My customAttrib',
       isEvent: true,
     };
-    // Act
-    try {
-      await v2.executeWorkflow(
-        {
-          inputData: workflowData,
-          targetEntity: 'someEntity',
-        },
+    // Act & Assert
+    await expect(
+      v2.executeWorkflow(
+        { inputData: workflowData, targetEntity: 'someEntity' },
         workflowInfo.id,
         'someUserEntity',
         'someToken',
-      );
-    } catch (err) {
-      // Assert
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err.message).toEqual(
-        'Error executing workflow with id test_workflowId, No States that match the start state',
-      );
-    }
+      ),
+    ).rejects.toThrow(
+      'Error executing workflow with id test_workflowId, No States that match the start state',
+    );
   });
 
   it('executes a given workflow: event type, no event ref error', async () => {
@@ -573,24 +554,17 @@ describe('executeWorkflow as event type', () => {
       customAttrib: 'My customAttrib',
       isEvent: true,
     };
-    // Act
-    try {
-      await v2.executeWorkflow(
-        {
-          inputData: workflowData,
-          targetEntity: 'someEntity',
-        },
+    // Act & Assert
+    await expect(
+      v2.executeWorkflow(
+        { inputData: workflowData, targetEntity: 'someEntity' },
         workflowInfo.id,
         'someUserEntity',
         'someToken',
-      );
-    } catch (err) {
-      // Assert
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err.message).toEqual(
-        'Error executing workflow with id test_workflowId, No event ref',
-      );
-    }
+      ),
+    ).rejects.toThrow(
+      'Error executing workflow with id test_workflowId, No event ref',
+    );
   });
 
   it('executes a given workflow: event type, no start event for event ref error', async () => {
@@ -605,24 +579,17 @@ describe('executeWorkflow as event type', () => {
       customAttrib: 'My customAttrib',
       isEvent: true,
     };
-    // Act
-    try {
-      await v2.executeWorkflow(
-        {
-          inputData: workflowData,
-          targetEntity: 'someEntity',
-        },
+    // Act & Assert
+    await expect(
+      v2.executeWorkflow(
+        { inputData: workflowData, targetEntity: 'someEntity' },
         workflowInfo.id,
         'someUserEntity',
         'someToken',
-      );
-    } catch (err) {
-      // Assert
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err.message).toEqual(
-        'Error executing workflow with id test_workflowId, No Events that match the start state eventRef',
-      );
-    }
+      ),
+    ).rejects.toThrow(
+      'Error executing workflow with id test_workflowId, No Events that match the start state eventRef',
+    );
   });
 
   it('executes a given workflow: event type, no correlation context attribute', async () => {
@@ -637,24 +604,17 @@ describe('executeWorkflow as event type', () => {
       customAttrib: 'My customAttrib',
       isEvent: true,
     };
-    // Act
-    try {
-      await v2.executeWorkflow(
-        {
-          inputData: workflowData,
-          targetEntity: 'someEntity',
-        },
+    // Act & Assert
+    await expect(
+      v2.executeWorkflow(
+        { inputData: workflowData, targetEntity: 'someEntity' },
         workflowInfo.id,
         'someUserEntity',
         'someToken',
-      );
-    } catch (err) {
-      // Assert
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(err.message).toEqual(
-        'Error executing workflow with id test_workflowId, No correlation context attribute name found in event with event name lock-event',
-      );
-    }
+      ),
+    ).rejects.toThrow(
+      'Error executing workflow with id test_workflowId, No correlation context attribute name found in event with event name lock-event',
+    );
   });
 });
 

--- a/workspaces/orchestrator/plugins/orchestrator-backend/src/types/pagination.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-backend/src/types/pagination.test.ts
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
-import { buildPagination } from './pagination';
+import { buildPagination, buildPaginationTmp } from './pagination';
 
 describe('buildPagination()', () => {
   it('should build the correct pagination obj when no query parameters are passed', () => {
     const mockRequest: any = {
       body: {},
     };
-    expect(buildPagination(mockRequest)).toEqual({});
+    expect(buildPagination(mockRequest)).toEqual({
+      limit: undefined,
+      offset: undefined,
+      order: undefined,
+      sortField: undefined,
+    });
   });
   it('should build the correct pagination obj when partial query parameters are passed', () => {
     const mockRequest: any = {
@@ -66,6 +71,62 @@ describe('buildPagination()', () => {
       },
     };
     expect(buildPagination(mockRequest)).toEqual({
+      limit: undefined,
+      offset: undefined,
+      order: undefined,
+      sortField: undefined,
+    });
+  });
+});
+
+describe('buildPaginationTmp()', () => {
+  it('should return empty pagination when no input is provided', () => {
+    expect(buildPaginationTmp(undefined)).toEqual({
+      limit: undefined,
+      offset: undefined,
+      order: undefined,
+      sortField: undefined,
+    });
+  });
+
+  it('should build correct pagination when only pageSize is provided', () => {
+    expect(buildPaginationTmp({ pageSize: 25 })).toEqual({
+      limit: 25,
+      offset: undefined,
+      order: undefined,
+      sortField: undefined,
+    });
+  });
+
+  it('should build correct pagination when all fields are provided', () => {
+    expect(
+      buildPaginationTmp({
+        offset: 10,
+        pageSize: 50,
+        orderBy: 'lastUpdated',
+        orderDirection: 'DESC',
+      }),
+    ).toEqual({
+      limit: 50,
+      offset: 10,
+      order: 'DESC',
+      sortField: 'lastUpdated',
+    });
+  });
+
+  it('should normalise orderDirection to uppercase', () => {
+    expect(buildPaginationTmp({ orderDirection: 'asc' as any })).toEqual({
+      limit: undefined,
+      offset: undefined,
+      order: 'ASC',
+      sortField: undefined,
+    });
+  });
+
+  it('should ignore non-numeric values for offset and pageSize', () => {
+    expect(
+      buildPaginationTmp({ offset: 'abc' as any, pageSize: 'xyz' as any }),
+    ).toEqual({
       limit: undefined,
       offset: undefined,
       order: undefined,

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/getWorkflowParams.test.ts
@@ -146,6 +146,31 @@ describe('createGetWorkflowParamsAction', () => {
     expect(ctx.output).toHaveBeenCalledWith('parameters', '{}');
   });
 
+  it('outputs empty parameters string when inputSchema is undefined', async () => {
+    mockApi.getWorkflowOverviewById.mockResolvedValue({
+      data: {
+        name: 'My Workflow',
+      },
+    });
+    mockApi.getWorkflowInputSchemaById.mockResolvedValue({
+      data: {
+        inputSchema: undefined,
+      },
+    });
+
+    const action = createGetWorkflowParamsAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'my-workflow',
+      },
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('title', 'My Workflow');
+    expect(ctx.output).toHaveBeenCalledWith('parameters', '{}');
+  });
+
   it('throws when the workflow is not found', async () => {
     mockApi.getWorkflowOverviewById.mockResolvedValue({
       data: undefined,

--- a/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
+++ b/workspaces/orchestrator/plugins/scaffolder-backend-module-orchestrator/src/actions/runWorkflow.test.ts
@@ -228,4 +228,24 @@ describe('createRunWorkflowAction', () => {
       name: 'WorkflowExecutionError',
     });
   });
+
+  it('re-throws generic non-Axios errors as-is', async () => {
+    const genericError = new Error('Unexpected internal failure');
+    mockApi.executeWorkflow.mockRejectedValue(genericError);
+
+    const action = createRunWorkflowAction(discoveryService, authService);
+    const ctx = createMockActionContext({
+      input: {
+        workflow_id: 'greeting',
+        parameters: {},
+      },
+      templateInfo: {
+        entityRef: 'component:default/sample-service',
+      },
+    });
+
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Unexpected internal failure',
+    );
+  });
 });


### PR DESCRIPTION
## Changes
- Expand DataIndexService, queryBuilder, DevModeService, V2 API/mapping/pagination tests
- Fix LokiProvider custom-limit assertion to use the actual fetch URL
- Extend scaffolder action tests (Axios / empty-schema paths)

Split from #3786 (backend slice).