### PR TITLE
fix(theme): prevent overlapping scrollbars on TechDocs pages

### DIFF
--- a/workspaces/theme/.changeset/fix-techdocs-double-scrollbar.md
+++ b/workspaces/theme/.changeset/fix-techdocs-double-scrollbar.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+prevent overlapping scrollbars on TechDocs pages

--- a/workspaces/theme/packages/app/package.json
+++ b/workspaces/theme/packages/app/package.json
@@ -54,7 +54,9 @@
     "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.0",
     "@backstage/frontend-test-utils": "^0.5.1",
+    "@playwright/test": "1.60.0",
     "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/workspaces/theme/plugins/theme/dev/ThemeTestPage.tsx
+++ b/workspaces/theme/plugins/theme/dev/ThemeTestPage.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import '@backstage/ui/css/styles.css';
 import Grid from '@mui/material/Grid';
 import { Header, Page, Content, InfoCard } from '@backstage/core-components';
 import { UserSettingsThemeToggle } from '@backstage/plugin-user-settings';

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -777,6 +777,15 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
               // Prevent overflow in the main container due to the margin
               maxHeight: `calc(100vh - 2 * ${general.pageInset})`,
             },
+            // Prevent TechDocs double scrollbar: the page-inset max-height puts
+            // <main>'s scrollbar at the same position as the ToC sidebar scrollbar.
+            // Letting <main> expand moves the scroll to the parent root instead.
+            "& > main:has([data-testid='techdocs-native-shadowroot'])": {
+              height: 'auto !important',
+              maxHeight: 'none !important',
+              borderRadius: '1rem',
+              marginRight: '0.5rem',
+            },
             // The Backstage suspense is an MUI LinearProgress that is not wrapped by
             // a `main`. We need to give it 100vh height to fill the page for the page
             // inset to look right.

--- a/workspaces/theme/yarn.lock
+++ b/workspaces/theme/yarn.lock
@@ -15506,6 +15506,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
+    "@axe-core/playwright": "npm:^4.11.0"
     "@backstage/cli": "npm:^0.36.0"
     "@backstage/core-components": "npm:^0.18.8"
     "@backstage/core-plugin-api": "npm:^1.12.4"
@@ -15531,6 +15532,7 @@ __metadata:
     "@backstage/ui": "npm:^0.13.1"
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
+    "@playwright/test": "npm:1.60.0"
     "@red-hat-developer-hub/backstage-plugin-bcc-test": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-bui-test": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-mui4-test": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!


## Fixes: 

https://redhat.atlassian.net/browse/RHDHBUGS-3461

## Summary

The page scrollbar and the TechDocs Table of Contents scrollbar overlap because both end up at the same horizontal position (~24px from the right edge).
    
  ## Root cause
The page-inset styles set `max-height` on `<main>`, which gives it its own scrollbar. Meanwhile, the TechDocs ToC sidebar inside the shadow DOM is fixed at `right: 24px`. Since the page-inset margin is also `1.5rem`(24px), the two scrollbars land right on top of each other.


  ## Fix

The fix removes the height constraint on `<main>` only when TechDocs content is present, using `main:has([data-testid='techdocs-native-shadowroot'])`. This lets `<main>` grow with its content so it no longer scrolls on its own, the scrolling moves to the outer page container instead, whose scrollbar sits at the viewport edge, away from the ToC scrollbar.

## Screenshots


https://github.com/user-attachments/assets/823fba1b-456c-4310-9b92-e02c2bc37fe3


 
 ## How to test
 
1. Import the sample techdocs from https://github.com/hiroyha-r/sample-catalog/blob/main/catalog-info.yaml 
2. Visit `sample-techdocs-1`  techdocs page.
3. Scrollbars should not overlap in the techdocs page.



 
 
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
