### PR TITLE
fix(extensions): show docs link for missing catalog entity tooltip

### DIFF
--- a/workspaces/extensions/.changeset/silver-toggle-guides.md
+++ b/workspaces/extensions/.changeset/silver-toggle-guides.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-extensions': patch
+---
+
+Add documentation link to Installed Packages missing catalog-entity tooltip and keep the enable toggle ON for loaded packages without an entity.

--- a/workspaces/extensions/plugins/extensions/report-alpha.api.md
+++ b/workspaces/extensions/plugins/extensions/report-alpha.api.md
@@ -309,7 +309,9 @@ export const extensionsTranslationRef: TranslationRef<
     readonly 'installedPackages.table.columns.actions': string;
     readonly 'installedPackages.table.tooltips.installationDisabled': string;
     readonly 'installedPackages.table.tooltips.packageProductionDisabled': string;
+    readonly 'installedPackages.table.tooltips.enableActionsTitle': string;
     readonly 'installedPackages.table.tooltips.enableActions': string;
+    readonly 'installedPackages.table.tooltips.enableActionsDocsLink': string;
     readonly 'installedPackages.table.tooltips.noDownloadPermissions': string;
     readonly 'installedPackages.table.tooltips.noEditPermissions': string;
     readonly 'installedPackages.table.tooltips.noTogglePermissions': string;

--- a/workspaces/extensions/plugins/extensions/src/alpha/translations/de.ts
+++ b/workspaces/extensions/plugins/extensions/src/alpha/translations/de.ts
@@ -158,8 +158,12 @@ const extensionsTranslationDe = createTranslationMessages({
       'Das Paket kann in der Produktionsumgebung nicht verwaltet werden.',
     'installedPackages.table.tooltips.installationDisabled':
       'Das Paket kann nicht verwaltet werden, da die Plugin-Installation deaktiviert ist. Um dies zu aktivieren, fügen Sie die Erweiterungskonfiguration in Ihrer Konfigurationsdatei für dynamische Plugins hinzu oder ändern Sie sie.',
+    'installedPackages.table.tooltips.enableActionsTitle':
+      'Die Katalogentität fehlt',
     'installedPackages.table.tooltips.enableActions':
-      'Um Aktionen zu aktivieren, fügen Sie ein Katalogelement für dieses Paket hinzu',
+      'Um Aktionen zu aktivieren, fügen Sie ein Katalogelement für dieses Paket hinzu.',
+    'installedPackages.table.tooltips.enableActionsDocsLink':
+      'Dokumentation anzeigen',
     'installedPackages.table.tooltips.noDownloadPermissions':
       'Sie haben keine Berechtigung, die Konfiguration herunterzuladen. Wenden Sie sich an den Administrator, um Zugriff oder Unterstützung anzufordern.',
     'installedPackages.table.tooltips.noEditPermissions':

--- a/workspaces/extensions/plugins/extensions/src/alpha/translations/es.ts
+++ b/workspaces/extensions/plugins/extensions/src/alpha/translations/es.ts
@@ -159,8 +159,12 @@ const extensionsTranslationEs = createTranslationMessages({
       'No se puede gestionar el paquete en el entorno de producción.',
     'installedPackages.table.tooltips.installationDisabled':
       'No se puede gestionar el paquete porque la instalación del complemento está deshabilitada. Para habilitarlo, agregue o modifique la configuración de extensiones en su archivo de configuración de complementos dinámicos.',
+    'installedPackages.table.tooltips.enableActionsTitle':
+      'Falta la entidad de catálogo',
     'installedPackages.table.tooltips.enableActions':
-      'Para habilitar acciones, agregue una entidad de catálogo para este paquete',
+      'Para habilitar acciones, agregue una entidad de catálogo para este paquete.',
+    'installedPackages.table.tooltips.enableActionsDocsLink':
+      'Ver documentación',
     'installedPackages.table.tooltips.noDownloadPermissions':
       'No tiene permiso para descargar la configuración. Comuníquese con su administrador para solicitar acceso o asistencia.',
     'installedPackages.table.tooltips.noEditPermissions':

--- a/workspaces/extensions/plugins/extensions/src/alpha/translations/fr.ts
+++ b/workspaces/extensions/plugins/extensions/src/alpha/translations/fr.ts
@@ -158,8 +158,12 @@ const extensionsTranslationFr = createTranslationMessages({
       'Le paquet ne peut pas être géré en environnement de production.',
     'installedPackages.table.tooltips.installationDisabled':
       'Le paquet ne peut pas être géré car le plugin d’installation est désactivé. Pour l’activer, ajouter ou modifier la configuration des extensions dans votre fichier de configuration dynamic-plugins.',
+    'installedPackages.table.tooltips.enableActionsTitle':
+      "L'entité de catalogue est manquante",
     'installedPackages.table.tooltips.enableActions':
-      'Pour activer les actions, ajoutez une entité de catalogue pour ce paquet',
+      'Pour activer les actions, ajoutez une entité de catalogue pour ce paquet.',
+    'installedPackages.table.tooltips.enableActionsDocsLink':
+      'Voir la documentation',
     'installedPackages.table.tooltips.noDownloadPermissions':
       'Vous n’avez pas l’autorisation de télécharger la configuration. Contactez votre administrateur pour demander un accès ou une assistance.',
     'installedPackages.table.tooltips.noEditPermissions':

--- a/workspaces/extensions/plugins/extensions/src/alpha/translations/it.ts
+++ b/workspaces/extensions/plugins/extensions/src/alpha/translations/it.ts
@@ -160,8 +160,12 @@ const extensionsTranslationIt = createTranslationMessages({
       "Impossibile gestire il pacchetto nell'ambiente di produzione.",
     'installedPackages.table.tooltips.installationDisabled':
       "Impossibile gestire il pacchetto perché l'installazione del plugin è disabilitata. Per abilitarla, aggiungere o modificare la configurazione delle estensioni nel file di configurazione dynamic-plugins.",
+    'installedPackages.table.tooltips.enableActionsTitle':
+      "L'entità del catalogo è mancante",
     'installedPackages.table.tooltips.enableActions':
-      "Per abilitare le azioni, aggiungere un'entità catalogo per questo pacchetto",
+      "Per abilitare le azioni, aggiungere un'entità catalogo per questo pacchetto.",
+    'installedPackages.table.tooltips.enableActionsDocsLink':
+      'Visualizza documentazione',
     'installedPackages.table.tooltips.noDownloadPermissions':
       "L'utente non dispone dell'autorizzazione per scaricare la configurazione. Contattare l'amministratore per richiedere l'accesso o l'assistenza.",
     'installedPackages.table.tooltips.noEditPermissions':

--- a/workspaces/extensions/plugins/extensions/src/alpha/translations/ja.ts
+++ b/workspaces/extensions/plugins/extensions/src/alpha/translations/ja.ts
@@ -160,8 +160,12 @@ const extensionsTranslationJa = createTranslationMessages({
       'パッケージは実稼働環境では管理できません。',
     'installedPackages.table.tooltips.installationDisabled':
       'プラグインのインストールが無効になっているため、パッケージを管理できません。これを有効にするには、dynamic-plugins 設定ファイルで拡張機能設定を追加または変更してください。',
+    'installedPackages.table.tooltips.enableActionsTitle':
+      'カタログエンティティーがありません',
     'installedPackages.table.tooltips.enableActions':
-      'アクションを有効にするには、このパッケージのカタログエンティティーを追加してください',
+      'アクションを有効にするには、このパッケージのカタログエンティティーを追加してください。',
+    'installedPackages.table.tooltips.enableActionsDocsLink':
+      'ドキュメントを表示',
     'installedPackages.table.tooltips.noDownloadPermissions':
       '設定をダウンロードする権限がありません。管理者に連絡し、アクセス権を要求またはサポートを依頼してください。',
     'installedPackages.table.tooltips.noEditPermissions':

--- a/workspaces/extensions/plugins/extensions/src/alpha/translations/ref.ts
+++ b/workspaces/extensions/plugins/extensions/src/alpha/translations/ref.ts
@@ -205,8 +205,10 @@ export const extensionsMessages = {
           'Package cannot be managed in the production environment.',
         installationDisabled:
           'Package cannot be managed because plugin installation is disabled. To enable it, add or modify the extensions configuration in your dynamic-plugins configuration file.',
+        enableActionsTitle: 'The catalog-entity is missing',
         enableActions:
-          'To enable actions, add a catalog entity for this package',
+          'To enable actions, add a catalog entity for this package.',
+        enableActionsDocsLink: 'View documentation',
         noDownloadPermissions:
           "You don't have permission to download the configuration. Contact your administrator to request access or assistance.",
         noEditPermissions:

--- a/workspaces/extensions/plugins/extensions/src/components/InstalledPackages/InstalledPackagesTable.test.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/InstalledPackages/InstalledPackagesTable.test.tsx
@@ -16,7 +16,13 @@
 
 import type { ComponentProps } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { mockApis, MockErrorApi, TestApiProvider } from '@backstage/test-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { errorApiRef } from '@backstage/core-plugin-api';
@@ -27,6 +33,7 @@ import { extensionsApiRef } from '../../api';
 import { dynamicPluginsInfoApiRef } from '../../api';
 import { InstalledPackagesTable } from './InstalledPackagesTable';
 import { useNodeEnvironment } from '../../hooks/useNodeEnvironment';
+import { useExtensionsConfiguration } from '../../hooks/useExtensionsConfiguration';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),
@@ -38,7 +45,12 @@ jest.mock('../../hooks/useNodeEnvironment', () => ({
   useNodeEnvironment: jest.fn(),
 }));
 
+jest.mock('../../hooks/useExtensionsConfiguration', () => ({
+  useExtensionsConfiguration: jest.fn(),
+}));
+
 const useNodeEnvironmentMock = useNodeEnvironment as jest.Mock;
+const useExtensionsConfigurationMock = useExtensionsConfiguration as jest.Mock;
 
 type TestApiProviderApis = NonNullable<
   ComponentProps<typeof TestApiProvider>['apis']
@@ -69,6 +81,12 @@ describe('InstalledPackagesTable', () => {
   beforeEach(() => {
     queryClient.clear();
     queryClient.setDefaultOptions({ queries: { retry: false } });
+    useNodeEnvironmentMock.mockReturnValue({
+      data: { nodeEnv: 'development' },
+    });
+    useExtensionsConfigurationMock.mockReturnValue({
+      data: { enabled: true },
+    });
   });
 
   it('renders rows for all dynamic-plugins-info entries and maps names when entity exists', async () => {
@@ -170,6 +188,54 @@ describe('InstalledPackagesTable', () => {
     const disabledButtons = screen.getAllByRole('button', { hidden: true });
     // There are three disabled action buttons rendered wrapped in span
     expect(disabledButtons.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // RHDHBUGS-2289: loaded custom package without catalog entity
+  it('shows toggle ON and docs link in tooltip when catalog entity is missing', async () => {
+    const dynamicPlugins = [
+      {
+        name: '@acme/third-party-widget-dynamic',
+        version: '9.9.9',
+        role: 'frontend-plugin',
+        platform: 'web',
+      },
+    ];
+
+    const entities = { items: [], totalItems: 0, pageInfo: {} };
+
+    const apis = [
+      [
+        dynamicPluginsInfoApiRef,
+        { listLoadedPlugins: jest.fn().mockResolvedValue(dynamicPlugins) },
+      ],
+      [
+        extensionsApiRef,
+        { getPackages: jest.fn().mockResolvedValue(entities) },
+      ],
+    ] as const;
+
+    renderWithProviders(apis);
+
+    await waitFor(() =>
+      expect(screen.getByText('Installed packages (1)')).toBeInTheDocument(),
+    );
+
+    const toggle = screen.getByRole('checkbox');
+    expect(toggle).toBeChecked();
+
+    // Disabled controls don't receive pointer events; hover the custom Tooltip child.
+    const tooltipAnchor = toggle.closest('span') ?? toggle;
+    fireEvent.mouseOver(tooltipAnchor);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(/the catalog-entity is missing/i);
+    expect(tooltip).toHaveTextContent(/to enable actions/i);
+    const docsLink = within(tooltip).getByRole('link', {
+      name: /view documentation/i,
+    });
+    expect(docsLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('catalog-entities/extensions'),
+    );
   });
 
   it('disables actions in the production env', async () => {

--- a/workspaces/extensions/plugins/extensions/src/components/InstalledPackages/RowActions.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/InstalledPackages/RowActions.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
+import type { HTMLAttributes, ReactElement, ReactNode } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { Link } from '@backstage/core-components';
@@ -22,10 +23,17 @@ import { Link } from '@backstage/core-components';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
+import MuiLink from '@mui/material/Link';
+import Tooltip, {
+  tooltipClasses,
+  type TooltipProps,
+} from '@mui/material/Tooltip';
 import Switch from '@mui/material/Switch';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 
 import { ExtensionsPackageInstallStatus } from '@red-hat-developer-hub/backstage-plugin-extensions-common';
 
@@ -35,9 +43,91 @@ import { usePackageConfig } from '../../hooks/usePackageConfig';
 import { usePackage } from '../../hooks/usePackage';
 import { downloadPackageYAML } from '../../utils/downloadPackageYaml';
 import { apiErrorMessage } from '../../utils';
+import { CATALOG_ENTITY_DOCS_URL } from '../../consts';
 import { usePluginConfigurationPermissions } from '../../hooks/usePluginConfigurationPermissions';
 import { useEnablePlugin } from '../../hooks/useEnablePlugin';
 import { useInstallationContext } from '../InstallationContext';
+
+/**
+ * MUI Light tooltip — white surface with shadow for rich content.
+ * @see https://v5.mui.com/material-ui/react-tooltip/#customization
+ */
+const LightTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: theme.palette.common.white,
+    color: theme.palette.text.primary,
+    boxShadow: theme.shadows[2],
+    fontSize: theme.typography.body2.fontSize,
+    maxWidth: 280,
+    padding: theme.spacing(1.5),
+  },
+}));
+
+/**
+ * Forwards ref + DOM listeners so Tooltip works with disabled controls.
+ * @see https://v5.mui.com/material-ui/react-tooltip/#custom-child-element
+ */
+const TooltipChild = forwardRef<
+  HTMLSpanElement,
+  HTMLAttributes<HTMLSpanElement> & { children: ReactNode }
+>(function TooltipChild({ children, ...props }, ref) {
+  return (
+    <Box component="span" display="inline-flex" ref={ref} {...props}>
+      {children}
+    </Box>
+  );
+});
+
+const MissingCatalogEntityTooltip = ({
+  children,
+}: {
+  children: ReactElement;
+}) => {
+  const { t } = useTranslation();
+  const title: ReactNode = (
+    <Box>
+      <Typography
+        variant="subtitle2"
+        component="div"
+        sx={{ fontWeight: 600, mb: 0.5 }}
+      >
+        {t('installedPackages.table.tooltips.enableActionsTitle')}
+      </Typography>
+      <Typography
+        variant="body2"
+        component="div"
+        color="text.secondary"
+        sx={{ mb: 1.5 }}
+      >
+        {t('installedPackages.table.tooltips.enableActions')}
+      </Typography>
+      <MuiLink
+        href={CATALOG_ENTITY_DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        variant="body2"
+        underline="hover"
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+        onClick={event => event.stopPropagation()}
+      >
+        {t('installedPackages.table.tooltips.enableActionsDocsLink')}
+        <OpenInNewIcon sx={{ fontSize: '1rem' }} />
+      </MuiLink>
+    </Box>
+  );
+
+  return (
+    <LightTooltip title={title} describeChild>
+      <TooltipChild>{children}</TooltipChild>
+    </LightTooltip>
+  );
+};
 
 export type InstalledPackageRow = {
   displayName: string;
@@ -94,13 +184,16 @@ export const DownloadPackageYaml = ({
     !pkg.hasEntity || packageConfigPermission.data?.read !== 'ALLOW';
 
   if (disabled) {
+    if (!pkg.hasEntity) {
+      return (
+        <MissingCatalogEntityTooltip>
+          {disabledIcon}
+        </MissingCatalogEntityTooltip>
+      );
+    }
     return (
       <Tooltip
-        title={
-          pkg.hasEntity
-            ? t('installedPackages.table.tooltips.noDownloadPermissions')
-            : t('installedPackages.table.tooltips.enableActions')
-        }
+        title={t('installedPackages.table.tooltips.noDownloadPermissions')}
       >
         {disabledIcon}
       </Tooltip>
@@ -184,9 +277,9 @@ export const EditPackage = ({
 
   if (!pkg.hasEntity) {
     return (
-      <Tooltip title={t('installedPackages.table.tooltips.enableActions')}>
+      <MissingCatalogEntityTooltip>
         {disabledEditIcon}
-      </Tooltip>
+      </MissingCatalogEntityTooltip>
     );
   }
   const packagePath = getPackagePath({
@@ -314,13 +407,16 @@ export const TogglePackage = ({
   }
 
   if (!pkg.hasEntity || packageConfigPermission.data?.write !== 'ALLOW') {
+    if (!pkg.hasEntity) {
+      return (
+        <MissingCatalogEntityTooltip>
+          {disabledIcon}
+        </MissingCatalogEntityTooltip>
+      );
+    }
     return (
       <Tooltip
-        title={
-          pkg.hasEntity
-            ? t('installedPackages.table.tooltips.noTogglePermissions')
-            : t('installedPackages.table.tooltips.enableActions')
-        }
+        title={t('installedPackages.table.tooltips.noTogglePermissions')}
       >
         {disabledIcon}
       </Tooltip>
@@ -402,13 +498,22 @@ export const TogglePackage = ({
 export const UninstallPackage = ({ pkg }: { pkg: InstalledPackageRow }) => {
   const { t } = useTranslation();
   if (!pkg.hasEntity || pkg.missingDynamicArtifact) {
+    if (!pkg.hasEntity) {
+      return (
+        <MissingCatalogEntityTooltip>
+          <IconButton
+            size="small"
+            disabled
+            sx={{ color: theme => theme.palette.action.disabled }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </MissingCatalogEntityTooltip>
+      );
+    }
     return (
       <Tooltip
-        title={
-          !pkg.hasEntity
-            ? t('installedPackages.table.tooltips.enableActions')
-            : t('tooltips.missingDynamicArtifact' as any, { type: 'package' })
-        }
+        title={t('tooltips.missingDynamicArtifact' as any, { type: 'package' })}
       >
         <IconButton
           size="small"

--- a/workspaces/extensions/plugins/extensions/src/consts.ts
+++ b/workspaces/extensions/plugins/extensions/src/consts.ts
@@ -20,3 +20,7 @@ export const colors = {
   generallyAvailable: '#6EC664',
   custom: '#EC7A08',
 } as const;
+
+/** Catalog entity example docs for packages and plugins */
+export const CATALOG_ENTITY_DOCS_URL =
+  'https://github.com/redhat-developer/rhdh-plugin-export-overlays/tree/main/catalog-entities/extensions';


### PR DESCRIPTION
## Description
When a custom package is loaded but has no catalog entity, the Installed Packages actions tooltip now includes a "View documentation" link to catalog-entity examples. Loaded packages without an entity continue to show the enable toggle in the ON position (actions remain disabled until an entity is added).

### Root cause
The missing-entity tooltip (`enableActions`) was plain text with no documentation link. Toggle ON for loaded packages without an entity was already handled by defaulting `installStatus` to `Installed`; this change locks that behavior in with a regression test and improves the tooltip UX per RHDHBUGS-2289.

## Fixed
- [RHDHBUGS-2289](https://redhat.atlassian.net/browse/RHDHBUGS-2289) — Custom plugins on Installed Packages UI are incorrectly showing as disabled


## Screenshots

<img width="766" height="471" alt="Screenshot 2026-07-23 at 1 30 56 PM" src="https://github.com/user-attachments/assets/b38b3abe-70db-4e77-8ad1-0d27c2ef0423" />

https://github.com/user-attachments/assets/09f91df8-a70b-4220-91e5-1d6af9fb1786

## Test setup

```
## Test plan

### Prerequisites
- Node 24 (`node -v`)
- Dependencies installed (`yarn install`)
- If `better-sqlite3` fails to load after a Node upgrade: `yarn rebuild better-sqlite3`
- Bulk Import frontend present under `dynamic-plugins-root/` (or install via dynamic plugins)

### Local setup
1. Ensure these catalog entities exist (from this PR):
   - `catalog-entities/extensions/plugins/bulk-import.yaml`
   - `catalog-entities/extensions/packages/red-hat-developer-hub-backstage-plugin-bulk-import.yaml` (v7.3.7)
   - `catalog-entities/extensions/packages/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml`
   - `catalog-entities/extensions/{plugins,packages,collections}/all.yaml`

2. In `app-config.local.yaml` (or your local overlay), register the Extensions locations:

```yaml
catalog:
  locations:
    - type: file
      target: ../../catalog-entities/all.yaml
    - type: file
      target: ../../catalog-entities/extensions/plugins/all.yaml
      rules:
        - allow: [Location, Plugin]
    - type: file
      target: ../../catalog-entities/extensions/packages/all.yaml
      rules:
        - allow: [Location, Package]

catalog:
  rules:
    - allow: [Component, System, API, Resource, Group, Location, Template, User, Plugin, Package, PluginCollection]

dynamicPlugins:
  frontend:
    red-hat-developer-hub.backstage-plugin-bulk-import:
      appIcons:
        - name: bulkImportIcon
          module: Legacy
          importName: BulkImportIcon
      dynamicRoutes:
        - path: /bulk-import
          importName: BulkImportPage
          module: Legacy
          menuItem:
            icon: bulkImportIcon
            text: Bulk import
```

## Test Plan
- [ ] Install a third-party plugin enabled in dynamic-plugins.yaml without a catalog entity
- [ ] Open Extensions → Installed packages
- [ ] Confirm the package toggle is ON (checked) though actions stay disabled
- [ ] Hover the toggle and confirm tooltip includes a “View documentation” link to catalog-entity examples
- [ ] Confirm packages that already have catalog entities are unchanged

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.

Made with [Cursor](https://cursor.com)