### PR TITLE
chore(scorecard): exclude AGENTS.md and CLAUDE.md from prettier

### DIFF
--- a/workspaces/scorecard/.prettierignore
+++ b/workspaces/scorecard/.prettierignore
@@ -1,5 +1,7 @@
 .eslintrc.js
 .vscode
+AGENTS.md
+CLAUDE.md
 coverage
 dist
 dist-types


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` and `CLAUDE.md` to the scorecard workspace's `.prettierignore` so prettier doesn't reformat these agent instruction files.

## Test plan
- [x] Verified the `.prettierignore` entries are alphabetically sorted and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)