### PR TITLE
 chore(bulk-import): optimize bulk-import

### DIFF
--- a/workspaces/bulk-import/.changeset/smart-crews-wish.md
+++ b/workspaces/bulk-import/.changeset/smart-crews-wish.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+optimize bulk-import

--- a/workspaces/bulk-import/packages/app/src/modules/nav/Sidebar.tsx
+++ b/workspaces/bulk-import/packages/app/src/modules/nav/Sidebar.tsx
@@ -20,38 +20,31 @@ import {
   SidebarGroup,
   SidebarItem,
   SidebarScrollWrapper,
-  SidebarSpace,
 } from '@backstage/core-components';
 import { NavContentBlueprint } from '@backstage/plugin-app-react';
-import {
-  Settings as SidebarSettings,
-  UserSettingsSignInAvatar,
-} from '@backstage/plugin-user-settings';
 import MenuIcon from '@mui/icons-material/Menu';
 import { SidebarLogo } from './SidebarLogo';
 
 export const SidebarContent = NavContentBlueprint.make({
   params: {
-    component: ({ items }) => (
-      <Sidebar>
-        <SidebarLogo />
-        <SidebarDivider />
-        <SidebarGroup label="Menu" icon={<MenuIcon />}>
-          {items.map((item, index) => (
-            <SidebarItem {...item} key={index} />
-          ))}
-        </SidebarGroup>
-        <SidebarScrollWrapper />
-        <SidebarSpace />
-        <SidebarDivider />
-        <SidebarGroup
-          label="Settings"
-          icon={<UserSettingsSignInAvatar />}
-          to="/settings"
-        >
-          <SidebarSettings />
-        </SidebarGroup>
-      </Sidebar>
-    ),
+    component: ({ navItems }) => {
+      return (
+        <Sidebar>
+          <SidebarLogo />
+          <SidebarDivider />
+          <SidebarGroup label="Menu" icon={<MenuIcon />}>
+            {navItems.rest().map(item => (
+              <SidebarItem
+                key={item.node.spec.id}
+                to={item.href}
+                text={item.title}
+                icon={() => item.icon}
+              />
+            ))}
+          </SidebarGroup>
+          <SidebarScrollWrapper />
+        </Sidebar>
+      );
+    },
   },
 });

--- a/workspaces/bulk-import/plugins/bulk-import/report-alpha.api.md
+++ b/workspaces/bulk-import/plugins/bulk-import/report-alpha.api.md
@@ -11,7 +11,6 @@ import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendModule } from '@backstage/frontend-plugin-api';
-import { IconComponent } from '@backstage/frontend-plugin-api';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { OverridableExtensionDefinition } from '@backstage/frontend-plugin-api';
@@ -116,13 +115,13 @@ export const bulkImportTranslationRef: TranslationRef<
     readonly 'steps.generateCatalogInfoItems': string;
     readonly 'steps.editPullRequest': string;
     readonly 'steps.trackStatus': string;
-    readonly 'addRepositories.generateCatalogInfo': string;
-    readonly 'addRepositories.editPullRequest': string;
     readonly 'addRepositories.approvalTool.title': string;
     readonly 'addRepositories.approvalTool.tooltip': string;
     readonly 'addRepositories.approvalTool.github': string;
     readonly 'addRepositories.approvalTool.gitlab': string;
     readonly 'addRepositories.approvalTool.description': string;
+    readonly 'addRepositories.generateCatalogInfo': string;
+    readonly 'addRepositories.editPullRequest': string;
     readonly 'addRepositories.repositoryType.title': string;
     readonly 'addRepositories.repositoryType.group': string;
     readonly 'addRepositories.repositoryType.repository': string;
@@ -253,27 +252,6 @@ const _default: OverridableFrontendPlugin<
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
       ) => ExtensionBlueprintParams<AnyApiFactory>;
-    }>;
-    'nav-item:bulk-import': OverridableExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
     }>;
     'page:bulk-import': OverridableExtensionDefinition<{
       kind: 'page';

--- a/workspaces/bulk-import/plugins/bulk-import/src/alpha.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/alpha.tsx
@@ -23,7 +23,6 @@ import {
   createRouteRef,
   createSubRouteRef,
   identityApiRef,
-  NavItemBlueprint,
   PageBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { TranslationBlueprint } from '@backstage/plugin-app-react';
@@ -32,7 +31,7 @@ import {
   bulkImportApiRef,
   BulkImportBackendClient,
 } from './api/BulkImportBackendClient';
-import BulkImportIcon from './components/BulkImportSidebarItem';
+import BulkImportIcon from './components/BulkImportIcon';
 import { bulkImportTranslations } from './translations';
 
 // NFS Route References - created using @backstage/frontend-plugin-api
@@ -73,38 +72,10 @@ const bulkImportPage = PageBlueprint.make({
   params: {
     path: '/bulk-import',
     routeRef: rootRouteRef,
+    title: 'Bulk import',
+    icon: <BulkImportIcon />,
     noHeader: true,
     loader: () => import('./components').then(({ Router }) => <Router />),
-  },
-});
-
-/**
- * Nav Item Extension
- *
- * NOTE: This nav item is always visible in the sidebar. Unlike the legacy
- * BulkImportSidebarItem component, NavItemBlueprint does not support runtime
- * permission checking because:
- *
- * 1. Extension factories run at app startup, before user authentication
- * 2. NavItemBlueprint only accepts static data (title, icon, routeRef)
- * 3. React hooks like usePermission cannot be used in extension factories
- *
- * Permission checking is handled at the PAGE level instead. Users without
- * the required permissions will see a permission error when accessing the page.
- *
- * For apps requiring permission-gated nav visibility, use the legacy
- * BulkImportSidebarItem component from the main package export:
- *
- * @example
- * ```tsx
- * import { BulkImportSidebarItem } from '@red-hat-developer-hub/backstage-plugin-bulk-import';
- * ```
- */
-const bulkImportNavItem = NavItemBlueprint.make({
-  params: {
-    title: 'Bulk import',
-    routeRef: rootRouteRef,
-    icon: BulkImportIcon,
   },
 });
 
@@ -115,7 +86,7 @@ const bulkImportNavItem = NavItemBlueprint.make({
  */
 export default createFrontendPlugin({
   pluginId: 'bulk-import',
-  extensions: [bulkImportApi, bulkImportPage, bulkImportNavItem],
+  extensions: [bulkImportApi, bulkImportPage],
   routes: {
     root: rootRouteRef,
     tasks: importHistoryRouteRef,

--- a/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/api/BulkImportBackendClient.ts
@@ -32,7 +32,7 @@ import {
   OrgAndRepoResponse,
   SortingOrderEnum,
 } from '../types';
-import { getApi } from '../utils/repository-utils';
+import { getApi } from '../utils/getApi';
 import { IBulkImportRESTPathProvider } from './BulkImportBackendClientBase';
 import { OrchestratorBulkImportBackendClientPathProvider } from './OrchestratorBulkImportBackendClientPathProvider';
 import { PRBulkImportBackendClientPathProvider } from './PRBulkImportBackendClientPathProvider';

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportIcon.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportIcon.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTheme } from '@mui/material/styles';
+
+import bulkImportBlackImg from '../images/BulkImportIcon-Black.svg';
+import bulkImportWhiteImg from '../images/BulkImportIcon-White.svg';
+
+/**
+ * @public
+ * Bulk Import Icon (kept free of sidebar/permission deps for NFS sync).
+ */
+export const BulkImportIcon = () => {
+  const theme = useTheme();
+  const isDarkTheme = theme.palette.mode === 'dark';
+
+  return (
+    <img
+      src={isDarkTheme ? bulkImportWhiteImg : bulkImportBlackImg}
+      alt="bulk import icon"
+      style={{ height: '25px' }}
+    />
+  );
+};
+
+export default BulkImportIcon;

--- a/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/components/BulkImportSidebarItem.tsx
@@ -18,32 +18,12 @@ import { SidebarItem } from '@backstage/core-components';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { usePermission } from '@backstage/plugin-permission-react';
 
-import { useTheme } from '@mui/material/styles';
-
 import { bulkImportPermission } from '@red-hat-developer-hub/backstage-plugin-bulk-import-common';
 
 import { useTranslation } from '../hooks/useTranslation';
-import { getImageForIconClass } from '../utils/icons';
+import { BulkImportIcon } from './BulkImportIcon';
 
-/**
- * @public
- * Bulk Import Icon
- */
-export const BulkImportIcon = () => {
-  const theme = useTheme();
-  const isDarkTheme = theme.palette.mode === 'dark';
-  const iconClass = isDarkTheme
-    ? 'icon-bulk-import-white'
-    : 'icon-bulk-import-black';
-
-  return (
-    <img
-      src={getImageForIconClass(iconClass)}
-      alt="bulk import icon"
-      style={{ height: '25px' }}
-    />
-  );
-};
+export { BulkImportIcon } from './BulkImportIcon';
 
 export const BulkImportSidebarItem = () => {
   const { t } = useTranslation();

--- a/workspaces/bulk-import/plugins/bulk-import/src/index.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/index.ts
@@ -28,4 +28,4 @@ export {
   BulkImportSidebarItem,
 } from './plugin';
 
-export { default as BulkImportIcon } from './components/BulkImportSidebarItem';
+export { default as BulkImportIcon } from './components/BulkImportIcon';

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/getApi.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/getApi.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { APITypes } from '../types';
+
+/** Builds bulk-import backend list URLs (kept out of repository-utils UI graph). */
+export const getApi = (
+  backendUrl: string,
+  page: number,
+  size: number,
+  searchString: string,
+  approvalTool: string,
+  options?: APITypes,
+) => {
+  const params = new URLSearchParams({
+    pagePerIntegration: String(page),
+    sizePerIntegration: String(size),
+    search: searchString,
+    approvalTool,
+  });
+
+  if (options?.fetchOrganizations) {
+    return `${backendUrl}/api/bulk-import/organizations?${params.toString()}`;
+  }
+  if (options?.orgName) {
+    const orgName = encodeURIComponent(options?.orgName);
+    return `${backendUrl}/api/bulk-import/organizations/${orgName}/repositories?${params.toString()}`;
+  }
+  return `${backendUrl}/api/bulk-import/repositories?${params.toString()}`;
+};

--- a/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.tsx
+++ b/workspaces/bulk-import/plugins/bulk-import/src/utils/repository-utils.tsx
@@ -19,16 +19,15 @@ import { Link, StatusOK } from '@backstage/core-components';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 import Typography from '@mui/material/Typography';
-import * as jsyaml from 'js-yaml';
+import { loadAll } from 'js-yaml';
 import { get } from 'lodash';
-import * as yaml from 'yaml';
+import { stringify } from 'yaml';
 import * as yup from 'yup';
 
 import { WaitingForPR } from '../components/WaitingForPR';
 import {
   AddedRepositories,
   AddRepositoryData,
-  APITypes,
   ApprovalTool,
   CreateImportJobRepository,
   ErrorType,
@@ -49,6 +48,8 @@ import {
 } from '../types';
 import { getWorkflowStatusInfo } from './orchestratorStatus';
 import { getTaskStatusInfo } from './task-status';
+
+export { getApi } from './getApi';
 
 export const TaskLink = ({
   taskId,
@@ -521,7 +522,7 @@ export const prepareDataForSubmission = (
           organization: repo.orgName || '',
           defaultBranch: repo.defaultBranch || '',
         },
-        catalogInfoContent: yaml.stringify(
+        catalogInfoContent: stringify(
           repo.catalogInfoYaml?.prTemplate?.yaml,
           null,
           2,
@@ -539,31 +540,6 @@ export const prepareDataForSubmission = (
     },
     [],
   );
-
-export const getApi = (
-  backendUrl: string,
-  page: number,
-  size: number,
-  searchString: string,
-  approvalTool: string,
-  options?: APITypes,
-) => {
-  const params = new URLSearchParams({
-    pagePerIntegration: String(page),
-    sizePerIntegration: String(size),
-    search: searchString,
-    approvalTool,
-  });
-
-  if (options?.fetchOrganizations) {
-    return `${backendUrl}/api/bulk-import/organizations?${params.toString()}`;
-  }
-  if (options?.orgName) {
-    const orgName = encodeURIComponent(options?.orgName);
-    return `${backendUrl}/api/bulk-import/organizations/${orgName}/repositories?${params.toString()}`;
-  }
-  return `${backendUrl}/api/bulk-import/repositories?${params.toString()}`;
-};
 
 export const getCustomisedErrorMessage = (
   status: (RepositoryStatus | string)[] | undefined,
@@ -636,7 +612,7 @@ export const evaluatePRTemplate = (
 ): { pullReqPreview: PullRequestPreview; isInvalidEntity: boolean } => {
   const gitProvider = isGithubJob(repositoryStatus) ? 'github' : 'gitlab';
   try {
-    const entity = jsyaml.loadAll(
+    const entity = loadAll(
       repositoryStatus[gitProvider]?.pullRequest.catalogInfoContent ?? '',
     )[0] as Entity;
     const isInvalid =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**

https://redhat.atlassian.net/browse/RHIDP-15551

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
- Cut NFS Module Federation sync size for bulk-import by keeping heavy UI/API graphs off the alpha entry (~468 KB → ~118 KB sync, about −75%).
- Replaced deprecated NavItemBlueprint with PageBlueprint title + icon, and update the NFS demo sidebar to render auto-discovered navItems.
- Extracted a thin BulkImportIcon and move getApi out of repository-utils so the alpha/API path no longer pulls sidebar, permissions, or the full icons/utils UI graph.
- Remaining NFS vs OFS gap (~90 KB) is mostly @backstage/frontend-plugin-api blueprint wiring and its zod schema dependencies (ApiBlueprint / PageBlueprint), not plugin UI. The leftover zod cost is inherent to NFS page/API blueprints.


## NFS alpha expose summary

Metric | BEFORE | AFTER | Δ
-- | -- | -- | --
Sync chunks | 5 | 3 | -2
Sync size | 467.6 KB | 117.8 KB | -349.8 KB (-74.8%)
Async chunks | 201 | 204 | +3
Async size (listed) | 1937.4 KB | 2320.7 KB | +383.3 KB




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
