### PR TITLE
fix(theme): make `app` optional in config schema

### DIFF
--- a/workspaces/theme/.changeset/smart-flies-ring.md
+++ b/workspaces/theme/.changeset/smart-flies-ring.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Made `app` optional in config schema to avoid requiring it when no branding is configured

--- a/workspaces/theme/plugins/theme/config.d.ts
+++ b/workspaces/theme/plugins/theme/config.d.ts
@@ -20,7 +20,7 @@
 // Keep in sync with ThemeConfig and related types in src/types.ts.
 
 export interface Config {
-  app: {
+  app?: {
     branding?: {
       /**
        * Theme configuration.


### PR DESCRIPTION
## Summary
- Makes the `app` property optional in the theme plugin's `config.d.ts` schema
- Avoids requiring the `app` key when no branding is configured

## Test plan
- [ ] Verify the theme plugin works without an `app` key in `app-config.yaml`
- [ ] Verify existing configurations with `app.branding` still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)