### PR TITLE
Harden changeset feedback workflow for checkout fork-PR blocking

### DIFF
--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -1,3 +1,8 @@
+# Security: pull_request_target runs the base branch version of this workflow,
+# so PRs cannot modify it to exfiltrate credentials. Fork PR merge refs are
+# checked out only for inspection (git diff, package.json, changeset files);
+# backstage/actions/changeset-feedback does not execute code from the PR tree.
+# See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
 name: Automate changeset feedback
 on:
   pull_request_target:
@@ -33,6 +38,10 @@ jobs:
           # Fetch the commit that's merged into the base rather than the target ref
           # This will let us diff only the contents of the PR, without fetching more history
           ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+          # Required after actions/checkout backported fork-PR blocking to v4.
+          # Safe here: changeset-feedback inspects files only; no npm/build steps run.
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: fetch base
         run: git fetch --depth 1 origin "$GITHUB_BASE_REF"
 


### PR DESCRIPTION
## Summary

- Documents the `pull_request_target` security model for this workflow (trusted base-branch workflow; fork merge ref checked out for inspection only).
- Adds `allow-unsafe-pr-checkout: true` so fork PRs continue to receive changeset feedback after GitHub backported fork-PR checkout blocking to `actions/checkout` v4.
- Sets `persist-credentials: false` on checkout to reduce token exposure on the runner.

The `backstage/actions/changeset-feedback` action only runs `git diff`, reads `package.json` / `.changeset/*.md` files, and posts a PR comment via the GitHub App. It does not run `npm install`, build scripts, or other executable content from the PR tree.

## Test plan

- [ ] Open or sync a fork PR targeting `main` and confirm **Automate changeset feedback** completes (checkout no longer fails on merge ref).
- [ ] Confirm the bot still posts/updates the changeset feedback comment.
- [ ] Confirm same-repo PRs are unaffected.


Made with [Cursor](https://cursor.com)