### PR TITLE
chore: remove broken postinstall scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
+      - name: Install root dependencies
+        run: yarn install --immutable
+        working-directory: ${{ github.workspace }}
+
       - name: yarn install
         run: yarn install --immutable
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -72,6 +72,10 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
 
+      - name: Install root dependencies
+        run: yarn install --immutable
+        working-directory: ${{ github.workspace }}
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/workspaces/adoption-insights/package.json
+++ b/workspaces/adoption-insights/package.json
@@ -30,8 +30,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/ai-integrations/package.json
+++ b/workspaces/ai-integrations/package.json
@@ -24,8 +24,7 @@
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/app-defaults/package.json
+++ b/workspaces/app-defaults/package.json
@@ -24,8 +24,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:fix": "prettier --write .",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": [
     "packages/*",

--- a/workspaces/augment/package.json
+++ b/workspaces/augment/package.json
@@ -27,7 +27,7 @@
     "prettier:fix": "prettier --write .",
     "chores": "yarn prettier:fix && yarn lint:all --fix && yarn tsc:full && yarn build:api-reports && yarn test:all",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "node scripts/patch-agents-core.js && cd ../../ && yarn install"
+    "postinstall": "node scripts/patch-agents-core.js"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/boost/package.json
+++ b/workspaces/boost/package.json
@@ -24,8 +24,7 @@
     "prettier:fix": "prettier --write .",
     "chores": "yarn prettier:fix && yarn lint:all --fix && yarn tsc:full && yarn build:api-reports && yarn openspec:validate && yarn test:all",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "openspec:validate": "openspec validate --all --json",
-    "postinstall": "cd ../../ && yarn install"
+    "openspec:validate": "openspec validate --all --json"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/bulk-import/package.json
+++ b/workspaces/bulk-import/package.json
@@ -23,7 +23,6 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install",
     "test:e2e:legacy": "APP_MODE=legacy playwright test",
     "test:e2e:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:all": "yarn test:e2e:legacy && yarn test:e2e:nfs",

--- a/workspaces/cost-management/package.json
+++ b/workspaces/cost-management/package.json
@@ -25,8 +25,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/dcm/package.json
+++ b/workspaces/dcm/package.json
@@ -27,7 +27,6 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install",
     "e2e-test": "playwright test",
     "e2e-test:live": "playwright test --project=live"
   },

--- a/workspaces/extensions/package.json
+++ b/workspaces/extensions/package.json
@@ -29,8 +29,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/global-header/package.json
+++ b/workspaces/global-header/package.json
@@ -30,8 +30,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/homepage/package.json
+++ b/workspaces/homepage/package.json
@@ -30,8 +30,7 @@
     "playwright": "bash -c 'if [[ \"$*\" == \"test\" ]]; then yarn test:e2e:all; else npx playwright \"$@\"; fi' _",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/install-dynamic-plugins/package.json
+++ b/workspaces/install-dynamic-plugins/package.json
@@ -25,8 +25,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/intelligent-assistant/package.json
+++ b/workspaces/intelligent-assistant/package.json
@@ -32,8 +32,7 @@
     "lint:fix": "backstage-cli package lint --fix",
     "prettier:check": "prettier --ignore-unknown --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": [
     "packages/*",

--- a/workspaces/konflux/package.json
+++ b/workspaces/konflux/package.json
@@ -23,8 +23,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/mcp-integrations/package.json
+++ b/workspaces/mcp-integrations/package.json
@@ -25,8 +25,7 @@
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/noop/package.json
+++ b/workspaces/noop/package.json
@@ -9,7 +9,6 @@
     "build:api-reports:only": "exit 0",
     "build:knip-reports": "exit 0",
     "fix": "exit 0",
-    "postinstall": "cd ../../ && yarn install",
     "prettier:check": "exit 0",
     "tsc:full": "exit 0",
     "test:all": "exit 0"

--- a/workspaces/orchestrator/package.json
+++ b/workspaces/orchestrator/package.json
@@ -25,7 +25,6 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "./scripts/postinstall",
     "enable-in-rhdh-repo": "node scripts/export-to-rhdh-repo.js && node scripts/update-config-in-rhdh-repo.js"
   },
   "workspaces": {

--- a/workspaces/orchestrator/scripts/postinstall
+++ b/workspaces/orchestrator/scripts/postinstall
@@ -1,6 +1,0 @@
-#!/bin/bash
-mydir=`pwd`
-cd ../../ && yarn install
-cd $mydir
-cd plugins/orchestrator-common
-yarn openapi:check

--- a/workspaces/quickstart/package.json
+++ b/workspaces/quickstart/package.json
@@ -22,7 +22,6 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install",
     "test:e2e": "yarn test:e2e:all",
     "test:e2e:legacy": "APP_MODE=legacy playwright test",
     "test:e2e:nfs": "APP_MODE=nfs playwright test",

--- a/workspaces/repo-tools/package.json
+++ b/workspaces/repo-tools/package.json
@@ -24,8 +24,7 @@
     "new": "backstage-cli new --scope internal",
     "build:api-reports": "yarn build:api-reports:only --tsc",
     "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type --validate-release-tags",
-    "build:knip-reports": "backstage-repo-tools knip-reports",
-    "postinstall": "cd ../../ && yarn install"
+    "build:knip-reports": "backstage-repo-tools knip-reports"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -21,8 +21,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": [
     "packages/*",

--- a/workspaces/scorecard/package.json
+++ b/workspaces/scorecard/package.json
@@ -30,8 +30,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/theme/package.json
+++ b/workspaces/theme/package.json
@@ -29,8 +29,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope red-hat-developer-hub"
   },
   "workspaces": [
     "packages/*",

--- a/workspaces/translations/package.json
+++ b/workspaces/translations/package.json
@@ -25,8 +25,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/x2a/package.json
+++ b/workspaces/x2a/package.json
@@ -29,8 +29,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "chores": "yarn prettier:fix && yarn lint:all --fix && yarn tsc:full && yarn build:api-reports && yarn test:all:pg",
-    "new": "backstage-cli new --scope @red-hat-developer-hub",
-    "postinstall": "cd ../../ && yarn install"
+    "new": "backstage-cli new --scope @red-hat-developer-hub"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
Every workspace inherited a `"postinstall": "cd ../../ && yarn install"` script from the community-plugins repo convention. This was a workaround to ensure root-level dependencies were installed when CI ran `yarn install` inside a workspace directory.

This workaround was superseded upstream by backstage/community-plugins#1903, which added an explicit root install step to the CI workflows. Our release workflow already has an equivalent step, but the CI workflow was missing one. Add it now so the postinstall can be safely removed.

Workspaces in this repo are independent projects and should not depend on the parent package or other workspaces. This postinstall violated that boundary.