### PR TITLE
test(orchestrator): good-practice coverage follow-up (RHIDP-15513)

### DIFF
--- a/workspaces/orchestrator/.changeset/calm-pandas-extract.md
+++ b/workspaces/orchestrator/.changeset/calm-pandas-extract.md
@@ -1,6 +1,0 @@
----
-'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
-'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
----
-
-Extract colocated helper modules for unit-test coverage of pure UI logic.

--- a/workspaces/orchestrator/.changeset/calm-pandas-extract.md
+++ b/workspaces/orchestrator/.changeset/calm-pandas-extract.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-react': patch
+---
+
+Extract colocated helper modules for unit-test coverage of pure UI logic.

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/package.json
@@ -52,6 +52,8 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.36.2",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
     "@types/json-schema": "7.0.15",
     "@types/lodash": "^4.14.151",
     "@types/react": "^18.2.58",

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.helpers.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.helpers.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { JSONSchema7 } from 'json-schema';
+
+import { getNumSteps, removeHiddenSteps } from './OrchestratorForm.helpers';
+
+describe('getNumSteps', () => {
+  it('returns undefined for non-object schemas', () => {
+    expect(getNumSteps({ type: 'string' })).toBeUndefined();
+  });
+
+  it('returns undefined when properties are missing', () => {
+    expect(getNumSteps({ type: 'object' })).toBeUndefined();
+  });
+
+  it('returns undefined for single-step schemas with non-object fields', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+    expect(getNumSteps(schema)).toBeUndefined();
+  });
+
+  it('returns the step count for multi-step object schemas', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        step1: { type: 'object', properties: {} },
+        step2: { type: 'object', properties: {} },
+      },
+    };
+    expect(getNumSteps(schema)).toBe(2);
+  });
+});
+
+describe('removeHiddenSteps', () => {
+  it('returns the schema unchanged when there are no hidden empty steps', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        step1: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      },
+    };
+
+    expect(removeHiddenSteps(schema)).toBe(schema);
+  });
+
+  it('removes empty object steps marked with ui:widget hidden', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        visible: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+        hidden: {
+          type: 'object',
+          properties: {},
+          'ui:widget': 'hidden',
+        } as JSONSchema7 & Record<string, unknown>,
+      },
+    };
+
+    expect(removeHiddenSteps(schema)).toEqual({
+      type: 'object',
+      properties: {
+        visible: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      },
+    });
+  });
+
+  it('keeps hidden steps that still have properties', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        hiddenButNotEmpty: {
+          type: 'object',
+          properties: { keep: { type: 'string' } },
+          'ui:widget': 'hidden',
+        } as JSONSchema7 & Record<string, unknown>,
+      },
+    };
+
+    expect(removeHiddenSteps(schema)).toBe(schema);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.helpers.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.helpers.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+
+export const getNumSteps = (schema: JSONSchema7): number | undefined => {
+  if (schema.type !== 'object' || !schema.properties) return undefined;
+  const isMultiStep = Object.values(schema.properties).every(
+    prop => (prop as JSONSchema7).type === 'object',
+  );
+  return isMultiStep ? Object.keys(schema.properties).length : undefined;
+};
+
+/**
+ * Remove hidden steps from the schema.
+ *
+ * A wizard step is removed when
+ *   "type": "object"
+ *   "ui:widget": "hidden"
+ *   and properties are empty ("properties": {})
+ *
+ * @param schema - The schema to remove hidden steps from.
+ * @returns The schema with hidden steps removed.
+ */
+export const removeHiddenSteps = (schema: JSONSchema7): JSONSchema7 => {
+  if (typeof schema.properties === 'object') {
+    const hiddenSteps = Object.entries(schema.properties)
+      .map(([key, value]: [string, JSONSchema7Definition]) => {
+        const uiWidget = get(value, 'ui:widget');
+        if (
+          typeof value !== 'boolean' &&
+          value.type === 'object' &&
+          uiWidget === 'hidden' &&
+          value.properties &&
+          Object.keys(value.properties).length === 0
+        ) {
+          return key;
+        }
+        return undefined;
+      })
+      .filter(Boolean) as string[];
+
+    if (hiddenSteps.length > 0) {
+      const newSchema = cloneDeep(schema);
+      hiddenSteps.forEach(step => {
+        delete newSchema.properties?.[step];
+      });
+
+      return newSchema;
+    }
+  }
+
+  return schema;
+};

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/OrchestratorForm.tsx
@@ -19,9 +19,7 @@ import { ComponentType, Fragment, useCallback, useMemo, useState } from 'react';
 import { JsonObject } from '@backstage/types';
 
 import { UiSchema } from '@rjsf/utils';
-import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
-import cloneDeep from 'lodash/cloneDeep';
-import get from 'lodash/get';
+import type { JSONSchema7 } from 'json-schema';
 
 import {
   OrchestratorFormContextProps,
@@ -37,17 +35,10 @@ import {
   StepperContextProvider,
   useStepperContext,
 } from '../utils/StepperContext';
+import { getNumSteps, removeHiddenSteps } from './OrchestratorForm.helpers';
 import OrchestratorFormWrapper from './OrchestratorFormWrapper';
 import ReviewStep from './ReviewStep';
 import SingleStepForm from './SingleStepForm';
-
-const getNumSteps = (schema: JSONSchema7): number | undefined => {
-  if (schema.type !== 'object' || !schema.properties) return undefined;
-  const isMultiStep = Object.values(schema.properties).every(
-    prop => (prop as JSONSchema7).type === 'object',
-  );
-  return isMultiStep ? Object.keys(schema.properties).length : undefined;
-};
 
 /**
  * @public
@@ -65,48 +56,6 @@ export type OrchestratorFormProps = {
   t: TranslationFunction;
   executeLabel?: string;
   executeAsEventLabel?: string;
-};
-
-/**
- * Remove hidden steps from the schema.
- *
- * A wizard step is removed when
- *   "type": "object"
- *   "ui:widget": "hidden"
- *   and properties are empty ("properties": {})
- *
- * @param schema - The schema to remove hidden steps from.
- * @returns The schema with hidden steps removed.
- */
-const removeHiddenSteps = (schema: JSONSchema7): JSONSchema7 => {
-  if (typeof schema.properties === 'object') {
-    const hiddenSteps = Object.entries(schema.properties)
-      .map(([key, value]: [string, JSONSchema7Definition]) => {
-        const uiWidget = get(value, 'ui:widget');
-        if (
-          typeof value !== 'boolean' &&
-          value.type === 'object' &&
-          uiWidget === 'hidden' &&
-          value.properties &&
-          Object.keys(value.properties).length === 0
-        ) {
-          return key;
-        }
-        return undefined;
-      })
-      .filter(Boolean) as string[];
-
-    if (hiddenSteps.length > 0) {
-      const newSchema = cloneDeep(schema);
-      hiddenSteps.forEach(step => {
-        delete newSchema.properties?.[step];
-      });
-
-      return newSchema;
-    }
-  }
-
-  return schema;
 };
 
 type ReviewStepHostProps = {

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/SubmitButton.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/components/SubmitButton.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import SubmitButton from './SubmitButton';
+
+describe('SubmitButton', () => {
+  it('renders children and invokes handleClick', () => {
+    const handleClick = jest.fn();
+    render(
+      <SubmitButton submitting={false} handleClick={handleClick}>
+        Run
+      </SubmitButton>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button while submitting', () => {
+    render(
+      <SubmitButton submitting handleClick={jest.fn()}>
+        Run
+      </SubmitButton>,
+    );
+
+    expect(screen.getByRole('button', { name: /Run/ })).toBeDisabled();
+  });
+
+  it('focuses the button when focusOnMount is set', () => {
+    render(
+      <SubmitButton submitting={false} focusOnMount>
+        Run
+      </SubmitButton>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Run' })).toHaveFocus();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/StepperContext.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/StepperContext.test.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+
+import { StepperContextProvider, useStepperContext } from './StepperContext';
+
+const wrapper =
+  (reviewStep: ReactNode = <div>review</div>) =>
+  ({ children }: { children: ReactNode }) => (
+    <StepperContextProvider reviewStep={reviewStep} t={key => key}>
+      {children}
+    </StepperContextProvider>
+  );
+
+describe('StepperContext', () => {
+  it('throws when used outside of the provider', () => {
+    expect(() => renderHook(() => useStepperContext())).toThrow(
+      'Context StepperContext is not defined',
+    );
+  });
+
+  it('advances and goes back through steps', () => {
+    const { result } = renderHook(() => useStepperContext(), {
+      wrapper: wrapper(),
+    });
+
+    expect(result.current.activeStep).toBe(0);
+
+    act(() => {
+      result.current.handleNext();
+    });
+    expect(result.current.activeStep).toBe(1);
+
+    act(() => {
+      result.current.handleBack();
+    });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('only allows goToStep for previous steps', () => {
+    const { result } = renderHook(() => useStepperContext(), {
+      wrapper: wrapper(),
+    });
+
+    act(() => {
+      result.current.handleNext();
+      result.current.handleNext();
+    });
+    expect(result.current.activeStep).toBe(2);
+
+    act(() => {
+      result.current.goToStep(3);
+    });
+    expect(result.current.activeStep).toBe(2);
+
+    act(() => {
+      result.current.goToStep(0);
+    });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('tracks validating and fetching counters', () => {
+    const { result } = renderHook(() => useStepperContext(), {
+      wrapper: wrapper(),
+    });
+
+    act(() => {
+      result.current.handleValidateStarted();
+      result.current.handleFetchStarted();
+      result.current.handleFetchStarted();
+    });
+    expect(result.current.isValidating).toBe(true);
+    expect(result.current.isFetching).toBe(true);
+
+    act(() => {
+      result.current.handleFetchEnded();
+    });
+    expect(result.current.isFetching).toBe(true);
+
+    act(() => {
+      result.current.handleFetchEnded();
+      result.current.handleValidateEnded();
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('invokes clearFormErrorsRef when going back', () => {
+    const clearFormErrors = jest.fn();
+    const { result } = renderHook(() => useStepperContext(), {
+      wrapper: wrapper(),
+    });
+
+    result.current.clearFormErrorsRef.current = clearFormErrors;
+
+    act(() => {
+      result.current.handleNext();
+      result.current.handleBack();
+    });
+
+    expect(clearFormErrors).toHaveBeenCalled();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/extractStaticDefaults.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/extractStaticDefaults.test.ts
@@ -116,4 +116,103 @@ describe('extractStaticDefaults', () => {
       foo: 'existing',
     });
   });
+
+  it('resolves $ref defaults from root schema paths', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      $defs: {
+        Named: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', default: 'from-ref' },
+          },
+        },
+      },
+      properties: {
+        person: { $ref: '#/$defs/Named' },
+      },
+    };
+
+    expect(extractStaticDefaults(schema)).toEqual({
+      person: { name: 'from-ref' },
+    });
+  });
+
+  it('applies defaults from anyOf, if/then/else, and dependencies', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        mode: { type: 'string' },
+      },
+      anyOf: [
+        {
+          properties: {
+            anyField: { type: 'string', default: 'any' },
+          },
+        },
+      ],
+      if: {
+        properties: {
+          mode: { const: 'on' },
+        },
+      },
+      then: {
+        properties: {
+          thenField: { type: 'string', default: 'then' },
+        },
+      },
+      else: {
+        properties: {
+          elseField: { type: 'string', default: 'else' },
+        },
+      },
+      dependencies: {
+        mode: {
+          properties: {
+            depField: { type: 'string', default: 'dep' },
+          },
+        },
+      },
+    };
+
+    expect(extractStaticDefaults(schema)).toEqual({
+      anyField: 'any',
+      thenField: 'then',
+      elseField: 'else',
+      depField: 'dep',
+    });
+  });
+
+  it('merges nested defaults with existing nested form data', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            a: { type: 'string', default: 'default-a' },
+            b: { type: 'string', default: 'default-b' },
+          },
+        },
+      },
+    };
+
+    expect(
+      extractStaticDefaults(schema, { nested: { a: 'existing-a' } }),
+    ).toEqual({
+      nested: { a: 'existing-a', b: 'default-b' },
+    });
+  });
+
+  it('ignores boolean schema nodes while processing properties', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        allowed: { type: 'string', default: 'ok' },
+        denied: true,
+      },
+    };
+
+    expect(extractStaticDefaults(schema)).toEqual({ allowed: 'ok' });
+  });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/pruneFormData.test.ts
@@ -835,5 +835,185 @@ describe('pruneFormData', () => {
 
       expect(result).toEqual({ mode: 'simple', conditional: 'keep' });
     });
+
+    it('should resolve $ref via $defs when omitting nested fields', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        $defs: {
+          SecretStep: {
+            type: 'object',
+            properties: {
+              token: {
+                type: 'string',
+                omitFromWorkflowInput: true,
+              } as JSONSchema7,
+              name: { type: 'string' },
+            },
+          },
+        },
+        properties: {
+          step: { $ref: '#/$defs/SecretStep' },
+        },
+      };
+
+      const result = omitFromWorkflowInput(
+        { step: { token: 'secret', name: 'keep' } },
+        schema,
+      );
+
+      expect(result).toEqual({ step: { name: 'keep' } });
+    });
+
+    it('should omit entire arrays when items schema has omitFromWorkflowInput', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          keep: { type: 'string' },
+          secrets: {
+            type: 'array',
+            items: {
+              type: 'string',
+              omitFromWorkflowInput: true,
+            } as JSONSchema7,
+          },
+        },
+      };
+
+      const result = omitFromWorkflowInput(
+        { keep: 'yes', secrets: ['a', 'b'] },
+        schema,
+      );
+
+      expect(result).toEqual({ keep: 'yes' });
+    });
+
+    it('should prune object items inside arrays with omitFromWorkflowInput fields', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          rows: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                label: { type: 'string' },
+                secret: {
+                  type: 'string',
+                  omitFromWorkflowInput: true,
+                } as JSONSchema7,
+              },
+            },
+          },
+        },
+      };
+
+      const result = omitFromWorkflowInput(
+        {
+          rows: [
+            { label: 'one', secret: 'x' },
+            { label: 'two', secret: 'y' },
+          ],
+        },
+        schema,
+      );
+
+      expect(result).toEqual({
+        rows: [{ label: 'one' }, { label: 'two' }],
+      });
+    });
+  });
+
+  describe('allOf if/then/else and schema-level oneOf', () => {
+    it('should keep then-branch properties when if condition matches', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          mode: { type: 'string' },
+        },
+        allOf: [
+          {
+            if: {
+              properties: { mode: { const: 'advanced' } },
+            },
+            then: {
+              properties: {
+                detail: { type: 'string' },
+              },
+            },
+            else: {
+              properties: {
+                simpleNote: { type: 'string' },
+              },
+            },
+          },
+        ],
+      };
+
+      expect(
+        pruneFormData(
+          { mode: 'advanced', detail: 'keep', simpleNote: 'drop' },
+          schema,
+        ),
+      ).toEqual({ mode: 'advanced', detail: 'keep' });
+    });
+
+    it('should keep else-branch properties when if condition does not match', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          mode: { type: 'string' },
+        },
+        allOf: [
+          {
+            if: {
+              properties: { mode: { const: 'advanced' } },
+            },
+            then: {
+              properties: {
+                detail: { type: 'string' },
+              },
+            },
+            else: {
+              properties: {
+                simpleNote: { type: 'string' },
+              },
+            },
+          },
+        ],
+      };
+
+      expect(
+        pruneFormData(
+          { mode: 'simple', detail: 'drop', simpleNote: 'keep' },
+          schema,
+        ),
+      ).toEqual({ mode: 'simple', simpleNote: 'keep' });
+    });
+
+    it('should fall back to all oneOf branch properties when no branch matches', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        oneOf: [
+          {
+            properties: {
+              kind: { const: 'a' },
+              aOnly: { type: 'string' },
+            },
+          },
+          {
+            properties: {
+              kind: { const: 'b' },
+              bOnly: { type: 'string' },
+            },
+          },
+        ],
+      };
+
+      // No formData keys participate in either branch, so the oneOf loop falls
+      // back to allowing every branch property — still dropping unrelated keys.
+      expect(pruneFormData({ unrelated: 'drop' }, schema)).toEqual({});
+      // kind:'c' matches neither const, so fallback keeps kind from all branches.
+      expect(pruneFormData({ kind: 'c' }, schema)).toEqual({ kind: 'c' });
+    });
   });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/schemaHasUiHiddenFields.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/schemaHasUiHiddenFields.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { JSONSchema7 } from 'json-schema';
+
+import { schemaHasUiHiddenFields } from './schemaHasUiHiddenFields';
+
+describe('schemaHasUiHiddenFields', () => {
+  it('returns false when schema has no ui:hidden markers', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+
+    expect(schemaHasUiHiddenFields(schema)).toBe(false);
+  });
+
+  it('returns true when a property has ui:hidden', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        secret: {
+          type: 'string',
+          'ui:hidden': true,
+        } as JSONSchema7 & Record<string, unknown>,
+      },
+    };
+
+    expect(schemaHasUiHiddenFields(schema)).toBe(true);
+  });
+
+  it('returns true for nested object properties with ui:hidden', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        step: {
+          type: 'object',
+          properties: {
+            hiddenField: {
+              type: 'string',
+              'ui:hidden': { path: '/show', value: true },
+            } as JSONSchema7 & Record<string, unknown>,
+          },
+        },
+      },
+    };
+
+    expect(schemaHasUiHiddenFields(schema)).toBe(true);
+  });
+
+  it('returns true when array items schema has ui:hidden', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              note: {
+                type: 'string',
+                'ui:hidden': true,
+              } as JSONSchema7 & Record<string, unknown>,
+            },
+          },
+        },
+      },
+    };
+
+    expect(schemaHasUiHiddenFields(schema)).toBe(true);
+  });
+
+  it('returns true when a tuple items entry has ui:hidden', () => {
+    const schema: JSONSchema7 = {
+      type: 'array',
+      items: [
+        { type: 'string' },
+        {
+          type: 'string',
+          'ui:hidden': true,
+        } as JSONSchema7 & Record<string, unknown>,
+      ],
+    };
+
+    expect(schemaHasUiHiddenFields(schema)).toBe(true);
+  });
+
+  it('returns false for boolean schema values', () => {
+    expect(schemaHasUiHiddenFields(true as unknown as JSONSchema7)).toBe(false);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/useValidator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-react/src/utils/useValidator.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+import { renderHook } from '@testing-library/react';
+import type { JSONSchema7 } from 'json-schema';
+
+import { StepperContextProvider } from './StepperContext';
+import useValidator from './useValidator';
+
+const multiStepSchema: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    step1: {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+      },
+    },
+    step2: {
+      type: 'object',
+      required: ['email'],
+      properties: {
+        email: { type: 'string' },
+      },
+    },
+  },
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <StepperContextProvider reviewStep={<div>review</div>} t={key => key}>
+    {children}
+  </StepperContextProvider>
+);
+
+describe('useValidator', () => {
+  it('returns all errors for single-step schemas', () => {
+    const { result } = renderHook(() => useValidator(false), { wrapper });
+    const schema: JSONSchema7 = {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+
+    const validation = result.current.validateFormData({}, schema);
+
+    expect(validation.errors.length).toBeGreaterThan(0);
+    expect(validation.errors.some(err => err.property?.includes('name'))).toBe(
+      true,
+    );
+  });
+
+  it('filters multi-step errors to the active step', () => {
+    const { result } = renderHook(() => useValidator(true), { wrapper });
+
+    const validation = result.current.validateFormData({}, multiStepSchema);
+
+    expect(
+      validation.errors.every(err => err.property?.startsWith('.step1.')),
+    ).toBe(true);
+    expect(validation.errors.some(err => err.property?.includes('step2'))).toBe(
+      false,
+    );
+  });
+
+  it('exposes activeStep for forced re-renders', () => {
+    const { result } = renderHook(() => useValidator(true), { wrapper });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('delegates isValid to the underlying AJV validator', () => {
+    const { result } = renderHook(() => useValidator(false), { wrapper });
+    const schema: JSONSchema7 = {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+
+    expect(result.current.isValid(schema, {}, schema)).toBe(false);
+    expect(result.current.isValid(schema, { name: 'ok' }, schema)).toBe(true);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.helpers.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.helpers.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ProcessInstanceStatusDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { VALUE_UNAVAILABLE } from '../../constants';
+import { WorkflowRunDetail } from '../types/WorkflowRunDetail';
+import {
+  buildStartedDateRange,
+  combineFilters,
+  filterWorkflowRunsBySearch,
+  formatStartedRelative,
+  hasNextPageFromFetch,
+  trimOverflowPage,
+} from './WorkflowRunsTabContent.helpers';
+
+describe('combineFilters', () => {
+  it('returns undefined when no filters are active', () => {
+    expect(combineFilters([undefined, undefined])).toBeUndefined();
+  });
+
+  it('returns the single active filter', () => {
+    const filter = { operator: 'EQ' as const, field: 'state', value: 'Active' };
+    expect(combineFilters([undefined, filter])).toEqual(filter);
+  });
+
+  it('AND-combines multiple filters', () => {
+    const a = { operator: 'EQ' as const, field: 'state', value: 'Active' };
+    const b = { operator: 'EQ' as const, field: 'processId', value: 'wf' };
+    expect(combineFilters([a, b])).toEqual({
+      operator: 'AND',
+      filters: [a, b],
+    });
+  });
+});
+
+describe('formatStartedRelative', () => {
+  it('returns unavailable when start is missing', () => {
+    expect(formatStartedRelative(undefined)).toBe(VALUE_UNAVAILABLE);
+  });
+
+  it('formats a valid ISO timestamp relatively', () => {
+    const result = formatStartedRelative(new Date().toISOString());
+    expect(result).not.toBe(VALUE_UNAVAILABLE);
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('buildStartedDateRange', () => {
+  // Local calendar date avoids TZ drift in assertions.
+  const now = new Date(2024, 5, 15, 12, 0, 0);
+
+  it('builds Today / Yesterday / Last 7 days / This month ranges', () => {
+    const today = buildStartedDateRange('Today', now)!;
+    expect(new Date(today[0]).getDate()).toBe(15);
+    expect(new Date(today[0]).getHours()).toBe(0);
+    expect(new Date(today[1]).getHours()).toBe(23);
+
+    const yesterday = buildStartedDateRange('Yesterday', now)!;
+    expect(new Date(yesterday[0]).getDate()).toBe(14);
+    expect(new Date(yesterday[1]).getDate()).toBe(14);
+
+    const last7 = buildStartedDateRange('Last 7 days', now)!;
+    expect(new Date(last7[0]).getDate()).toBe(8);
+
+    const month = buildStartedDateRange('This month', now)!;
+    expect(new Date(month[0]).getDate()).toBe(1);
+    expect(new Date(month[0]).getMonth()).toBe(5);
+  });
+
+  it('returns undefined for unknown selector values', () => {
+    expect(buildStartedDateRange('All', now)).toBeUndefined();
+  });
+});
+
+describe('trimOverflowPage / hasNextPageFromFetch', () => {
+  it('trims the overflow probe row', () => {
+    expect(trimOverflowPage([1, 2, 3, 4], 3)).toEqual([1, 2, 3]);
+    expect(trimOverflowPage([1, 2, 3], 3)).toEqual([1, 2, 3]);
+  });
+
+  it('detects an additional page from the overflow row', () => {
+    expect(hasNextPageFromFetch(4, 3)).toBe(true);
+    expect(hasNextPageFromFetch(3, 3)).toBe(false);
+  });
+});
+
+describe('filterWorkflowRunsBySearch', () => {
+  const rows: WorkflowRunDetail[] = [
+    {
+      id: 'abc-123',
+      processName: 'Greeting',
+      workflowId: 'greeting',
+      start: 'Jun 1, 2024',
+      startIso: '2024-06-01T00:00:00.000Z',
+      duration: '1 minute',
+      state: ProcessInstanceStatusDTO.Completed,
+      version: '1.0.0',
+      targetEntity: 'component:default/app',
+      initiatorEntity: 'user:default/alice',
+      hasVariables: false,
+    },
+    {
+      id: 'xyz-999',
+      processName: 'Assessment',
+      workflowId: 'assessment',
+      start: 'Jun 2, 2024',
+      startIso: '2024-06-02T00:00:00.000Z',
+      duration: '2 minutes',
+      state: ProcessInstanceStatusDTO.Error,
+      hasVariables: false,
+    },
+  ];
+
+  it('returns all rows for empty search', () => {
+    expect(filterWorkflowRunsBySearch(rows, '  ')).toEqual(rows);
+  });
+
+  it('filters by id, name, state, and entity fields', () => {
+    expect(filterWorkflowRunsBySearch(rows, 'greeting')).toEqual([rows[0]]);
+    expect(filterWorkflowRunsBySearch(rows, 'alice')).toEqual([rows[0]]);
+    expect(filterWorkflowRunsBySearch(rows, 'error')).toEqual([rows[1]]);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.helpers.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.helpers.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DateTime } from 'luxon';
+
+import { Filter } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { VALUE_UNAVAILABLE } from '../../constants';
+import { WorkflowRunDetail } from '../types/WorkflowRunDetail';
+
+export const combineFilters = (
+  filters: (Filter | undefined)[],
+): Filter | undefined => {
+  const activeFilters = filters.filter(Boolean) as Filter[];
+  if (activeFilters.length === 0) {
+    return undefined;
+  }
+  if (activeFilters.length === 1) {
+    return activeFilters[0];
+  }
+  return {
+    operator: 'AND',
+    filters: activeFilters,
+  };
+};
+
+export const formatStartedRelative = (startIso?: string) => {
+  if (!startIso) {
+    return VALUE_UNAVAILABLE;
+  }
+
+  return DateTime.fromISO(startIso).toRelative() ?? VALUE_UNAVAILABLE;
+};
+
+/**
+ * Builds a [start, end] ISO range for the started filter selector.
+ *
+ * Note: selector values are currently the localized option strings themselves
+ * (see WorkflowRunsTabContent). The switch below matches the English labels.
+ */
+export const buildStartedDateRange = (
+  startedSelectorValue: string,
+  now: Date = new Date(),
+): [string, string] | undefined => {
+  const endOfToday = new Date(now);
+  endOfToday.setHours(23, 59, 59, 999);
+
+  switch (startedSelectorValue) {
+    case 'Today': {
+      const startOfToday = new Date(now);
+      startOfToday.setHours(0, 0, 0, 0);
+      return [startOfToday.toISOString(), endOfToday.toISOString()];
+    }
+    case 'Yesterday': {
+      const startOfYesterday = new Date(now);
+      startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+      startOfYesterday.setHours(0, 0, 0, 0);
+
+      const endOfYesterday = new Date(startOfYesterday);
+      endOfYesterday.setHours(23, 59, 59, 999);
+
+      return [startOfYesterday.toISOString(), endOfYesterday.toISOString()];
+    }
+    case 'Last 7 days': {
+      const startOfLast7Days = new Date(now);
+      startOfLast7Days.setDate(startOfLast7Days.getDate() - 7);
+      startOfLast7Days.setHours(0, 0, 0, 0);
+
+      return [startOfLast7Days.toISOString(), endOfToday.toISOString()];
+    }
+    case 'This month': {
+      const startOfCurrentMonth = new Date(now);
+      startOfCurrentMonth.setDate(1);
+      startOfCurrentMonth.setHours(0, 0, 0, 0);
+
+      return [startOfCurrentMonth.toISOString(), endOfToday.toISOString()];
+    }
+    default:
+      return undefined;
+  }
+};
+
+/** Drops the overflow probe row fetched via pageSize + 1. */
+export const trimOverflowPage = <T>(items: T[], pageSize: number): T[] => {
+  if (items.length === pageSize + 1) {
+    return items.slice(0, -1);
+  }
+  return items;
+};
+
+export const hasNextPageFromFetch = (
+  itemCount: number,
+  pageSize: number,
+): boolean => itemCount === pageSize + 1;
+
+export const filterWorkflowRunsBySearch = (
+  rows: WorkflowRunDetail[],
+  search: string,
+): WorkflowRunDetail[] => {
+  const query = search.trim().toLowerCase();
+  if (!query) {
+    return rows;
+  }
+
+  return rows.filter(
+    row =>
+      row.id.toLowerCase().includes(query) ||
+      row.processName.toLowerCase().includes(query) ||
+      (row.version?.toLowerCase().includes(query) ?? false) ||
+      (row.targetEntity?.toLowerCase().includes(query) ?? false) ||
+      (row.initiatorEntity?.toLowerCase().includes(query) ?? false) ||
+      (row.state?.toLowerCase().includes(query) ?? false) ||
+      row.start.toLowerCase().includes(query),
+  );
+};

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
@@ -41,11 +41,9 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import MuiLink from '@mui/material/Link';
 import TablePagination from '@mui/material/TablePagination';
-import { DateTime } from 'luxon';
 
 import {
   FieldFilter,
-  Filter,
   NestedFilter,
   orchestratorAdminViewPermission,
   orchestratorInstanceAdminViewPermission,
@@ -88,6 +86,14 @@ import { WorkflowInstanceStatusIndicator } from '../ui/WorkflowInstanceStatusInd
 import { VariablesDialog } from '../WorkflowInstancePage/VariablesDialog';
 import { mapProcessInstanceToDetails } from '../WorkflowInstancePage/WorkflowInstancePageContent';
 import { WorkflowLogsDialog } from '../WorkflowInstancePage/WorkflowLogsDialog';
+import {
+  buildStartedDateRange,
+  combineFilters,
+  filterWorkflowRunsBySearch,
+  formatStartedRelative,
+  hasNextPageFromFetch,
+  trimOverflowPage,
+} from './WorkflowRunsTabContent.helpers';
 
 type WorkflowRunsFetchResult = {
   items: WorkflowRunDetail[];
@@ -108,14 +114,6 @@ const EntityRefTableCell = ({
   return <EntityRefLink entityRef={entityRef} defaultKind={defaultKind} />;
 };
 
-const formatStartedRelative = (startIso?: string) => {
-  if (!startIso) {
-    return VALUE_UNAVAILABLE;
-  }
-
-  return DateTime.fromISO(startIso).toRelative() ?? VALUE_UNAVAILABLE;
-};
-
 const makeSelectItemsFromProcessInstanceValues = (t: any): SelectItem[] => [
   { label: t('table.status.running'), value: ProcessInstanceStatusDTO.Active },
   { label: t('table.status.failed'), value: ProcessInstanceStatusDTO.Error },
@@ -131,22 +129,6 @@ const makeSelectItemsFromProcessInstanceValues = (t: any): SelectItem[] => [
 ];
 
 const ENTITY_FILTER_KINDS = ['Component', 'System'];
-
-const combineFilters = (
-  filters: (Filter | undefined)[],
-): Filter | undefined => {
-  const activeFilters = filters.filter(Boolean) as Filter[];
-  if (activeFilters.length === 0) {
-    return undefined;
-  }
-  if (activeFilters.length === 1) {
-    return activeFilters[0];
-  }
-  return {
-    operator: 'AND',
-    filters: activeFilters,
-  };
-};
 
 export const WorkflowRunsTabContent = ({
   showRunsEmptyState = true,
@@ -318,67 +300,12 @@ export const WorkflowRunsTabContent = ({
       let startedFilter: FieldFilter | undefined = undefined;
 
       if (startedSelectorValue !== Selector.AllItems) {
-        let dateRange: [string, string] | undefined = undefined;
-
-        const currentDate = new Date();
-        const endOfToday = new Date(currentDate);
-        endOfToday.setHours(23, 59, 59, 999);
-
-        switch (startedSelectorValue) {
-          case 'Today': {
-            const startOfToday = new Date();
-            startOfToday.setHours(0, 0, 0, 0);
-            dateRange = [startOfToday.toISOString(), endOfToday.toISOString()];
-            break;
-          }
-          case 'Yesterday': {
-            const startOfYesterday = new Date();
-            startOfYesterday.setDate(startOfYesterday.getDate() - 1);
-            startOfYesterday.setHours(0, 0, 0, 0);
-
-            const endOfYesterday = new Date(startOfYesterday);
-            endOfYesterday.setHours(23, 59, 59, 999);
-
-            dateRange = [
-              startOfYesterday.toISOString(),
-              endOfYesterday.toISOString(),
-            ];
-            break;
-          }
-          case 'Last 7 days': {
-            const startOfLast7Days = new Date();
-            startOfLast7Days.setDate(startOfLast7Days.getDate() - 7);
-            startOfLast7Days.setHours(0, 0, 0, 0);
-
-            dateRange = [
-              startOfLast7Days.toISOString(),
-              endOfToday.toISOString(),
-            ];
-            break;
-          }
-          case 'This month': {
-            const startOfCurrentMonth = new Date();
-            startOfCurrentMonth.setDate(1);
-            startOfCurrentMonth.setHours(0, 0, 0, 0);
-
-            dateRange = [
-              startOfCurrentMonth.toISOString(),
-              endOfToday.toISOString(),
-            ];
-            break;
-          }
-          default:
-            dateRange = undefined;
-        }
-
-        startedFilter =
-          startedSelectorValue !== Selector.AllItems
-            ? {
-                operator: 'BETWEEN',
-                value: dateRange,
-                field: 'start',
-              }
-            : undefined;
+        const dateRange = buildStartedDateRange(startedSelectorValue);
+        startedFilter = {
+          operator: 'BETWEEN',
+          value: dateRange,
+          field: 'start',
+        };
       }
 
       let targetEntityFilter: NestedFilter | undefined;
@@ -698,31 +625,15 @@ export const WorkflowRunsTabContent = ({
     ];
   }, [canViewRunVariables, handleViewRunVariables, t]);
 
-  const data = useMemo(() => {
-    const items = runItems ?? [];
-    if (items.length === pageSize + 1) {
-      return items.slice(0, -1);
-    }
-    return items;
-  }, [runItems, pageSize]);
-  const hasNextPage = (runItems?.length ?? 0) === pageSize + 1;
-  const filteredData = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) {
-      return data;
-    }
-
-    return data.filter(
-      row =>
-        row.id.toLowerCase().includes(query) ||
-        row.processName.toLowerCase().includes(query) ||
-        (row.version?.toLowerCase().includes(query) ?? false) ||
-        (row.targetEntity?.toLowerCase().includes(query) ?? false) ||
-        (row.initiatorEntity?.toLowerCase().includes(query) ?? false) ||
-        (row.state?.toLowerCase().includes(query) ?? false) ||
-        row.start.toLowerCase().includes(query),
-    );
-  }, [data, search]);
+  const data = useMemo(
+    () => trimOverflowPage(runItems ?? [], pageSize),
+    [runItems, pageSize],
+  );
+  const hasNextPage = hasNextPageFromFetch(runItems?.length ?? 0, pageSize);
+  const filteredData = useMemo(
+    () => filterWorkflowRunsBySearch(data, search),
+    [data, search],
+  );
   const displayedRunCount = useMemo(() => {
     if (search.trim()) {
       return filteredData.length;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
@@ -44,6 +44,7 @@ import TablePagination from '@mui/material/TablePagination';
 
 import {
   FieldFilter,
+  Filter,
   NestedFilter,
   orchestratorAdminViewPermission,
   orchestratorInstanceAdminViewPermission,

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.helpers.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.helpers.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkflowOverviewDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { slicePaginatedPage } from './WorkflowsTabContent.helpers';
+
+describe('slicePaginatedPage', () => {
+  const overviews = [
+    { workflowId: 'a' },
+    { workflowId: 'b' },
+    { workflowId: 'c' },
+    { workflowId: 'd' },
+  ] as WorkflowOverviewDTO[];
+
+  it('returns the requested page slice', () => {
+    expect(slicePaginatedPage(overviews, 0, 2)).toEqual([
+      overviews[0],
+      overviews[1],
+    ]);
+    expect(slicePaginatedPage(overviews, 1, 2)).toEqual([
+      overviews[2],
+      overviews[3],
+    ]);
+  });
+
+  it('returns a short final page when near the end', () => {
+    expect(slicePaginatedPage(overviews, 1, 3)).toEqual([overviews[3]]);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.helpers.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.helpers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkflowOverviewDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+export const slicePaginatedPage = (
+  overviews: WorkflowOverviewDTO[],
+  page: number,
+  pageSize: number,
+) => {
+  const start = page * pageSize;
+  return overviews.slice(start, start + pageSize);
+};

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowsTabContent.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../hooks/useWorkflowsCount';
 import { filterWorkflowOverviewsBySearch } from '../../utils/filterWorkflowOverviews';
 import { OrchestratorEmptyState } from '../ui/OrchestratorEmptyState';
+import { slicePaginatedPage } from './WorkflowsTabContent.helpers';
 import { WorkflowsTable } from './WorkflowsTable';
 
 type WorkflowsTabContentViewProps = {
@@ -93,15 +94,6 @@ export const WorkflowsTabContentView = ({
       ) : null}
     </Content>
   );
-};
-
-const slicePaginatedPage = (
-  overviews: WorkflowOverviewDTO[],
-  page: number,
-  pageSize: number,
-) => {
-  const start = page * pageSize;
-  return overviews.slice(start, start + pageSize);
 };
 
 const WorkflowsTabContentWithFetch = ({

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.helpers.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.helpers.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ProcessInstanceStatusDTO } from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import {
+  getAuthTokenDescriptors,
+  isAbortableState,
+  isRerunnableState,
+} from './WorkflowInstancePage.helpers';
+
+describe('getAuthTokenDescriptors', () => {
+  it('returns undefined when schema is missing', async () => {
+    await expect(getAuthTokenDescriptors(undefined)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when AuthRequester widget is absent', async () => {
+    await expect(
+      getAuthTokenDescriptors({
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns descriptors from an AuthRequester ui:props block', async () => {
+    const descriptors = [{ provider: 'oidc', name: 'token' }];
+    await expect(
+      getAuthTokenDescriptors({
+        type: 'object',
+        properties: {
+          auth: {
+            type: 'object',
+            'ui:widget': 'AuthRequester',
+            'ui:props': { authTokenDescriptors: descriptors },
+          },
+        },
+      }),
+    ).resolves.toEqual(descriptors);
+  });
+});
+
+describe('isAbortableState / isRerunnableState', () => {
+  it('marks Active and Error as abortable', () => {
+    expect(isAbortableState(ProcessInstanceStatusDTO.Active)).toBe(true);
+    expect(isAbortableState(ProcessInstanceStatusDTO.Error)).toBe(true);
+    expect(isAbortableState(ProcessInstanceStatusDTO.Completed)).toBe(false);
+  });
+
+  it('marks Completed, Aborted, and Error as rerunnable', () => {
+    expect(isRerunnableState(ProcessInstanceStatusDTO.Completed)).toBe(true);
+    expect(isRerunnableState(ProcessInstanceStatusDTO.Aborted)).toBe(true);
+    expect(isRerunnableState(ProcessInstanceStatusDTO.Error)).toBe(true);
+    expect(isRerunnableState(ProcessInstanceStatusDTO.Active)).toBe(false);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.helpers.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.helpers.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+
+import {
+  AuthTokenDescriptor,
+  isJsonObject,
+  ProcessInstanceStatusDTO,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { deepSearchObject } from '../../utils/deepSearchObject';
+
+// For re-trigger, the wizard is not rendered, so there is no place where to instantiate the AuthRequester widget.
+// Let's parse the data input schema and try to find & interpret it.
+export const getAuthTokenDescriptors = async (
+  dataInputSchema: JsonObject | undefined,
+): Promise<AuthTokenDescriptor[] | undefined> => {
+  if (!dataInputSchema) {
+    return undefined;
+  }
+
+  const authRequester = deepSearchObject(
+    dataInputSchema,
+    (obj: JsonObject): boolean => {
+      const uiWidget = obj['ui:widget'];
+      const uiProps = obj['ui:props'];
+
+      const authTokenDescriptors = isJsonObject(uiProps)
+        ? uiProps.authTokenDescriptors
+        : undefined;
+      return (
+        uiWidget === 'AuthRequester' && Array.isArray(authTokenDescriptors)
+      );
+    },
+  );
+  if (!authRequester) {
+    return undefined;
+  }
+
+  const uiProps = (authRequester as JsonObject)['ui:props'] as JsonObject;
+  return uiProps.authTokenDescriptors as AuthTokenDescriptor[];
+};
+
+export const isAbortableState = (
+  state: ProcessInstanceStatusDTO | undefined,
+): boolean =>
+  state === ProcessInstanceStatusDTO.Active ||
+  state === ProcessInstanceStatusDTO.Error;
+
+export const isRerunnableState = (
+  state: ProcessInstanceStatusDTO | undefined,
+): boolean =>
+  state === ProcessInstanceStatusDTO.Completed ||
+  state === ProcessInstanceStatusDTO.Aborted ||
+  state === ProcessInstanceStatusDTO.Error;

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowInstancePage.tsx
@@ -51,9 +51,7 @@ import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 
 import {
-  AuthTokenDescriptor,
   capitalize,
-  isJsonObject,
   orchestratorWorkflowUsePermission,
   orchestratorWorkflowUseSpecificPermission,
   ProcessInstanceDTO,
@@ -75,7 +73,6 @@ import {
   workflowRouteRef,
 } from '../../routes';
 import { orchestratorTranslationRef } from '../../translations';
-import { deepSearchObject } from '../../utils/deepSearchObject';
 import {
   extractSsoReauthorizeUrl,
   isSamlSsoError,
@@ -90,6 +87,11 @@ import {
   PermissionDeniedPanel,
 } from '../ui/PermissionDeniedPanel';
 import { SamlSsoExpiredDialog } from '../ui/SamlSsoExpiredDialog';
+import {
+  getAuthTokenDescriptors,
+  isAbortableState,
+  isRerunnableState,
+} from './WorkflowInstancePage.helpers';
 import { WorkflowInstancePageContent } from './WorkflowInstancePageContent';
 
 const useStyles = makeStyles()(theme => ({
@@ -191,37 +193,6 @@ const AbortConfirmationDialogActions = (
   );
 };
 
-// For re-trigger, the wizard is not rendered, so there is no place where to instantiate the AuthRequester widget.
-// Let's parse the data input schema and try to find & interpret it.
-const getAuthTokenDescriptors = async (
-  dataInputSchema: JsonObject | undefined,
-): Promise<AuthTokenDescriptor[] | undefined> => {
-  if (!dataInputSchema) {
-    return undefined;
-  }
-
-  const authRequester = deepSearchObject(
-    dataInputSchema,
-    (obj: JsonObject): boolean => {
-      const uiWidget = obj['ui:widget'];
-      const uiProps = obj['ui:props'];
-
-      const authTokenDescriptors = isJsonObject(uiProps)
-        ? uiProps.authTokenDescriptors
-        : undefined;
-      return (
-        uiWidget === 'AuthRequester' && Array.isArray(authTokenDescriptors)
-      );
-    },
-  );
-  if (!authRequester) {
-    return undefined;
-  }
-
-  const uiProps = (authRequester as JsonObject)['ui:props'] as JsonObject;
-  return uiProps.authTokenDescriptors as AuthTokenDescriptor[];
-};
-
 // hack
 type LocalTranslationFunction =
   | TranslationFunction<typeof orchestratorTranslationRef.T>
@@ -316,14 +287,8 @@ export const WorkflowInstancePage = () => {
       return res.data?.inputSchema;
     }, [orchestratorApi, workflowId]);
 
-  const canAbort =
-    value?.state === ProcessInstanceStatusDTO.Active ||
-    value?.state === ProcessInstanceStatusDTO.Error;
-
-  const canRerun =
-    value?.state === ProcessInstanceStatusDTO.Completed ||
-    value?.state === ProcessInstanceStatusDTO.Aborted ||
-    value?.state === ProcessInstanceStatusDTO.Error;
+  const canAbort = isAbortableState(value?.state);
+  const canRerun = isRerunnableState(value?.state);
 
   const toggleAbortConfirmationDialog = useCallback(() => {
     setIsAbortConfirmationDialogOpen(prev => !prev);

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.helpers.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.helpers.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  extractIsoTimestamp,
+  extractWaitingNodeId,
+} from './WorkflowResult.helpers';
+
+describe('extractIsoTimestamp', () => {
+  it('returns undefined when no summary line matches', () => {
+    expect(
+      extractIsoTimestamp(['Workflow completed'], 'started'),
+    ).toBeUndefined();
+  });
+
+  it('extracts an ISO timestamp for a matching keyword', () => {
+    expect(
+      extractIsoTimestamp(
+        ['Workflow started at 2024-06-01T12:34:56.789Z'],
+        'started',
+      ),
+    ).toBe('2024-06-01T12:34:56.789Z');
+  });
+});
+
+describe('extractWaitingNodeId', () => {
+  it('parses the waiting node id', () => {
+    expect(
+      extractWaitingNodeId(
+        'Waiting at node ApproveTask since 2024-06-01T12:00:00Z',
+      ),
+    ).toBe('ApproveTask');
+  });
+
+  it('returns undefined when the message has no node marker', () => {
+    expect(extractWaitingNodeId('Still waiting')).toBeUndefined();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.helpers.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.helpers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ExecutionSummaryKeyword =
+  | 'started'
+  | 'failed'
+  | 'retriggered'
+  | 'waiting'
+  | 'completed'
+  | 'aborted';
+
+export const extractIsoTimestamp = (
+  executionSummary: string[],
+  keyword: ExecutionSummaryKeyword,
+): string | undefined => {
+  const matchingMessage = executionSummary.find(str =>
+    str.toLowerCase().includes(keyword),
+  );
+  if (!matchingMessage) {
+    return undefined;
+  }
+
+  const timeMatch = matchingMessage.match(
+    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/,
+  );
+  return timeMatch?.[1];
+};
+
+export const extractWaitingNodeId = (
+  waitingMessage: string,
+): string | undefined => {
+  const nodeMatch = waitingMessage.match(/node (\S+) since/);
+  return nodeMatch?.[1];
+};

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.helpers.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.helpers.ts
@@ -33,8 +33,8 @@ export const extractIsoTimestamp = (
     return undefined;
   }
 
-  const timeMatch = matchingMessage.match(
-    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/,
+  const timeMatch = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/.exec(
+    matchingMessage,
   );
   return timeMatch?.[1];
 };
@@ -42,6 +42,6 @@ export const extractIsoTimestamp = (
 export const extractWaitingNodeId = (
   waitingMessage: string,
 ): string | undefined => {
-  const nodeMatch = waitingMessage.match(/node (\S+) since/);
+  const nodeMatch = /node (\S+) since/.exec(waitingMessage);
   return nodeMatch?.[1];
 };

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/WorkflowResult.tsx
@@ -62,6 +62,10 @@ import {
   WorkflowDescriptionModalProps,
 } from './WorkflowDescriptionModal';
 import { WorkflowLogsDialog } from './WorkflowLogsDialog';
+import {
+  extractIsoTimestamp,
+  extractWaitingNodeId,
+} from './WorkflowResult.helpers';
 
 const useStyles = makeStyles()(theme => ({
   cardContent: {
@@ -125,32 +129,10 @@ const ResultMessage = ({
   const errorMessage = error?.message || error?.toString();
   const executionSummaryArray: string[] = executionSummary ?? [];
 
-  const extractIsoTimestamp = (
-    keyword:
-      | 'started'
-      | 'failed'
-      | 'retriggered'
-      | 'waiting'
-      | 'completed'
-      | 'aborted',
-  ): string | undefined => {
-    const matchingMessage = executionSummaryArray.find(str =>
-      str.toLowerCase().includes(keyword),
-    );
-    if (!matchingMessage) {
-      return undefined;
-    }
-
-    const timeMatch = matchingMessage.match(
-      /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/,
-    );
-    return timeMatch?.[1];
-  };
-
   const getTimeFromExecutionSummary = (
     keyword: 'started' | 'failed' | 'retriggered' | 'waiting' | 'completed',
   ): string[] => {
-    const isoTime = extractIsoTimestamp(keyword);
+    const isoTime = extractIsoTimestamp(executionSummaryArray, keyword);
     if (!isoTime) {
       return [''];
     }
@@ -167,7 +149,8 @@ const ResultMessage = ({
   };
 
   const getAbortTimeAgo = (): string => {
-    const isoTime = extractIsoTimestamp('aborted') ?? end;
+    const isoTime =
+      extractIsoTimestamp(executionSummaryArray, 'aborted') ?? end;
     if (!isoTime) {
       return '';
     }
@@ -183,8 +166,7 @@ const ResultMessage = ({
       getTimeFromExecutionSummary('waiting');
 
     if (waitingMessage) {
-      const nodeMatch = waitingMessage.match(/node (\S+) since/);
-      const node = nodeMatch?.[1] ?? 'unknown';
+      const node = extractWaitingNodeId(waitingMessage) ?? 'unknown';
       return (
         <Trans
           message="run.status.runningWaitingAtNode"

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/mapProcessInstanceToDetails.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/mapProcessInstanceToDetails.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ProcessInstanceDTO,
+  ProcessInstanceStatusDTO,
+} from '@red-hat-developer-hub/backstage-plugin-orchestrator-common';
+
+import { VALUE_UNAVAILABLE } from '../../constants';
+import { mapProcessInstanceToDetails } from './WorkflowInstancePageContent';
+
+const t = (key: string) => key;
+
+describe('mapProcessInstanceToDetails', () => {
+  it('maps a completed instance with duration and variables', () => {
+    const instance = {
+      id: 'inst-1',
+      processId: 'wf-1',
+      processName: 'Greeting',
+      state: ProcessInstanceStatusDTO.Completed,
+      start: '2024-01-01T10:00:00.000Z',
+      end: '2024-01-01T10:00:05.000Z',
+      description: 'demo',
+      version: '1.0',
+      initiatorEntity: 'user:default/alice',
+      targetEntity: 'component:default/app',
+      workflowdata: { result: 'ok', input: { name: 'world' } },
+    } as ProcessInstanceDTO;
+
+    const details = mapProcessInstanceToDetails(instance, t);
+
+    expect(details.id).toBe('inst-1');
+    expect(details.workflowId).toBe('wf-1');
+    expect(details.processName).toBe('Greeting');
+    expect(details.state).toBe(ProcessInstanceStatusDTO.Completed);
+    expect(details.startIso).toBe('2024-01-01T10:00:00.000Z');
+    expect(details.duration).not.toBe(VALUE_UNAVAILABLE);
+    expect(details.hasVariables).toBe(true);
+    expect(details.initiatorEntity).toBe('user:default/alice');
+    expect(details.targetEntity).toBe('component:default/app');
+  });
+
+  it('uses unavailable placeholders when start/name are missing', () => {
+    const instance = {
+      id: 'inst-2',
+      processId: 'wf-2',
+      state: ProcessInstanceStatusDTO.Active,
+    } as ProcessInstanceDTO;
+
+    const details = mapProcessInstanceToDetails(instance, t);
+
+    expect(details.processName).toBe(VALUE_UNAVAILABLE);
+    expect(details.start).toBe(VALUE_UNAVAILABLE);
+    expect(details.duration).toBe(VALUE_UNAVAILABLE);
+    expect(details.hasVariables).toBe(false);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/mapProcessInstanceToDetails.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/WorkflowInstancePage/mapProcessInstanceToDetails.test.ts
@@ -38,6 +38,7 @@ describe('mapProcessInstanceToDetails', () => {
       initiatorEntity: 'user:default/alice',
       targetEntity: 'component:default/app',
       workflowdata: { result: 'ok', input: { name: 'world' } },
+      nodes: [],
     } as ProcessInstanceDTO;
 
     const details = mapProcessInstanceToDetails(instance, t);
@@ -58,6 +59,7 @@ describe('mapProcessInstanceToDetails', () => {
       id: 'inst-2',
       processId: 'wf-2',
       state: ProcessInstanceStatusDTO.Active,
+      nodes: [],
     } as ProcessInstanceDTO;
 
     const details = mapProcessInstanceToDetails(instance, t);

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/PermissionDeniedPanel.test.ts
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/PermissionDeniedPanel.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  extractRequiredPermission,
+  isAccessDeniedError,
+} from './PermissionDeniedPanel';
+
+describe('isAccessDeniedError', () => {
+  it('returns false for undefined errors', () => {
+    expect(isAccessDeniedError(undefined)).toBe(false);
+  });
+
+  it.each([
+    'Access denied for user',
+    'Unauthorized request',
+    'Action is not allowed',
+    'Missing permission to view',
+  ])('detects access denial phrasing: %s', message => {
+    expect(isAccessDeniedError(new Error(message))).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isAccessDeniedError(new Error('Network timeout'))).toBe(false);
+  });
+});
+
+describe('extractRequiredPermission', () => {
+  it('returns undefined when there is no error message', () => {
+    expect(extractRequiredPermission(undefined)).toBeUndefined();
+    expect(extractRequiredPermission(new Error(''))).toBeUndefined();
+  });
+
+  it('extracts a quoted permission name from the message', () => {
+    expect(
+      extractRequiredPermission(
+        new Error(
+          "User lacks 'orchestrator.workflow.use.permission' to continue",
+        ),
+      ),
+    ).toBe('orchestrator.workflow.use.permission');
+  });
+
+  it('returns undefined when no permission token is quoted', () => {
+    expect(
+      extractRequiredPermission(new Error('Access denied')),
+    ).toBeUndefined();
+  });
+});

--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -11777,6 +11777,8 @@ __metadata:
     "@rjsf/material-ui": "npm:^5.21.2"
     "@rjsf/utils": "npm:^5.21.2"
     "@rjsf/validator-ajv8": "npm:^5.21.2"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^14.0.0"
     "@types/json-schema": "npm:7.0.15"
     "@types/lodash": "npm:^4.14.151"
     "@types/react": "npm:^18.2.58"


### PR DESCRIPTION
- Adds unit tests for existing orchestrator / form-react logic.
- Extracts helper code to *.helpers.ts modules - without expanding the package public API.
- Covers those helpers with focused unit tests; adds RTL tests for stepper, validator, and SubmitButton.
- Adds @testing-library/react / @testing-library/jest-dom to orchestrator-form-react for the new RTL tests.
- Leaves heavy page-shell RTL uncovered.