### PR TITLE
chore(fullsend): add rhdh-coding skill to code and fix agents

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -22,6 +22,7 @@ roles:
 allowed_remote_resources:
     - https://raw.githubusercontent.com/fullsend-ai/fullsend/
     - https://raw.githubusercontent.com/fullsend-ai/agents/
+    - https://github.com/redhat-developer/rhdh-skill/
 create_issues:
     allow_targets:
         repos:

--- a/.fullsend/rhdh/harness/code.yaml
+++ b/.fullsend/rhdh/harness/code.yaml
@@ -1,6 +1,8 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/code.yaml#sha256=050382941bb4c4a3dad5f00253de854684c0d22dd8cc1ca0a548079774470aad
 agent: rhdh/agents/code.md
 policy: rhdh/policies/code.yaml
+skills:
+  - https://github.com/redhat-developer/rhdh-skill/tree/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn

--- a/.fullsend/rhdh/harness/fix.yaml
+++ b/.fullsend/rhdh/harness/fix.yaml
@@ -1,6 +1,8 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/fix.yaml#sha256=f966f0b8cd9b58289f19b446cfc4fd343c9079d9c9acee0260824b57e896e068
 agent: rhdh/agents/fix.md
 policy: rhdh/policies/code.yaml
+skills:
+  - https://github.com/redhat-developer/rhdh-skill/tree/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn


### PR DESCRIPTION
## Summary

Re-applies #4023 (reverted in #4080) with the correct URL format for fullsend skill directories.

**What broke:** The previous PR used `raw.githubusercontent.com` URLs for skills. Skills are directories (not single files) and must use the `github.com/{owner}/{repo}/tree/{ref}/{path}` format so fullsend's `ParseForgeURL` validation passes and the directory tree can be fetched via git sparse checkout.

**What's fixed:**
- Skill URLs now use `https://github.com/redhat-developer/rhdh-skill/tree/<commit>/skills/rhdh-coding#sha256=<hash>`
- `allowed_remote_resources` uses `https://github.com/redhat-developer/rhdh-skill/` to match the skill URL prefix

## Changes

| File | Change |
|------|--------|
| `.fullsend/config.yaml` | Add `https://github.com/redhat-developer/rhdh-skill/` to `allowed_remote_resources` |
| `.fullsend/rhdh/harness/code.yaml` | Add `rhdh-coding` skill with correct `github.com/tree/` URL |
| `.fullsend/rhdh/harness/fix.yaml` | Add `rhdh-coding` skill with correct `github.com/tree/` URL |

## Why this format

From fullsend source (`internal/harness/harness.go` ValidateResourceTypes):
- Skills are validated via `forge.ParseForgeURL()` which requires `github.com/{owner}/{repo}/tree/{ref}/{path}`
- `raw.githubusercontent.com` is only used for single-file resources (harness `base:` field)
- Skills are fetched as directory trees via `gitfetch.FetchTree` (git sparse checkout)

## Test plan

- [ ] Trigger `/fs-code` on a test issue and verify the `rhdh-coding` skill is uploaded to the sandbox
- [ ] Confirm harness validation passes (no `ParseForgeURL` errors)
- [ ] Verify the skill's tree hash matches after fetch (`ComputeTreeHash` integrity check)

Made with [Cursor](https://cursor.com)