### PR TITLE
fix(extensions): fix accessibility violations in Extensions plugin

### DIFF
--- a/workspaces/extensions/.changeset/bright-waves-glow.md
+++ b/workspaces/extensions/.changeset/bright-waves-glow.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-extensions': patch
+---
+
+Fix accessibility violations (role-img-alt, aria-prohibited-attr, label) and remove suppression flag from e2e accessibility tests.

--- a/workspaces/extensions/e2e-tests/utils/accessibility.ts
+++ b/workspaces/extensions/e2e-tests/utils/accessibility.ts
@@ -21,21 +21,18 @@ export async function runAccessibilityTests(
   page: Page,
   testInfo: TestInfo,
   attachName = 'accessibility-scan-results.json',
-  options: { skipFailures?: boolean } = { skipFailures: true },
 ) {
   const accessibilityScanResults = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
     .analyze();
 
   await testInfo.attach(attachName, {
-    body: JSON.stringify(accessibilityScanResults.violations, null, 2),
+    body: JSON.stringify(accessibilityScanResults, null, 2),
     contentType: 'application/json',
   });
 
-  if (!options?.skipFailures) {
-    expect(
-      accessibilityScanResults.violations,
-      'Accessibility violations found',
-    ).toEqual([]);
-  }
+  expect(
+    accessibilityScanResults.violations,
+    'Accessibility violations found',
+  ).toEqual([]);
 }

--- a/workspaces/extensions/plugins/extensions/src/components/Badges.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/Badges.tsx
@@ -142,7 +142,11 @@ export const BadgeTriange = ({ plugin }: { plugin: ExtensionsPlugin }) => {
     <div style={{ position: 'relative' }}>
       <div style={{ position: 'absolute' }}>
         <Tooltip title={options.tooltip} placement="top" arrow>
-          <div style={{ width: size, height: size }}>
+          <div
+            role="img"
+            aria-label={options.tooltip}
+            style={{ width: size, height: size }}
+          >
             <div
               style={{
                 position: 'absolute',

--- a/workspaces/extensions/plugins/extensions/src/components/PluginIcon.test.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/PluginIcon.test.tsx
@@ -38,8 +38,9 @@ const testPlugin: ExtensionsPlugin = {
 describe('PluginIcon', () => {
   it('should render without error', () => {
     const { getByRole } = render(<PluginIcon plugin={testPlugin} size={40} />);
-    expect(getByRole('img')).toBeInTheDocument();
-    expect(getByRole('img').style.backgroundImage).toEqual(
+    const img = getByRole('img', { name: 'APIs with Test plugin' });
+    expect(img).toBeInTheDocument();
+    expect(img.style.backgroundImage).toEqual(
       'url("https://backstage.io/icons/test-plugin.png")',
     );
   });

--- a/workspaces/extensions/plugins/extensions/src/components/PluginIcon.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/PluginIcon.tsx
@@ -53,6 +53,7 @@ export const PluginIcon = ({
   return (
     <CardMedia
       image={icon}
+      title={plugin.metadata.title ?? plugin.metadata.name}
       sx={{
         width: size,
         height: size,

--- a/workspaces/extensions/plugins/extensions/src/shared-components/CustomSelectFilter.tsx
+++ b/workspaces/extensions/plugins/extensions/src/shared-components/CustomSelectFilter.tsx
@@ -44,6 +44,8 @@ export interface CustomSelectFilterProps {
 }
 
 export const CustomSelectFilter = (props: CustomSelectFilterProps) => {
+  const inputId = `extensions-filter-${props.label.toLowerCase().replace(/\s+/g, '-')}`;
+
   return (
     <Box
       sx={{
@@ -52,6 +54,7 @@ export const CustomSelectFilter = (props: CustomSelectFilterProps) => {
       }}
     >
       <InputLabel
+        htmlFor={inputId}
         sx={{
           margin: theme => theme.spacing(1, 0),
           transform: 'initial',
@@ -67,6 +70,7 @@ export const CustomSelectFilter = (props: CustomSelectFilterProps) => {
         {props.label}
       </InputLabel>
       <Autocomplete
+        id={inputId}
         multiple
         disableCloseOnSelect
         aria-label={props.label}


### PR DESCRIPTION
## Description

Fix three accessibility violations in the Extensions plugin that were suppressed by the `skipFailures` flag in e2e accessibility tests:

1. **role-img-alt** — MUI `CardMedia` elements with `role="img"` lacked an accessible name. Added `title` attribute using the plugin display name to `PluginIcon`.
2. **aria-prohibited-attr** — Badge triangle tooltip wrappers (`BadgeTriange`) had `aria-label` forwarded to a plain `<div>` with no role. Added `role="img"` and explicit `aria-label` to the tooltip child element.
3. **label** — Filter combobox inputs (Category, Author, Support type) had no associated labels. Added `id` prop to `Autocomplete` and `htmlFor` to `InputLabel` in `CustomSelectFilter` to create proper label associations.

Also removed the `skipFailures` flag from `e2e-tests/utils/accessibility.ts` so the e2e suite now enforces full WCAG 2.x accessibility.

## Fixed
- Fixes https://github.com/redhat-developer/rhdh-plugins/issues/3838

## UI before changes
![Before fix](https://raw.githubusercontent.com/its-mitesh-kumar/rhdh-plugins/fix/extensions-3838-accessibility-violations/workspaces/extensions/.github/screenshots/before-fix.gif)

## UI after changes
![After fix](https://raw.githubusercontent.com/its-mitesh-kumar/rhdh-plugins/fix/extensions-3838-accessibility-violations/workspaces/extensions/.github/screenshots/after-fix.gif)

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.