### PR TITLE
Revert "chore(fullsend): add rhdh-coding skill to code and fix agents (#4023)"

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -22,7 +22,6 @@ roles:
 allowed_remote_resources:
     - https://raw.githubusercontent.com/fullsend-ai/fullsend/
     - https://raw.githubusercontent.com/fullsend-ai/agents/
-    - https://raw.githubusercontent.com/redhat-developer/rhdh-skill/
 create_issues:
     allow_targets:
         repos:

--- a/.fullsend/rhdh/harness/code.yaml
+++ b/.fullsend/rhdh/harness/code.yaml
@@ -1,8 +1,6 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/code.yaml#sha256=050382941bb4c4a3dad5f00253de854684c0d22dd8cc1ca0a548079774470aad
 agent: rhdh/agents/code.md
 policy: rhdh/policies/code.yaml
-skills:
-  - https://raw.githubusercontent.com/redhat-developer/rhdh-skill/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn

--- a/.fullsend/rhdh/harness/fix.yaml
+++ b/.fullsend/rhdh/harness/fix.yaml
@@ -1,8 +1,6 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/fix.yaml#sha256=f966f0b8cd9b58289f19b446cfc4fd343c9079d9c9acee0260824b57e896e068
 agent: rhdh/agents/fix.md
 policy: rhdh/policies/code.yaml
-skills:
-  - https://raw.githubusercontent.com/redhat-developer/rhdh-skill/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This reverts PR #4023 / commit 05594dd9d028c6396bb623166b425434ea74b308.

Because it looks like it broke fullsend. I will revert this change and we can check tomorrow again.

```
Error: loading harness: invalid harness: skills[1] URL must be hosted on a supported forge (github.com): unsupported forge host "raw.githubusercontent.com"
```

https://github.com/redhat-developer/rhdh-plugins/actions/runs/30472450792/job/90645852779#step:16:1 