### PR TITLE
chore(codecov): expand ignores for wiring, locales, and demo packages (RHIDP-15513)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -50,8 +50,9 @@ ignore:
   - "**/*.test.tsx"
   - "**/*.spec.ts"
   - "**/*.spec.tsx"
-  # Package entry barrels only. Nested index.ts(x) files often hold real logic
-  # (API clients, services, components) and must remain in the coverage denominator.
+  # Package entry points / NFS plugin wiring (createFrontendPlugin, blueprints).
+  # Nested index.ts(x) under api/, components/, services/ often hold real logic
+  # and must remain in the coverage denominator (hence the /src/ prefix).
   - "**/src/index.ts"
   - "**/src/index.tsx"
   - "**/__fixtures__/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -50,7 +50,10 @@ ignore:
   - "**/*.test.tsx"
   - "**/*.spec.ts"
   - "**/*.spec.tsx"
-  - "**/index.ts"
+  # Package entry barrels only. Nested index.ts(x) files often hold real logic
+  # (API clients, services, components) and must remain in the coverage denominator.
+  - "**/src/index.ts"
+  - "**/src/index.tsx"
   - "**/__fixtures__/**"
   - "**/__tests__/**"
   - "**/__mocks__/**"
@@ -64,7 +67,24 @@ ignore:
   - "workspaces/*/packages/app/**"
   - "workspaces/*/packages/app-legacy/**"
   - "workspaces/*/packages/backend/**"
-  - "workspaces/plugins/*-test/**"
+  # Test-helper plugins live under workspaces/<workspace>/plugins/*-test
+  - "workspaces/*/plugins/*-test/**"
+  - "**/generated/**"
+  # Locale catalogs, test helpers, and Backstage plugin wiring (no business logic).
+  # Do not ignore src/alpha/** wholesale — those folders often contain real logic.
+  - "workspaces/*/plugins/*/src/translations/**"
+  - "workspaces/*/plugins/*/src/test-utils/**"
+  - "workspaces/*/plugins/*/src/plugin.ts"
+  - "workspaces/*/plugins/*/src/alpha.ts"
+  - "workspaces/*/plugins/*/src/alpha.tsx"
+  - "workspaces/*/plugins/*/src/alpha/index.ts"
+  - "workspaces/*/plugins/*/src/alpha/index.tsx"
+  - "workspaces/*/plugins/*/src/alpha/plugin.ts"
+  # Route tables / i18n wrappers; page behavior is covered by e2e where needed.
+  - "workspaces/*/plugins/*/src/components/Router.tsx"
+  - "workspaces/*/plugins/*/src/components/Trans.tsx"
+  # Frontend string/number constants only (not *-common constants modules).
+  - "workspaces/orchestrator/plugins/orchestrator/src/constants.ts"
 
 component_management:
   # GENERATED — do not edit by hand.
@@ -75,14 +95,13 @@ component_management:
   # Only workspaces that exist in this repository are included.
   # Note: workspaces with mixed support-level packages appear in multiple components.
   individual_components:
-    # Generally-Available Plugins — 6 workspace(s)
+    # Generally-Available Plugins — 5 workspace(s)
     - component_id: generally-available-plugins
       name: 'Generally-Available Plugins'
       paths:
         - workspaces/adoption-insights/
         - workspaces/global-header/
         - workspaces/homepage/
-        - workspaces/intelligent-assistant/
         - workspaces/orchestrator/
         - workspaces/quickstart/
     # Tech-Preview Plugins — 4 workspace(s)


### PR DESCRIPTION
## Changes
- Ignore demo `packages/app|app-legacy|backend`, generated code, and `*-test` helper plugins
- Ignore package entry / NFS wiring (`src/index.ts(x)`, `plugin.ts`, `alpha.ts(x)`), translations, test-utils, Router/Trans
- Keep `constants.ts` ignore scoped to orchestrator frontend only
- Sync `component_management` with overlay metadata (required when touching `codecov.yml`)

## Notes on review feedback
- **`component_management` / intelligent-assistant:** Not a product demotion. Overlay metadata still uses the `lightspeed` workspace path, so the generator cannot map `intelligent-assistant` into GA. Verified with `scripts/generate-codecov-components.sh --check --overlay <overlay>`. The workspace remains in `flag_management`. It will reappear in GA once overlays are renamed/updated.
- **`**/src/index.tsx`:** Kept intentionally — those files are NFS/plugin wiring (same class as `alpha.tsx` / `plugin.ts`). Comment updated to say so; nested `index.tsx` under components stay counted.

Split from #3786 (codecov slice).