### PR TITLE
fix(intelligent-assistant): use chat.update permission for conversation PUT

### DIFF
--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
@@ -31,6 +31,7 @@ import {
   lightspeedChatCreatePermission,
   lightspeedChatDeletePermission,
   lightspeedChatReadPermission,
+  lightspeedChatUpdatePermission,
   lightspeedMcpManagePermission,
   lightspeedMcpReadPermission,
   lightspeedPermissions,
@@ -809,7 +810,7 @@ export async function createRouter(
   router.put(
     '/v2/conversations/:conversation_id',
     generalRateLimiter,
-    requirePermission(lightspeedChatCreatePermission),
+    requirePermission(lightspeedChatUpdatePermission),
     async (request, response) => {
       try {
         const { userEntityRef } = getIdentity(request);


### PR DESCRIPTION
## Summary
- Require `intelligent-assistant.chat.update` (`lightspeedChatUpdatePermission`) on `PUT /v2/conversations/:conversation_id` instead of `intelligent-assistant.chat.create`
- Aligns the conversation update route with the dedicated update permission already defined in common and documented in RBAC examples

## Test plan
- [ ] Confirm `PUT /v2/conversations/:conversation_id` returns 403 when the caller has create but not update permission
- [ ] Confirm the same route succeeds when the caller has `intelligent-assistant.chat.update`
- [ ] Spot-check other conversation routes still use their expected permissions (create/read/delete)


Made with [Cursor](https://cursor.com)