### PR TITLE
fix(ci): allow fork PR checkout in changeset feedback workflow

### DIFF
--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -33,6 +33,8 @@ jobs:
           # Fetch the commit that's merged into the base rather than the target ref
           # This will let us diff only the contents of the PR, without fetching more history
           ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: fetch base
         run: git fetch --depth 1 origin "$GITHUB_BASE_REF"
 


### PR DESCRIPTION
## Summary

- GitHub Actions now blocks checking out fork PR code from `pull_request_target` workflows by default
- The `automate_changeset_feedback.yml` workflow fails for all fork PRs with: _"Refusing to check out fork pull request code from a 'pull_request_target' workflow"_
- Adds `allow-unsafe-pr-checkout: true` to the `actions/checkout` step

See: https://gh.io/securely-using-pull_request_target


Made with [Cursor](https://cursor.com)