### PR TITLE
feat(orchestrator): expose RJSF widget config to templates

### DIFF
--- a/workspaces/orchestrator/.changeset/public-rjsf-widget-config.md
+++ b/workspaces/orchestrator/.changeset/public-rjsf-widget-config.md
@@ -1,6 +1,5 @@
 ---
 '@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
-'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
 ---
 
 Expose the dedicated `orchestrator.rjsf-widgets` configuration namespace to form widget templates. Values in this namespace are public to the frontend and must not contain secrets.

--- a/workspaces/orchestrator/.changeset/public-rjsf-widget-config.md
+++ b/workspaces/orchestrator/.changeset/public-rjsf-widget-config.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': patch
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
+---
+
+Expose the dedicated `orchestrator.rjsf-widgets` configration namespace to form widget templates. Values in this namespace are public to the frontend and must not contain secrets.

--- a/workspaces/orchestrator/.changeset/public-rjsf-widget-config.md
+++ b/workspaces/orchestrator/.changeset/public-rjsf-widget-config.md
@@ -3,4 +3,4 @@
 '@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': patch
 ---
 
-Expose the dedicated `orchestrator.rjsf-widgets` configration namespace to form widget templates. Values in this namespace are public to the frontend and must not contain secrets.
+Expose the dedicated `orchestrator.rjsf-widgets` configuration namespace to form widget templates. Values in this namespace are public to the frontend and must not contain secrets.

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -728,6 +728,16 @@ The widgets manage waiting for asynchronous promises and chains of functions to 
 When exposing additional keys in the future, we will consider not only the [frontend-visibility](https://backstage.io/docs/conf/defining/#visibility) but security as well, since a malicious workflow can retrieve configuration of plugins or Backstage, eventually with their secrets.
 That’s the reason for listing the exposed keys explicitly.
 
+Values referenced through `rjsfConfig` are configured under `orchestrator.rjsf-widgets`:
+
+```yaml
+orchestrator:
+  rjsf-widgets:
+    defaultEnvironment: production
+```
+
+All values in this namespace are exposed to the frontend and must not contain secrets.
+
 |                                 Key Family                                  |                                                      Key                                                       |                                                                                                                                                                                                                                     Value of at runtime\<br\>(skipping promises for simplicity)                                                                                                                                                                                                                                     |
 | :-------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                   current                                   |                                           \[whatever property name\]                                           |                                                                                                                    Value of other field/property of the form. The properties build hierarchy separated by `.` (dots) matching the structure of fields/objects defined by the data input schema. Arrays or branches of a complex object structure can be passed as well, data are encoded into JSON in that case.                                                                                                                    |

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -84,7 +84,7 @@ export interface Config {
       url: string;
     };
     /**
-     * Public string values available to form widget templates through `rjsfConfig.<key>.
+     * Public string values available to form widget templates through `rjsfConfig.<key>`.
      * Do not store secrets in this configuration because workflow authors can access every value.
      * @deepVisibility frontend
      */

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -84,6 +84,14 @@ export interface Config {
       url: string;
     };
     /**
+     * Public string values available to form widget templates through `rjsfConfig.<key>.
+     * Do not store secrets in this configuration because workflow authors can access every value.
+     * @deepVisibility frontend
+     */
+    'rjsf-widgets'?: {
+      [key: string]: string;
+    };
+    /**
      * Kafka configuration for event-triggered workflows (KafkaJS-style).
      * When present, the UI can show actions such as "Run as Event".
      * @visibility frontend

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
@@ -121,6 +121,17 @@ describe('useTemplateUnitEvaluator', () => {
     );
   });
 
+  it('evaluates rjsfConfig.* units from public widget configuration', async () => {
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('rjsfConfig.defaultEnvironment', {} as any),
+    ).resolves.toBe('from-config');
+    expect(configApi.getOptionalString).toHaveBeenCalledWith(
+      'orchestrator.rjsf-widgets.defaultEnvironment'
+    );
+  });
+
   it('evaluates fetch response selector units', async () => {
     mockedApplySelectorString.mockResolvedValue('resolved-value');
     const { result } = renderHook(() => useTemplateUnitEvaluator());

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
@@ -128,7 +128,7 @@ describe('useTemplateUnitEvaluator', () => {
       result.current('rjsfConfig.defaultEnvironment', {} as any),
     ).resolves.toBe('from-config');
     expect(configApi.getOptionalString).toHaveBeenCalledWith(
-      'orchestrator.rjsf-widgets.defaultEnvironment'
+      'orchestrator.rjsf-widgets.defaultEnvironment',
     );
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Expose `orchestrator.rjsf-widgets` as frontend configuration so workflow form templates can access public string values through `rjsfConfig.<key>`

- Add the frontend visible configuration schema.
- Add evaluator test coverage for `rjsfConfig`
- Document configuration and usage and warn that values are public and must not contain secrets

#### Example Usage

```yaml
orchestrator:
  rjsf-widgets:
    defaultEnvironment: production
```

- The form widget evaluator already resolves [`rjsfConfig.<key>`](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.ts#L224-L227). However, this namespace was not declared as frontend visible in the Backstage config schema, so its values were filtered out before reaching the frontend

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
