### PR TITLE
fix(scorecard): add scalprum config and default app config example

### DIFF
--- a/workspaces/scorecard/.changeset/tame-files-ask.md
+++ b/workspaces/scorecard/.changeset/tame-files-ask.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': patch
+---
+
+Add scalprum config and default app configuration example

--- a/workspaces/scorecard/plugins/scorecard/app-config.yaml
+++ b/workspaces/scorecard/plugins/scorecard/app-config.yaml
@@ -1,0 +1,26 @@
+dynamicPlugins:
+  frontend:
+    red-hat-developer-hub.backstage-plugin-scorecard:
+      # Legacy exports require `module: Legacy` — they are not available on the default module.
+      translationResources:
+        - importName: scorecardTranslations
+          module: Legacy
+          ref: scorecardTranslationRef
+      dynamicRoutes:
+        - path: /scorecard/aggregations/:aggregationId/metrics/:metricId
+          importName: ScorecardPage
+          module: Legacy
+      entityTabs:
+        - path: '/scorecard'
+          title: Scorecard
+          mountPoint: entity.page.scorecard
+      mountPoints:
+        - mountPoint: entity.page.scorecard/cards
+          importName: EntityScorecardContent
+          module: Legacy
+          config:
+            layout:
+              gridColumn: 1 / -1
+          if:
+            allOf:
+              - isKind: component

--- a/workspaces/scorecard/plugins/scorecard/package.json
+++ b/workspaces/scorecard/plugins/scorecard/package.json
@@ -103,6 +103,14 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
+  "scalprum": {
+    "name": "red-hat-developer-hub.backstage-plugin-scorecard",
+    "exposedModules": {
+      "PluginRoot": "./src/index.ts",
+      "Legacy": "./src/legacyExports.ts",
+      "ScorecardTranslationsModule": "./src/scorecardTranslationsModuleExport.ts"
+    }
+  },
   "files": [
     "dist"
   ]


### PR DESCRIPTION
## add scalprum config and default app config example

  ## Summary
  - Adds scalprum configuration to the scorecard plugin's `package.json`, exposing `PluginRoot`, `Legacy`, and `ScorecardTranslationsModule` modules for dynamic plugin loading in RHDH
  - Adds an `app-config.yaml` example showing how to configure the scorecard plugin as a dynamic plugin (routes, entity tabs, mount points, translation resources)
  - Includes a changeset for a patch release


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
