### PR TITLE
feat(x2a-backend): make AAP sync timeout configurable via app-config

### DIFF
--- a/workspaces/x2a/.changeset/aap-sync-timeout.md
+++ b/workspaces/x2a/.changeset/aap-sync-timeout.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': minor
+---
+
+Make AAP project sync timeout configurable via `x2a.credentials.aap.syncTimeoutSeconds` in app-config.

--- a/workspaces/x2a/plugins/x2a-backend/config.d.ts
+++ b/workspaces/x2a/plugins/x2a-backend/config.d.ts
@@ -196,6 +196,13 @@ export interface Config {
          * @visibility backend
          */
         skipSSLVerification?: boolean;
+        /**
+         * Timeout in seconds for AAP project sync after publish.
+         * Increase for cross-datacenter deployments where receptor mesh latency is high.
+         * Defaults to 120 if not set (convertor default).
+         * @visibility backend
+         */
+        syncTimeoutSeconds?: number;
       };
     };
   };

--- a/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts
+++ b/workspaces/x2a/plugins/x2a-backend/src/services/JobResourceBuilder.ts
@@ -101,6 +101,8 @@ export class JobResourceBuilder {
     // Resolve SSL verification: skip=false by default (SSL is verified)
     const skipSSL = config.credentials.aap?.skipSSLVerification ?? false;
 
+    const syncTimeout = config.credentials.aap?.syncTimeoutSeconds;
+
     return {
       apiVersion: 'v1',
       kind: 'Secret',
@@ -135,6 +137,10 @@ export class JobResourceBuilder {
 
         // AAP SSL verification setting (derived from skipSSLVerification config)
         AAP_VERIFY_SSL: String(!skipSSL),
+
+        ...(syncTimeout !== undefined
+          ? { AAP_SYNC_TIMEOUT_S: String(syncTimeout) }
+          : {}),
       },
     };
   }


### PR DESCRIPTION
## Summary

Makes the AAP project sync timeout configurable via `app-config.yaml` so deployments can tune it without rebuilding the convertor image.

**New config option:**
```yaml
x2a:
  credentials:
    aap:
      syncTimeoutSeconds: 300  # default: 120 (convertor default)
```

**Changes:**
- `config.d.ts`: Added `syncTimeoutSeconds` to the AAP credentials config type and schema
- `JobResourceBuilder.ts`: Passes `AAP_SYNC_TIMEOUT_S` env var to the convertor job via the project secret when `syncTimeoutSeconds` is set

**Why:** Cross-datacenter deployments (e.g. RDU2→TLV2) experience AAP receptor mesh latency that exceeds the convertor's default 120s timeout, causing a 71% publish failure rate. This was discovered during CI testing where all publish phases consistently timed out.

## Companion PR

This requires the convertor-side change to read the `AAP_SYNC_TIMEOUT_S` env var:
- https://github.com/x2ansible/x2a-convertor/pull/258

Both PRs are needed together:
1. **Convertor PR #258** — reads `AAP_SYNC_TIMEOUT_S` env var (defaults to 120s if unset, backward-compatible)
2. **This PR** — passes the configured value from `app-config.yaml` to the convertor job

cc @pczarnik @eloy-coto

Made with [Cursor](https://cursor.com)