### PR TITLE
chore(intelligent-assistant): bump backstage-plugin-theme to ^0.14.10

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/clever-trees-wave.md
+++ b/workspaces/intelligent-assistant/.changeset/clever-trees-wave.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': patch
+---
+
+Bump `@red-hat-developer-hub/backstage-plugin-theme` to `^0.14.10` to pick up the inlined config.d.ts fix that resolves the `matchMedia` schema crash during dynamic plugin export.

--- a/workspaces/intelligent-assistant/packages/app-legacy/package.json
+++ b/workspaces/intelligent-assistant/packages/app-legacy/package.json
@@ -49,7 +49,7 @@
     "@material-ui/icons": "^4.9.1",
     "@mui/material": "^5.12.2",
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant": "workspace:^",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.8",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.10",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.30.4",

--- a/workspaces/intelligent-assistant/packages/app/package.json
+++ b/workspaces/intelligent-assistant/packages/app/package.json
@@ -38,7 +38,7 @@
     "@material-ui/icons": "^4.9.1",
     "@red-hat-developer-hub/backstage-plugin-app-react": "^0.1.0",
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant": "workspace:^",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.8",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.10",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.30.4",

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/package.json
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/package.json
@@ -83,7 +83,7 @@
     "@patternfly/react-table": "^6.4.1",
     "@red-hat-developer-hub/backstage-plugin-app-react": "^0.1.0",
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common": "workspace:^",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.9",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.10",
     "@tanstack/react-query": "^5.59.15",
     "monaco-editor": "^0.55.0",
     "react-dropzone": "^14.4.0",

--- a/workspaces/intelligent-assistant/yarn.lock
+++ b/workspaces/intelligent-assistant/yarn.lock
@@ -9399,7 +9399,7 @@ __metadata:
     "@patternfly/react-table": "npm:^6.4.1"
     "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.1.0"
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.9"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.10"
     "@spotify/prettier-config": "npm:^15.0.0"
     "@tanstack/react-query": "npm:^5.59.15"
     "@testing-library/dom": "npm:^10.0.0"
@@ -9421,9 +9421,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.8, @red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.9":
-  version: 0.14.9
-  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.9"
+"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.10":
+  version: 0.14.10
+  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.10"
   dependencies:
     "@backstage/frontend-plugin-api": "npm:^0.15.1"
     "@backstage/plugin-app-react": "npm:^0.2.1"
@@ -9435,7 +9435,7 @@ __metadata:
     "@mui/material": ^5.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/4d07ca0766f37e9b347074b7409143c245081c47f15dabd39b47c1a352203b7ccf52fe3cfd934d5d6075b61a746daf6467338bda596ee6b3c251954a683864e5
+  checksum: 10c0/fbc7d8806e24b85cbe6a295473c3ed300e971f997d97622efce83e495e21670c962b9892ed3c40059d02f810e3d01ce56bca211bb94ca93401f4337f9623cb68
   languageName: node
   linkType: hard
 
@@ -14402,7 +14402,7 @@ __metadata:
     "@mui/material": "npm:^5.12.2"
     "@playwright/test": "npm:1.61.0"
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.8"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.10"
     "@testing-library/dom": "npm:^9.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
@@ -14454,7 +14454,7 @@ __metadata:
     "@playwright/test": "npm:1.61.0"
     "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.1.0"
     "@red-hat-developer-hub/backstage-plugin-intelligent-assistant": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.8"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.10"
     "@testing-library/dom": "npm:^9.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"


### PR DESCRIPTION
## Description

Bumps `@red-hat-developer-hub/backstage-plugin-theme` from `^0.14.9` to `^0.14.10` in the intelligent-assistant workspace to pick up the inlined `config.d.ts` fix from [#3814](https://github.com/redhat-developer/rhdh-plugins/pull/3814).

Theme `0.14.10` has fully inlined `ThemeConfig` types in `config.d.ts` (zero imports), which resolves the `matchMedia` crash in `ts-json-schema-generator` during dynamic plugin export on Backstage 1.52.x.

Without this bump, the intelligent-assistant workspace's `yarn.lock` locks to `0.14.9` (which still has `import { ThemeConfig } from './'`), and the frontend plugin export fails with:
```
Error: No value declaration found for symbol "matchMedia"
```

## Fixed
- Unblocks [redhat-developer/rhdh-plugin-export-overlays#2785](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2785)

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

Made with [Cursor](https://cursor.com)