### PR TITLE
fix(quickstart): correct scalprum QuickstartPlugin module path

### DIFF
--- a/workspaces/quickstart/.changeset/fix-scalprum-extension.md
+++ b/workspaces/quickstart/.changeset/fix-scalprum-extension.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-quickstart': patch
+---
+
+Fix scalprum `QuickstartPlugin` exposed module path from `./src/index.ts` to `./src/index.tsx`.

--- a/workspaces/quickstart/plugins/quickstart/package.json
+++ b/workspaces/quickstart/plugins/quickstart/package.json
@@ -111,7 +111,7 @@
     "name": "red-hat-developer-hub.backstage-plugin-quickstart",
     "exposedModules": {
       "PluginRoot": "./src/index.tsx",
-      "QuickstartPlugin": "./src/index.ts",
+      "QuickstartPlugin": "./src/index.tsx",
       "Alpha": "./src/alpha.ts"
     }
   },


### PR DESCRIPTION
The `QuickstartPlugin` entry in the scalprum `exposedModules` config referenced `./src/index.ts` but the actual file is `./src/index.tsx`. This went unnoticed because webpack resolves the extension automatically during local development, but the stricter packaging step fails on the exact path.

Introduced in #3530.