### PR TITLE
fix(intelligent-assistant): use chat.update permission for conversation PUT

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/crisp-routes-align.md
+++ b/workspaces/intelligent-assistant/.changeset/crisp-routes-align.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': patch
+---
+
+Require `intelligent-assistant.chat.update` on `PUT /v2/conversations/:conversation_id` instead of the `intelligent-assistant.chat.create` permission.

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
@@ -31,6 +31,7 @@ import {
   lightspeedChatCreatePermission,
   lightspeedChatDeletePermission,
   lightspeedChatReadPermission,
+  lightspeedChatUpdatePermission,
   lightspeedMcpManagePermission,
   lightspeedMcpReadPermission,
   lightspeedPermissions,
@@ -809,7 +810,7 @@ export async function createRouter(
   router.put(
     '/v2/conversations/:conversation_id',
     generalRateLimiter,
-    requirePermission(lightspeedChatCreatePermission),
+    requirePermission(lightspeedChatUpdatePermission),
     async (request, response) => {
       try {
         const { userEntityRef } = getIdentity(request);


### PR DESCRIPTION
## Description
Require `intelligent-assistant.chat.update` on `PUT /v2/conversations/:conversation_id` instead of `intelligent-assistant.chat.create`. This aligns the conversation update route with the dedicated update permission already defined in common and documented in RBAC examples.

## Fixed
- https://redhat.atlassian.net/browse/RHIDP-13067

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)