### PR TITLE
fix(fullsend): allow rhdh-skill URLs on code and fix harnesses

### DIFF
--- a/.fullsend/rhdh/harness/code.yaml
+++ b/.fullsend/rhdh/harness/code.yaml
@@ -3,6 +3,10 @@ agent: rhdh/agents/code.md
 policy: rhdh/policies/code.yaml
 skills:
   - https://github.com/redhat-developer/rhdh-skill/tree/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
+# Harness-level allowlist required for URL skills (not inherited from base or
+# config.yaml). Must also be covered by config.yaml allowed_remote_resources.
+allowed_remote_resources:
+  - https://github.com/redhat-developer/rhdh-skill/
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn

--- a/.fullsend/rhdh/harness/fix.yaml
+++ b/.fullsend/rhdh/harness/fix.yaml
@@ -3,6 +3,10 @@ agent: rhdh/agents/fix.md
 policy: rhdh/policies/code.yaml
 skills:
   - https://github.com/redhat-developer/rhdh-skill/tree/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded
+# Harness-level allowlist required for URL skills (not inherited from base or
+# config.yaml). Must also be covered by config.yaml allowed_remote_resources.
+allowed_remote_resources:
+  - https://github.com/redhat-developer/rhdh-skill/
 host_files:
   - src: rhdh/bin/yarn
     dest: /sandbox/workspace/bin/yarn


### PR DESCRIPTION
## Summary
- Code/fix dispatch was failing with `URL .../rhdh-skill/.../rhdh-coding is not in allowed_remote_resources` (e.g. [run 30655318049](https://github.com/redhat-developer/rhdh-plugins/actions/runs/30655318049/job/91238191583)).
- [#4096](https://github.com/redhat-developer/rhdh-plugins/pull/4096) added the skill and the **config.yaml** allowlist, but URL skills are resolved against the **harness** `allowed_remote_resources`, which is not inherited from `base:` or config.
- Add `https://github.com/redhat-developer/rhdh-skill/` to `.fullsend/rhdh/harness/{code,fix}.yaml` (still covered by the existing config.yaml entry).

## Test plan
- [ ] Confirm CI/dispatch for a `/fs-code` (or issue code trigger) gets past remote resource resolution
- [ ] Spot-check that harness prefixes remain covered by `.fullsend/config.yaml` `allowed_remote_resources`


Made with [Cursor](https://cursor.com)