### PR TITLE
chore(homepage): optimize how homepage layout is loaded

### DIFF
--- a/workspaces/homepage/.changeset/rich-seals-hang.md
+++ b/workspaces/homepage/.changeset/rich-seals-hang.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-homepage': patch
+---
+
+optimized how homepage layout is loaded

--- a/workspaces/homepage/plugins/homepage/report-alpha.api.md
+++ b/workspaces/homepage/plugins/homepage/report-alpha.api.md
@@ -8,7 +8,9 @@ import { TranslationRef } from '@backstage/frontend-plugin-api';
 import { TranslationResource } from '@backstage/frontend-plugin-api';
 
 // @alpha
-export const homePageModule: FrontendModule;
+const homePageModule: FrontendModule;
+export default homePageModule;
+export { homePageModule };
 
 // @public
 export const homepageTranslationRef: TranslationRef<

--- a/workspaces/homepage/plugins/homepage/src/alpha/extensions/homePageLayoutExtension.tsx
+++ b/workspaces/homepage/plugins/homepage/src/alpha/extensions/homePageLayoutExtension.tsx
@@ -15,7 +15,6 @@
  */
 
 import { HomePageLayoutBlueprint } from '@backstage/plugin-home-react/alpha';
-import { HomePageLayout } from '../components/HomePageLayout';
 import { HomePageCardConfig } from '../../types';
 
 /**
@@ -23,6 +22,9 @@ import { HomePageCardConfig } from '../../types';
  *
  * Config-driven layout with `widgetLayout` (priority, breakpoints per widget),
  * supports both customizable (drag/drop) and read-only modes.
+ *
+ * The layout component is loaded via dynamic `import()` inside the async
+ * loader so it stays out of the Module Federation sync chunk graph.
  *
  * @alpha
  */
@@ -57,8 +59,12 @@ export const homePageLayoutExtension =
       const layoutConfig = config.widgetLayout ?? {};
 
       return originalFactory({
-        loader: async () =>
-          function CustomHomePageLayout({ widgets }) {
+        loader: async () => {
+          const { HomePageLayout } = await import(
+            '../components/HomePageLayout'
+          );
+
+          return function CustomHomePageLayout({ widgets }) {
             const processedWidgets: HomePageCardConfig[] = widgets
               .map(widget => {
                 const widgetConfig = layoutConfig[widget.name ?? ''];
@@ -85,7 +91,8 @@ export const homePageLayoutExtension =
                 customizable={customizable}
               />
             );
-          },
+          };
+        },
       });
     },
   });

--- a/workspaces/homepage/plugins/homepage/src/alpha/index.ts
+++ b/workspaces/homepage/plugins/homepage/src/alpha/index.ts
@@ -83,3 +83,10 @@ export const homepageTranslationsModule = createFrontendModule({
  * @alpha
  */
 export { homepageTranslationRef, homepageTranslations } from '../translations';
+
+/**
+ * Default export required for Module Federation to emit the `alpha` NFS expose.
+ *
+ * @alpha
+ */
+export default homePageModule;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://redhat.atlassian.net/browse/RHIDP-15510

## Code changes
1. **homePageLayoutExtension.tsx** — removed static HomePageLayout import; loader now does:
const { HomePageLayout } = await import('../components/HomePageLayout');

2. **alpha/index.ts** — added export default homePageModule so backstage-cli package bundle emits the NFS alpha MF expose (needed to measure NFS sync).

3. **Header** / **HomePageStylesProvider** stay as static imports inside HomePageLayout.tsx. That is fine: once the layout is dynamically imported, those modules land in async chunks, not NFS sync.

## NFS `alpha` expose summary

| Metric | BEFORE | AFTER | Δ |
|--------|--------|-------|---|
| Sync chunks | 21 | 11 | -10 |
| **Sync size** | **1439.8 KB** | **784.5 KB** | **-655.4 KB (-45.5%)** |
| Async chunks | 227 | 240 | +13 |
| Async size (listed) | 1212.2 KB | 1946.3 KB | +734.1 KB |




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
