### PR TITLE
chore(scorecard): optimize scorecard

### DIFF
--- a/workspaces/scorecard/.changeset/hungry-mangos-guess.md
+++ b/workspaces/scorecard/.changeset/hungry-mangos-guess.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': patch
+---
+
+optimized how scorecard homepage is loaded

--- a/workspaces/scorecard/plugins/scorecard/src/alpha/extensions/homePageCards.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/alpha/extensions/homePageCards.tsx
@@ -16,7 +16,6 @@
 
 import { HomePageWidgetBlueprint } from '@backstage/plugin-home-react/alpha';
 import type { RendererProps } from '@backstage/plugin-home-react';
-import { ScorecardHomepageCardWithProvider } from '../../components/ScorecardHomepageSection';
 
 const defaultCardLayout = {
   width: {
@@ -31,38 +30,20 @@ const defaultCardLayout = {
   },
 } as const;
 
-function AggregatedCardWithDeprecatedMetricIdContent() {
-  return <ScorecardHomepageCardWithProvider metricId="jira.openIssues" />;
-}
-
-function AggregatedCardWithDefaultAggregationContent() {
-  return <ScorecardHomepageCardWithProvider aggregationId="github.openPRs" />;
-}
-
-function AggregatedCardWithJiraOpenIssuesContent() {
-  return <ScorecardHomepageCardWithProvider aggregationId="openIssuesKpi" />;
-}
-
-function AggregatedCardWithGithubOpenPrsContent() {
-  return <ScorecardHomepageCardWithProvider aggregationId="openPrsKpi" />;
-}
-
-function AggregatedCardWithGithubFilecheckLicenseContent() {
-  return (
-    <ScorecardHomepageCardWithProvider aggregationId="licenseFileExistsKpi" />
-  );
-}
-
-function AggregatedCardWithGithubFilecheckCodeownersContent() {
-  return (
-    <ScorecardHomepageCardWithProvider aggregationId="filecheck.codeowners" />
-  );
-}
-
-function AggregatedCardWithGithubOpenPrsWeightedContent() {
-  return (
-    <ScorecardHomepageCardWithProvider aggregationId="openPrsWeightedKpi" />
-  );
+function lazyScorecardWidget(
+  factory: (
+    ScorecardHomepageCardWithProvider: React.ComponentType<{
+      metricId?: string;
+      aggregationId?: string;
+    }>,
+  ) => () => JSX.Element,
+) {
+  return async () => {
+    const { ScorecardHomepageCardWithProvider } = await import(
+      '../../components/ScorecardHomepageSection'
+    );
+    return { Content: factory(ScorecardHomepageCardWithProvider) };
+  };
 }
 
 function BorderlessHomeWidgetRenderer({ Content }: RendererProps) {
@@ -83,10 +64,10 @@ export const aggregatedCardWithDeprecatedMetricIdWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithDeprecatedMetricIdContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          <ScorecardHomepageCardWithProvider metricId="jira.openIssues" />,
+      ),
     },
   });
 
@@ -104,10 +85,10 @@ export const aggregatedCardWithDefaultAggregationWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithDefaultAggregationContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          <ScorecardHomepageCardWithProvider aggregationId="github.openPRs" />,
+      ),
     },
   });
 
@@ -125,10 +106,10 @@ export const aggregatedCardWithJiraOpenIssuesWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithJiraOpenIssuesContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          <ScorecardHomepageCardWithProvider aggregationId="openIssuesKpi" />,
+      ),
     },
   });
 
@@ -146,10 +127,10 @@ export const aggregatedCardWithGithubOpenPrsWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithGithubOpenPrsContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          <ScorecardHomepageCardWithProvider aggregationId="openPrsKpi" />,
+      ),
     },
   });
 
@@ -167,10 +148,12 @@ export const aggregatedCardWithGithubFilecheckLicenseWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithGithubFilecheckLicenseContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          (
+            <ScorecardHomepageCardWithProvider aggregationId="licenseFileExistsKpi" />
+          ),
+      ),
     },
   });
 
@@ -188,10 +171,12 @@ export const aggregatedCardWithGithubFilecheckCodeownersWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithGithubFilecheckCodeownersContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          (
+            <ScorecardHomepageCardWithProvider aggregationId="filecheck.codeowners" />
+          ),
+      ),
     },
   });
 
@@ -209,9 +194,11 @@ export const aggregatedCardWithGithubOpenPrsWeightedWidget =
       componentProps: {
         Renderer: BorderlessHomeWidgetRenderer,
       },
-      components: () =>
-        Promise.resolve({
-          Content: AggregatedCardWithGithubOpenPrsWeightedContent,
-        }),
+      components: lazyScorecardWidget(
+        ScorecardHomepageCardWithProvider => () =>
+          (
+            <ScorecardHomepageCardWithProvider aggregationId="openPrsWeightedKpi" />
+          ),
+      ),
     },
   });

--- a/workspaces/scorecard/plugins/scorecard/src/alpha/extensions/homePageCards.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/alpha/extensions/homePageCards.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ComponentType, ReactElement } from 'react';
 import { HomePageWidgetBlueprint } from '@backstage/plugin-home-react/alpha';
 import type { RendererProps } from '@backstage/plugin-home-react';
 
@@ -32,11 +33,11 @@ const defaultCardLayout = {
 
 function lazyScorecardWidget(
   factory: (
-    ScorecardHomepageCardWithProvider: React.ComponentType<{
+    ScorecardHomepageCardWithProvider: ComponentType<{
       metricId?: string;
       aggregationId?: string;
     }>,
-  ) => () => JSX.Element,
+  ) => () => ReactElement,
 ) {
   return async () => {
     const { ScorecardHomepageCardWithProvider } = await import(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves: https://redhat.atlassian.net/browse/RHIDP-15511

## Code changes
1. homePageCards.tsx — removed static `ScorecardHomepageCardWithProvider` import; each widget's `components` callback now uses a `lazyScorecardWidget` helper that does:
```
  const { ScorecardHomepageCardWithProvider } = await import(
    '../../components/ScorecardHomepageSection'
  );
```
  2. The 7 per-widget wrapper functions (AggregatedCardWith*Content) are replaced by inline factory callbacks passed to lazyScorecardWidget, which performs the dynamic import once and passes the component to the factory.

## NFS `alpha` expose summary


| Metric | BEFORE | AFTER | Δ |
|--------|--------|-------|---|
| Sync chunks | 9 | 6 | -3 |
| **Sync size** | **1,591.3 KB** | **1,041.7 KB** | **-549.6 KB (-34.5%)** |
| Async chunks | 206 | 215 | +9 |
| Async size (listed) | 1,190.3 KB | 1,805.6 KB | +615.3 KB |




<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
