### PR TITLE
chore(fullsend): add rhdh-coding skill to code and fix agents

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -22,6 +22,7 @@ roles:
 allowed_remote_resources:
     - https://raw.githubusercontent.com/fullsend-ai/fullsend/
     - https://raw.githubusercontent.com/fullsend-ai/agents/
+    - https://raw.githubusercontent.com/redhat-developer/rhdh-skill/
 create_issues:
     allow_targets:
         repos:

--- a/.fullsend/rhdh/harness/code.yaml
+++ b/.fullsend/rhdh/harness/code.yaml
@@ -1,6 +1,8 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/code.yaml#sha256=050382941bb4c4a3dad5f00253de854684c0d22dd8cc1ca0a548079774470aad
 agent: rhdh/agents/code.md
 policy: rhdh/policies/code.yaml
+skills:
+  - https://raw.githubusercontent.com/redhat-developer/rhdh-skill/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn

--- a/.fullsend/rhdh/harness/fix.yaml
+++ b/.fullsend/rhdh/harness/fix.yaml
@@ -1,6 +1,8 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/fix.yaml#sha256=f966f0b8cd9b58289f19b446cfc4fd343c9079d9c9acee0260824b57e896e068
 agent: rhdh/agents/fix.md
 policy: rhdh/policies/code.yaml
+skills:
+  - https://raw.githubusercontent.com/redhat-developer/rhdh-skill/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn


### PR DESCRIPTION
## Summary

- Adds the `rhdh-coding` skill from [`redhat-developer/rhdh-skill`](https://github.com/redhat-developer/rhdh-skill) to the fullsend code and fix agent harnesses via URL-pinned references with sha256 integrity hashes.
- Allows `raw.githubusercontent.com/redhat-developer/rhdh-skill/` in `allowed_remote_resources`.
- Both agents gain RHDH-specific plugin development patterns (BUI, NFS, backend conventions, testing, dynamic plugin config) alongside their existing upstream skills (`code-implementation`, `fix-review`).

## Changes

| File | Change |
|------|--------|
| `.fullsend/config.yaml` | Add `rhdh-skill` repo to `allowed_remote_resources` |
| `.fullsend/rhdh/harness/code.yaml` | Add `rhdh-coding` skill to `skills:` field |
| `.fullsend/rhdh/harness/fix.yaml` | Add `rhdh-coding` skill to `skills:` field |

## How it works

The harness merge logic concatenates base + child skills. The upstream base already declares `code-implementation` (for code) and `fix-review` (for fix). Adding `rhdh-coding` in the child harness means sandbox agents get both skills at runtime.

Skill pinned at [`e841099`](https://github.com/redhat-developer/rhdh-skill/commit/e84109919ae6085e3dcfe568c695e6dda54874ce) with tree hash `5a4bc35...cded`.

## Test plan

- [ ] Trigger `/fs-code` on a test issue and verify the `rhdh-coding` skill appears in the agent's skill list
- [ ] Confirm the agent uses RHDH coding patterns (BUI, NFS conventions) when implementing

Made with [Cursor](https://cursor.com)