### PR TITLE
fix(scorecard): update RHDH theme to resolve rhdh-cli build issues

### DIFF
--- a/workspaces/scorecard/packages/app-legacy/package.json
+++ b/workspaces/scorecard/packages/app-legacy/package.json
@@ -52,7 +52,7 @@
     "@openshift/dynamic-plugin-sdk": "^5.0.1",
     "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "^1.10.2",
     "@red-hat-developer-hub/backstage-plugin-scorecard": "workspace:^",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.0",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.11",
     "@roadiehq/backstage-plugin-github-pull-requests": "^3.5.1",
     "@roadiehq/backstage-plugin-jira": "^2.13.1",
     "@scalprum/react-core": "0.11.1",

--- a/workspaces/scorecard/packages/app/package.json
+++ b/workspaces/scorecard/packages/app/package.json
@@ -38,7 +38,7 @@
     "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "1.11.0",
     "@red-hat-developer-hub/backstage-plugin-scorecard": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.0",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.11",
     "react": "^18.0.2",
     "react-dom": "^18.0.2"
   },

--- a/workspaces/scorecard/plugins/scorecard/package.json
+++ b/workspaces/scorecard/plugins/scorecard/package.json
@@ -85,7 +85,7 @@
     "@backstage/plugin-user-settings": "^0.9.3",
     "@backstage/test-utils": "^1.7.18",
     "@backstage/ui": "^0.15.0",
-    "@red-hat-developer-hub/backstage-plugin-theme": "^0.13.0",
+    "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.11",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",

--- a/workspaces/scorecard/yarn.lock
+++ b/workspaces/scorecard/yarn.lock
@@ -10450,7 +10450,7 @@ __metadata:
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.13.0"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.11"
     "@tanstack/react-query": "npm:^5.95.2"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
@@ -10468,25 +10468,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.13.0"
-  dependencies:
-    "@mui/icons-material": "npm:^5.17.1"
-  peerDependencies:
-    "@backstage/core-plugin-api": ^1.12.0
-    "@backstage/theme": ^0.7.0
-    "@material-ui/icons": ^4.11.3
-    "@mui/icons-material": ^5.17.1
-    "@mui/material": ^5.0.0
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/561c04203e9047f4df3fd9a0c29eb0e6b578740899dc3da07870f807a4c3324fb6880e2501f168b60d9a121521eb1f6a9d65d9d837e803f469415e2c0f526053
-  languageName: node
-  linkType: hard
-
-"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.0":
-  version: 0.14.7
-  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.7"
+"@red-hat-developer-hub/backstage-plugin-theme@npm:^0.14.11":
+  version: 0.14.11
+  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.11"
   dependencies:
     "@backstage/frontend-plugin-api": "npm:^0.15.1"
     "@backstage/plugin-app-react": "npm:^0.2.1"
@@ -10494,11 +10478,11 @@ __metadata:
   peerDependencies:
     "@backstage/core-plugin-api": ^1.12.4
     "@backstage/theme": ^0.7.2
-    "@material-ui/icons": ^4.11.3
     "@mui/icons-material": ^5.17.1
     "@mui/material": ^5.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/6b8f066fb2b4884478888574860127b235bb54ec1ae11599ac7423d0cc8a598a172b87d3e0df0756f50d338731de802fbfaaa452dd7796f5de49ff741122510b
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/3b3907cd3bff0de6e55a8b683230df12b199dbf7147dcd874cc91590915ad604e81f5398867aaff8028b5ec5e156e0c7e93bd62de0a74e4e9756f0d27b00cf1a
   languageName: node
   linkType: hard
 
@@ -15504,7 +15488,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "npm:^1.10.2"
     "@red-hat-developer-hub/backstage-plugin-scorecard": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.0"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.11"
     "@roadiehq/backstage-plugin-github-pull-requests": "npm:^3.5.1"
     "@roadiehq/backstage-plugin-jira": "npm:^2.13.1"
     "@scalprum/react-core": "npm:0.11.1"
@@ -15560,7 +15544,7 @@ __metadata:
     "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "npm:1.11.0"
     "@red-hat-developer-hub/backstage-plugin-scorecard": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.0"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.11"
     "@types/react": "npm:^18"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"


### PR DESCRIPTION
## Summary
- Bump `@red-hat-developer-hub/backstage-plugin-theme` to `^0.14.11` across the scorecard workspace (app, app-legacy, and scorecard plugin)
- Aligns the theme dependency versions and picks up latest fixes

## Test plan
- [ ] CI passes (build, lint, tests)
- [ ] Scorecard plugin renders correctly with the updated theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)