### PR TITLE
chore(intelligent-assistant): bump backstage-plugin-theme to ^0.14.9

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/gentle-foxes-smile.md
+++ b/workspaces/intelligent-assistant/.changeset/gentle-foxes-smile.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': patch
+---
+
+Updated dependency `@red-hat-developer-hub/backstage-plugin-theme` to `^0.14.9`.

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/package.json
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/package.json
@@ -83,7 +83,7 @@
     "@patternfly/react-table": "^6.4.1",
     "@red-hat-developer-hub/backstage-plugin-app-react": "^0.1.0",
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common": "workspace:^",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.8",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.9",
     "@tanstack/react-query": "^5.59.15",
     "monaco-editor": "^0.55.0",
     "react-dropzone": "^14.4.0",

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -9399,7 +9399,7 @@ __metadata:
     "@patternfly/react-table": "npm:^6.4.1"
     "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.1.0"
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.8"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.9"
     "@spotify/prettier-config": "npm:^15.0.0"
     "@tanstack/react-query": "npm:^5.59.15"
     "@testing-library/dom": "npm:^10.0.0"
@@ -9436,6 +9436,24 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
   checksum: 10c0/9dc6f44a9eca0f0a033609ef1887837908737bf4e3eba2ff614202c9ad1c4886ef6a52e30c5c25015607205104846786dceabbf37f760835037e7016711bac4e
+  languageName: node
+  linkType: hard
+
+"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.9":
+  version: 0.14.9
+  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.9"
+  dependencies:
+    "@backstage/frontend-plugin-api": "npm:^0.15.1"
+    "@backstage/plugin-app-react": "npm:^0.2.1"
+    "@mui/icons-material": "npm:^5.17.1"
+  peerDependencies:
+    "@backstage/core-plugin-api": ^1.12.4
+    "@backstage/theme": ^0.7.2
+    "@mui/icons-material": ^5.17.1
+    "@mui/material": ^5.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/4d07ca0766f37e9b347074b7409143c245081c47f15dabd39b47c1a352203b7ccf52fe3cfd934d5d6075b61a746daf6467338bda596ee6b3c251954a683864e5
   languageName: node
   linkType: hard
 

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -9421,25 +9421,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.8":
-  version: 0.14.8
-  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.8"
-  dependencies:
-    "@backstage/frontend-plugin-api": "npm:^0.15.1"
-    "@backstage/plugin-app-react": "npm:^0.2.1"
-    "@mui/icons-material": "npm:^5.17.1"
-  peerDependencies:
-    "@backstage/core-plugin-api": ^1.12.4
-    "@backstage/theme": ^0.7.2
-    "@mui/icons-material": ^5.17.1
-    "@mui/material": ^5.0.0
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/9dc6f44a9eca0f0a033609ef1887837908737bf4e3eba2ff614202c9ad1c4886ef6a52e30c5c25015607205104846786dceabbf37f760835037e7016711bac4e
-  languageName: node
-  linkType: hard
-
-"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.9":
+"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.8, @red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.9":
   version: 0.14.9
   resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.9"
   dependencies:


### PR DESCRIPTION
## Description
Bumps `@red-hat-developer-hub/backstage-plugin-theme` dependency from `^0.14.8` to `^0.14.9` in the Intelligent Assistant frontend plugin to pick up the latest theme fixes and improvements.

## Fixed
- TODO: Add Jira ticket URL

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)