### PR TITLE
fix(theme): fill SidebarPage viewport to close NFS layout gap

### DIFF
--- a/workspaces/theme/.changeset/fix-sidebar-page-viewport-gap.md
+++ b/workspaces/theme/.changeset/fix-sidebar-page-viewport-gap.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Fixed empty space and background mismatch on short NFS pages: BackstageSidebarPage fills the viewport and becomes a column flex container so BUI Containers can grow, and content wells use mainSectionBackgroundColor to match the article/content area

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ThemeConfig } from '../types';
+import { customDarkTheme } from '../darkTheme';
 import { createComponents, type Components } from './createComponents';
 
 interface TestCase {
@@ -84,5 +85,70 @@ describe('createComponents', () => {
       const actual = createComponents(testCase.config);
       expect(actual).toEqual(testCase.expected);
     });
+  });
+
+  it('sets BackstageSidebarPage minHeight to fill the viewport', () => {
+    const actual = createComponents({});
+    expect(actual.BackstageSidebarPage?.styleOverrides?.root).toEqual(
+      expect.objectContaining({
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+      }),
+    );
+  });
+
+  it('stretches main with mainSectionBackgroundColor inside the page inset', () => {
+    const actual = createComponents({ palette: customDarkTheme() });
+    const root = actual.BackstageSidebarPage?.styleOverrides?.root as
+      | Record<string, unknown>
+      | undefined;
+    const desktop = root?.['@media (min-width: 600px)'] as
+      | Record<string, unknown>
+      | undefined;
+    expect(
+      desktop?.["& > [class*='MuiLinearProgress-root'], & > main"],
+    ).toEqual(
+      expect.objectContaining({
+        backgroundColor: '#292929',
+        minHeight: 'calc(100vh - 2 * 1.5rem)',
+        maxHeight: 'calc(100vh - 2 * 1.5rem)',
+      }),
+    );
+  });
+
+  it('paints BUI content Containers with mainSectionBackgroundColor', () => {
+    const actual = createComponents({ palette: customDarkTheme() });
+    const root = actual.BackstageSidebarPage?.styleOverrides?.root as
+      | Record<string, unknown>
+      | undefined;
+    const desktop = root?.['@media (min-width: 600px)'] as
+      | Record<string, unknown>
+      | undefined;
+    expect(
+      desktop?.["& > [class*='bui-Container']:not([class*='bui-Header'])"],
+    ).toEqual(
+      expect.objectContaining({
+        backgroundColor: '#292929',
+      }),
+    );
+  });
+
+  it('grows BackstageContent article to fill the flex column', () => {
+    const actual = createComponents({ palette: customDarkTheme() });
+    const root = actual.BackstageSidebarPage?.styleOverrides?.root as
+      | Record<string, unknown>
+      | undefined;
+    const desktop = root?.['@media (min-width: 600px)'] as
+      | Record<string, unknown>
+      | undefined;
+    expect(
+      desktop?.['& > article, & > [class*="BackstageContent-root"]'],
+    ).toEqual(
+      expect.objectContaining({
+        flex: 1,
+        backgroundColor: '#292929',
+      }),
+    );
   });
 });

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -754,6 +754,15 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
     components.BackstageSidebarPage = {
       styleOverrides: {
         root: {
+          // Fill the viewport so short pages don't leave a gap below the shell.
+          // App root wrappers (e.g. ApplicationDrawer) can collapse to content
+          // height; without a min-height here the page-inset background stops
+          // early and body/html shows through (RHDHBUGS-3498).
+          minHeight: '100vh',
+          // Let BUI Container's flex: 1 grow into the remaining viewport below
+          // PluginHeader / Header slots (those slots set flex: none).
+          display: 'flex',
+          flexDirection: 'column',
           // Controls the page inset as in PF6 -- only in desktop view
           '@media (min-width: 600px)': {
             backgroundColor:
@@ -773,8 +782,24 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
               clipPath: 'rect(0 100% 100% 0 round 1rem)',
               // Emulate the PatternFly 6 page inset using a margin
               margin: general.pageInset,
+              // Fill the inset well so short pages use mainSectionBackgroundColor
+              // (#292929) instead of leaving a pageInset (#151515) band below content.
+              backgroundColor: general.mainSectionBackgroundColor,
+              minHeight: `calc(100vh - 2 * ${general.pageInset})`,
               // Prevent overflow in the main container due to the margin
               maxHeight: `calc(100vh - 2 * ${general.pageInset})`,
+            },
+            // NFS / BUI pages use Container instead of <main>. Match the content
+            // well color (same token as BackstageContent) and rely on flex: 1
+            // from BUI rather than 100vh so PluginHeader siblings are not overflowed.
+            "& > [class*='bui-Container']:not([class*='bui-Header'])": {
+              backgroundColor: general.mainSectionBackgroundColor,
+            },
+            // Settings and other pages render BackstageContent as <article>.
+            // Grow it to fill the flex column so pageInset doesn't show as a band.
+            '& > article, & > [class*="BackstageContent-root"]': {
+              flex: 1,
+              backgroundColor: general.mainSectionBackgroundColor,
             },
             // Prevent TechDocs double scrollbar: the page-inset max-height puts
             // <main>'s scrollbar at the same position as the ToC sidebar scrollbar.


### PR DESCRIPTION
## Description

Fixes the NFS viewport gap on short pages (e.g. Settings) by restoring height participation on `BackstageSidebarPage` in the theme plugin. Short pages no longer collapse to content height and leave a body/page-inset bleed under the shell.

The page root now uses `minHeight: 100vh` with a column flex layout so BUI containers can grow, and desktop content wells (`main`, article/`BackstageContent`, non-header `bui-Container`) use `mainSectionBackgroundColor` with a matching `minHeight` on `main`. This is a shell-level theme fix — not an `ApplicationDrawer` change (supersedes the approach in #4077).

## Fixed
- [RHDHBUGS-3498](https://redhat.atlassian.net/browse/RHDHBUGS-3498) — [ApplicationDrawer] Empty space at bottom of viewport in NFS mode

## Test Plan
- [ ] Start an NFS app that loads the RHDH theme (e.g. `workspaces/intelligent-assistant`, `workspaces/app-defaults` with theme, or RHDH `yarn workspace backend start:next`)
- [ ] Open **Settings** (or another short page) in **dark** theme — no empty band below content; page-inset / `#root` fills the viewport (no body background bleed)
- [ ] Repeat in **light** theme — same: no empty gap under short content
- [ ] Open/close **ApplicationDrawer** — content still shifts correctly; no layout regression
- [ ] Spot-check a longer page (Catalog index / entity Overview) — no unexpected scrollbars or overflow from `main` `minHeight`/`maxHeight`
- [ ] Confirm TechDocs (if available) still avoids double scrollbar (`main:has([data-testid='techdocs-native-shadowroot'])` override)

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

Made with [Cursor](https://cursor.com)

<img width="3024" height="1652" alt="image" src="https://github.com/user-attachments/assets/072fa3fa-bba7-4c13-b24c-db72ff01b932" />
