### PR TITLE
fix(orchestrator): fix accessibility violations in WorkflowSuccessRatioCell

### DIFF
--- a/workspaces/orchestrator/.changeset/bright-clouds-shine.md
+++ b/workspaces/orchestrator/.changeset/bright-clouds-shine.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix accessibility violations (aria-progressbar-name, aria-prohibited-attr) in WorkflowSuccessRatioCell component.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowSuccessRatioCell.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/WorkflowSuccessRatioCell.tsx
@@ -59,14 +59,12 @@ export const WorkflowSuccessRatioCell = ({
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-      <Box
-        sx={{ position: 'relative', display: 'inline-flex' }}
-        aria-label={`${percent}%`}
-      >
+      <Box sx={{ position: 'relative', display: 'inline-flex' }}>
         <CircularProgress
           variant="determinate"
           value={100}
           size={PROGRESS_SIZE}
+          aria-hidden="true"
           sx={{ color: trackColor }}
         />
         <CircularProgress
@@ -74,6 +72,7 @@ export const WorkflowSuccessRatioCell = ({
           value={percent}
           size={PROGRESS_SIZE}
           color={color}
+          aria-label={`${percent}% success ratio`}
           sx={{ position: 'absolute', left: 0 }}
         />
       </Box>


### PR DESCRIPTION
## Description

Fix accessibility violations in the `WorkflowSuccessRatioCell` component of the Orchestrator plugin. The `MuiCircularProgress` elements used to display success ratios in the workflows table were missing accessible names (`aria-progressbar-name` violation), and a wrapper `<div>` had an `aria-label` attribute without a valid ARIA role (`aria-prohibited-attr` violation).

### Root cause

`WorkflowSuccessRatioCell` renders two overlapping `CircularProgress` components (a background track and a foreground fill) inside a `Box` wrapper. The wrapper `<div>` had `aria-label` set directly, which violates ARIA rules since plain `<div>` elements without a role cannot have `aria-label`. Neither `CircularProgress` element had an accessible name, triggering `aria-progressbar-name` violations. The fix removes `aria-label` from the wrapper, marks the decorative track progress as `aria-hidden="true"`, and adds a descriptive `aria-label` to the foreground progress indicator.

Note: The `nested-interactive` violations reported from `MuiTableSortLabel` are from Backstage core's table component and cannot be fixed from the orchestrator plugin.

## Fixed
- Fixes https://github.com/redhat-developer/rhdh-plugins/issues/3845

## Test Plan
- [ ] Navigate to the Orchestrator workflows page
- [ ] Verify the success ratio column renders circular progress indicators correctly
- [ ] Run axe-core accessibility scan and verify no `aria-progressbar-name` or `aria-prohibited-attr` violations
- [ ] Verify `nested-interactive` violations (from Backstage core table) are the only remaining violations

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.