### PR TITLE
fix(intelligent-assistant): unify notebook terminology from document to resource

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/gentle-pandas-unite.md
+++ b/workspaces/intelligent-assistant/.changeset/gentle-pandas-unite.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': patch
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': patch
+---
+
+Unify notebook terminology from "document" to "resource" across all UI strings, translations, and backend messages.

--- a/workspaces/intelligent-assistant/e2e-tests/pages/NotebookAddDocumentModalPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/NotebookAddDocumentModalPage.ts
@@ -20,7 +20,7 @@ import type { LightspeedMessages } from '../utils/translations';
 import { substituteNotebookTemplate } from '../utils/notebookTranslation';
 
 /**
- * “Add a document to Notebook” modal: staged files, browse picker, localized Add(n).
+ * “Add a resource to Notebook” modal: staged files, browse picker, localized Add(n).
  */
 export class NotebookAddDocumentModalPage {
   constructor(

--- a/workspaces/intelligent-assistant/e2e-tests/pages/NotebookSurfacePage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/NotebookSurfacePage.ts
@@ -121,7 +121,7 @@ export class NotebookSurfacePage {
     });
   }
 
-  /** Composer stub while no documents are attached. */
+  /** Composer stub while no resources are attached. */
   disabledComposerPlaceholder(): Locator {
     return this.chatbotRegion().getByRole('textbox', {
       name: this.t['notebook.view.input.placeholder'],
@@ -180,7 +180,7 @@ export class NotebookSurfacePage {
   }
 
   /**
-   * New notebook with no documents: upload prompts, disclaimer, disabled composer (+ tooltip when hovered), sidebar Add.
+   * New notebook with no resources: upload prompts, disclaimer, disabled composer (+ tooltip when hovered), sidebar Add.
    */
   async expectNewNotebookEditorEmptyStateOnboarding(): Promise<void> {
     await expect(this.closeNotebookButton()).toBeVisible();
@@ -295,7 +295,7 @@ export class NotebookSurfacePage {
     await card.getByText(NOTEBOOK_UNTITLED_GRID_NAME, { exact: true }).click();
   }
 
-  /** Shown again when no documents remain in the sidebar list. */
+  /** Shown again when no resources remain in the sidebar list. */
   async expectNotebookEditorUploadResourceButtonVisible(
     timeout = 5_000,
   ): Promise<void> {

--- a/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
@@ -374,7 +374,7 @@ function createNotebookLightspeedRouteHandler(page: Page) {
     if (!docsFor(sid).has(docId)) {
       await route.fulfill({
         status: 404,
-        json: { status: 'error', error: 'Document not found' },
+        json: { status: 'error', error: 'Resource not found' },
       });
       return true;
     }

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/notebooks/documents/documentService.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/notebooks/documents/documentService.ts
@@ -153,7 +153,7 @@ export class DocumentService {
 
       if (conflictingFile) {
         throw new ConflictError(
-          `A document with the title "${newTitle || title}" already exists in this session`,
+          `A resource with the title "${newTitle || title}" already exists in this session`,
         );
       }
     }
@@ -205,7 +205,7 @@ export class DocumentService {
     const file = await this.findFileByTitle(sessionId, documentTitle);
 
     if (!file) {
-      throw new NotFoundError(`Document not found: ${documentTitle}`);
+      throw new NotFoundError(`Resource not found: ${documentTitle}`);
     }
     return {
       status: file.status,
@@ -274,7 +274,7 @@ export class DocumentService {
     const file = await this.findFileByTitle(sessionId, documentTitle);
 
     if (!file) {
-      throw new NotFoundError(`Document not found: ${documentTitle}`);
+      throw new NotFoundError(`Resource not found: ${documentTitle}`);
     }
 
     // Delete from vector store first

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/notebooks/notebooksRouters.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/notebooks/notebooksRouters.ts
@@ -405,7 +405,7 @@ export async function createNotebooksRouter(
         status: 'processing',
         document_id: newTitle || title,
         session_id: sessionId,
-        message: 'Document upload started',
+        message: 'Resource upload started',
       });
 
       // Upload document to vector store in background
@@ -451,7 +451,7 @@ export async function createNotebooksRouter(
         createDocumentResponse(
           documentId,
           sessionId,
-          'Document deleted successfully',
+          'Resource deleted successfully',
         ),
       );
     }),

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/AddDocumentModal.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/AddDocumentModal.test.tsx
@@ -50,7 +50,7 @@ describe('AddDocumentModal', () => {
   it('should render the modal when open', () => {
     render(<AddDocumentModal {...defaultProps} />);
 
-    expect(screen.getByText('Add a document to Notebook')).toBeInTheDocument();
+    expect(screen.getByText('Add a resource to Notebook')).toBeInTheDocument();
     expect(screen.getByText('Drag and drop files here')).toBeInTheDocument();
   });
 

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/de.ts
@@ -229,16 +229,16 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
     'notebook.upload.modal.selectedFiles':
       '{{count}} von {{max}} Dateien ausgewählt',
     'notebook.upload.modal.separator': 'oder',
-    'notebook.upload.modal.title': 'Dokument zum Notizbuch hinzufügen',
+    'notebook.upload.modal.title': 'Ressource zum Notizbuch hinzufügen',
     'notebook.view.close': 'Notizbuch schließen',
     'notebook.view.documents.add': 'Hinzufügen',
-    'notebook.view.documents.count': '{{count}} Dokumente',
+    'notebook.view.documents.count': '{{count}} Ressourcen',
     'notebook.view.documents.maxReached':
-      'Maximal 10 Dokumente sind erlaubt. Löschen Sie ein Dokument, um ein neues hochzuladen.',
-    'notebook.view.documents.uploading': 'Dokument wird hochgeladen',
+      'Maximal 10 Ressourcen sind erlaubt. Löschen Sie eine Ressource, um eine neue hochzuladen.',
+    'notebook.view.documents.uploading': 'Ressource wird hochgeladen',
     'notebook.view.input.disabledTooltip':
       'Wählen Sie mindestens eine geladene Ressource aus, um den Chat zu starten',
-    'notebook.view.input.placeholder': 'Fragen Sie zu Ihren Dokumenten...',
+    'notebook.view.input.placeholder': 'Fragen Sie zu Ihren Ressourcen...',
     'notebook.view.sidebar.collapse': 'Seitenleiste einklappen',
     'notebook.view.sidebar.expand': 'Seitenleiste ausklappen',
     'notebook.view.sidebar.resize': 'Größe der Seitenleiste ändern',
@@ -257,7 +257,7 @@ const intelligentAssistantTranslationDe = createTranslationMessages({
       'Dieses Notizbuch wird hier nicht mehr angezeigt. Dadurch werden auch zugehörige Aktivitäten wie Eingaben, Antworten und Feedback aus Ihrer Aktivität gelöscht.',
     'notebooks.delete.title': '{{name}} löschen?',
     'notebooks.delete.toast': 'Notizbuch gelöscht!',
-    'notebooks.documents': 'Dokumente',
+    'notebooks.documents': 'Ressourcen',
     'notebooks.empty.action': 'Neues Notizbuch erstellen',
     'notebooks.empty.description':
       'Erstellen Sie ein neues Notizbuch, um Ihre Quellen zu organisieren und KI-gestützte Erkenntnisse zu gewinnen.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/es.ts
@@ -226,16 +226,16 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
     'notebook.upload.modal.selectedFiles':
       '{{count}} de {{max}} archivos seleccionados',
     'notebook.upload.modal.separator': 'o',
-    'notebook.upload.modal.title': 'Agregar un documento al cuaderno',
+    'notebook.upload.modal.title': 'Agregar un recurso al cuaderno',
     'notebook.view.close': 'Cerrar cuaderno',
     'notebook.view.documents.add': 'Agregar',
-    'notebook.view.documents.count': '{{count}} Documentos',
+    'notebook.view.documents.count': '{{count}} Recursos',
     'notebook.view.documents.maxReached':
-      'Se permiten un máximo de 10 documentos. Elimina un documento para subir uno nuevo.',
-    'notebook.view.documents.uploading': 'Subiendo documento',
+      'Se permiten un máximo de 10 recursos. Elimina un recurso para subir uno nuevo.',
+    'notebook.view.documents.uploading': 'Subiendo recurso',
     'notebook.view.input.disabledTooltip':
       'Selecciona al menos un recurso cargado para comenzar a chatear',
-    'notebook.view.input.placeholder': 'Pregunta sobre tus documentos...',
+    'notebook.view.input.placeholder': 'Pregunta sobre tus recursos...',
     'notebook.view.sidebar.collapse': 'Contraer barra lateral',
     'notebook.view.sidebar.expand': 'Expandir barra lateral',
     'notebook.view.sidebar.resize': 'Redimensionar barra lateral',
@@ -253,7 +253,7 @@ const intelligentAssistantTranslationEs = createTranslationMessages({
       'Ya no verás este cuaderno aquí. Esto también eliminará actividad relacionada como solicitudes, respuestas y comentarios de tu actividad.',
     'notebooks.delete.title': '¿Eliminar {{name}}?',
     'notebooks.delete.toast': '¡Cuaderno eliminado!',
-    'notebooks.documents': 'Documentos',
+    'notebooks.documents': 'Recursos',
     'notebooks.empty.action': 'Crear un cuaderno nuevo',
     'notebooks.empty.description':
       'Crea un nuevo cuaderno para organizar tus fuentes y generar información con IA.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/fr.ts
@@ -228,17 +228,17 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
     'notebook.upload.modal.selectedFiles':
       '{{count}} sur {{max}} fichiers sélectionnés',
     'notebook.upload.modal.separator': 'ou',
-    'notebook.upload.modal.title': 'Ajouter un document au carnet',
+    'notebook.upload.modal.title': 'Ajouter une ressource au carnet',
     'notebook.view.close': 'Fermer le carnet',
     'notebook.view.documents.add': 'Ajouter',
-    'notebook.view.documents.count': '{{count}} Documents',
+    'notebook.view.documents.count': '{{count}} Ressources',
     'notebook.view.documents.maxReached':
-      'Maximum 10 documents autorisés. Supprimez un document pour en charger un nouveau.',
-    'notebook.view.documents.uploading': 'Chargement du document',
+      'Maximum 10 ressources autorisées. Supprimez une ressource pour en charger une nouvelle.',
+    'notebook.view.documents.uploading': 'Chargement de la ressource',
     'notebook.view.input.disabledTooltip':
       'Sélectionnez au moins une ressource chargée pour commencer à discuter',
     'notebook.view.input.placeholder':
-      'Posez des questions sur vos documents...',
+      'Posez des questions sur vos ressources...',
     'notebook.view.sidebar.collapse': 'Réduire la barre latérale',
     'notebook.view.sidebar.expand': 'Développer la barre latérale',
     'notebook.view.sidebar.resize': 'Redimensionner la barre latérale',
@@ -256,7 +256,7 @@ const intelligentAssistantTranslationFr = createTranslationMessages({
       'Vous ne verrez plus ce carnet ici. Cela supprimera également l’activité associée comme les requêtes, réponses et retours depuis votre activité.',
     'notebooks.delete.title': 'Supprimer {{name}} ?',
     'notebooks.delete.toast': 'Carnet supprimé !',
-    'notebooks.documents': 'Documents',
+    'notebooks.documents': 'Ressources',
     'notebooks.empty.action': 'Créer un nouveau carnet',
     'notebooks.empty.description':
       'Créez un nouveau carnet pour organiser vos sources et générer des informations alimentées par l’IA.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/it.ts
@@ -226,17 +226,17 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
     'notebook.upload.modal.selectedFiles':
       '{{count}} di {{max}} file selezionati',
     'notebook.upload.modal.separator': 'o',
-    'notebook.upload.modal.title': 'Aggiungi un documento al quaderno',
+    'notebook.upload.modal.title': 'Aggiungi una risorsa al quaderno',
     'notebook.view.close': 'Chiudi quaderno',
     'notebook.view.documents.add': 'Aggiungi',
-    'notebook.view.documents.count': '{{count}} Documenti',
+    'notebook.view.documents.count': '{{count}} Risorse',
     'notebook.view.documents.maxReached':
-      'Sono consentiti al massimo 10 documenti. Elimina un documento per caricarne uno nuovo.',
-    'notebook.view.documents.uploading': 'Caricamento documento',
+      'Sono consentite al massimo 10 risorse. Elimina una risorsa per caricarne una nuova.',
+    'notebook.view.documents.uploading': 'Caricamento risorsa',
     'notebook.view.input.disabledTooltip':
       'Seleziona almeno una risorsa caricata per iniziare a chattare',
     'notebook.view.input.placeholder':
-      'Chiedi informazioni sui tuoi documenti...',
+      'Chiedi informazioni sulle tue risorse...',
     'notebook.view.sidebar.collapse': 'Comprimi barra laterale',
     'notebook.view.sidebar.expand': 'Espandi barra laterale',
     'notebook.view.sidebar.resize': 'Ridimensiona barra laterale',
@@ -254,7 +254,7 @@ const intelligentAssistantTranslationIt = createTranslationMessages({
       'Non vedrai più questo quaderno qui. Questo eliminerà anche le attività correlate come prompt, risposte e feedback dalla tua attività.',
     'notebooks.delete.title': 'Eliminare {{name}}?',
     'notebooks.delete.toast': 'Quaderno eliminato!',
-    'notebooks.documents': 'Documenti',
+    'notebooks.documents': 'Risorse',
     'notebooks.empty.action': 'Crea un nuovo quaderno',
     'notebooks.empty.description':
       'Crea un nuovo quaderno per organizzare le tue fonti e generare insight basati su IA.',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ja.ts
@@ -222,16 +222,16 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
     'notebook.upload.modal.selectedFiles':
       '{{max}} 件中 {{count}} 件のファイルを選択',
     'notebook.upload.modal.separator': 'または',
-    'notebook.upload.modal.title': 'ノートブックにドキュメントを追加',
+    'notebook.upload.modal.title': 'ノートブックにリソースを追加',
     'notebook.view.close': 'ノートブックを閉じる',
     'notebook.view.documents.add': '追加',
-    'notebook.view.documents.count': '{{count}} 件のドキュメント',
+    'notebook.view.documents.count': '{{count}} 件のリソース',
     'notebook.view.documents.maxReached':
-      '最大10個のドキュメントが許可されています。新しいドキュメントをアップロードするには、ドキュメントを削除してください。',
-    'notebook.view.documents.uploading': 'ドキュメントをアップロード中',
+      '最大10個のリソースが許可されています。新しいリソースをアップロードするには、リソースを削除してください。',
+    'notebook.view.documents.uploading': 'リソースをアップロード中',
     'notebook.view.input.disabledTooltip':
       'チャットを開始するには、少なくとも1つのロード済みリソースを選択してください',
-    'notebook.view.input.placeholder': 'ドキュメントについて質問する...',
+    'notebook.view.input.placeholder': 'リソースについて質問する...',
     'notebook.view.sidebar.collapse': 'サイドバーを折りたたむ',
     'notebook.view.sidebar.expand': 'サイドバーを展開する',
     'notebook.view.sidebar.resize': 'サイドバーのサイズを変更する',
@@ -250,7 +250,7 @@ const intelligentAssistantTranslationJa = createTranslationMessages({
       'このノートブックはここに表示されなくなります。アクティビティに関連するプロンプト、応答、フィードバックも削除されます。',
     'notebooks.delete.title': '{{name}} を削除しますか?',
     'notebooks.delete.toast': 'ノートブックを削除しました！',
-    'notebooks.documents': 'ドキュメント',
+    'notebooks.documents': 'リソース',
     'notebooks.empty.action': '新しいノートブックを作成',
     'notebooks.empty.description':
       '新しいノートブックを作成してソースを整理し、AI による洞察を生成します。',

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/translations/ref.ts
@@ -35,7 +35,7 @@ export const intelligentAssistantMessages = {
   'notebooks.empty.description':
     'Start a new notebook to organize your sources and generate AI-powered insights.',
   'notebooks.empty.action': 'Create a new notebook',
-  'notebooks.documents': 'Documents',
+  'notebooks.documents': 'Resources',
   'notebooks.actions.rename': 'Rename',
   'notebooks.actions.delete': 'Delete',
   'notebooks.rename.title': 'Rename {{name}}?',
@@ -63,28 +63,28 @@ export const intelligentAssistantMessages = {
   // Notebook view
   'notebook.view.title': 'Untitled notebook',
   'notebook.view.close': 'Close notebook',
-  'notebook.view.documents.count': '{{count}} Documents',
+  'notebook.view.documents.count': '{{count}} Resources',
   'notebook.view.documents.add': 'Add',
   'notebook.view.upload.heading': 'Upload a resource to get started',
   'notebook.view.upload.action': 'Upload a resource',
   'notebook.view.processing.heading': 'Processing resources...',
   'notebook.view.processing.description':
     'Your files are being indexed. You can start asking questions once processing is complete.',
-  'notebook.view.input.placeholder': 'Ask about your documents...',
+  'notebook.view.input.placeholder': 'Ask about your resources...',
   'notebook.view.input.disabledTooltip':
     'Select at least one loaded resource to start chatting',
   'notebook.view.sidebar.collapse': 'Collapse sidebar',
   'notebook.view.sidebar.expand': 'Expand sidebar',
   'notebook.view.sidebar.resize': 'Resize sidebar',
-  'notebook.view.documents.uploading': 'Uploading document',
+  'notebook.view.documents.uploading': 'Uploading resource',
   'notebook.view.documents.maxReached':
-    'Maximum 10 documents are allowed. Delete a document to upload a new document.',
+    'Maximum 10 resources are allowed. Delete a resource to upload a new resource.',
   'notebook.view.documents.uploadsInProgress':
-    'Please wait for current uploads to complete before adding more documents.',
+    'Please wait for current uploads to complete before adding more resources.',
   'notebook.upload.failed': '"{{fileName}}" upload failed.',
 
   // Notebook upload modal
-  'notebook.upload.modal.title': 'Add a document to Notebook',
+  'notebook.upload.modal.title': 'Add a resource to Notebook',
   'notebook.upload.modal.dragDropTitle': 'Drag and drop files here',
   'notebook.upload.modal.browseButton': 'Upload',
   'notebook.upload.modal.separator': 'or',


### PR DESCRIPTION
## Description

Unify the Lightspeed Notebook UI terminology by replacing all occurrences of "document/documents" with "resource/resources". This was an inconsistency left over from a previous version — the correct term per design is "resource". Changes span all 6 translation files (EN, DE, ES, FR, IT, JA), backend API messages, and test assertions.

## Fixes 
- https://redhat.atlassian.net/browse/RHIDP-15951

## UI before changes

https://github.com/user-attachments/assets/45504886-3ac8-474c-aa36-0939bad23074

## UI after change

https://github.com/user-attachments/assets/a9a42310-3a9a-4144-ae0a-ee0e614c60a8



## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)