### PR TITLE
refactor(install-dynamic-plugins): extract protocol constants and predicates

### DIFF
--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/catalog-index.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/catalog-index.ts
@@ -21,12 +21,8 @@ import { InstallException } from './errors';
 import { log } from './log';
 import { resolveImage } from './image-resolver';
 import { type Skopeo } from './skopeo';
-import {
-  DOCKER_PROTO,
-  DPDY_FILENAME,
-  MAX_ENTRY_SIZE,
-  OCI_PROTO,
-} from './types';
+import { DOCKER_PROTO, isDockerUrl, OCI_PROTO } from './protocols';
+import { DPDY_FILENAME, MAX_ENTRY_SIZE } from './types';
 import { fileExists, isAllowedEntryType, isInside } from './util';
 
 type OciManifest = {
@@ -98,7 +94,7 @@ export async function extractCatalogIndexLayers(
     path.join(os.tmpdir(), 'rhdh-catalog-index-'),
   );
   try {
-    const url = resolved.startsWith(DOCKER_PROTO)
+    const url = isDockerUrl(resolved)
       ? resolved
       : `${DOCKER_PROTO}${resolved.replace(OCI_PROTO, '')}`;
     const localDir = path.join(workDir, 'idx');

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.ts
@@ -20,7 +20,7 @@ import { InstallException } from './errors';
 import { log } from './log';
 import { resolveImage } from './image-resolver';
 import { type Skopeo } from './skopeo';
-import { DOCKER_PROTO, OCI_PROTO } from './types';
+import { DOCKER_PROTO, OCI_PROTO } from './protocols';
 
 type OciManifest = {
   layers?: Array<{ digest: string }>;

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-resolver.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-resolver.ts
@@ -15,7 +15,8 @@
  */
 import { log } from './log';
 import { type Skopeo } from './skopeo';
-import { DOCKER_PROTO, OCI_PROTO, RHDH_FALLBACK, RHDH_REGISTRY } from './types';
+import { DOCKER_PROTO, isDockerUrl, isOciUrl, OCI_PROTO } from './protocols';
+import { RHDH_FALLBACK, RHDH_REGISTRY } from './types';
 
 /**
  * Resolve a (possibly oci:// / docker://) image reference. If it points at
@@ -38,9 +39,9 @@ export async function resolveImage(
 }
 
 function stripProto(image: string): { proto: string; raw: string } {
-  if (image.startsWith(OCI_PROTO))
+  if (isOciUrl(image))
     return { proto: OCI_PROTO, raw: image.slice(OCI_PROTO.length) };
-  if (image.startsWith(DOCKER_PROTO))
+  if (isDockerUrl(image))
     return { proto: DOCKER_PROTO, raw: image.slice(DOCKER_PROTO.length) };
   return { proto: '', raw: image };
 }

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-npm.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-npm.ts
@@ -20,6 +20,7 @@ import { verifyIntegrity } from './integrity';
 import { log } from './log';
 import { run } from './run';
 import { extractNpmPackage } from './tar-extract';
+import { isLocalPath } from './protocols';
 import { CONFIG_HASH_FILE, isPluginDisabled, type Plugin } from './types';
 import { markAsFresh } from './util';
 
@@ -57,7 +58,7 @@ export async function installNpmPlugin(
   const pkg = plugin.package;
   const config: Record<string, unknown> = plugin.pluginConfig ?? {};
 
-  const isLocal = pkg.startsWith('./');
+  const isLocal = isLocalPath(pkg);
   const actualPkg = isLocal ? path.join(process.cwd(), pkg.slice(2)) : pkg;
 
   const verifyRemoteIntegrity = !isLocal && !skipIntegrity;

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer.ts
@@ -45,6 +45,7 @@ import {
 } from './merger';
 import { computePluginHash } from './plugin-hash';
 import { Skopeo } from './skopeo';
+import { isLocalPath, isOciUrl } from './protocols';
 import {
   CONFIG_HASH_FILE,
   DPDY_FILENAME,
@@ -53,7 +54,6 @@ import {
   GLOBAL_CONFIG_FILENAME,
   isPluginDisabled,
   LOCK_FILENAME,
-  OCI_PROTO,
   type Plugin,
   type PluginMap,
   type PluginSpec,
@@ -379,11 +379,11 @@ function categorize(allPlugins: PluginMap): Categorized {
       log(`\n======= Skipping disabled plugin ${plugin.package}`);
       continue;
     }
-    if (plugin.package.startsWith(OCI_PROTO)) {
+    if (isOciUrl(plugin.package)) {
       oci.push(plugin);
       continue;
     }
-    if (plugin.package.startsWith('./')) {
+    if (isLocalPath(plugin.package)) {
       const localPath = path.join(process.cwd(), plugin.package.slice(2));
       if (existsSync(localPath)) npm.push(plugin);
       else skipped.push(plugin);

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.ts
@@ -24,10 +24,10 @@ import {
   type ParsedOciKey,
   tryParseOciRegistryAndPath,
 } from './oci-key';
+import { isOciUrl, OCI_PROTO } from './protocols';
 import {
   type DynamicPluginsConfig,
   isPluginDisabled,
-  OCI_PROTO,
   type Plugin,
   type PluginMap,
   type PluginSpec,
@@ -137,7 +137,7 @@ export async function mergePlugin(
       `content of the 'plugins.package' field must be a string in ${configFile}`,
     );
   }
-  if (plugin.package.startsWith(OCI_PROTO)) {
+  if (isOciUrl(plugin.package)) {
     await mergeOciPlugin(plugin, allPlugins, configFile, level, imageCache);
   } else {
     mergeNpmPlugin(plugin, allPlugins, configFile, level);
@@ -431,7 +431,7 @@ function processOciEntry(
   sourceFile: string,
 ): void {
   const pkg = plugin.package;
-  if (typeof pkg !== 'string' || !pkg.startsWith(OCI_PROTO)) return;
+  if (typeof pkg !== 'string' || !isOciUrl(pkg)) return;
   const disabled = isPluginDisabled(plugin);
   const parsed = tryParseOciRegistryAndPath(pkg);
   if (!parsed) {
@@ -555,7 +555,7 @@ export function filterDisabledOciPlugins(
   const out: PluginSpec[] = [];
   for (const plugin of plugins) {
     const pkg = plugin.package;
-    if (typeof pkg === 'string' && pkg.startsWith(OCI_PROTO)) {
+    if (typeof pkg === 'string' && isOciUrl(pkg)) {
       const parsed = tryParseOciRegistryAndPath(pkg);
       if (parsed && disabledRegistries.has(parsed.registry)) {
         log(`\n======= Disabling OCI plugin ${pkg}`);

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/npm-key.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/npm-key.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isLocalPath } from './protocols';
 
 // [@scope/]name[@version]
 const NPM_PACKAGE_PATTERN = /^(@[^/]+\/)?([^@]+)(?:@(.+))?$/;
@@ -32,7 +33,7 @@ const GIT_URL_PATTERNS: RegExp[] = [
 
 export function npmPluginKey(pkg: string): string {
   // Local packages and tarballs have no version to strip.
-  if (pkg.startsWith('./') || pkg.endsWith('.tgz')) return pkg;
+  if (isLocalPath(pkg) || pkg.endsWith('.tgz')) return pkg;
 
   // Aliases: "my-alias@npm:real-pkg@1.2.3" -> "my-alias@npm:real-pkg"
   const aliasKey = tryParseAlias(pkg);

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/oci-key.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/oci-key.ts
@@ -16,7 +16,8 @@
 import { InstallException } from './errors';
 import { log } from './log';
 import { type OciImageCache } from './image-cache';
-import { OCI_PROTO, RECOGNIZED_ALGORITHMS } from './types';
+import { OCI_PROTO } from './protocols';
+import { RECOGNIZED_ALGORITHMS } from './types';
 
 const OCI_PATTERN = [
   '^(',

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/plugin-hash.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/plugin-hash.ts
@@ -16,6 +16,7 @@
 import { createHash } from 'node:crypto';
 import { statSync, existsSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
+import { isLocalPath } from './protocols';
 import { type Plugin } from './types';
 
 /**
@@ -41,7 +42,7 @@ export function computePluginHash(plugin: Plugin): string {
       continue;
     copy[k] = v;
   }
-  if (plugin.package.startsWith('./')) {
+  if (isLocalPath(plugin.package)) {
     copy._local_package_info = localPackageInfo(plugin.package);
   }
   const serialized = stableStringify(copy);

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/protocols.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/protocols.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DOCKER_PROTO = 'docker://';
+export const OCI_PROTO = 'oci://';
+
+export function isOciUrl(value: string): boolean {
+  return value.startsWith(OCI_PROTO);
+}
+
+export function isDockerUrl(value: string): boolean {
+  return value.startsWith(DOCKER_PROTO);
+}
+
+export function isHttpUrl(value: string): boolean {
+  return value.startsWith('https://') || value.startsWith('http://');
+}
+
+export function isLocalPath(value: string): boolean {
+  return value.startsWith('./');
+}

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/types.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/types.ts
@@ -70,8 +70,6 @@ export type DynamicPluginsConfig = {
   plugins?: PluginSpec[];
 };
 
-export const DOCKER_PROTO = 'docker://';
-export const OCI_PROTO = 'oci://';
 /**
  * Tag suffix that, by convention, opts an OCI plugin into `pullPolicy: Always`
  * when no explicit policy is set — mirrors the Python script's behaviour and


### PR DESCRIPTION
Move `DOCKER_PROTO` and `OCI_PROTO` out of `types.ts` into a dedicated `protocols.ts` module and add predicate functions (`isOciUrl`, `isDockerUrl`, `isHttpUrl`, `isLocalPath`) to replace scattered `startsWith` checks across the codebase.