### PR TITLE
fix(app-defaults): add minHeight to ApplicationDrawer wrapper for full viewport height

### DIFF
--- a/workspaces/app-defaults/.changeset/bright-drawer-fix.md
+++ b/workspaces/app-defaults/.changeset/bright-drawer-fix.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-app-react': patch
+---
+
+Fixed ApplicationDrawer wrapper div breaking flexbox height chain, causing empty space at bottom of viewport in NFS mode

--- a/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.test.tsx
+++ b/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.test.tsx
@@ -15,11 +15,14 @@
  */
 
 import { render, screen, act } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 import { useAppDrawer } from '../hooks/useAppDrawer';
 import { drawerStore } from '../utils/drawerStore';
 import { ApplicationDrawer } from './ApplicationDrawer';
 import type { AppDrawerContent } from '../types';
+
+const theme = createTheme({ palette: { background: { default: '#292929' } } });
 
 function OpenButton({ id }: { id: string }) {
   const { openDrawer } = useAppDrawer();
@@ -33,10 +36,12 @@ function CloseButton({ id }: { id: string }) {
 
 function renderWithProvider(contents: AppDrawerContent[]) {
   return render(
-    <ApplicationDrawer contents={contents}>
-      <OpenButton id="test-drawer" />
-      <CloseButton id="test-drawer" />
-    </ApplicationDrawer>,
+    <ThemeProvider theme={theme}>
+      <ApplicationDrawer contents={contents}>
+        <OpenButton id="test-drawer" />
+        <CloseButton id="test-drawer" />
+      </ApplicationDrawer>
+    </ThemeProvider>,
   );
 }
 
@@ -90,14 +95,18 @@ describe('ApplicationDrawer', () => {
     );
   });
 
-  it('applies minHeight 100vh to wrapper div for full viewport height', () => {
+  it('applies grid layout with minHeight 100vh and theme background for full viewport height', () => {
     const contents: AppDrawerContent[] = [
       { id: 'test-drawer', element: <div>Content</div> },
     ];
     const { container } = renderWithProvider(contents);
 
     const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.display).toBe('grid');
+    expect(wrapper.style.gridTemplateRows).toBe('1fr');
+    expect(wrapper.style.gridTemplateColumns).toBe('1fr');
     expect(wrapper.style.minHeight).toBe('100vh');
+    expect(wrapper.style.backgroundColor).toBeTruthy();
   });
 
   it('removes CSS class and variable when drawer is closed', () => {

--- a/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.test.tsx
+++ b/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.test.tsx
@@ -90,6 +90,16 @@ describe('ApplicationDrawer', () => {
     );
   });
 
+  it('applies minHeight 100vh to wrapper div for full viewport height', () => {
+    const contents: AppDrawerContent[] = [
+      { id: 'test-drawer', element: <div>Content</div> },
+    ];
+    const { container } = renderWithProvider(contents);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.minHeight).toBe('100vh');
+  });
+
   it('removes CSS class and variable when drawer is closed', () => {
     const contents: AppDrawerContent[] = [
       { id: 'test-drawer', element: <div>Content</div> },

--- a/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.tsx
+++ b/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.tsx
@@ -16,6 +16,8 @@
 
 import { useEffect, useRef } from 'react';
 
+import { useTheme } from '@mui/material/styles';
+
 import { useAppDrawer } from '../hooks/useAppDrawer';
 import { DrawerPanel } from './DrawerPanel';
 import type { AppDrawerContent } from '../types';
@@ -45,6 +47,7 @@ export const ApplicationDrawer = ({
   children,
   contents,
 }: ApplicationDrawerProps) => {
+  const theme = useTheme();
   const { activeDrawerId, getWidth, setWidth } = useAppDrawer();
   const initializedRef = useRef<Set<string>>(new Set());
 
@@ -81,7 +84,11 @@ export const ApplicationDrawer = ({
     <>
       <div
         style={{
+          display: 'grid',
+          gridTemplateRows: '1fr',
+          gridTemplateColumns: '1fr',
           minHeight: '100vh',
+          backgroundColor: theme.palette.background.default,
           transition: `margin-right 225ms cubic-bezier(${
             isOpen ? '0, 0, 0.2, 1' : '0.4, 0, 0.6, 1'
           })`,

--- a/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.tsx
+++ b/workspaces/app-defaults/plugins/app-react/src/drawer/components/ApplicationDrawer.tsx
@@ -81,6 +81,7 @@ export const ApplicationDrawer = ({
     <>
       <div
         style={{
+          minHeight: '100vh',
           transition: `margin-right 225ms cubic-bezier(${
             isOpen ? '0, 0, 0.2, 1' : '0.4, 0, 0.6, 1'
           })`,


### PR DESCRIPTION
## Description

The `ApplicationDrawer` wrapper `<div>` in `@red-hat-developer-hub/backstage-plugin-app-react` lacked height constraints, a layout mode, and a background color. This caused an empty visual gap at the bottom of the viewport and a background color mismatch in NFS mode.

This PR adds `minHeight: '100vh'`, a CSS grid layout, and `backgroundColor: theme.palette.background.default` to the wrapper, ensuring the page fills the viewport and the background is consistent with the RHDH theme.

### Root cause

In NFS mode, the DOM hierarchy is:

```
<body>                            → background: #333333 (BUI --bui-bg-app)
  └─ <div> (React root)           → transparent
      └─ <div> (ApplicationDrawer)→ NO height, NO background ← the bug
          └─ <div> (BackstageSidebarPage) → background: #151515 (RHDH pageInsetBackgroundColor)
              └─ <main>           → margin + clip-path (PF6 page inset)
                  └─ <article>    → background: #292929 (RHDH mainSectionBackgroundColor)
```

The `ApplicationDrawer` wrapper had only `transition` and `marginRight` styles — no height constraint, no layout mode, and no background color. This caused two problems:

1. **Empty gap at bottom**: Without `minHeight: 100vh`, the wrapper collapsed to its content's natural height on short pages (e.g. Settings), leaving a gap at the bottom where the body's `#333333` background was visible.
2. **Background bleed-through**: Without an explicit `backgroundColor`, the body's `#333333` (from BUI's `--bui-bg-app` CSS variable) bled through the transparent wrapper in any areas not covered by child content, creating a visible color mismatch against the RHDH theme's `#292929` content background.

### Fix

- **`minHeight: '100vh'`** — ensures the wrapper always extends to at least the full viewport height
- **`display: 'grid'` with `gridTemplateRows: '1fr'`** — ensures child content properly fills the wrapper's height
- **`backgroundColor: theme.palette.background.default`** — masks the body's `#333333` with the RHDH theme's `#292929`, ensuring visual consistency; uses the MUI theme value so it works correctly in both light and dark modes

## Fixed
- [RHDHBUGS-3498](https://redhat.atlassian.net/browse/RHDHBUGS-3498) — [ApplicationDrawer] - Wrapper div breaks flexbox height chain, causing empty space at bottom of viewport

## UI after changes
<img width="1512" height="982" alt="S_ 2026-07-30 at 5 46 13 AM" src="https://github.com/user-attachments/assets/02f4c313-91ad-4429-9ec5-2ab629892bdb" />

## How to verify locally

### NFS mode (New Frontend System)

```bash
cd workspaces/intelligent-assistant
NOTEBOOKS_QUERY_MODEL=unused NOTEBOOKS_QUERY_PROVIDER_ID=unused yarn start
```

1. Open http://localhost:3000 in Chrome
2. Navigate to **Settings > General** — verify the page fills the full viewport with no empty gap or lighter-colored band at the bottom
3. Check the **Catalog** page — verify consistent background with no color mismatch
4. Switch between **Light** and **Dark** themes in Settings > Appearance — verify no background bleed in either theme
5. Open the **app drawer** (intelligent assistant FAB button) — verify content shifts correctly via `margin-right`
6. Inspect the ApplicationDrawer wrapper `<div>` in DevTools — confirm it has `min-height: 100vh`, `display: grid`, and `background-color` matching the theme

### OFS mode (Old Frontend System) — regression check

```bash
cd workspaces/intelligent-assistant
yarn start:legacy
```

1. Navigate to **Settings** — verify the PF6 page inset (rounded corners, dark border frame) still renders correctly
2. Verify no visual regressions compared to current main branch

## Test Plan
- [x] Unit test updated: verifies `display: grid`, `gridTemplateRows: 1fr`, `gridTemplateColumns: 1fr`, `minHeight: 100vh`, and `backgroundColor` on the wrapper div
- [ ] Manual verification in NFS mode (steps above)
- [ ] Manual verification in OFS mode (regression check)
- [ ] Theme switching verified (light ↔ dark)

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.