### PR TITLE
fix(global-header): scope accessibility test to #global-header element

### DIFF
--- a/workspaces/global-header/e2e-tests/globalHeader.test.ts
+++ b/workspaces/global-header/e2e-tests/globalHeader.test.ts
@@ -105,7 +105,7 @@ test('Verify Global header to be visible', async ({
     - link "${translations.notifications.title}":
       - /url: /notifications
     `);
-  await runAccessibilityTests(page, testInfo);
+  await runAccessibilityTests(page, testInfo, undefined, '#global-header');
 });
 
 test('Verify Hover texts to be visible', async () => {

--- a/workspaces/global-header/e2e-tests/utils/accessibility.ts
+++ b/workspaces/global-header/e2e-tests/utils/accessibility.ts
@@ -21,11 +21,20 @@ export async function runAccessibilityTests(
   page: Page,
   testInfo: TestInfo,
   attachName = 'accessibility-scan-results.json',
+  include?: string,
 ) {
-  const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-    .disableRules(['nested-interactive'])
-    .analyze();
+  let builder = new AxeBuilder({ page }).withTags([
+    'wcag2a',
+    'wcag2aa',
+    'wcag21a',
+    'wcag21aa',
+  ]);
+
+  if (include) {
+    builder = builder.include(include);
+  }
+
+  const accessibilityScanResults = await builder.analyze();
 
   await testInfo.attach(attachName, {
     body: JSON.stringify(accessibilityScanResults, null, 2),


### PR DESCRIPTION
## Description 
### Raised using bug-fix skill
Replaced the blanket `disableRules(['nested-interactive'])` workaround in the global-header accessibility test with a targeted `AxeBuilder.include('#global-header')` scope. The 211 `nested-interactive` violations originate from the upstream Backstage catalog table (react-beautiful-dnd adds `role="button"` to draggable column headers, which nest inside MUI `TableSortLabel` buttons), not from the global header itself. By scoping the axe analysis to only the `#global-header` element, the test now validates the header's own accessibility without suppressing any axe rules.

### Root cause
The `nested-interactive` axe-core violations came from the Backstage catalog table rendered below the global header — `react-beautiful-dnd` adds `role="button"` to draggable `<th>` elements, which already contain MUI `<TableSortLabel>` buttons. The previous fix disabled the `nested-interactive` rule entirely, masking any real violations in the global header. The `<AppBar id="global-header">` component itself has a clean interactive structure with no nested controls.

## Fixed
- [RHDHBUGS-2247](https://redhat.atlassian.net/browse/RHDHBUGS-2247) — Accessibility Violation in Global Header – Nested Interactive Controls

## UI before changes
[screenrecordings_global-header-RHDHBUGS-2247_before-fix (1).webm](https://github.com/user-attachments/assets/96ce07fd-dfc0-47ab-b453-d8fc1a4d5efe)


## UI after changes
[screenrecordings_global-header-RHDHBUGS-2247_after-fix (1).webm](https://github.com/user-attachments/assets/c8abda6d-1e68-4e1b-81df-4f17ed61ddac)


## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.