### PR TITLE
chore(app-auth): cut NFS alpha sync by lazy SignInPage blueprint

### DIFF
--- a/workspaces/app-defaults/.changeset/app-auth-lazy-signin.md
+++ b/workspaces/app-defaults/.changeset/app-auth-lazy-signin.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-app-auth': minor
+---
+
+**BREAKING**: `SignInPage` is no longer exported from `@red-hat-developer-hub/backstage-plugin-app-auth/alpha`. Use `appAuthModule` (or the package default export); the page loads through `SignInPageBlueprint` with a dynamic `import()`.
+
+Replaces `import appPlugin from '@backstage/plugin-app'` + extension override with `SignInPageBlueprint` from `@backstage/plugin-app-react` so the NFS alpha Module Federation sync chunk no longer pulls the full `@backstage/plugin-app` tree (AppRoot, `@backstage/ui`, framer-motion, markdown, MUI v4).

--- a/workspaces/app-defaults/plugins/app-auth/README.md
+++ b/workspaces/app-defaults/plugins/app-auth/README.md
@@ -5,7 +5,7 @@ RHDH sign-in page (multi-provider) and OIDC / Keycloak / PingFederate / Auth0 / 
 ## Usage
 
 - **Dynamic loading**: default export is a `FrontendModule` suitable for `@backstage/frontend-dynamic-feature-loader`.
-- **Static / alpha**: import from `@red-hat-developer-hub/backstage-plugin-app-auth/alpha` for `appAuthModule`, `SignInPage`, `signInTranslationRef`, and auth API refs.
+- **Static / alpha**: import from `@red-hat-developer-hub/backstage-plugin-app-auth/alpha` for `appAuthModule`, `signInTranslationRef`, and auth API refs. The sign-in page UI is registered by the module via `SignInPageBlueprint` and lazy-loaded — it is not a public alpha export.
 
 ## Config
 

--- a/workspaces/app-defaults/plugins/app-auth/package.json
+++ b/workspaces/app-defaults/plugins/app-auth/package.json
@@ -51,7 +51,7 @@
     "@backstage/core-components": "^0.18.11",
     "@backstage/core-plugin-api": "^1.12.7",
     "@backstage/frontend-plugin-api": "^0.17.2",
-    "@backstage/plugin-app": "^0.5.0",
+    "@backstage/plugin-app-react": "^0.2.4",
     "@mui/material": "5.18.0"
   },
   "peerDependencies": {

--- a/workspaces/app-defaults/plugins/app-auth/report-alpha.api.md
+++ b/workspaces/app-defaults/plugins/app-auth/report-alpha.api.md
@@ -10,7 +10,6 @@ import { OAuthApi } from '@backstage/core-plugin-api';
 import { OpenIdConnectApi } from '@backstage/core-plugin-api';
 import { ProfileInfoApi } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
-import { SignInPageProps } from '@backstage/core-plugin-api';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
 
 // @alpha
@@ -39,9 +38,6 @@ export const pingfederateAuthApiRef: ApiRef<CustomAuthApiRefType>;
 
 // @alpha
 export const samlAuthApiRef: ApiRef<CustomAuthApiRefType>;
-
-// @alpha
-export function SignInPage(props: SignInPageProps): React.JSX.Element;
 
 // @alpha
 export const signInTranslationRef: TranslationRef<

--- a/workspaces/app-defaults/plugins/app-auth/src/alpha.ts
+++ b/workspaces/app-defaults/plugins/app-auth/src/alpha.ts
@@ -17,11 +17,14 @@
 /**
  * New Frontend System: RHDH sign-in and auth API extensions for the app plugin.
  *
+ * The sign-in page UI is not re-exported here — it loads via
+ * {@link appAuthModule}'s SignInPageBlueprint loader so MUI / core-components
+ * stay off the Module Federation alpha sync chunk.
+ *
  * @packageDocumentation
  */
 
 export { appAuthModule } from './appAuthModule';
-export { SignInPage } from './components/SignInPage';
 export * from './AuthApiRefs';
 export * from './translations/signIn';
 

--- a/workspaces/app-defaults/plugins/app-auth/src/appAuthModule.tsx
+++ b/workspaces/app-defaults/plugins/app-auth/src/appAuthModule.tsx
@@ -24,7 +24,7 @@ import {
   ApiBlueprint,
   createFrontendModule,
 } from '@backstage/frontend-plugin-api';
-import appPlugin from '@backstage/plugin-app';
+import { SignInPageBlueprint } from '@backstage/plugin-app-react';
 
 import {
   auth0AuthApiRef,
@@ -33,7 +33,6 @@ import {
   pingfederateAuthApiRef,
   samlAuthApiRef,
 } from './AuthApiRefs';
-import { SignInPage } from './components/SignInPage';
 
 const oidcAuthApi = ApiBlueprint.make({
   name: 'oidc-auth',
@@ -159,10 +158,13 @@ const samlAuthApi = ApiBlueprint.make({
     }),
 });
 
-const signInPageOverride = appPlugin.getExtension('sign-in-page:app').override({
+/**
+ * Replaces the default app sign-in page. The page component is loaded via
+ * dynamic import so core-components / MUI stay off the NFS alpha sync chunk.
+ */
+const signInPage = SignInPageBlueprint.make({
   params: {
-    loader: async () => (props: Parameters<typeof SignInPage>[0]) =>
-      <SignInPage {...props} />,
+    loader: () => import('./components/SignInPage').then(m => m.SignInPage),
   },
 });
 
@@ -175,7 +177,7 @@ const signInPageOverride = appPlugin.getExtension('sign-in-page:app').override({
 export const appAuthModule = createFrontendModule({
   pluginId: 'app',
   extensions: [
-    signInPageOverride,
+    signInPage,
     oidcAuthApi,
     keycloakAuthApi,
     pingfederateAuthApi,

--- a/workspaces/app-defaults/yarn.lock
+++ b/workspaces/app-defaults/yarn.lock
@@ -9430,7 +9430,7 @@ __metadata:
     "@backstage/core-components": "npm:^0.18.11"
     "@backstage/core-plugin-api": "npm:^1.12.7"
     "@backstage/frontend-plugin-api": "npm:^0.17.2"
-    "@backstage/plugin-app": "npm:^0.5.0"
+    "@backstage/plugin-app-react": "npm:^0.2.4"
     "@backstage/test-utils": "npm:^1.7.19"
     "@mui/material": "npm:5.18.0"
     "@testing-library/jest-dom": "npm:^6.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://redhat.atlassian.net/browse/RHIDP-15998

**Solution description:**
- Cut NFS ./alpha Module Federation sync for @red-hat-developer-hub/backstage-plugin-app-auth from ~1503 KB → 121 KB (−92%).
- Replaced import appPlugin from '@backstage/plugin-app' + extension override with SignInPageBlueprint from @backstage/plugin-app-react.
- Used dynamic loader: () => import('./components/SignInPage').then(m => m.SignInPage).
- BREAKING: stopped exporting SignInPage from /alpha so UI stays off the sync chunk; consumers should use `appAuthModule` only.
- Swapped dependency @backstage/plugin-app → @backstage/plugin-app-react; updated README, API report, and changeset.

**NFS alpha expose summary**

Metric | BEFORE | AFTER | Δ
-- | -- | -- | --
Sync chunks | 4 | 2 | -2
Sync size | 1503 KB | 121 KB | -1382 KB (-92%)
Async chunks | 194 | 197 | +3
Async size | 948 KB | ~1681 KB | +733 KB

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
