### PR TITLE
fix(theme): fix broken config.d.ts import in published package

### DIFF
--- a/workspaces/theme/.changeset/bright-lamps-glow.md
+++ b/workspaces/theme/.changeset/bright-lamps-glow.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Fix broken `config.d.ts` import path: change `import { ThemeConfig } from './src'` to `'./dist'` so the published package resolves correctly during config schema validation.

--- a/workspaces/theme/.changeset/bright-lamps-glow.md
+++ b/workspaces/theme/.changeset/bright-lamps-glow.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-theme': patch
 ---
 
-Fix broken `config.d.ts` import path: change `import { ThemeConfig } from './src'` to `'./dist'` so the published package resolves correctly during config schema validation.
+Fix broken `config.d.ts` import path: change `import { ThemeConfig } from './src'` to `'./'` so the published package resolves correctly during config schema validation.

--- a/workspaces/theme/plugins/theme/config.d.ts
+++ b/workspaces/theme/plugins/theme/config.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ThemeConfig } from './src';
+import { ThemeConfig } from './';
 
 export interface Config {
   app: {


### PR DESCRIPTION
## Description

The published `@red-hat-developer-hub/backstage-plugin-theme` package (all versions including 0.14.8) ships a `config.d.ts` that imports `ThemeConfig` from `./src`:

```typescript
import { ThemeConfig } from './src';
```

However, the published package does **not** include a `src/` directory — only `dist/` (as specified in the `"files"` field of `package.json`). This causes a TypeScript resolution failure when the `@red-hat-developer-hub/cli` validates config schemas during dynamic plugin export.

### Root cause

The `config.d.ts` file references `./src`, which exists in the source repository but is **not shipped** in the published npm package. The `backstage-cli package prepack` rewrites `package.json` fields (`main`, `types`, `exports`) from `./src` to `./dist`, but it does **not** transform `config.d.ts`.

### Why it was working before

All rhdh-plugin-export-overlays workspaces that depend on this theme package were on Backstage **1.49.x** or earlier. At those versions, the `@red-hat-developer-hub/cli` uses the **legacy Scalprum export path**, which does not perform strict TypeScript validation of `configSchema` files across the dependency tree — so the broken import was never evaluated.

### Why it's breaking now

The `intelligent-assistant` workspace (renamed from `lightspeed`) was bumped to Backstage **1.52.x**. At this version, the CLI switches to the **standard module federation export path**, which performs strict TypeScript compilation of all `configSchema` files discovered in the dependency tree. It finds the theme package's `config.d.ts`, attempts to compile it, and fails:

```
Error: Invalid TypeScript configuration schema:
../../node_modules/@red-hat-developer-hub/backstage-plugin-theme/config.d.ts(17,29):
  error TS2307: Cannot find module './src' or its corresponding type declarations.
```

This will affect **every** frontend plugin that depends on `@red-hat-developer-hub/backstage-plugin-theme` as workspaces are bumped to Backstage 1.52.x+.

### Fix

Change the import from `./src` to `./` so it resolves via the package's own entry point — works both in the source repo (`main` points to `./src/index.ts`) and in the published package (`main` is rewritten to `./dist/index.esm.js` by `prepack`).

### How to test locally

```bash
# 1. Go to any frontend plugin that depends on the theme package
cd workspaces/intelligent-assistant/plugins/intelligent-assistant

# 2. Reproduce the error (before fix)
npx @red-hat-developer-hub/cli@1.10.7 plugin export
# Error: Cannot find module './src' or its corresponding type declarations.

# 3. Apply the fix to node_modules
sed -i '' "s|from './src'|from './'|" ../../node_modules/@red-hat-developer-hub/backstage-plugin-theme/config.d.ts

# 4. Re-run export — the config schema error is resolved
npx @red-hat-developer-hub/cli@1.10.7 plugin export
# No more TS2307 error
```

CI log: https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/runs/29493405433/job/87604761738

## Fixed
- Unblocks [redhat-developer/rhdh-plugin-export-overlays#2785](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2785) (intelligent-assistant rename)
- Will unblock all future 1.52.x+ workspace exports that depend on the theme package

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)