### PR TITLE
docs(ai-integrations): OpenSpec for AiResource agent typed schema (RHIDP-15866/15867)

### DIFF
--- a/workspaces/ai-integrations/openspec/changes/ai-resource-catalog-entity-kind/specs/ai-resource-discovery/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/ai-resource-catalog-entity-kind/specs/ai-resource-discovery/spec.md
@@ -22,13 +22,13 @@ The catalog SHALL support filtering AIResource entities by `spec.type`.
 
 #### Scenario: Filter by content type
 
-- **WHEN** a client calls `GET /api/catalog/entities?filter=kind=AIResource,spec.type=skills`
-- **THEN** the response contains only AIResource entities that declare `spec.type: skills`
+- **WHEN** a client calls `GET /api/catalog/entities?filter=kind=AIResource,spec.type=skill`
+- **THEN** the response contains only AIResource entities that declare `spec.type: skill`
 
 #### Scenario: Filter returns entities matching exact type value
 
-- **WHEN** a client filters on `spec.type=agents`
-- **THEN** only AIResource entities with `spec.type: agents` are returned
+- **WHEN** a client filters on `spec.type=agent`
+- **THEN** only AIResource entities with `spec.type: agent` are returned
 
 ---
 

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/.openspec.yaml
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/.openspec.yaml
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/.openspec.yaml
@@ -1,2 +1,3 @@
 schema: spec-driven
 created: 2026-07-29
+status: draft

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/design.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/design.md
@@ -1,10 +1,22 @@
+# Design: AiResource Agent Typed Schema
+
+## Canonical Touchpoints
+
+- RHDHPLAN-1507 — AI Asset Entity Model & Ingestion Framework (agent type ownership)
+- RHIDP-15865 — Epic: AiResource agent type schema + upstream RFC/PR
+- RHIDP-15866 — Spike: confirm agent catalog field set
+- RHIDP-15867 — AiResource agent typed schema (examples/fixtures)
+- RHIDP-15868 — Catalog processor validation for agent type
+- RHIDP-15869 — Upstream RFC + PR (parallel; not a merge gate)
+- RHDHPLAN-1113 — AiResource foundation (skills/rules; not agent ownership)
+
 ## Context
 
-RHIDP-15867 adds a typed `AiResource` agent schema in rhdh-plugins. The AiResource foundation (RHDHPLAN-1113 / workspace change `ai-resource-catalog-entity-kind`) already supports skill-shaped entities (`spec.type: skill`) with RHDH extensions such as `spec.scope` and OCI `source-location` validation. Agent typing was deferred pending a field-mapping spike (RHIDP-15866).
+RHIDP-15867 / RHIDP-15868 add a typed `AiResource` agent schema and catalog processor validation in rhdh-plugins. The AiResource foundation (RHDHPLAN-1113 / workspace change `ai-resource-catalog-entity-kind`) already supports skill-shaped entities (`spec.type: skill`) with RHDH extensions such as `spec.scope` and OCI `source-location` validation. Agent typing was deferred pending a field-mapping spike (RHIDP-15866).
 
-Spike research mapped OpenAI Agents SDK `AgentConfiguration` → Augment runtime config → Responses API. RHIDP-15866 and this change share one deliverable: the **decided catalog field mapping** below (in this design) plus thin schema requirements in `specs/ai-resource-agent-schema/spec.md`. Ownership of the agent type under program planning is RHDHPLAN-1507.
+Field choices were informed by runtime/agent-config research (including OpenAI Agents SDK `AgentConfiguration` coverage in Augment). That research is **provenance for the mapping table below**, not a product claim that catalog agents are “OpenAI-compatible.”
 
-This change encodes the **catalog entity schema** for agents—not Augment runtime config and not catalog processor enforcement (RHIDP-15868). Upstream RFC + PR is a parallel track (RHIDP-15869), not a merge gate.
+This change covers schema + processor validation for agents. Upstream RFC + PR is a parallel track (RHIDP-15869), not a merge gate.
 
 **Stakeholders**: RHDH AI team; platform engineers authoring catalog YAML; dual-track consumers (rhdh-plugins now, upstream Backstage later).
 
@@ -13,22 +25,23 @@ This change encodes the **catalog entity schema** for agents—not Augment runti
 **Goals:**
 
 - Define TypeScript types (and schema tests) for `kind: AiResource` with `spec.type: agent`
-- Align agent fields to OpenAI Agents SDK `AgentConfiguration` **core** fields without importing the SDK
-- Record the spike mapping (SDK → AiResource spec/metadata / OOS) as OpenSpec DoD for RHIDP-15866 + RHIDP-15867
+- Record the spike field mapping as OpenSpec DoD for RHIDP-15866 + RHIDP-15867
 - Provide example YAML / fixtures for a representative agent
+- Validate agent-specific fields in the catalog processor (RHIDP-15868)
 - Document dual-track approach and clear pending-agent language in OpenSpec/design
 - Use singular `spec.type: agent` consistent with `skill` / `rule`
 
 **Non-Goals:**
 
-- Catalog processor validation rules (RHIDP-15868)
 - Upstream RFC + PR (RHIDP-15869)
-- Agent runtime / SDK orchestration / Runner wiring
+- Agent runtime / orchestration / Runner wiring
 - Agent-specific entity detail UI
 - `rhdh.io/ai-asset-*` annotation mapping updates
 - Migration from interim `Component` + `ai-agent`
 - Augment-only config fields (`mcpServers`, `asTools`, `enableRAG`, `guardrails`, etc.)
 - Full `modelSettings` parity (`parallelToolCalls`, `reasoning`, `truncation`, penalties, prompt-cache, etc.)
+- Entity-ref format enforcement for `handoffs` / `tools`
+- OpenAI compatibility as a marketed contract
 
 ## Decisions
 
@@ -40,48 +53,50 @@ This change encodes the **catalog entity schema** for agents—not Augment runti
 
 **Rationale**: Story AC and upstream alignment require singular type values for filtering and authorship.
 
-### D2 — Field-align to SDK core; no SDK package dependency
+### D2 — No OpenAI Agents SDK package dependency
 
-**Choice**: Mirror OpenAI Agents SDK `AgentConfiguration` / `ModelSettings` names and shapes in our TypeScript interfaces (and any JSON-schema-like validators used in tests). Do **not** add `@openai/agents-core` as a dependency.
+**Choice**: Implement catalog types and validators in this workspace without importing `@openai/agents-core` (or related Agents SDK packages).
 
-**Rationale**: Story explicitly forbids SDK import; catalog schema must stay portable for upstream contribution and avoid coupling to Augment’s runtime adapter stack.
+**Rationale**: Catalog model must stay portable for upstream contribution and must not couple to a runtime SDK.
 
-### D3 — Spike mapping: SDK → AiResource (v1)
+### D3 — Spike mapping: research reference → AiResource (v1)
 
 Standard AiResource fields remain as for other types (`type`, `owner`, `lifecycle`; optional RHDH `scope`; content via `backstage.io/source-location` when applicable).
 
 Agent configuration fields live in **metadata/spec**, not in agent-specific annotations. Cross-cutting `rhdh.io/ai-asset-*` annotations are owned elsewhere (e.g. RHIDP-15258).
 
-| SDK `AgentConfiguration`    | AiResource                       | Required | Notes                                                                        |
-| --------------------------- | -------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `name`                      | `metadata.name`                  | Yes      | No `spec.name`; optional `metadata.title` for display                        |
-| `instructions`              | `spec.instructions`              | Yes      | Non-empty string only (no function form in YAML)                             |
-| `handoffDescription`        | `spec.handoffDescription`        | No       | string                                                                       |
-| `model`                     | `spec.model`                     | No       | string model id                                                              |
-| `handoffs`                  | `spec.handoffs`                  | No       | `string[]`, opaque at schema layer                                           |
-| `tools`                     | `spec.tools`                     | No       | `string[]`, opaque at schema layer                                           |
-| `toolUseBehavior`           | `spec.toolUseBehavior`           | No       | `'run_llm_again'` \| `'stop_on_first_tool'` \| `string[]`; function form OOS |
-| `resetToolChoice`           | `spec.resetToolChoice`           | No       | boolean                                                                      |
-| `modelSettings.temperature` | `spec.modelSettings.temperature` | No       |                                                                              |
-| `modelSettings.maxTokens`   | `spec.modelSettings.maxTokens`   | No       |                                                                              |
-| `modelSettings.toolChoice`  | `spec.modelSettings.toolChoice`  | No       |                                                                              |
-| `outputType`                | `spec.outputSchema`              | No       | JSON Schema object and/or simple string type name                            |
+The “Research reference” column records where the catalog field was derived from during the spike; it is not a compatibility guarantee.
 
-**Explicitly OOS / follow-up** (not in v1 catalog schema): other `modelSettings` (`parallelToolCalls`, `reasoning`, `truncation`, penalties, prompt-cache, `providerData`, …), SDK `prompt` object, SDK guardrail hooks, MCP object graphs, Augment-only keys (`enableRAG`, `asTools`, `publishAs`, …), function-valued `instructions` / `toolUseBehavior`.
+| Research reference (SDK `AgentConfiguration`) | AiResource                       | Required | Notes                                                                                                                         |
+| --------------------------------------------- | -------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                        | `metadata.name`                  | Yes      | No `spec.name`; optional `metadata.title` for display                                                                         |
+| `instructions`                                | `spec.instructions`              | Yes      | Non-empty string only (no function form in YAML)                                                                              |
+| `handoffDescription`                          | `spec.handoffDescription`        | No       | string                                                                                                                        |
+| `model`                                       | `spec.model`                     | No       | string model id                                                                                                               |
+| `handoffs`                                    | `spec.handoffs`                  | No       | `string[]`, opaque (no entity-ref format check)                                                                               |
+| `tools`                                       | `spec.tools`                     | No       | `string[]`, opaque (no entity-ref format check)                                                                               |
+| `toolUseBehavior`                             | `spec.toolUseBehavior`           | No       | `'run_llm_again'` \| `'stop_on_first_tool'` \| `string[]`; function/object callback forms OOS                                 |
+| `resetToolChoice`                             | `spec.resetToolChoice`           | No       | boolean                                                                                                                       |
+| `modelSettings.temperature`                   | `spec.modelSettings.temperature` | No       | number                                                                                                                        |
+| `modelSettings.maxTokens`                     | `spec.modelSettings.maxTokens`   | No       | number                                                                                                                        |
+| `modelSettings.toolChoice`                    | `spec.modelSettings.toolChoice`  | No       | string (`auto` / `none` / `required`) or structured object as typed in schema                                                 |
+| `outputType`                                  | `spec.outputSchema`              | No       | **Deliberate adaptation**: catalog uses JSON Schema object and/or simple string type name, not a runtime type/class reference |
 
-**Rationale**: Core SDK-aligned surface that runtime adapters already cover; keeps catalog authoring light; richer settings and ref-format enforcement deferred.
+**Explicitly OOS / follow-up** (not in v1 catalog schema): other `modelSettings` (`parallelToolCalls`, `reasoning`, `truncation`, penalties, prompt-cache, `providerData`, …), prompt objects, guardrail hooks, MCP object graphs, Augment-only keys (`enableRAG`, `asTools`, `publishAs`, …), function-valued `instructions` / `toolUseBehavior`.
 
-### D4 — Opaque `handoffs` / `tools` until processor story
+**Rationale**: Small, YAML-friendly agent surface for catalog authorship; richer settings and ref-format enforcement deferred.
 
-**Choice**: Schema accepts `string[]` only. Do not require catalog entity-ref format in RHIDP-15867.
+### D4 — Opaque `handoffs` / `tools` (schema and processor)
 
-**Rationale**: Matches “string keys, resolve later” runtime patterns. RHIDP-15868 may tighten formats and relations.
+**Choice**: Accept `string[]` only. Do not require catalog entity-ref format in RHIDP-15867 or RHIDP-15868.
 
-### D5 — Schema layer in rhdh-plugins, not processor rules in this story
+**Rationale**: Matches “string keys, resolve later” patterns; entity-ref tightening deferred by agreement.
 
-**Choice**: Deliver types, example YAML, fixtures, and schema/unit tests. Do not expand `AIResourceExtensionsProcessor` with agent-field rules here.
+### D5 — Schema + processor in this OpenSpec; agent-only processor rules
 
-**Rationale**: Separates “schema + examples” DoD from ingestion validation (RHIDP-15868).
+**Choice**: Deliver types, examples, schema tests, **and** catalog processor validation for agent-specific fields. Processor does **not** re-validate core entity fields (`owner`, `lifecycle`, etc.) beyond existing catalog behavior.
+
+**Rationale**: Epic cohesion (15867 + 15868 share one field set). Keep processor focused on agent fields.
 
 ### D6 — Dual-track documentation (rhdh-plugins + upstream)
 
@@ -95,33 +110,33 @@ Agent configuration fields live in **metadata/spec**, not in agent-specific anno
 
 **Rationale**: Exercises required `instructions` and optional handoff/`modelSettings` fields in a realistic catalog authoring scenario.
 
-### D8 — Correct plural `agents` filter examples in related docs
+### D8 — Correct plural type examples in sibling discovery OpenSpec
 
-**Choice**: Where change-local or README examples filter on `spec.type=agents`, update to `agent` when touched by this work.
+**Choice**: Update `ai-resource-catalog-entity-kind` discovery scenarios from plural `agents` / `skills` to singular `agent` / `skill` as part of this change.
 
-**Rationale**: Prevents discovery/doc drift against the singular discriminator (D1).
+**Rationale**: Removes contradictory guidance against D1.
 
-### D9 — Spike + schema share this OpenSpec
+### D9 — Spike + schema + processor share this OpenSpec
 
-**Choice**: RHIDP-15866 DoD is this design’s mapping table (D3) plus the thin requirements in `specs/ai-resource-agent-schema/spec.md`, linked from a Jira comment on the spike. No separate spike markdown outside OpenSpec is required.
+**Choice**: RHIDP-15866 DoD is this design’s mapping table (D3) plus thin schema/ingestion requirements. No separate spike markdown outside OpenSpec is required.
 
-**Rationale**: One source of truth for schema story and upstream RFC inputs.
+**Rationale**: One source of truth for schema, processor, and later upstream RFC inputs.
 
 ## Risks / Trade-offs
 
-| Risk                                                 | Mitigation                                                                                             |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Upstream AiResource agent shape diverges             | Keep fields SDK-core and documented; dual-track notes that upstream may refine names                   |
-| Authors confuse Augment YAML with catalog schema     | Examples use only D3 fields; design explicitly excludes Augment-only keys                              |
-| `handoffs` / `tools` string semantics underspecified | Opaque at schema layer; processor story (RHIDP-15868) may tighten                                      |
-| `outputSchema` typing too loose or too strict        | Accept object (JSON Schema) or simple string type name; tests cover both valid forms and clear rejects |
-| Scope creep into processor / UI / annotations        | Non-goals + story OOS list; keep tasks schema-focused                                                  |
+| Risk                                                 | Mitigation                                                               |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ |
+| Upstream AiResource agent shape diverges             | Keep fields documented; dual-track notes that upstream may refine names  |
+| Authors confuse Augment YAML with catalog schema     | Examples use only D3 fields; design excludes Augment-only keys           |
+| `handoffs` / `tools` string semantics underspecified | Opaque by design; entity-ref rules deferred                              |
+| `outputSchema` typing too loose or too strict        | Accept object (JSON Schema) or simple string type name; tests cover both |
+| Scope creep into UI / annotations / upstream         | Non-goals; 15869 remains parallel OOS                                    |
 
 ## Migration Plan
 
-- Additive only: new agent type schema and examples; no migration of existing `Component` / `ai-agent` entities (OOS).
-- Rollback: remove agent types/examples/tests; skill/rule AiResource paths unchanged.
-- No catalog data migration required for this story.
+- Additive only: new agent type schema, examples, and processor rules; no migration of existing `Component` / `ai-agent` entities (OOS).
+- Rollback: remove agent types/examples/tests/processor rules; skill/rule AiResource paths unchanged.
+- No catalog data migration required for this change.
 
 ## Open Questions
 

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/design.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/design.md
@@ -122,6 +122,27 @@ The “Research reference” column records where the catalog field was derived 
 
 **Rationale**: One source of truth for schema, processor, and later upstream RFC inputs.
 
+### D10 — How to implement the agent schema (follow existing patterns)
+
+**Choice**: Implement `spec.type: agent` the same way upstream models typed AiResource variants and typed API subtypes—do **not** invent a parallel schema style.
+
+**Primary reference — AiResource skill/rule discriminated types** (in `@backstage/catalog-model` alpha / `@backstage/plugin-catalog-backend-module-ai-model`):
+
+- `AiResourceEntityV1alpha1` union: default | `SkillAiResourceEntityV1alpha1` | `RuleAiResourceEntityV1alpha1`
+- Per-type validators / guards: `skillAiResourceEntityV1alpha1Validator`, `ruleAiResourceEntityV1alpha1Validator`, `isSkillAiResourceEntity`, `isRuleAiResourceEntity`
+- Kind registration via `aiResourceEntityModel` / `catalogModuleAiResourceEntityModel`
+
+Agent should follow that pattern: add an `AgentAiResourceEntity…` (name TBD) member of the AiResource union (or an RHDH-local extension layer that mirrors it until upstream accepts agent), with a `KindValidator` + type guard keyed on `spec.type: 'agent'`.
+
+**Secondary reference — MCP server API discriminated extension** (same catalog-model alpha surface):
+
+- `McpServerApiEntity` with `spec.type: 'mcp-server'`, `mcpServerApiEntityValidator`, `isMcpServerApiEntity`, `mcpServerApiEntityModel`
+- Shows how Backstage extends an existing kind with a typed `spec.type` branch (useful precedent for dual-track / upstream PR work)
+
+**Local RHDH extension precedent**: this workspace’s `AIResourceExtensionsProcessor` for `spec.scope` / OCI checks—agent **field** validation (RHIDP-15868) should extend that processor path for agent-specific rules, while the **typed schema** itself follows the catalog-model validator pattern above.
+
+**Rationale**: Without these pointers, implementers (human or coding agent) will invent ad-hoc types that diverge from skill/rule and force manual rework. Gabe’s review feedback on this PR.
+
 ## Risks / Trade-offs
 
 | Risk                                                 | Mitigation                                                               |
@@ -140,5 +161,5 @@ The “Research reference” column records where the catalog field was derived 
 
 ## Open Questions
 
-1. Exact package home for agent types (e.g. shared common package vs catalog module)—resolve during implementation by following where skill/rule entity types already live (or introduce a small shared types module if none exist).
+1. Whether v1 ships only an RHDH-local agent validator/types mirroring upstream skill/rule, or also opens the upstream catalog-model PR in lockstep (RHIDP-15869 remains the formal upstream track either way).
 2. UI / annotation-mapping / Component→AiResource migration ownership remain TBC and out of this change.

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/design.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/design.md
@@ -1,0 +1,129 @@
+## Context
+
+RHIDP-15867 adds a typed `AiResource` agent schema in rhdh-plugins. The AiResource foundation (RHDHPLAN-1113 / workspace change `ai-resource-catalog-entity-kind`) already supports skill-shaped entities (`spec.type: skill`) with RHDH extensions such as `spec.scope` and OCI `source-location` validation. Agent typing was deferred pending a field-mapping spike (RHIDP-15866).
+
+Spike research mapped OpenAI Agents SDK `AgentConfiguration` → Augment runtime config → Responses API. RHIDP-15866 and this change share one deliverable: the **decided catalog field mapping** below (in this design) plus thin schema requirements in `specs/ai-resource-agent-schema/spec.md`. Ownership of the agent type under program planning is RHDHPLAN-1507.
+
+This change encodes the **catalog entity schema** for agents—not Augment runtime config and not catalog processor enforcement (RHIDP-15868). Upstream RFC + PR is a parallel track (RHIDP-15869), not a merge gate.
+
+**Stakeholders**: RHDH AI team; platform engineers authoring catalog YAML; dual-track consumers (rhdh-plugins now, upstream Backstage later).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define TypeScript types (and schema tests) for `kind: AiResource` with `spec.type: agent`
+- Align agent fields to OpenAI Agents SDK `AgentConfiguration` **core** fields without importing the SDK
+- Record the spike mapping (SDK → AiResource spec/metadata / OOS) as OpenSpec DoD for RHIDP-15866 + RHIDP-15867
+- Provide example YAML / fixtures for a representative agent
+- Document dual-track approach and clear pending-agent language in OpenSpec/design
+- Use singular `spec.type: agent` consistent with `skill` / `rule`
+
+**Non-Goals:**
+
+- Catalog processor validation rules (RHIDP-15868)
+- Upstream RFC + PR (RHIDP-15869)
+- Agent runtime / SDK orchestration / Runner wiring
+- Agent-specific entity detail UI
+- `rhdh.io/ai-asset-*` annotation mapping updates
+- Migration from interim `Component` + `ai-agent`
+- Augment-only config fields (`mcpServers`, `asTools`, `enableRAG`, `guardrails`, etc.)
+- Full `modelSettings` parity (`parallelToolCalls`, `reasoning`, `truncation`, penalties, prompt-cache, etc.)
+
+## Decisions
+
+### D1 — Discriminator is singular `spec.type: agent`
+
+**Choice**: Use `spec.type: agent` (singular), matching upstream skill/rule style.
+
+**Alternatives considered**: `agents` (plural) as in an older discovery example — rejected for inconsistency with `skill` / `rule`.
+
+**Rationale**: Story AC and upstream alignment require singular type values for filtering and authorship.
+
+### D2 — Field-align to SDK core; no SDK package dependency
+
+**Choice**: Mirror OpenAI Agents SDK `AgentConfiguration` / `ModelSettings` names and shapes in our TypeScript interfaces (and any JSON-schema-like validators used in tests). Do **not** add `@openai/agents-core` as a dependency.
+
+**Rationale**: Story explicitly forbids SDK import; catalog schema must stay portable for upstream contribution and avoid coupling to Augment’s runtime adapter stack.
+
+### D3 — Spike mapping: SDK → AiResource (v1)
+
+Standard AiResource fields remain as for other types (`type`, `owner`, `lifecycle`; optional RHDH `scope`; content via `backstage.io/source-location` when applicable).
+
+Agent configuration fields live in **metadata/spec**, not in agent-specific annotations. Cross-cutting `rhdh.io/ai-asset-*` annotations are owned elsewhere (e.g. RHIDP-15258).
+
+| SDK `AgentConfiguration`    | AiResource                       | Required | Notes                                                                        |
+| --------------------------- | -------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| `name`                      | `metadata.name`                  | Yes      | No `spec.name`; optional `metadata.title` for display                        |
+| `instructions`              | `spec.instructions`              | Yes      | Non-empty string only (no function form in YAML)                             |
+| `handoffDescription`        | `spec.handoffDescription`        | No       | string                                                                       |
+| `model`                     | `spec.model`                     | No       | string model id                                                              |
+| `handoffs`                  | `spec.handoffs`                  | No       | `string[]`, opaque at schema layer                                           |
+| `tools`                     | `spec.tools`                     | No       | `string[]`, opaque at schema layer                                           |
+| `toolUseBehavior`           | `spec.toolUseBehavior`           | No       | `'run_llm_again'` \| `'stop_on_first_tool'` \| `string[]`; function form OOS |
+| `resetToolChoice`           | `spec.resetToolChoice`           | No       | boolean                                                                      |
+| `modelSettings.temperature` | `spec.modelSettings.temperature` | No       |                                                                              |
+| `modelSettings.maxTokens`   | `spec.modelSettings.maxTokens`   | No       |                                                                              |
+| `modelSettings.toolChoice`  | `spec.modelSettings.toolChoice`  | No       |                                                                              |
+| `outputType`                | `spec.outputSchema`              | No       | JSON Schema object and/or simple string type name                            |
+
+**Explicitly OOS / follow-up** (not in v1 catalog schema): other `modelSettings` (`parallelToolCalls`, `reasoning`, `truncation`, penalties, prompt-cache, `providerData`, …), SDK `prompt` object, SDK guardrail hooks, MCP object graphs, Augment-only keys (`enableRAG`, `asTools`, `publishAs`, …), function-valued `instructions` / `toolUseBehavior`.
+
+**Rationale**: Core SDK-aligned surface that runtime adapters already cover; keeps catalog authoring light; richer settings and ref-format enforcement deferred.
+
+### D4 — Opaque `handoffs` / `tools` until processor story
+
+**Choice**: Schema accepts `string[]` only. Do not require catalog entity-ref format in RHIDP-15867.
+
+**Rationale**: Matches “string keys, resolve later” runtime patterns. RHIDP-15868 may tighten formats and relations.
+
+### D5 — Schema layer in rhdh-plugins, not processor rules in this story
+
+**Choice**: Deliver types, example YAML, fixtures, and schema/unit tests. Do not expand `AIResourceExtensionsProcessor` with agent-field rules here.
+
+**Rationale**: Separates “schema + examples” DoD from ingestion validation (RHIDP-15868).
+
+### D6 — Dual-track documentation (rhdh-plugins + upstream)
+
+**Choice**: Agent typing lands first in rhdh-plugins under RHDHPLAN-1507 ownership, with upstream RFC/PR (RHIDP-15869) in parallel and **not** a merge gate. Remove “pending 1113” / deferred-agent wording for `spec.type: agent`.
+
+**Rationale**: Explicit story DoD; avoids blocking local catalog progress on upstream merge.
+
+### D7 — Examples model a multi-agent handoff shape
+
+**Choice**: Provide at least one example (or fixture set) with a router-style agent (`handoffs` + `handoffDescription` on specialists) using only D3 fields—not Augment-only keys.
+
+**Rationale**: Exercises required `instructions` and optional handoff/`modelSettings` fields in a realistic catalog authoring scenario.
+
+### D8 — Correct plural `agents` filter examples in related docs
+
+**Choice**: Where change-local or README examples filter on `spec.type=agents`, update to `agent` when touched by this work.
+
+**Rationale**: Prevents discovery/doc drift against the singular discriminator (D1).
+
+### D9 — Spike + schema share this OpenSpec
+
+**Choice**: RHIDP-15866 DoD is this design’s mapping table (D3) plus the thin requirements in `specs/ai-resource-agent-schema/spec.md`, linked from a Jira comment on the spike. No separate spike markdown outside OpenSpec is required.
+
+**Rationale**: One source of truth for schema story and upstream RFC inputs.
+
+## Risks / Trade-offs
+
+| Risk                                                 | Mitigation                                                                                             |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Upstream AiResource agent shape diverges             | Keep fields SDK-core and documented; dual-track notes that upstream may refine names                   |
+| Authors confuse Augment YAML with catalog schema     | Examples use only D3 fields; design explicitly excludes Augment-only keys                              |
+| `handoffs` / `tools` string semantics underspecified | Opaque at schema layer; processor story (RHIDP-15868) may tighten                                      |
+| `outputSchema` typing too loose or too strict        | Accept object (JSON Schema) or simple string type name; tests cover both valid forms and clear rejects |
+| Scope creep into processor / UI / annotations        | Non-goals + story OOS list; keep tasks schema-focused                                                  |
+
+## Migration Plan
+
+- Additive only: new agent type schema and examples; no migration of existing `Component` / `ai-agent` entities (OOS).
+- Rollback: remove agent types/examples/tests; skill/rule AiResource paths unchanged.
+- No catalog data migration required for this story.
+
+## Open Questions
+
+1. Exact package home for agent types (e.g. shared common package vs catalog module)—resolve during implementation by following where skill/rule entity types already live (or introduce a small shared types module if none exist).
+2. UI / annotation-mapping / Component→AiResource migration ownership remain TBC and out of this change.

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Platform engineers need a first-class way to register AI agents in the Software Catalog with validated, discoverable metadata—same pattern as skills and rules. Today `AiResource` supports skill-shaped entities, but there is no typed `spec.type: agent` schema aligned to the OpenAI Agents SDK `AgentConfiguration` core fields. RHIDP-15867 delivers that schema (plus examples/fixtures and OpenSpec updates) so agent entities can be authored and schema-validated in rhdh-plugins without importing the SDK.
+
+## What Changes
+
+- Add a typed agent schema for `kind: AiResource` / `AIResource` with `spec.type: agent`, field-aligned to OpenAI Agents SDK `AgentConfiguration` **core** fields (TypeScript types / JSON schema style; **no** `@openai/agents-core` import).
+- Encode the decided spike mapping (RHIDP-15866) in OpenSpec design: SDK `AgentConfiguration` core → AiResource `metadata`/`spec` fields; only agent-specific required field is non-empty `spec.instructions`.
+- Add example `catalog-info.yaml` and/or test fixtures covering a representative agent (required + optional fields).
+- Update in-repo OpenSpec/design docs for `AiResource` + agent ownership under RHDHPLAN-1507; remove “pending 1113” language for the agent type where it appears.
+- Add unit/schema tests that accept valid agent entities and reject clearly invalid shapes at the schema layer.
+- Align naming with upstream skill/rule style: singular `spec.type: agent` (not `agents`).
+
+## Capabilities
+
+### New Capabilities
+
+- `ai-resource-agent-schema`: Typed schema, examples/fixtures, and schema-layer validation for `AiResource` entities with `spec.type: agent`, using the spike mapping in `design.md` (SDK-aligned, no SDK dependency).
+
+### Modified Capabilities
+
+_(none — long-lived `openspec/specs/` has no promoted capabilities yet; agent typing is net-new. Related change-local discovery examples that used `spec.type: agents` are corrected via this change’s design/docs, not a delta against a promoted spec.)_
+
+## Impact
+
+- **Schema / types**: New or extended TypeScript (and any colocated JSON schema) for agent-shaped `AiResource` in this workspace; no SDK package dependency.
+- **Examples / fixtures**: New catalog YAML under `examples/` (and/or test fixtures) demonstrating agent entities.
+- **Tests**: Schema/unit tests for valid and invalid agent shapes.
+- **Docs / OpenSpec**: Design and change materials updated for dual-track (rhdh-plugins + upstream) and agent ownership (RHDHPLAN-1507).
+- **Out of scope (separate stories)**: Catalog processor validation rules, upstream RFC+PR, agent runtime/SDK orchestration, agent entity detail UI, `rhdh.io/ai-asset-*` mapping updates, migration from interim `Component` + `ai-agent`, feature-level docs/QE.
+- **Jira**: RHIDP-15867 (schema story); RHIDP-15866 (spike — DoD is this change’s design mapping + thin schema requirements); RHIDP-15868 / RHIDP-15869 (processor / upstream, OOS); program ownership RHDHPLAN-1507.

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/proposal.md
@@ -1,31 +1,55 @@
+# Proposal: AiResource Agent Typed Schema
+
 ## Why
 
-Platform engineers need a first-class way to register AI agents in the Software Catalog with validated, discoverable metadata—same pattern as skills and rules. Today `AiResource` supports skill-shaped entities, but there is no typed `spec.type: agent` schema aligned to the OpenAI Agents SDK `AgentConfiguration` core fields. RHIDP-15867 delivers that schema (plus examples/fixtures and OpenSpec updates) so agent entities can be authored and schema-validated in rhdh-plugins without importing the SDK.
+Platform engineers need a first-class way to register AI agents in the Software Catalog with validated, discoverable metadata—same pattern as skills and rules. Today `AiResource` supports skill-shaped entities, but there is no typed `spec.type: agent` schema (with examples and catalog processor validation) so agent entities can be authored, schema-checked, and safely ingested in rhdh-plugins.
 
 ## What Changes
 
-- Add a typed agent schema for `kind: AiResource` / `AIResource` with `spec.type: agent`, field-aligned to OpenAI Agents SDK `AgentConfiguration` **core** fields (TypeScript types / JSON schema style; **no** `@openai/agents-core` import).
-- Encode the decided spike mapping (RHIDP-15866) in OpenSpec design: SDK `AgentConfiguration` core → AiResource `metadata`/`spec` fields; only agent-specific required field is non-empty `spec.instructions`.
+- Add a typed agent schema for `kind: AiResource` with `spec.type: agent` (TypeScript types / schema-style validation; no OpenAI Agents SDK package dependency).
+- Encode the decided field mapping (RHIDP-15866) in OpenSpec design; only agent-specific required field is non-empty `spec.instructions`.
 - Add example `catalog-info.yaml` and/or test fixtures covering a representative agent (required + optional fields).
+- Extend catalog processor validation for agent entities (RHIDP-15868): reject missing/invalid agent-specific fields with actionable errors.
 - Update in-repo OpenSpec/design docs for `AiResource` + agent ownership under RHDHPLAN-1507; remove “pending 1113” language for the agent type where it appears.
-- Add unit/schema tests that accept valid agent entities and reject clearly invalid shapes at the schema layer.
-- Align naming with upstream skill/rule style: singular `spec.type: agent` (not `agents`).
+- Add unit/schema and processor tests for accept/reject paths.
+- Align naming with upstream skill/rule style: singular `spec.type: agent` (not `agents`); correct sibling discovery examples accordingly.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `ai-resource-agent-schema`: Typed schema, examples/fixtures, and schema-layer validation for `AiResource` entities with `spec.type: agent`, using the spike mapping in `design.md` (SDK-aligned, no SDK dependency).
+- `ai-resource-agent-schema`: Typed schema, examples/fixtures, and schema-layer validation for `AiResource` entities with `spec.type: agent`, using the field mapping in `design.md`.
+- `ai-resource-agent-ingestion`: Catalog processor validation for agent-shaped `AiResource` entities (agent-specific fields only).
 
 ### Modified Capabilities
 
-_(none — long-lived `openspec/specs/` has no promoted capabilities yet; agent typing is net-new. Related change-local discovery examples that used `spec.type: agents` are corrected via this change’s design/docs, not a delta against a promoted spec.)_
+_(none promoted under `openspec/specs/` yet. Sibling change-local discovery examples that used plural `agents`/`skills` are corrected as part of this change.)_
+
+## Non-goals
+
+- Upstream RFC + PR (RHIDP-15869; parallel, not a merge gate)
+- Agent runtime / orchestration
+- Agent-specific entity detail UI
+- `rhdh.io/ai-asset-*` annotation mapping updates
+- Migration from interim `Component` + `ai-agent`
+- Feature-level docs and QE
+- Full `modelSettings` parity beyond the v1 mapping
+- Catalog entity-ref format enforcement for `handoffs` / `tools` (deferred)
+- Marketing or guaranteeing “OpenAI-compatible” agents (research provenance lives in design only)
+
+## Canonical Touchpoints
+
+- **Jira**: RHIDP-15865 (epic), RHIDP-15866 (spike), RHIDP-15867 (schema), RHIDP-15868 (processor), RHIDP-15869 (upstream, OOS)
+- **Program**: RHDHPLAN-1507 (agent type ownership)
+- **Foundation**: RHDHPLAN-1113 / `ai-resource-catalog-entity-kind` (AiResource kind; skills/rules)
+- **Long-lived specs (`openspec/specs/`)**: None yet
+
+**Change type**: feature-spec
 
 ## Impact
 
-- **Schema / types**: New or extended TypeScript (and any colocated JSON schema) for agent-shaped `AiResource` in this workspace; no SDK package dependency.
-- **Examples / fixtures**: New catalog YAML under `examples/` (and/or test fixtures) demonstrating agent entities.
-- **Tests**: Schema/unit tests for valid and invalid agent shapes.
-- **Docs / OpenSpec**: Design and change materials updated for dual-track (rhdh-plugins + upstream) and agent ownership (RHDHPLAN-1507).
-- **Out of scope (separate stories)**: Catalog processor validation rules, upstream RFC+PR, agent runtime/SDK orchestration, agent entity detail UI, `rhdh.io/ai-asset-*` mapping updates, migration from interim `Component` + `ai-agent`, feature-level docs/QE.
-- **Jira**: RHIDP-15867 (schema story); RHIDP-15866 (spike — DoD is this change’s design mapping + thin schema requirements); RHIDP-15868 / RHIDP-15869 (processor / upstream, OOS); program ownership RHDHPLAN-1507.
+- **Schema / types**: New or extended TypeScript for agent-shaped `AiResource` in this workspace.
+- **Catalog processor**: Agent-specific validation in the AiResource extensions processor path.
+- **Examples / fixtures**: New catalog YAML under `examples/` (and/or test fixtures).
+- **Tests**: Schema/unit and processor accept/reject coverage.
+- **Docs / OpenSpec**: Dual-track (rhdh-plugins + upstream) and singular type discriminator docs.

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-ingestion/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-ingestion/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Processor validates agent-specific fields
+
+When an AiResource entity declares `spec.type: agent`, the catalog processor MUST validate agent-specific fields from the design mapping. Validation MUST be limited to agent-specific fields and MUST NOT re-implement core entity validation for fields such as `spec.owner` or `spec.lifecycle`.
+
+#### Scenario: Valid agent entity ingests
+
+- **WHEN** an AiResource entity with `spec.type: agent` and non-empty `spec.instructions` (and correctly typed optional agent fields, if present) is ingested
+- **THEN** the catalog processor accepts it
+
+#### Scenario: Missing instructions rejected at ingestion
+
+- **WHEN** an AiResource entity with `spec.type: agent` omits `spec.instructions` or sets it to an empty string
+- **THEN** the catalog processor rejects ingestion with an actionable error that names `spec.instructions`
+
+#### Scenario: Invalid optional agent field shape rejected at ingestion
+
+- **WHEN** an AiResource entity with `spec.type: agent` sets an optional agent field to a clearly wrong type (for example `spec.handoffs` as a non-array, or `spec.resetToolChoice` as a non-boolean)
+- **THEN** the catalog processor rejects ingestion with an actionable error naming the invalid field
+
+---
+
+### Requirement: Opaque handoffs and tools at processor layer
+
+For `spec.type: agent`, the processor MUST accept `spec.handoffs` and `spec.tools` as arrays of strings without requiring catalog entity-ref format.
+
+#### Scenario: Opaque string arrays accepted on ingest
+
+- **WHEN** an otherwise valid agent entity sets `spec.handoffs` and/or `spec.tools` to arrays of arbitrary non-empty strings
+- **THEN** the catalog processor accepts the entity without entity-ref format errors
+
+---
+
+### Requirement: Actionable processor errors
+
+Agent validation errors MUST identify the field path, the problem (missing/empty/wrong type), and MUST NOT expose internal class names or stack traces to catalog authors.
+
+#### Scenario: Error names the field
+
+- **WHEN** processor validation fails for an agent entity
+- **THEN** the error message includes the relevant `spec.*` field path
+
+---
+
+### Requirement: Non-agent AiResources unchanged
+
+AiResource entities that are not `spec.type: agent` MUST continue to follow existing extension processor behavior (for example scope / OCI rules) without new agent-field requirements.
+
+#### Scenario: Skill entity not subject to agent instructions rule
+
+- **WHEN** an AiResource entity declares `spec.type: skill` and omits `spec.instructions`
+- **THEN** the agent-specific instructions validation does not apply
+
+---
+
+### Requirement: Processor automated tests
+
+Automated tests MUST cover processor accept and reject paths for agent entities, including missing `spec.instructions` and at least one invalid optional field shape.
+
+#### Scenario: Accept path covered
+
+- **WHEN** the processor test suite runs against a valid agent entity
+- **THEN** ingestion validation succeeds
+
+#### Scenario: Reject path covered
+
+- **WHEN** the processor test suite runs against an agent entity missing `spec.instructions`
+- **THEN** the suite asserts a validation failure

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-ingestion/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-ingestion/spec.md
@@ -14,6 +14,11 @@ When an AiResource entity declares `spec.type: agent`, the catalog processor MUS
 - **WHEN** an AiResource entity with `spec.type: agent` omits `spec.instructions` or sets it to an empty string
 - **THEN** the catalog processor rejects ingestion with an actionable error that names `spec.instructions`
 
+#### Scenario: Wrong-type instructions rejected at ingestion
+
+- **WHEN** an AiResource entity with `spec.type: agent` sets `spec.instructions` to a non-string value (for example a number or array)
+- **THEN** the catalog processor rejects ingestion with an actionable error that names `spec.instructions`
+
 #### Scenario: Invalid optional agent field shape rejected at ingestion
 
 - **WHEN** an AiResource entity with `spec.type: agent` sets an optional agent field to a clearly wrong type (for example `spec.handoffs` as a non-array, or `spec.resetToolChoice` as a non-boolean)

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-schema/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-schema/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Agent type discriminator
+
+AiResource entities that represent agents MUST declare `spec.type` with the exact value `agent` (singular). The schema MUST NOT treat `agents` as a valid agent type discriminator.
+
+#### Scenario: Singular agent type accepted
+
+- **WHEN** an AiResource entity declares `spec.type: agent` with otherwise valid agent fields
+- **THEN** the agent schema accepts the entity
+
+#### Scenario: Plural agents type rejected for agent schema
+
+- **WHEN** an entity is validated as an agent-shaped AiResource and declares `spec.type: agents`
+- **THEN** the agent schema rejects it as an invalid agent type value
+
+---
+
+### Requirement: Required agent fields
+
+An agent-shaped AiResource (`spec.type: agent`) MUST include `spec.instructions` as a non-empty string, and MUST include the standard entity identity and ownership fields required of AiResource entities in this workspace (`metadata.name`, `spec.owner`, `spec.lifecycle`). The schema MUST NOT require a separate `spec.name` field; SDK `name` maps to `metadata.name`.
+
+#### Scenario: Minimal valid agent accepted
+
+- **WHEN** an AiResource entity declares `spec.type: agent`, non-empty `spec.instructions`, `spec.owner`, `spec.lifecycle`, and a valid `metadata.name`
+- **THEN** the agent schema accepts the entity
+
+#### Scenario: Missing instructions rejected
+
+- **WHEN** an AiResource entity declares `spec.type: agent` but omits `spec.instructions` or sets it to an empty string
+- **THEN** the agent schema rejects the entity with an error that names `spec.instructions`
+
+---
+
+### Requirement: Optional fields per spike mapping
+
+The agent schema MUST allow the optional agent fields defined in the spike mapping in this change’s `design.md` (SDK-aligned `AgentConfiguration` core fields under `spec` / `metadata`, not agent-specific annotations). Optional field membership and shapes SHALL follow that mapping table rather than a divergent inventory in code.
+
+At minimum, the mapping’s optional catalog fields include: `spec.handoffDescription`, `spec.model`, `spec.handoffs` (`string[]`), `spec.tools` (`string[]`), `spec.toolUseBehavior`, `spec.resetToolChoice`, `spec.modelSettings` (`temperature`, `maxTokens`, `toolChoice` only for v1), and `spec.outputSchema`.
+
+#### Scenario: Optional fields from mapping accepted
+
+- **WHEN** a valid agent entity includes optional fields from the spike mapping with correctly typed values
+- **THEN** the agent schema accepts the entity
+
+#### Scenario: Omitted optional fields accepted
+
+- **WHEN** a minimal valid agent entity omits all optional agent-specific fields
+- **THEN** the agent schema accepts the entity
+
+#### Scenario: Invalid optional field type rejected
+
+- **WHEN** an agent entity sets `spec.handoffs` to a non-array value or `spec.resetToolChoice` to a non-boolean value
+- **THEN** the agent schema rejects the entity with an error naming the invalid field
+
+#### Scenario: Opaque handoffs and tools strings accepted
+
+- **WHEN** an agent entity sets `spec.handoffs` and `spec.tools` to arrays of arbitrary non-empty strings
+- **THEN** the agent schema accepts them without requiring catalog entity-ref format
+
+---
+
+### Requirement: Agent fields in spec and metadata only
+
+Agent configuration fields from the spike mapping MUST be represented on the entity as `metadata.*` / `spec.*` fields. The agent schema MUST NOT introduce agent-specific annotations for those SDK-aligned configuration fields.
+
+#### Scenario: Spec-placed instructions accepted
+
+- **WHEN** an agent entity provides `spec.instructions` (and omits agent-config annotations for the same data)
+- **THEN** the agent schema accepts the entity
+
+---
+
+### Requirement: No SDK package dependency
+
+The rhdh-plugins agent schema implementation MUST NOT import `@openai/agents-core` or other OpenAI Agents SDK packages. Field alignment is by documented shape and naming only.
+
+#### Scenario: Schema module has no agents-core import
+
+- **WHEN** the agent schema TypeScript sources and their direct dependencies are inspected
+- **THEN** they do not import `@openai/agents-core` or `@openai/agents`
+
+---
+
+### Requirement: Examples and fixtures for agent entities
+
+The workspace MUST provide example catalog YAML and/or test fixtures that demonstrate a representative agent entity covering required fields and a non-empty subset of optional fields from the spike mapping (including at least one of `handoffs` or `modelSettings`).
+
+#### Scenario: Example catalog YAML exists
+
+- **WHEN** a developer opens the workspace examples (or equivalent fixtures) for agent AiResources
+- **THEN** at least one `kind: AiResource` document with `spec.type: agent` and non-empty `spec.instructions` is present
+
+#### Scenario: Fixture usable by schema tests
+
+- **WHEN** schema/unit tests run
+- **THEN** they load a representative agent fixture (or inline equivalent) that exercises required and optional fields
+
+---
+
+### Requirement: Schema-layer validation tests
+
+Unit or schema tests MUST cover acceptance of valid agent entities and rejection of clearly invalid shapes at the schema layer (missing required fields, wrong `spec.type` for agent validation, wrong types on optional fields).
+
+#### Scenario: Valid agent test passes
+
+- **WHEN** the agent schema test suite runs against a minimal valid agent entity
+- **THEN** the suite reports acceptance (no schema validation errors)
+
+#### Scenario: Invalid agent test fails closed
+
+- **WHEN** the agent schema test suite runs against an agent entity missing `spec.instructions`
+- **THEN** the suite asserts a schema validation failure
+
+---
+
+### Requirement: Dual-track documentation for agent type
+
+In-repo OpenSpec/design materials for this change MUST describe AiResource agent typing as owned under RHDHPLAN-1507 in rhdh-plugins, with upstream contribution tracked in parallel and not a merge gate. Materials MUST NOT leave agent typing described as blocked solely on RHDHPLAN-1113. The spike mapping table in `design.md` MUST remain the shared field-set source for RHIDP-15866 and RHIDP-15867.
+
+#### Scenario: Design states dual-track ownership and spike mapping
+
+- **WHEN** a reader opens this change’s design/proposal artifacts
+- **THEN** they find explicit dual-track (rhdh-plugins + upstream) language, RHDHPLAN-1507 ownership for the agent type, and the SDK→AiResource mapping table

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-schema/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-schema/spec.md
@@ -32,6 +32,11 @@ These are schema-layer requirements for agent authoring and tests; catalog proce
 - **WHEN** an AiResource entity declares `spec.type: agent` but omits `spec.instructions` or sets it to an empty string
 - **THEN** the agent schema rejects the entity with an error that names `spec.instructions`
 
+#### Scenario: Wrong-type instructions rejected
+
+- **WHEN** an AiResource entity declares `spec.type: agent` but sets `spec.instructions` to a non-string value (for example a number or array)
+- **THEN** the agent schema rejects the entity with an error that names `spec.instructions`
+
 ---
 
 ### Requirement: Optional fields per design mapping

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-schema/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/specs/ai-resource-agent-schema/spec.md
@@ -18,11 +18,13 @@ AiResource entities that represent agents MUST declare `spec.type` with the exac
 
 ### Requirement: Required agent fields
 
-An agent-shaped AiResource (`spec.type: agent`) MUST include `spec.instructions` as a non-empty string, and MUST include the standard entity identity and ownership fields required of AiResource entities in this workspace (`metadata.name`, `spec.owner`, `spec.lifecycle`). The schema MUST NOT require a separate `spec.name` field; SDK `name` maps to `metadata.name`.
+An agent-shaped AiResource (`spec.type: agent`) MUST include `spec.instructions` as a non-empty string. Entity identity uses `metadata.name` (there is no separate `spec.name`). Standard catalog fields such as `spec.owner` and `spec.lifecycle` remain normal AiResource/entity expectations and are not redefined by this agent schema capability.
+
+These are schema-layer requirements for agent authoring and tests; catalog processor behavior for agent-specific fields is specified under `ai-resource-agent-ingestion`.
 
 #### Scenario: Minimal valid agent accepted
 
-- **WHEN** an AiResource entity declares `spec.type: agent`, non-empty `spec.instructions`, `spec.owner`, `spec.lifecycle`, and a valid `metadata.name`
+- **WHEN** an AiResource entity declares `spec.type: agent`, non-empty `spec.instructions`, and a valid `metadata.name`
 - **THEN** the agent schema accepts the entity
 
 #### Scenario: Missing instructions rejected
@@ -32,15 +34,15 @@ An agent-shaped AiResource (`spec.type: agent`) MUST include `spec.instructions`
 
 ---
 
-### Requirement: Optional fields per spike mapping
+### Requirement: Optional fields per design mapping
 
-The agent schema MUST allow the optional agent fields defined in the spike mapping in this change’s `design.md` (SDK-aligned `AgentConfiguration` core fields under `spec` / `metadata`, not agent-specific annotations). Optional field membership and shapes SHALL follow that mapping table rather than a divergent inventory in code.
+The agent schema MUST allow the optional agent fields defined in this change’s `design.md` mapping table (under `spec` / `metadata`, not agent-specific annotations). Optional field membership and shapes SHALL follow that mapping rather than a divergent inventory in code.
 
 At minimum, the mapping’s optional catalog fields include: `spec.handoffDescription`, `spec.model`, `spec.handoffs` (`string[]`), `spec.tools` (`string[]`), `spec.toolUseBehavior`, `spec.resetToolChoice`, `spec.modelSettings` (`temperature`, `maxTokens`, `toolChoice` only for v1), and `spec.outputSchema`.
 
 #### Scenario: Optional fields from mapping accepted
 
-- **WHEN** a valid agent entity includes optional fields from the spike mapping with correctly typed values
+- **WHEN** a valid agent entity includes optional fields from the design mapping with correctly typed values
 - **THEN** the agent schema accepts the entity
 
 #### Scenario: Omitted optional fields accepted
@@ -62,7 +64,7 @@ At minimum, the mapping’s optional catalog fields include: `spec.handoffDescri
 
 ### Requirement: Agent fields in spec and metadata only
 
-Agent configuration fields from the spike mapping MUST be represented on the entity as `metadata.*` / `spec.*` fields. The agent schema MUST NOT introduce agent-specific annotations for those SDK-aligned configuration fields.
+Agent configuration fields from the design mapping MUST be represented on the entity as `metadata.*` / `spec.*` fields. The agent schema MUST NOT introduce agent-specific annotations for those configuration fields.
 
 #### Scenario: Spec-placed instructions accepted
 
@@ -71,9 +73,9 @@ Agent configuration fields from the spike mapping MUST be represented on the ent
 
 ---
 
-### Requirement: No SDK package dependency
+### Requirement: No OpenAI Agents SDK package dependency
 
-The rhdh-plugins agent schema implementation MUST NOT import `@openai/agents-core` or other OpenAI Agents SDK packages. Field alignment is by documented shape and naming only.
+The rhdh-plugins agent schema implementation MUST NOT import `@openai/agents-core` or other OpenAI Agents SDK packages.
 
 #### Scenario: Schema module has no agents-core import
 
@@ -84,7 +86,7 @@ The rhdh-plugins agent schema implementation MUST NOT import `@openai/agents-cor
 
 ### Requirement: Examples and fixtures for agent entities
 
-The workspace MUST provide example catalog YAML and/or test fixtures that demonstrate a representative agent entity covering required fields and a non-empty subset of optional fields from the spike mapping (including at least one of `handoffs` or `modelSettings`).
+The workspace MUST provide example catalog YAML and/or test fixtures that demonstrate a representative agent entity covering required fields and a non-empty subset of optional fields from the design mapping (including at least one of `handoffs` or `modelSettings`).
 
 #### Scenario: Example catalog YAML exists
 
@@ -100,7 +102,7 @@ The workspace MUST provide example catalog YAML and/or test fixtures that demons
 
 ### Requirement: Schema-layer validation tests
 
-Unit or schema tests MUST cover acceptance of valid agent entities and rejection of clearly invalid shapes at the schema layer (missing required fields, wrong `spec.type` for agent validation, wrong types on optional fields).
+Unit or schema tests MUST cover acceptance of valid agent entities and rejection of clearly invalid shapes at the schema layer (missing required agent fields, wrong `spec.type` for agent validation, wrong types on optional fields).
 
 #### Scenario: Valid agent test passes
 
@@ -116,9 +118,9 @@ Unit or schema tests MUST cover acceptance of valid agent entities and rejection
 
 ### Requirement: Dual-track documentation for agent type
 
-In-repo OpenSpec/design materials for this change MUST describe AiResource agent typing as owned under RHDHPLAN-1507 in rhdh-plugins, with upstream contribution tracked in parallel and not a merge gate. Materials MUST NOT leave agent typing described as blocked solely on RHDHPLAN-1113. The spike mapping table in `design.md` MUST remain the shared field-set source for RHIDP-15866 and RHIDP-15867.
+In-repo OpenSpec/design materials for this change MUST describe AiResource agent typing as owned under RHDHPLAN-1507 in rhdh-plugins, with upstream contribution tracked in parallel and not a merge gate. Materials MUST NOT leave agent typing described as blocked solely on RHDHPLAN-1113. The field mapping table in `design.md` MUST remain the shared field-set source for RHIDP-15866, RHIDP-15867, and RHIDP-15868.
 
-#### Scenario: Design states dual-track ownership and spike mapping
+#### Scenario: Design states dual-track ownership and field mapping
 
 - **WHEN** a reader opens this change’s design/proposal artifacts
-- **THEN** they find explicit dual-track (rhdh-plugins + upstream) language, RHDHPLAN-1507 ownership for the agent type, and the SDK→AiResource mapping table
+- **THEN** they find explicit dual-track (rhdh-plugins + upstream) language, RHDHPLAN-1507 ownership for the agent type, and the AiResource agent field mapping table

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/tasks.md
@@ -1,0 +1,36 @@
+## 1. Locate schema home and baseline
+
+- [ ] 1.1 Find where AiResource / skill entity types (if any) live in this workspace, or choose a package home for agent types (prefer shared common / catalog-adjacent module)
+- [ ] 1.2 Confirm current `spec.type` examples (`skill`) and any docs that still say `agents` (plural) or “pending 1113” for agent typing
+
+## 2. Agent TypeScript schema
+
+- [ ] 2.1 Add TypeScript types for agent-shaped AiResource (`spec.type: 'agent'`) with required `instructions` and optional fields from design D3 spike mapping (`handoffDescription`, `model`, `handoffs`, `tools`, `toolUseBehavior`, `resetToolChoice`, `modelSettings.{temperature,maxTokens,toolChoice}`, `outputSchema`)
+- [ ] 2.2 Add a schema validator or type-guard helper used by tests (no `@openai/agents-core` import; opaque `string[]` for handoffs/tools)
+- [ ] 2.3 Export public types from the chosen package entrypoint / API report as needed
+
+## 3. Examples and fixtures
+
+- [ ] 3.1 Add example `catalog-info.yaml` (under `examples/`) with at least one `kind: AiResource`, `spec.type: agent`, non-empty `spec.instructions`
+- [ ] 3.2 Include optional fields in the example/fixture set (at least `handoffs` or `modelSettings`; prefer a small router + specialist handoff shape)
+- [ ] 3.3 Wire the example into local catalog locations or document how to register it (follow existing skill example pattern)
+
+## 4. Schema / unit tests
+
+- [ ] 4.1 Add tests that accept a minimal valid agent entity
+- [ ] 4.2 Add tests that accept a valid agent with optional SDK-aligned fields populated
+- [ ] 4.3 Add tests that reject missing/empty `spec.instructions`, wrong type discriminator (`agents`), and clearly wrong optional field types
+- [ ] 4.4 Assert schema sources do not depend on OpenAI Agents SDK packages
+
+## 5. Docs and OpenSpec DoD
+
+- [x] 5.1 Record spike mapping in design.md (D3) and thin schema requirements; dual-track + RHDHPLAN-1507 ownership documented
+- [ ] 5.2 Update related workspace docs/examples that still use `spec.type: agents` or imply agent typing is blocked only on RHDHPLAN-1113
+- [ ] 5.3 Update package README (if present) with agent field table / link to examples
+- [x] 5.4 Comment on RHIDP-15866 linking `openspec/changes/airesource-agent-typed-schema/` as spike deliverable
+
+## 6. Verification
+
+- [ ] 6.1 Run targeted unit/schema tests for the new agent schema
+- [ ] 6.2 Run lint/typecheck for touched packages
+- [ ] 6.3 Smoke-check that skill/rule AiResource examples and existing extension processor behavior remain unchanged

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/tasks.md
@@ -2,14 +2,14 @@
 
 ## 1. Locate schema home and baseline
 
-- [ ] 1.1 Find where AiResource / skill entity types (if any) live in this workspace, or choose a package home for agent types (prefer shared common / catalog-adjacent module)
+- [ ] 1.1 Follow design D10: start from upstream `@backstage/catalog-model` alpha AiResource skill/rule types + validators (`SkillAiResourceEntityV1alpha1`, `skillAiResourceEntityV1alpha1Validator`, etc.) and the MCP `mcp-server` API extension (`McpServerApiEntity` / `mcpServerApiEntityValidator`) as the implementation pattern; choose RHDH package home by mirroring how those models are consumed in this workspace
 - [x] 1.2 Correct sibling discovery OpenSpec plural `agents`/`skills` examples to singular `agent`/`skill`; confirm skill examples and remove “pending 1113” agent language where touched
 
 ## 2. Agent TypeScript schema
 
-- [ ] 2.1 Add TypeScript types for agent-shaped AiResource (`spec.type: 'agent'`) with required `instructions` and optional fields from design D3 (`handoffDescription`, `model`, `handoffs`, `tools`, `toolUseBehavior`, `resetToolChoice`, `modelSettings.{temperature,maxTokens,toolChoice}`, `outputSchema`)
-- [ ] 2.2 Add a schema validator or type-guard helper used by tests (no OpenAI Agents SDK import; opaque `string[]` for handoffs/tools)
-- [ ] 2.3 Export public types from the chosen package entrypoint / API report as needed
+- [ ] 2.1 Add an agent AiResource typed variant (union member / local mirror) with `spec.type: 'agent'`, required `instructions`, and optional fields from design D3—matching the skill/rule discriminated-type style (not an ad-hoc standalone interface)
+- [ ] 2.2 Add `KindValidator` + type guard for agent (same shape as `skillAiResourceEntityV1alpha1Validator` / `isSkillAiResourceEntity`); no OpenAI Agents SDK import; opaque `string[]` for handoffs/tools
+- [ ] 2.3 Wire validator into catalog model / backend module registration the way skill/rule (and MCP `mcp-server`) validators are registered; export public types from the chosen package entrypoint / API report as needed
 
 ## 3. Examples and fixtures
 

--- a/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/airesource-agent-typed-schema/tasks.md
@@ -1,12 +1,14 @@
+# Tasks: AiResource Agent Typed Schema
+
 ## 1. Locate schema home and baseline
 
 - [ ] 1.1 Find where AiResource / skill entity types (if any) live in this workspace, or choose a package home for agent types (prefer shared common / catalog-adjacent module)
-- [ ] 1.2 Confirm current `spec.type` examples (`skill`) and any docs that still say `agents` (plural) or “pending 1113” for agent typing
+- [x] 1.2 Correct sibling discovery OpenSpec plural `agents`/`skills` examples to singular `agent`/`skill`; confirm skill examples and remove “pending 1113” agent language where touched
 
 ## 2. Agent TypeScript schema
 
-- [ ] 2.1 Add TypeScript types for agent-shaped AiResource (`spec.type: 'agent'`) with required `instructions` and optional fields from design D3 spike mapping (`handoffDescription`, `model`, `handoffs`, `tools`, `toolUseBehavior`, `resetToolChoice`, `modelSettings.{temperature,maxTokens,toolChoice}`, `outputSchema`)
-- [ ] 2.2 Add a schema validator or type-guard helper used by tests (no `@openai/agents-core` import; opaque `string[]` for handoffs/tools)
+- [ ] 2.1 Add TypeScript types for agent-shaped AiResource (`spec.type: 'agent'`) with required `instructions` and optional fields from design D3 (`handoffDescription`, `model`, `handoffs`, `tools`, `toolUseBehavior`, `resetToolChoice`, `modelSettings.{temperature,maxTokens,toolChoice}`, `outputSchema`)
+- [ ] 2.2 Add a schema validator or type-guard helper used by tests (no OpenAI Agents SDK import; opaque `string[]` for handoffs/tools)
 - [ ] 2.3 Export public types from the chosen package entrypoint / API report as needed
 
 ## 3. Examples and fixtures
@@ -18,19 +20,26 @@
 ## 4. Schema / unit tests
 
 - [ ] 4.1 Add tests that accept a minimal valid agent entity
-- [ ] 4.2 Add tests that accept a valid agent with optional SDK-aligned fields populated
+- [ ] 4.2 Add tests that accept a valid agent with optional mapped fields populated
 - [ ] 4.3 Add tests that reject missing/empty `spec.instructions`, wrong type discriminator (`agents`), and clearly wrong optional field types
 - [ ] 4.4 Assert schema sources do not depend on OpenAI Agents SDK packages
 
-## 5. Docs and OpenSpec DoD
+## 5. Catalog processor validation (RHIDP-15868)
 
-- [x] 5.1 Record spike mapping in design.md (D3) and thin schema requirements; dual-track + RHDHPLAN-1507 ownership documented
-- [ ] 5.2 Update related workspace docs/examples that still use `spec.type: agents` or imply agent typing is blocked only on RHDHPLAN-1113
-- [ ] 5.3 Update package README (if present) with agent field table / link to examples
-- [x] 5.4 Comment on RHIDP-15866 linking `openspec/changes/airesource-agent-typed-schema/` as spike deliverable
+- [ ] 5.1 Extend the AiResource extensions processor to validate agent-specific fields when `spec.type: agent`
+- [ ] 5.2 Reject missing/empty `spec.instructions` and wrong optional agent field shapes with actionable errors
+- [ ] 5.3 Do not enforce entity-ref format on `handoffs` / `tools`; do not add new owner/lifecycle processor rules
+- [ ] 5.4 Add processor tests for accept and reject paths; ensure non-agent AiResources are unaffected
 
-## 6. Verification
+## 6. Docs and OpenSpec DoD
 
-- [ ] 6.1 Run targeted unit/schema tests for the new agent schema
-- [ ] 6.2 Run lint/typecheck for touched packages
-- [ ] 6.3 Smoke-check that skill/rule AiResource examples and existing extension processor behavior remain unchanged
+- [x] 6.1 Record field mapping in design.md (D3), thin schema + ingestion requirements, dual-track + RHDHPLAN-1507 ownership
+- [ ] 6.2 Update related workspace docs that still imply agent typing is blocked only on RHDHPLAN-1113
+- [ ] 6.3 Update package README (if present) with agent field table / link to examples
+- [x] 6.4 Comment on RHIDP-15866 linking `openspec/changes/airesource-agent-typed-schema/` as spike deliverable
+
+## 7. Verification
+
+- [ ] 7.1 Run targeted unit/schema and processor tests for agent coverage
+- [ ] 7.2 Run lint/typecheck for touched packages
+- [ ] 7.3 Smoke-check that skill/rule AiResource examples and non-agent extension processor behavior remain unchanged


### PR DESCRIPTION
## Summary
- Add OpenSpec change `airesource-agent-typed-schema` capturing the RHIDP-15866 spike field mapping (OpenAI Agents SDK `AgentConfiguration` → AiResource `metadata`/`spec`) and thin RHIDP-15867 schema requirements.
- Document dual-track approach (rhdh-plugins first under RHDHPLAN-1507; upstream RFC/PR parallel via RHIDP-15869) and keep processor validation (RHIDP-15868) out of scope.
- No implementation code in this PR — docs/OpenSpec only (`.claude/` resources intentionally excluded).

## Test plan
- [ ] Review `design.md` D3 mapping table against agreed spike decisions
- [ ] Confirm `specs/ai-resource-agent-schema/spec.md` stays thin (required `instructions` + optional fields per mapping)

Resolves: RHIDP-15866 (spike deliverable)
Related: RHIDP-15867, RHIDP-15865


Made with [Cursor](https://cursor.com)