### PR TITLE
fix(global-header): restore keyboard navigation for menu items without links

### DIFF
--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/MenuSection.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Fragment } from 'react';
 import type { ComponentType, FC } from 'react';
 import Divider from '@mui/material/Divider';
 import Box from '@mui/material/Box';
@@ -69,17 +68,46 @@ export const MenuSection: FC<MenuSectionConfig> = ({
 
   return (
     <>
-      {sectionLabel && (
-        <MenuItem
-          sx={{
-            p: 0,
-          }}
-          disableRipple
-          disableTouchRipple
-          component={hasClickableSubheader ? Link : Fragment}
-          to={optionalLink}
-          onClick={handleClose}
-        >
+      {sectionLabel &&
+        (hasClickableSubheader ? (
+          <MenuItem
+            sx={{
+              p: 0,
+            }}
+            disableRipple
+            disableTouchRipple
+            component={Link}
+            to={optionalLink}
+            onClick={handleClose}
+          >
+            <ListSubheader
+              sx={{
+                backgroundColor: 'transparent',
+                m: 0,
+                color: 'text.disabled',
+                lineHeight: 2,
+                mt: '0.5rem',
+                fontWeight: 400,
+              }}
+            >
+              {translatedSectionLabel}
+            </ListSubheader>
+
+            {optionalLinkLabel && (
+              <Box
+                sx={{
+                  fontSize: '0.875em',
+                  mr: 2,
+                  flexGrow: 1,
+                  textAlign: 'right',
+                  mt: '0.5rem',
+                }}
+              >
+                {optionalLinkLabel}
+              </Box>
+            )}
+          </MenuItem>
+        ) : (
           <ListSubheader
             sx={{
               backgroundColor: 'transparent',
@@ -92,22 +120,7 @@ export const MenuSection: FC<MenuSectionConfig> = ({
           >
             {translatedSectionLabel}
           </ListSubheader>
-
-          {optionalLinkLabel && (
-            <Box
-              sx={{
-                fontSize: '0.875em',
-                mr: 2,
-                flexGrow: 1,
-                textAlign: 'right',
-                mt: '0.5rem',
-              }}
-            >
-              {optionalLinkLabel}
-            </Box>
-          )}
-        </MenuItem>
-      )}
+        ))}
 
       {items.map(
         (
@@ -132,8 +145,7 @@ export const MenuSection: FC<MenuSectionConfig> = ({
               handleClose();
             }}
             sx={{ py: 0.5, color: 'inherit', textDecoration: 'none' }}
-            component={link ? Link : Fragment}
-            to={link}
+            {...(link ? { component: Link, to: link } : {})}
           >
             <Component
               icon={icon}


### PR DESCRIPTION
## Summary

- **[RHDHBUGS-1931]** Fix keyboard accessibility in Help dropdown menu — arrow keys now navigate all items correctly
- `MenuItem` with `component={Fragment}` silently dropped `role="menuitem"` and `tabIndex`, making items without a `link` prop (e.g. `SupportButton`) invisible to MUI's keyboard navigation
- Section headers without links now render `<ListSubheader>` directly instead of wrapping in a no-op `<MenuItem component={Fragment}>`

## Root Cause

In `MenuSection.tsx`, when a menu item had no `link` prop, `MenuItem` was rendered with `component={Fragment}`. React's `Fragment` drops all props passed to it, so MUI's injected `role="menuitem"` and `tabIndex` attributes were never emitted to the DOM. MUI's `MenuList` uses sibling traversal with `nextElementSibling` to handle ArrowUp/ArrowDown, and elements without these attributes are skipped — making those items unreachable by keyboard.

The Help dropdown's `SupportButton` (which manages its own navigation internally) has no `link` in its mount point config, so it was always rendered via `Fragment`.

## Test plan

- [ ] Open Help dropdown — verify ArrowUp/ArrowDown navigates between all items
- [ ] Open Application Launcher dropdown — verify arrow key navigation still works (regression check)
- [ ] Verify section headers with links (e.g. App Launcher "Documentation" header) remain clickable
- [ ] Verify section headers without links are not keyboard-focusable (correct a11y behavior)
- [ ] Verify mouse clicks on all menu items still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)