### PR TITLE
FLPATH-4285 | [DCM] Server-side pagination not implemented

### DIFF
--- a/workspaces/dcm/.changeset/server-side-pagination-all-tabs.md
+++ b/workspaces/dcm/.changeset/server-side-pagination-all-tabs.md
@@ -1,0 +1,28 @@
+---
+'@red-hat-developer-hub/backstage-plugin-dcm': minor
+'@red-hat-developer-hub/backstage-plugin-dcm-common': minor
+---
+
+Add server-side cursor pagination to all tabs and harden pagination handling across APIs.
+
+**All six tabs now use server-side cursor pagination**
+
+Previously only Service Types, Catalog Items, and Catalog Item Instances fetched data page-by-page from the backend. Providers, Policies, and Resources loaded everything in a single call and silently lost records beyond the first page.
+
+- **Providers** and **Policies** — converted to the `useCrudTab` + manual token-stack pattern (same as Catalog Items). Next / Previous buttons appear below the table; search resets to page 1 client-side without an extra round-trip.
+- **Resources** — converted to `usePaginatedFetch` (same as Service Types). Retains the same read-only layout.
+
+**`dcm-common`: new pagination utilities and updated API interfaces**
+
+- `buildPaginationQuery` extracted from `CatalogClient` into `dcm-common/src/utils/buildPaginationQuery.ts` and exported publicly so all clients can share the same URL-builder.
+- `ProvidersApi` / `ProvidersClient` — `listProviders` now accepts an optional `PaginationParams` argument.
+- `PolicyManagerApi` / `PolicyManagerClient` — `listPolicies` now accepts an optional `PaginationParams` argument.
+- `ServiceTypeList`, `CatalogItemList`, `CatalogItemInstanceList` — `next_page_token` is now optional (`?`) to match the real backend behaviour where the field is absent (not just empty) when there is only one page of results.
+
+**Dropdown calls capped at 25 items**
+
+Service-type dropdown loads (used in the Providers and Catalog Items create/edit forms) and the catalog-item dropdown load (used in the Instances create form) now pass `max_page_size: 25`. This prevents the select from silently showing an incomplete list when there are more than the default page size of items.
+
+**Test coverage**
+
+Added `ProvidersTabContent.test.tsx` and `ResourcesTabContent.test.tsx` with full cursor navigation test suites (initial load, error/retry, Next/Previous button states and token passing). Updated `PoliciesTabContent.test.tsx` with equivalent cursor navigation tests and refreshed mock return types.

--- a/workspaces/dcm/.changeset/server-side-pagination-all-tabs.md
+++ b/workspaces/dcm/.changeset/server-side-pagination-all-tabs.md
@@ -9,7 +9,7 @@ Add server-side cursor pagination to all tabs and harden pagination handling acr
 
 Previously only Service Types, Catalog Items, and Catalog Item Instances fetched data page-by-page from the backend. Providers, Policies, and Resources loaded everything in a single call and silently lost records beyond the first page.
 
-- **Providers** and **Policies** — converted to the `useCrudTab` + manual token-stack pattern (same as Catalog Items). Next / Previous buttons appear below the table; search resets to page 1 client-side without an extra round-trip.
+- **Providers** and **Policies** — converted to `usePaginatedCrudTab` (same pattern as Catalog Items). Next / Previous buttons appear below the table; search filters the current page client-side without an extra round-trip.
 - **Resources** — converted to `usePaginatedFetch` (same as Service Types). Retains the same read-only layout.
 
 **`dcm-common`: new pagination utilities and updated API interfaces**
@@ -19,9 +19,9 @@ Previously only Service Types, Catalog Items, and Catalog Item Instances fetched
 - `PolicyManagerApi` / `PolicyManagerClient` — `listPolicies` now accepts an optional `PaginationParams` argument.
 - `ServiceTypeList`, `CatalogItemList`, `CatalogItemInstanceList` — `next_page_token` is now optional (`?`) to match the real backend behaviour where the field is absent (not just empty) when there is only one page of results.
 
-**Dropdown calls capped at 25 items**
+**Dropdown options loaded once on mount**
 
-Service-type dropdown loads (used in the Providers and Catalog Items create/edit forms) and the catalog-item dropdown load (used in the Instances create form) now pass `max_page_size: 25`. This prevents the select from silently showing an incomplete list when there are more than the default page size of items.
+Service-type dropdown loads (used in the Providers and Catalog Items create/edit forms) are now fetched once on component mount via a dedicated `useEffect`, not on every page navigation. The request uses `max_page_size: 100` to avoid silently truncating valid options.
 
 **Test coverage**
 

--- a/workspaces/dcm/plugins/dcm-common/report.api.md
+++ b/workspaces/dcm/plugins/dcm-common/report.api.md
@@ -8,6 +8,9 @@ import type { DiscoveryApi } from '@backstage/core-plugin-api';
 import type { FetchApi } from '@backstage/core-plugin-api';
 
 // @public
+export function buildPaginationQuery(params: PaginationParams): string;
+
+// @public
 export interface CatalogApi {
   // (undocumented)
   createCatalogItem(catalogItem: CatalogItem): Promise<CatalogItem>;
@@ -30,11 +33,13 @@ export interface CatalogApi {
   // (undocumented)
   getServiceType(serviceTypeId: string): Promise<ServiceType>;
   // (undocumented)
-  listCatalogItemInstances(): Promise<CatalogItemInstanceList>;
+  listCatalogItemInstances(
+    params?: PaginationParams,
+  ): Promise<CatalogItemInstanceList>;
   // (undocumented)
-  listCatalogItems(): Promise<CatalogItemList>;
+  listCatalogItems(params?: PaginationParams): Promise<CatalogItemList>;
   // (undocumented)
-  listServiceTypes(): Promise<ServiceTypeList>;
+  listServiceTypes(params?: PaginationParams): Promise<ServiceTypeList>;
   rehydrateCatalogItemInstance(
     catalogItemInstanceId: string,
   ): Promise<CatalogItemInstance>;
@@ -68,11 +73,13 @@ export class CatalogClient extends DcmBaseClient implements CatalogApi {
   // (undocumented)
   getServiceType(serviceTypeId: string): Promise<ServiceType>;
   // (undocumented)
-  listCatalogItemInstances(): Promise<CatalogItemInstanceList>;
+  listCatalogItemInstances(
+    params?: PaginationParams,
+  ): Promise<CatalogItemInstanceList>;
   // (undocumented)
-  listCatalogItems(): Promise<CatalogItemList>;
+  listCatalogItems(params?: PaginationParams): Promise<CatalogItemList>;
   // (undocumented)
-  listServiceTypes(): Promise<ServiceTypeList>;
+  listServiceTypes(params?: PaginationParams): Promise<ServiceTypeList>;
   // (undocumented)
   rehydrateCatalogItemInstance(
     catalogItemInstanceId: string,
@@ -126,7 +133,7 @@ export interface CatalogItemInstance {
 // @public
 export interface CatalogItemInstanceList {
   // (undocumented)
-  next_page_token: string;
+  next_page_token?: string;
   // (undocumented)
   results: CatalogItemInstance[];
 }
@@ -142,7 +149,7 @@ export interface CatalogItemInstanceSpec {
 // @public
 export interface CatalogItemList {
   // (undocumented)
-  next_page_token: string;
+  next_page_token?: string;
   // (undocumented)
   results: CatalogItem[];
 }
@@ -279,6 +286,12 @@ export interface ListServiceTypeInstancesParams {
 }
 
 // @public
+export interface PaginationParams {
+  max_page_size?: number;
+  page_token?: string;
+}
+
+// @public
 export function parseDcmEntityStatus(raw: string): DcmEntityStatus | undefined;
 
 // @public
@@ -319,7 +332,7 @@ export interface PolicyManagerApi {
   // (undocumented)
   getPolicy(policyId: string): Promise<Policy>;
   // (undocumented)
-  listPolicies(): Promise<PolicyList>;
+  listPolicies(params?: PaginationParams): Promise<PolicyList>;
   // (undocumented)
   updatePolicy(policyId: string, patch: Partial<Policy>): Promise<Policy>;
 }
@@ -336,7 +349,7 @@ export class PolicyManagerClient
   // (undocumented)
   getPolicy(policyId: string): Promise<Policy>;
   // (undocumented)
-  listPolicies(): Promise<PolicyList>;
+  listPolicies(params?: PaginationParams): Promise<PolicyList>;
   // (undocumented)
   protected readonly serviceName = 'Policy Manager';
   // (undocumented)
@@ -403,7 +416,7 @@ export interface ProvidersApi {
   // (undocumented)
   getProvider(providerId: string): Promise<Provider>;
   // (undocumented)
-  listProviders(): Promise<ProviderList>;
+  listProviders(params?: PaginationParams): Promise<ProviderList>;
 }
 
 // @public
@@ -417,7 +430,7 @@ export class ProvidersClient extends DcmBaseClient implements ProvidersApi {
   // (undocumented)
   getProvider(providerId: string): Promise<Provider>;
   // (undocumented)
-  listProviders(): Promise<ProviderList>;
+  listProviders(params?: PaginationParams): Promise<ProviderList>;
   // (undocumented)
   protected readonly serviceName = 'Providers';
 }
@@ -507,7 +520,7 @@ export interface ServiceTypeInstanceSpec {
 // @public
 export interface ServiceTypeList {
   // (undocumented)
-  next_page_token: string;
+  next_page_token?: string;
   // (undocumented)
   results: ServiceType[];
 }

--- a/workspaces/dcm/plugins/dcm-common/src/clients/CatalogApi.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/CatalogApi.ts
@@ -22,6 +22,7 @@ import type {
   ServiceType,
   ServiceTypeList,
 } from '../types/catalog';
+import type { PaginationParams } from '../types/common';
 
 /**
  * Interface for the DCM Catalog API client.
@@ -30,12 +31,12 @@ import type {
  */
 export interface CatalogApi {
   // Service Types
-  listServiceTypes(): Promise<ServiceTypeList>;
+  listServiceTypes(params?: PaginationParams): Promise<ServiceTypeList>;
   getServiceType(serviceTypeId: string): Promise<ServiceType>;
   createServiceType(serviceType: ServiceType): Promise<ServiceType>;
 
   // Catalog Items
-  listCatalogItems(): Promise<CatalogItemList>;
+  listCatalogItems(params?: PaginationParams): Promise<CatalogItemList>;
   getCatalogItem(catalogItemId: string): Promise<CatalogItem>;
   createCatalogItem(catalogItem: CatalogItem): Promise<CatalogItem>;
   updateCatalogItem(
@@ -45,7 +46,9 @@ export interface CatalogApi {
   deleteCatalogItem(catalogItemId: string): Promise<void>;
 
   // Catalog Item Instances
-  listCatalogItemInstances(): Promise<CatalogItemInstanceList>;
+  listCatalogItemInstances(
+    params?: PaginationParams,
+  ): Promise<CatalogItemInstanceList>;
   getCatalogItemInstance(
     catalogItemInstanceId: string,
   ): Promise<CatalogItemInstance>;

--- a/workspaces/dcm/plugins/dcm-common/src/clients/CatalogClient.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/CatalogClient.ts
@@ -22,6 +22,8 @@ import type {
   ServiceType,
   ServiceTypeList,
 } from '../types/catalog';
+import type { PaginationParams } from '../types/common';
+import { buildPaginationQuery } from '../utils/buildPaginationQuery';
 import type { CatalogApi } from './CatalogApi';
 import { DcmBaseClient } from './DcmBaseClient';
 
@@ -39,8 +41,12 @@ export class CatalogClient extends DcmBaseClient implements CatalogApi {
 
   // ── Service Types ──────────────────────────────────────────────────────────
 
-  async listServiceTypes(): Promise<ServiceTypeList> {
-    return this.fetch<ServiceTypeList>('service-types');
+  async listServiceTypes(
+    params: PaginationParams = {},
+  ): Promise<ServiceTypeList> {
+    return this.fetch<ServiceTypeList>(
+      `service-types${buildPaginationQuery(params)}`,
+    );
   }
 
   async getServiceType(serviceTypeId: string): Promise<ServiceType> {
@@ -56,8 +62,12 @@ export class CatalogClient extends DcmBaseClient implements CatalogApi {
 
   // ── Catalog Items ──────────────────────────────────────────────────────────
 
-  async listCatalogItems(): Promise<CatalogItemList> {
-    return this.fetch<CatalogItemList>('catalog-items');
+  async listCatalogItems(
+    params: PaginationParams = {},
+  ): Promise<CatalogItemList> {
+    return this.fetch<CatalogItemList>(
+      `catalog-items${buildPaginationQuery(params)}`,
+    );
   }
 
   async getCatalogItem(catalogItemId: string): Promise<CatalogItem> {
@@ -90,8 +100,12 @@ export class CatalogClient extends DcmBaseClient implements CatalogApi {
 
   // ── Catalog Item Instances ─────────────────────────────────────────────────
 
-  async listCatalogItemInstances(): Promise<CatalogItemInstanceList> {
-    return this.fetch<CatalogItemInstanceList>('catalog-item-instances');
+  async listCatalogItemInstances(
+    params: PaginationParams = {},
+  ): Promise<CatalogItemInstanceList> {
+    return this.fetch<CatalogItemInstanceList>(
+      `catalog-item-instances${buildPaginationQuery(params)}`,
+    );
   }
 
   async getCatalogItemInstance(

--- a/workspaces/dcm/plugins/dcm-common/src/clients/PolicyManagerApi.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/PolicyManagerApi.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { PaginationParams } from '../types/common';
 import type { Policy, PolicyList } from '../types/policy-manager';
 
 /**
@@ -22,7 +23,7 @@ import type { Policy, PolicyList } from '../types/policy-manager';
  * @public
  */
 export interface PolicyManagerApi {
-  listPolicies(): Promise<PolicyList>;
+  listPolicies(params?: PaginationParams): Promise<PolicyList>;
   getPolicy(policyId: string): Promise<Policy>;
   createPolicy(policy: Policy): Promise<Policy>;
   updatePolicy(policyId: string, patch: Partial<Policy>): Promise<Policy>;

--- a/workspaces/dcm/plugins/dcm-common/src/clients/PolicyManagerClient.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/PolicyManagerClient.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import type { PaginationParams } from '../types/common';
 import type { Policy, PolicyList } from '../types/policy-manager';
+import { buildPaginationQuery } from '../utils/buildPaginationQuery';
 import type { PolicyManagerApi } from './PolicyManagerApi';
 import { DcmBaseClient } from './DcmBaseClient';
 
@@ -33,8 +35,8 @@ export class PolicyManagerClient
 {
   protected readonly serviceName = 'Policy Manager';
 
-  async listPolicies(): Promise<PolicyList> {
-    return this.fetch<PolicyList>('policies');
+  async listPolicies(params: PaginationParams = {}): Promise<PolicyList> {
+    return this.fetch<PolicyList>(`policies${buildPaginationQuery(params)}`);
   }
 
   async getPolicy(policyId: string): Promise<Policy> {

--- a/workspaces/dcm/plugins/dcm-common/src/clients/ProvidersClient.test.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/ProvidersClient.test.ts
@@ -59,6 +59,19 @@ describe('ProvidersClient', () => {
     );
   });
 
+  it('listProviders appends max_page_size and page_token query params', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValue(okJson({ providers: [MOCK_PROVIDER] }));
+    const client = makeClient(fetchFn);
+
+    await client.listProviders({ max_page_size: 10, page_token: 'tok-1' });
+
+    const [url] = fetchFn.mock.calls[0];
+    expect(url).toContain('max_page_size=10');
+    expect(url).toContain('page_token=tok-1');
+  });
+
   it('getProvider calls GET /providers/{id}', async () => {
     const fetchFn = jest.fn().mockResolvedValue(okJson(MOCK_PROVIDER));
     const client = makeClient(fetchFn);

--- a/workspaces/dcm/plugins/dcm-common/src/clients/ProvidersClient.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/ProvidersClient.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import type { PaginationParams } from '../types/common';
 import type { Provider, ProviderList } from '../types/providers';
+import { buildPaginationQuery } from '../utils/buildPaginationQuery';
 import type { ProvidersApi } from './ProvidersApi';
 import { DcmBaseClient } from './DcmBaseClient';
 
@@ -30,8 +32,8 @@ import { DcmBaseClient } from './DcmBaseClient';
 export class ProvidersClient extends DcmBaseClient implements ProvidersApi {
   protected readonly serviceName = 'Providers';
 
-  async listProviders(): Promise<ProviderList> {
-    return this.fetch<ProviderList>('providers');
+  async listProviders(params: PaginationParams = {}): Promise<ProviderList> {
+    return this.fetch<ProviderList>(`providers${buildPaginationQuery(params)}`);
   }
 
   async getProvider(providerId: string): Promise<Provider> {

--- a/workspaces/dcm/plugins/dcm-common/src/index.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/index.ts
@@ -38,3 +38,4 @@ export * from './types';
 export * from './clients';
 export { DcmClientError } from './errors/DcmClientError';
 export { extractApiError } from './utils/extractApiError';
+export { buildPaginationQuery } from './utils/buildPaginationQuery';

--- a/workspaces/dcm/plugins/dcm-common/src/types/catalog.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/types/catalog.ts
@@ -99,17 +99,17 @@ export interface UserValue {
 /** Paginated list of {@link ServiceType} resources. */
 export interface ServiceTypeList {
   results: ServiceType[];
-  next_page_token: string;
+  next_page_token?: string;
 }
 
 /** Paginated list of {@link CatalogItem} resources. */
 export interface CatalogItemList {
   results: CatalogItem[];
-  next_page_token: string;
+  next_page_token?: string;
 }
 
 /** Paginated list of {@link CatalogItemInstance} resources. */
 export interface CatalogItemInstanceList {
   results: CatalogItemInstance[];
-  next_page_token: string;
+  next_page_token?: string;
 }

--- a/workspaces/dcm/plugins/dcm-common/src/types/common.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/types/common.ts
@@ -50,3 +50,16 @@ export interface DcmHealth {
   status: string;
   path?: string;
 }
+
+/**
+ * Query parameters shared by all DCM list endpoints that support
+ * cursor-based pagination (AEP-158).
+ *
+ * @public
+ */
+export interface PaginationParams {
+  /** Maximum number of results to return in one page (1–100, default 100). */
+  max_page_size?: number;
+  /** Opaque page token returned by a previous list response. */
+  page_token?: string;
+}

--- a/workspaces/dcm/plugins/dcm-common/src/utils/buildPaginationQuery.test.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/utils/buildPaginationQuery.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildPaginationQuery } from './buildPaginationQuery';
+
+describe('buildPaginationQuery', () => {
+  it('returns empty string when no params are provided', () => {
+    expect(buildPaginationQuery({})).toBe('');
+  });
+
+  it('returns only max_page_size when only size is provided', () => {
+    expect(buildPaginationQuery({ max_page_size: 10 })).toBe(
+      '?max_page_size=10',
+    );
+  });
+
+  it('returns only page_token when only token is provided', () => {
+    expect(buildPaginationQuery({ page_token: 'tok-abc' })).toBe(
+      '?page_token=tok-abc',
+    );
+  });
+
+  it('returns both params when both are provided', () => {
+    const result = buildPaginationQuery({
+      max_page_size: 25,
+      page_token: 'tok-xyz',
+    });
+    expect(result).toContain('max_page_size=25');
+    expect(result).toContain('page_token=tok-xyz');
+    expect(result).toMatch(/^\?/);
+  });
+
+  it('omits page_token when it is an empty string', () => {
+    expect(buildPaginationQuery({ page_token: '' })).toBe('');
+  });
+
+  it('omits max_page_size when it is undefined', () => {
+    expect(
+      buildPaginationQuery({ max_page_size: undefined, page_token: 'tok' }),
+    ).toBe('?page_token=tok');
+  });
+});

--- a/workspaces/dcm/plugins/dcm-common/src/utils/buildPaginationQuery.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/utils/buildPaginationQuery.ts
@@ -15,17 +15,18 @@
  */
 
 import type { PaginationParams } from '../types/common';
-import type { Provider, ProviderList } from '../types/providers';
 
 /**
- * Interface for the DCM Providers API client.
+ * Builds a URL query string from pagination params.
+ * Returns an empty string when no params are set.
  *
  * @public
  */
-export interface ProvidersApi {
-  listProviders(params?: PaginationParams): Promise<ProviderList>;
-  getProvider(providerId: string): Promise<Provider>;
-  createProvider(provider: Provider): Promise<Provider>;
-  applyProvider(providerId: string, provider: Provider): Promise<Provider>;
-  deleteProvider(providerId: string): Promise<void>;
+export function buildPaginationQuery(params: PaginationParams): string {
+  const q = new URLSearchParams();
+  if (params.max_page_size !== undefined)
+    q.set('max_page_size', String(params.max_page_size));
+  if (params.page_token) q.set('page_token', params.page_token);
+  const qs = q.toString();
+  return qs ? `?${qs}` : '';
 }

--- a/workspaces/dcm/plugins/dcm/src/components/CursorPaginationControls.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/CursorPaginationControls.tsx
@@ -63,7 +63,7 @@ export function CursorPaginationControls({
   loading = false,
   pageSize,
   onPageSizeChange,
-  pageSizeOptions = [5, 15, 25],
+  pageSizeOptions = [5, 10, 25],
 }: CursorPaginationControlsProps) {
   const classes = useStyles();
   const { t } = useTranslation();
@@ -87,7 +87,7 @@ export function CursorPaginationControls({
         </Select>
       )}
       <Tooltip title={t('common.previousPage')}>
-        <span>
+        <Box component="span">
           <IconButton
             size="small"
             disabled={!hasPrev || loading}
@@ -96,10 +96,10 @@ export function CursorPaginationControls({
           >
             <ChevronLeftIcon />
           </IconButton>
-        </span>
+        </Box>
       </Tooltip>
       <Tooltip title={t('common.nextPage')}>
-        <span>
+        <Box component="span">
           <IconButton
             size="small"
             disabled={!hasNext || loading}
@@ -108,7 +108,7 @@ export function CursorPaginationControls({
           >
             <ChevronRightIcon />
           </IconButton>
-        </span>
+        </Box>
       </Tooltip>
     </Box>
   );

--- a/workspaces/dcm/plugins/dcm/src/components/CursorPaginationControls.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/CursorPaginationControls.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Table, type TableColumn } from '@backstage/core-components';
+import { Box, IconButton, MenuItem, Select, Tooltip } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import { useTranslation } from '../hooks/useTranslation';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(1, 2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+}));
+
+export type CursorPaginationControlsProps = Readonly<{
+  hasNext: boolean;
+  hasPrev: boolean;
+  onNext: () => void;
+  onPrev: () => void;
+  /** Disables both buttons while a page fetch is in progress. */
+  loading?: boolean;
+  /** Currently selected page size. Required when `onPageSizeChange` is provided. */
+  pageSize?: number;
+  /** Called with the newly selected page size. When omitted, the size selector is hidden. */
+  onPageSizeChange?: (size: number) => void;
+  /** Options shown in the page-size dropdown. Defaults to [5, 15, 25]. */
+  pageSizeOptions?: number[];
+}>;
+
+/**
+ * Previous / Next navigation row for cursor-based (server-side) pagination.
+ * Rendered below a table when the Backstage `<Table>`'s built-in pager is
+ * disabled (`paging: false`).
+ *
+ * When `onPageSizeChange` and `pageSize` are provided a rows-per-page selector
+ * is rendered to the left of the navigation buttons.
+ */
+export function CursorPaginationControls({
+  hasNext,
+  hasPrev,
+  onNext,
+  onPrev,
+  loading = false,
+  pageSize,
+  onPageSizeChange,
+  pageSizeOptions = [5, 15, 25],
+}: CursorPaginationControlsProps) {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  return (
+    <Box className={classes.root}>
+      {onPageSizeChange !== undefined && pageSize !== undefined && (
+        <Select
+          value={pageSize}
+          renderValue={val => `${val} ${t('common.rows')}`}
+          onChange={e => onPageSizeChange(Number(e.target.value))}
+          disabled={loading}
+          disableUnderline
+          inputProps={{ 'aria-label': t('common.rows') }}
+        >
+          {pageSizeOptions.map(opt => (
+            <MenuItem key={opt} value={opt}>
+              {opt}
+            </MenuItem>
+          ))}
+        </Select>
+      )}
+      <Tooltip title={t('common.previousPage')}>
+        <span>
+          <IconButton
+            size="small"
+            disabled={!hasPrev || loading}
+            onClick={onPrev}
+            aria-label={t('common.previousPage')}
+          >
+            <ChevronLeftIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Tooltip title={t('common.nextPage')}>
+        <span>
+          <IconButton
+            size="small"
+            disabled={!hasNext || loading}
+            onClick={onNext}
+            aria-label={t('common.nextPage')}
+          >
+            <ChevronRightIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}
+
+/**
+ * A `<Table>` in cursor-pagination mode (built-in pager disabled) with
+ * {@link CursorPaginationControls} rendered directly below it.
+ *
+ * Use this wherever cursor-based server pagination is enabled to avoid
+ * duplicating the table-options + controls wiring.
+ */
+export function CursorPaginatedTable<T extends object>({
+  data,
+  columns,
+  pagination,
+}: Readonly<{
+  data: T[];
+  columns: TableColumn<T>[];
+  pagination: CursorPaginationControlsProps;
+}>) {
+  return (
+    <>
+      <Table<T>
+        data={data}
+        columns={columns}
+        options={{
+          paging: false,
+          search: false,
+          sorting: true,
+          padding: 'default',
+          toolbar: false,
+          emptyRowsWhenPaging: false,
+        }}
+      />
+      <CursorPaginationControls {...pagination} />
+    </>
+  );
+}

--- a/workspaces/dcm/plugins/dcm/src/components/DcmCrudTabLayout.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/DcmCrudTabLayout.tsx
@@ -220,7 +220,9 @@ export function DcmCrudTabLayout<T extends object>({
         </Button>
       </Box>
       <InfoCard
-        title={`${entityLabel} (${filtered.length})`}
+        title={
+          cursorPagination ? entityLabel : `${entityLabel} (${filtered.length})`
+        }
         action={
           <Box display="flex" alignItems="center">
             <DcmSearchCardAction

--- a/workspaces/dcm/plugins/dcm/src/components/DcmCrudTabLayout.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/DcmCrudTabLayout.tsx
@@ -33,6 +33,7 @@ import MuiAlert from '@material-ui/lab/Alert';
 import type { BoxProps } from '@material-ui/core/Box';
 import { DcmDataCenterTabEmptyState } from './DcmDataCenterTabEmptyState';
 import { DcmSearchCardAction } from './dcmTabListHelpers';
+import { CursorPaginatedTable } from './CursorPaginationControls';
 import { useDcmStyles } from './dcmStyles';
 import { useTranslation } from '../hooks/useTranslation';
 
@@ -60,11 +61,27 @@ export type DcmCrudTabLayoutProps<T extends object> = Readonly<{
   search: string;
   onSearchChange: Dispatch<SetStateAction<string>>;
 
-  // ── Pagination ───────────────────────────────────────────────────────────
-  page: number;
-  pageSize: number;
-  onPageChange: (page: number, pageSize: number) => void;
-  onRowsPerPageChange: (pageSize: number) => void;
+  // ── Client-side pagination (mutually exclusive with cursorPagination) ────
+  page?: number;
+  pageSize?: number;
+  onPageChange?: (page: number, pageSize: number) => void;
+  onRowsPerPageChange?: (pageSize: number) => void;
+
+  /**
+   * When provided, server-side cursor-based pagination is used instead of the
+   * Backstage Table's built-in pager. The table is rendered with `paging:
+   * false` and {@link CursorPaginationControls} is shown below it.
+   */
+  cursorPagination?: {
+    hasNext: boolean;
+    hasPrev: boolean;
+    onNext: () => void;
+    onPrev: () => void;
+    loading?: boolean;
+    pageSize?: number;
+    onPageSizeChange?: (size: number) => void;
+    pageSizeOptions?: number[];
+  };
 
   // ── Empty state ──────────────────────────────────────────────────────────
   emptyTitle: string;
@@ -131,10 +148,11 @@ export function DcmCrudTabLayout<T extends object>({
   onDismissActionError,
   search,
   onSearchChange,
-  page,
-  pageSize,
+  page = 1,
+  pageSize = 5,
   onPageChange,
   onRowsPerPageChange,
+  cursorPagination,
   emptyTitle,
   emptyDescription,
   primaryActionLabel,
@@ -237,28 +255,38 @@ export function DcmCrudTabLayout<T extends object>({
           />
         )}
         <Box className={classes.cardContent}>
-          <Table<T>
-            data={paginated}
-            columns={columns}
-            options={{
-              paging: true,
-              pageSize,
-              pageSizeOptions: [5, 10, 25],
-              search: false,
-              sorting: true,
-              padding: 'default',
-              toolbar: false,
-              /** Avoid blank rows padding the table to `pageSize` when fewer rows exist. */
-              emptyRowsWhenPaging: false,
-            }}
-            totalCount={filtered.length}
-            page={page}
-            onPageChange={onPageChange}
-            onRowsPerPageChange={onRowsPerPageChange}
-            localization={{
-              pagination: { labelRowsPerPage: t('common.rows') },
-            }}
-          />
+          {cursorPagination ? (
+            <CursorPaginatedTable<T>
+              data={filtered}
+              columns={columns}
+              pagination={cursorPagination}
+            />
+          ) : (
+            <Table<T>
+              data={paginated}
+              columns={columns}
+              options={{
+                paging: true,
+                pageSize,
+                pageSizeOptions: [5, 10, 25],
+                search: false,
+                sorting: true,
+                padding: 'default',
+                toolbar: false,
+                /** Avoid blank rows padding the table to `pageSize` when fewer rows exist. */
+                emptyRowsWhenPaging: false,
+              }}
+              totalCount={filtered.length}
+              page={Math.max(0, page - 1)}
+              onPageChange={
+                onPageChange ? (p, ps) => onPageChange(p + 1, ps) : undefined
+              }
+              onRowsPerPageChange={onRowsPerPageChange}
+              localization={{
+                pagination: { labelRowsPerPage: t('common.rows') },
+              }}
+            />
+          )}
         </Box>
       </InfoCard>
     </Box>

--- a/workspaces/dcm/plugins/dcm/src/components/DcmCrudTabLayout.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/DcmCrudTabLayout.tsx
@@ -187,7 +187,11 @@ export function DcmCrudTabLayout<T extends object>({
     );
   }
 
-  if (items.length === 0) {
+  // Show global empty-state only when we are certain the dataset is truly
+  // empty (i.e. not just an empty cursor page on page 2+). If hasPrev is true
+  // the user deleted the last row on a non-first page — fall through to the
+  // table view so cursor controls remain accessible.
+  if (items.length === 0 && !cursorPagination?.hasPrev) {
     return (
       <>
         {actionError && (

--- a/workspaces/dcm/plugins/dcm/src/components/dcmTabListHelpers.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/dcmTabListHelpers.tsx
@@ -30,6 +30,7 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import SearchIcon from '@material-ui/icons/Search';
 import { useTranslation } from '../hooks/useTranslation';
+import { CursorPaginatedTable } from './CursorPaginationControls';
 
 const useStyles = makeStyles({
   filterInput: { minWidth: 200 },
@@ -107,12 +108,26 @@ function ActionsCell({ onEdit, onDelete }: ActionsCellProps) {
   );
 }
 
+export type CursorPaginationProps = Readonly<{
+  hasNext: boolean;
+  hasPrev: boolean;
+  onNext: () => void;
+  onPrev: () => void;
+  loading?: boolean;
+  /** Currently selected page size. Required when `onPageSizeChange` is provided. */
+  pageSize?: number;
+  /** Called with the newly selected page size. When omitted, the size selector is hidden. */
+  onPageSizeChange?: (size: number) => void;
+  /** Options shown in the page-size dropdown. Defaults to [5, 15, 25]. */
+  pageSizeOptions?: number[];
+}>;
+
 export type DcmSearchTableCardProps<T extends object> = Readonly<{
   title: string;
   /** Already-paginated rows to render. */
   data: T[];
   columns: TableColumn<T>[];
-  /** Total rows after filtering (drives the pagination footer). */
+  /** Total rows after filtering (drives the pagination footer). Ignored in cursor mode. */
   totalCount: number;
   page: number;
   pageSize: number;
@@ -121,6 +136,11 @@ export type DcmSearchTableCardProps<T extends object> = Readonly<{
   search: string;
   setSearch: Dispatch<SetStateAction<string>>;
   pageSizeOptions?: number[];
+  /**
+   * When provided, disables the Table's built-in pager and renders
+   * {@link CursorPaginationControls} below the table instead.
+   */
+  cursorPagination?: CursorPaginationProps;
 }>;
 
 /**
@@ -140,6 +160,7 @@ export function DcmSearchTableCard<T extends object>({
   search,
   setSearch,
   pageSizeOptions = [5, 10, 25],
+  cursorPagination,
 }: DcmSearchTableCardProps<T>) {
   const classes = useDcmStyles();
   const { t } = useTranslation();
@@ -157,31 +178,41 @@ export function DcmSearchTableCard<T extends object>({
       titleTypographyProps={{ className: classes.cardTitle }}
     >
       <Box className={classes.cardContent}>
-        <Table<T>
-          data={data}
-          columns={columns}
-          options={{
-            paging: true,
-            pageSize,
-            pageSizeOptions,
-            search: false,
-            sorting: true,
-            padding: 'default',
-            toolbar: false,
-            emptyRowsWhenPaging: false,
-          }}
-          totalCount={totalCount}
-          page={page}
-          onPageChange={(p, ps) => {
-            setPage(p);
-            setPageSize(ps);
-          }}
-          onRowsPerPageChange={ps => {
-            setPageSize(ps);
-            setPage(0);
-          }}
-          localization={{ pagination: { labelRowsPerPage: t('common.rows') } }}
-        />
+        {cursorPagination ? (
+          <CursorPaginatedTable<T>
+            data={data}
+            columns={columns}
+            pagination={cursorPagination}
+          />
+        ) : (
+          <Table<T>
+            data={data}
+            columns={columns}
+            options={{
+              paging: true,
+              pageSize,
+              pageSizeOptions,
+              search: false,
+              sorting: true,
+              padding: 'default',
+              toolbar: false,
+              emptyRowsWhenPaging: false,
+            }}
+            totalCount={totalCount}
+            page={Math.max(0, page - 1)}
+            onPageChange={(p, ps) => {
+              setPage(p + 1);
+              setPageSize(ps);
+            }}
+            onRowsPerPageChange={ps => {
+              setPageSize(ps);
+              setPage(1);
+            }}
+            localization={{
+              pagination: { labelRowsPerPage: t('common.rows') },
+            }}
+          />
+        )}
       </Box>
     </InfoCard>
   );

--- a/workspaces/dcm/plugins/dcm/src/components/dcmTabListHelpers.tsx
+++ b/workspaces/dcm/plugins/dcm/src/components/dcmTabListHelpers.tsx
@@ -30,7 +30,10 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import SearchIcon from '@material-ui/icons/Search';
 import { useTranslation } from '../hooks/useTranslation';
-import { CursorPaginatedTable } from './CursorPaginationControls';
+import {
+  CursorPaginatedTable,
+  type CursorPaginationControlsProps,
+} from './CursorPaginationControls';
 
 const useStyles = makeStyles({
   filterInput: { minWidth: 200 },
@@ -108,19 +111,8 @@ function ActionsCell({ onEdit, onDelete }: ActionsCellProps) {
   );
 }
 
-export type CursorPaginationProps = Readonly<{
-  hasNext: boolean;
-  hasPrev: boolean;
-  onNext: () => void;
-  onPrev: () => void;
-  loading?: boolean;
-  /** Currently selected page size. Required when `onPageSizeChange` is provided. */
-  pageSize?: number;
-  /** Called with the newly selected page size. When omitted, the size selector is hidden. */
-  onPageSizeChange?: (size: number) => void;
-  /** Options shown in the page-size dropdown. Defaults to [5, 15, 25]. */
-  pageSizeOptions?: number[];
-}>;
+/** Alias kept for backwards compatibility — use {@link CursorPaginationControlsProps} directly when possible. */
+export type CursorPaginationProps = CursorPaginationControlsProps;
 
 export type DcmSearchTableCardProps<T extends object> = Readonly<{
   title: string;

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.test.ts
@@ -330,4 +330,49 @@ describe('useCrudTab', () => {
       expect(result.current.items).toHaveLength(3);
     });
   });
+
+  describe('server-side pagination (PagedLoadResult)', () => {
+    it('extracts items and nextPageToken from a PagedLoadResult', async () => {
+      const opts = makeOptions({
+        loadFn: jest.fn().mockResolvedValue({
+          items: [...ITEMS],
+          nextPageToken: 'page2token',
+        }),
+      });
+      const { result } = renderHook(() => useCrudTab<Item, Form>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.items).toHaveLength(3);
+      expect(result.current.nextPageToken).toBe('page2token');
+    });
+
+    it('clears nextPageToken when last page is returned (empty token)', async () => {
+      const opts = makeOptions({
+        loadFn: jest.fn().mockResolvedValue({
+          items: [...ITEMS],
+          nextPageToken: '',
+        }),
+      });
+      const { result } = renderHook(() => useCrudTab<Item, Form>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.nextPageToken).toBe('');
+    });
+
+    it('nextPageToken defaults to empty string for plain array loadFn', async () => {
+      const { result } = renderHook(() =>
+        useCrudTab<Item, Form>(makeOptions()),
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.nextPageToken).toBe('');
+    });
+
+    it('clears nextPageToken on load failure', async () => {
+      const opts = makeOptions({
+        loadFn: jest.fn().mockRejectedValue(new Error('fail')),
+      });
+      const { result } = renderHook(() => useCrudTab<Item, Form>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.nextPageToken).toBe('');
+      expect(result.current.loadError).toBe('fail');
+    });
+  });
 });

--- a/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/useCrudTab.ts
@@ -46,9 +46,20 @@ function removeItemById<T>(
  * @template T - The domain entity type (e.g. Provider, Policy)
  * @template F - The form state type (e.g. ProviderForm)
  */
+/** Result shape returned by server-side-paginated load functions. */
+export interface PagedLoadResult<T> {
+  items: T[];
+  /** Opaque cursor returned by the API. Empty string or undefined means no next page. */
+  nextPageToken?: string;
+}
+
 export interface UseCrudTabOptions<T, F extends Record<string, unknown>> {
-  /** Fetches all items from the API. May also set secondary state as a side effect. */
-  loadFn: () => Promise<T[]>;
+  /**
+   * Fetches items from the API. Returns either a plain array (client-side
+   * pagination) or a {@link PagedLoadResult} object when server-side
+   * cursor-based pagination is in use.
+   */
+  loadFn: () => Promise<T[] | PagedLoadResult<T>>;
   /**
    * Creates a new item. Receives the raw form so the caller can apply any
    * transformation or pass extra params (e.g. a client-assigned ID).
@@ -109,6 +120,11 @@ export interface UseCrudTabResult<T, F extends Record<string, unknown>> {
   refreshing: boolean;
   loadError: string | null;
   reload: () => void;
+  /**
+   * Opaque cursor token for the next page, populated when `loadFn` returns a
+   * {@link PagedLoadResult}. Empty string means no next page or client-side mode.
+   */
+  nextPageToken: string;
 
   // ── Search + pagination ────────────────────────────────────────────────────
   search: string;
@@ -196,6 +212,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [nextPageToken, setNextPageToken] = useState('');
   const hasLoadedRef = useRef(false);
 
   // ── Search + pagination ──────────────────────────────────────────────────
@@ -263,12 +280,19 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     optsRef.current
       .loadFn()
       .then(result => {
-        setItems(result);
+        if (Array.isArray(result)) {
+          setItems(result);
+          setNextPageToken('');
+        } else {
+          setItems(result.items);
+          setNextPageToken(result.nextPageToken ?? '');
+        }
         hasLoadedRef.current = true;
       })
       .catch(err => {
         setLoadError(extractApiError(err));
         setItems([]);
+        setNextPageToken('');
         hasLoadedRef.current = false;
       })
       .finally(() => {
@@ -444,6 +468,7 @@ export function useCrudTab<T, F extends Record<string, unknown>>(
     refreshing,
     loadError,
     reload,
+    nextPageToken,
 
     // Search + pagination
     search,

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  usePaginatedCrudTab,
+  UsePaginatedCrudTabOptions,
+} from './usePaginatedCrudTab';
+import type { PaginatedLoadParams } from './usePaginatedCrudTab';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+type Item = { id: string; name: string };
+type Form = { name: string; [key: string]: unknown };
+
+const PAGE_1: Item[] = [
+  { id: '1', name: 'Alpha' },
+  { id: '2', name: 'Beta' },
+];
+const PAGE_2: Item[] = [{ id: '3', name: 'Gamma' }];
+
+const STORAGE_KEY = 'test-hook';
+
+function makeOptions(
+  overrides?: Partial<UsePaginatedCrudTabOptions<Item, Form>>,
+): UsePaginatedCrudTabOptions<Item, Form> {
+  return {
+    loadFn: jest
+      .fn()
+      .mockResolvedValue({ items: [...PAGE_1], nextPageToken: 'tok2' }),
+    createFn: jest
+      .fn()
+      .mockImplementation((form: Form) =>
+        Promise.resolve({ id: '99', name: form.name } as Item),
+      ),
+    deleteFn: jest.fn().mockResolvedValue(undefined),
+    getId: (item: Item) => item.id,
+    getSearchText: (item: Item) => [item.name],
+    emptyForm: () => ({ name: '' } as Form),
+    isValid: (form: Form) => Boolean(form.name?.trim()),
+    storageKey: STORAGE_KEY,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('usePaginatedCrudTab', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ── Initial load ────────────────────────────────────────────────────────────
+
+  describe('initial load', () => {
+    it('calls loadFn with pageToken=undefined and the persisted page size', async () => {
+      const opts = makeOptions();
+      renderHook(() => usePaginatedCrudTab<Item, Form>(opts));
+
+      await waitFor(() => expect(opts.loadFn as jest.Mock).toHaveBeenCalled());
+
+      const [[firstCall]] = (opts.loadFn as jest.Mock).mock.calls as [
+        [PaginatedLoadParams],
+      ][];
+      expect(firstCall.pageToken).toBeUndefined();
+      expect(firstCall.pageSize).toBeGreaterThan(0);
+    });
+
+    it('populates items and sets hasNext when nextPageToken is returned', async () => {
+      const opts = makeOptions();
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.items).toHaveLength(PAGE_1.length);
+      expect(result.current.cursorPagination.hasNext).toBe(true);
+      expect(result.current.cursorPagination.hasPrev).toBe(false);
+    });
+
+    it('hasPrev is false on the first page', async () => {
+      const opts = makeOptions();
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.cursorPagination.hasPrev).toBe(false);
+    });
+  });
+
+  // ── goNext ──────────────────────────────────────────────────────────────────
+
+  describe('goNext', () => {
+    it('passes the nextPageToken to loadFn and sets hasPrev=true', async () => {
+      const loadFn = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [...PAGE_1], nextPageToken: 'tok2' })
+        .mockResolvedValueOnce({ items: [...PAGE_2], nextPageToken: '' });
+
+      const opts = makeOptions({ loadFn });
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.cursorPagination.hasNext).toBe(true);
+
+      act(() => result.current.goNext());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const secondCallArgs = (loadFn.mock.calls[1] as [PaginatedLoadParams])[0];
+      expect(secondCallArgs.pageToken).toBe('tok2');
+
+      expect(result.current.cursorPagination.hasPrev).toBe(true);
+      expect(result.current.cursorPagination.hasNext).toBe(false);
+      expect(result.current.items).toHaveLength(PAGE_2.length);
+    });
+  });
+
+  // ── goPrev ──────────────────────────────────────────────────────────────────
+
+  describe('goPrev', () => {
+    it('returns to the first page token and shrinks the token stack', async () => {
+      const loadFn = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [...PAGE_1], nextPageToken: 'tok2' })
+        .mockResolvedValueOnce({ items: [...PAGE_2], nextPageToken: '' })
+        .mockResolvedValueOnce({ items: [...PAGE_1], nextPageToken: 'tok2' });
+
+      const opts = makeOptions({ loadFn });
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      // load page 1
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // go to page 2
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.cursorPagination.hasPrev).toBe(true);
+
+      // go back to page 1
+      act(() => result.current.goPrev());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const thirdCallArgs = (loadFn.mock.calls[2] as [PaginatedLoadParams])[0];
+      expect(thirdCallArgs.pageToken).toBeUndefined();
+
+      expect(result.current.cursorPagination.hasPrev).toBe(false);
+      expect(result.current.items).toHaveLength(PAGE_1.length);
+    });
+  });
+
+  // ── handlePageSizeChange ────────────────────────────────────────────────────
+
+  describe('handlePageSizeChange', () => {
+    it('resets to page 1 (undefined token) and reloads with the new size', async () => {
+      const loadFn = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [...PAGE_1], nextPageToken: 'tok2' })
+        .mockResolvedValueOnce({ items: [...PAGE_2], nextPageToken: '' })
+        .mockResolvedValue({ items: [...PAGE_1], nextPageToken: '' });
+
+      const opts = makeOptions({ loadFn });
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // navigate to page 2 to build up a token stack
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.cursorPagination.hasPrev).toBe(true);
+
+      const newSize = 25;
+      act(() => result.current.handlePageSizeChange(newSize));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // cursor must be reset
+      const lastCallArgs = (
+        loadFn.mock.calls[loadFn.mock.calls.length - 1] as [PaginatedLoadParams]
+      )[0];
+      expect(lastCallArgs.pageToken).toBeUndefined();
+      expect(lastCallArgs.pageSize).toBe(newSize);
+
+      // hasPrev must be gone — token stack cleared
+      expect(result.current.cursorPagination.hasPrev).toBe(false);
+    });
+
+    it('persists the new page size to localStorage', async () => {
+      const opts = makeOptions();
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.handlePageSizeChange(15));
+
+      expect(localStorage.getItem(`dcm:pageSize:${STORAGE_KEY}`)).toBe('15');
+    });
+  });
+
+  // ── handleSearchChange ──────────────────────────────────────────────────────
+
+  describe('handleSearchChange', () => {
+    it('filters the current page client-side without re-calling loadFn', async () => {
+      const loadFn = jest
+        .fn()
+        .mockResolvedValue({ items: [...PAGE_1], nextPageToken: 'tok2' });
+      const opts = makeOptions({ loadFn });
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      const callsBefore = (loadFn as jest.Mock).mock.calls.length;
+
+      act(() => result.current.handleSearchChange('alpha'));
+
+      // loadFn must NOT have been called again
+      expect((loadFn as jest.Mock).mock.calls).toHaveLength(callsBefore);
+
+      // Only "Alpha" should pass the filter
+      expect(result.current.filtered).toHaveLength(1);
+      expect(result.current.filtered[0].name).toBe('Alpha');
+    });
+
+    it('leaves the cursor token stack untouched', async () => {
+      const loadFn = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [...PAGE_1], nextPageToken: 'tok2' })
+        .mockResolvedValueOnce({ items: [...PAGE_2], nextPageToken: '' });
+
+      const opts = makeOptions({ loadFn });
+      const { result } = renderHook(() =>
+        usePaginatedCrudTab<Item, Form>(opts),
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // advance to page 2 so token stack is non-empty
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.cursorPagination.hasPrev).toBe(true);
+
+      act(() => result.current.handleSearchChange('gamma'));
+
+      // hasPrev (token stack) must be unchanged
+      expect(result.current.cursorPagination.hasPrev).toBe(true);
+    });
+  });
+});

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.test.ts
@@ -72,9 +72,9 @@ describe('usePaginatedCrudTab', () => {
 
       await waitFor(() => expect(opts.loadFn as jest.Mock).toHaveBeenCalled());
 
-      const [[firstCall]] = (opts.loadFn as jest.Mock).mock.calls as [
-        [PaginatedLoadParams],
-      ][];
+      const firstCall = (
+        (opts.loadFn as jest.Mock).mock.calls[0] as [PaginatedLoadParams]
+      )[0];
       expect(firstCall.pageToken).toBeUndefined();
       expect(firstCall.pageSize).toBeGreaterThan(0);
     });

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.ts
@@ -22,6 +22,7 @@ import {
   type UseCrudTabResult,
 } from './useCrudTab';
 import { usePersistedPageSize } from './usePersistedPageSize';
+import type { CursorPaginationControlsProps } from '../components/CursorPaginationControls';
 
 /** Parameters injected into the load function on every page request. */
 export interface PaginatedLoadParams {
@@ -55,18 +56,8 @@ export interface UsePaginatedCrudTabOptions<
   storageKey: string;
 }
 
-/** Props that can be passed directly to {@link DcmCrudTabLayout}'s `cursorPagination`. */
-export interface CursorPaginationProps {
-  hasNext: boolean;
-  hasPrev: boolean;
-  onNext: () => void;
-  onPrev: () => void;
-  loading: boolean;
-  /** Currently selected page size. */
-  pageSize: number;
-  /** Called with the newly selected page size; resets cursor to page 1 and reloads. */
-  onPageSizeChange: (size: number) => void;
-}
+/** Alias kept for backwards compatibility — use {@link CursorPaginationControlsProps} directly when possible. */
+export type CursorPaginationProps = CursorPaginationControlsProps;
 
 /**
  * Result returned by {@link usePaginatedCrudTab}.
@@ -79,8 +70,8 @@ export interface UsePaginatedCrudTabResult<T, F extends Record<string, unknown>>
   goNext: () => void;
   goPrev: () => void;
   /**
-   * Drop-in replacement for `crud.setSearch` that also resets cursor navigation
-   * to page 1 without triggering an extra API call.
+   * Drop-in replacement for `crud.setSearch`. Search is client-side filtering
+   * on the loaded page; cursor state (Prev/Next) is unchanged.
    */
   handleSearchChange: (value: React.SetStateAction<string>) => void;
   /**
@@ -119,7 +110,11 @@ export interface UsePaginatedCrudTabResult<T, F extends Record<string, unknown>>
 export function usePaginatedCrudTab<T, F extends Record<string, unknown>>(
   options: UsePaginatedCrudTabOptions<T, F>,
 ): UsePaginatedCrudTabResult<T, F> {
-  const [pageSize, setPageSize] = usePersistedPageSize(options.storageKey);
+  // Destructure storageKey so it is NOT forwarded to useCrudTab, which would
+  // create a second usePersistedPageSize call on the same localStorage key.
+  const { storageKey, ...crudOptions } = options;
+
+  const [pageSize, setPageSize] = usePersistedPageSize(storageKey);
   const pageSizeRef = useRef(pageSize);
   pageSizeRef.current = pageSize;
 
@@ -136,7 +131,7 @@ export function usePaginatedCrudTab<T, F extends Record<string, unknown>>(
   optsRef.current = options;
 
   const crud = useCrudTab<T, F>({
-    ...options,
+    ...crudOptions,
     loadFn: () =>
       optsRef.current.loadFn({
         pageToken: currentTokenRef.current,
@@ -180,13 +175,10 @@ export function usePaginatedCrudTab<T, F extends Record<string, unknown>>(
     [setPageSize, crudReload],
   );
 
-  // When the search changes, reset cursor navigation state (no API call
-  // needed — search filters the current page client-side).
+  // Search is client-side filtering on the already-loaded page; cursor state
+  // (Prev/Next) stays tied to the server page that was fetched.
   const handleSearchChange = useCallback(
     (value: React.SetStateAction<string>) => {
-      currentTokenRef.current = undefined;
-      tokenStackRef.current = [];
-      setTokenStack([]);
       setCrudSearch(value);
     },
     [setCrudSearch],

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedCrudTab.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  useCrudTab,
+  type PagedLoadResult,
+  type UseCrudTabOptions,
+  type UseCrudTabResult,
+} from './useCrudTab';
+import { usePersistedPageSize } from './usePersistedPageSize';
+
+/** Parameters injected into the load function on every page request. */
+export interface PaginatedLoadParams {
+  /** Opaque cursor for the current page, or undefined for the first page. */
+  pageToken: string | undefined;
+  /** Number of items to request per page. */
+  pageSize: number;
+}
+
+/**
+ * Options for {@link usePaginatedCrudTab}.
+ *
+ * Extends {@link UseCrudTabOptions} but replaces the no-arg `loadFn` with one
+ * that receives `{ pageToken, pageSize }`, and makes `storageKey` required (the
+ * hook always persists the page size).
+ */
+export interface UsePaginatedCrudTabOptions<
+  T,
+  F extends Record<string, unknown>,
+> extends Omit<UseCrudTabOptions<T, F>, 'loadFn' | 'storageKey'> {
+  /**
+   * Fetches one page of items. Receives cursor params so the implementation
+   * never needs to manage pagination refs directly. Return a plain array for
+   * client-side pagination or a {@link PagedLoadResult} for server cursor mode.
+   */
+  loadFn: (params: PaginatedLoadParams) => Promise<T[] | PagedLoadResult<T>>;
+  /**
+   * `localStorage` key used to persist the selected page size (e.g.
+   * `'providers'`, `'policies'`).  Must be unique per table.
+   */
+  storageKey: string;
+}
+
+/** Props that can be passed directly to {@link DcmCrudTabLayout}'s `cursorPagination`. */
+export interface CursorPaginationProps {
+  hasNext: boolean;
+  hasPrev: boolean;
+  onNext: () => void;
+  onPrev: () => void;
+  loading: boolean;
+  /** Currently selected page size. */
+  pageSize: number;
+  /** Called with the newly selected page size; resets cursor to page 1 and reloads. */
+  onPageSizeChange: (size: number) => void;
+}
+
+/**
+ * Result returned by {@link usePaginatedCrudTab}.
+ *
+ * Everything from {@link UseCrudTabResult} plus pre-built navigation helpers
+ * and a `cursorPagination` object ready to be spread onto `DcmCrudTabLayout`.
+ */
+export interface UsePaginatedCrudTabResult<T, F extends Record<string, unknown>>
+  extends UseCrudTabResult<T, F> {
+  goNext: () => void;
+  goPrev: () => void;
+  /**
+   * Drop-in replacement for `crud.setSearch` that also resets cursor navigation
+   * to page 1 without triggering an extra API call.
+   */
+  handleSearchChange: (value: React.SetStateAction<string>) => void;
+  /**
+   * Changes the page size, resets cursor navigation to page 1, and reloads.
+   * Updates `localStorage` via {@link usePersistedPageSize}.
+   */
+  handlePageSizeChange: (size: number) => void;
+  /** Ready-made object for the `cursorPagination` prop of `DcmCrudTabLayout`. */
+  cursorPagination: CursorPaginationProps;
+}
+
+/**
+ * Wrapper around {@link useCrudTab} that adds server-side cursor pagination.
+ *
+ * Encapsulates the token-stack pattern so individual tab components no longer
+ * need to manage `currentTokenRef`, `tokenStackRef`, `goNext`, `goPrev`, or
+ * `handleSearchChange` themselves.
+ *
+ * @example
+ * const crud = usePaginatedCrudTab<Provider, ProviderForm>({
+ *   loadFn: ({ pageToken, pageSize }) =>
+ *     providersApi.listProviders({ page_token: pageToken, max_page_size: pageSize })
+ *       .then(r => ({ items: r.providers ?? [], nextPageToken: r.next_page_token })),
+ *   storageKey: 'providers',
+ *   createFn: form => providersApi.createProvider(form),
+ *   ...
+ * });
+ *
+ * // In JSX:
+ * <DcmCrudTabLayout
+ *   onSearchChange={crud.handleSearchChange}
+ *   cursorPagination={crud.cursorPagination}
+ *   ...
+ * />
+ */
+export function usePaginatedCrudTab<T, F extends Record<string, unknown>>(
+  options: UsePaginatedCrudTabOptions<T, F>,
+): UsePaginatedCrudTabResult<T, F> {
+  const [pageSize, setPageSize] = usePersistedPageSize(options.storageKey);
+  const pageSizeRef = useRef(pageSize);
+  pageSizeRef.current = pageSize;
+
+  // Token for the CURRENT page. Updated via ref synchronously before reload.
+  const currentTokenRef = useRef<string | undefined>(undefined);
+
+  // Stack of tokens for previously-visited pages (enables Previous navigation).
+  const [tokenStack, setTokenStack] = useState<string[]>([]);
+  const tokenStackRef = useRef<string[]>([]);
+
+  // Keep the latest options in a ref so the stable loadFn wrapper always
+  // calls the freshest implementation without needing it in its dep array.
+  const optsRef = useRef(options);
+  optsRef.current = options;
+
+  const crud = useCrudTab<T, F>({
+    ...options,
+    loadFn: () =>
+      optsRef.current.loadFn({
+        pageToken: currentTokenRef.current,
+        pageSize: pageSizeRef.current,
+      }),
+  });
+
+  const { nextPageToken, reload: crudReload, setSearch: setCrudSearch } = crud;
+
+  // ── Cursor navigation ────────────────────────────────────────────────────
+
+  const goNext = useCallback(() => {
+    const tokenToPush = currentTokenRef.current ?? '';
+    currentTokenRef.current = nextPageToken || undefined;
+    tokenStackRef.current = [...tokenStackRef.current, tokenToPush];
+    setTokenStack(tokenStackRef.current);
+    crudReload();
+  }, [nextPageToken, crudReload]);
+
+  const goPrev = useCallback(() => {
+    const stack = tokenStackRef.current;
+    const prevToken = stack.at(-1);
+    currentTokenRef.current = prevToken || undefined;
+    tokenStackRef.current = stack.slice(0, -1);
+    setTokenStack(tokenStackRef.current);
+    crudReload();
+  }, [crudReload]);
+
+  // When the page size changes, update the ref immediately (so the next reload
+  // uses the new size without waiting for a re-render), reset the cursor to the
+  // first page, and trigger a reload.
+  const handlePageSizeChange = useCallback(
+    (newSize: number) => {
+      pageSizeRef.current = newSize;
+      setPageSize(newSize);
+      currentTokenRef.current = undefined;
+      tokenStackRef.current = [];
+      setTokenStack([]);
+      crudReload();
+    },
+    [setPageSize, crudReload],
+  );
+
+  // When the search changes, reset cursor navigation state (no API call
+  // needed — search filters the current page client-side).
+  const handleSearchChange = useCallback(
+    (value: React.SetStateAction<string>) => {
+      currentTokenRef.current = undefined;
+      tokenStackRef.current = [];
+      setTokenStack([]);
+      setCrudSearch(value);
+    },
+    [setCrudSearch],
+  );
+
+  return {
+    ...crud,
+    goNext,
+    goPrev,
+    handleSearchChange,
+    handlePageSizeChange,
+    cursorPagination: {
+      hasNext: Boolean(nextPageToken),
+      hasPrev: tokenStack.length > 0,
+      onNext: goNext,
+      onPrev: goPrev,
+      loading: crud.loading || crud.refreshing,
+      pageSize,
+      onPageSizeChange: handlePageSizeChange,
+    },
+  };
+}

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.test.ts
@@ -207,4 +207,50 @@ describe('usePaginatedFetch', () => {
       expect(result.current.hasPrev).toBe(false);
     });
   });
+
+  describe('search does not affect cursor state', () => {
+    it('hasNext remains true after search interaction (no resetCursor side-effect)', async () => {
+      // Page 1 of 2 — hasNext should be true after load.
+      const opts = makeOptions(makePages(10, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.hasNext).toBe(true);
+
+      // Simulate a parent component calling search (consumer-side state change).
+      // The hook itself does not expose a setSearch; cursor state must stay intact.
+      // Re-render with the same options to confirm nothing is reset.
+      // (The regression: resetCursor() used to clear nextToken, permanently
+      //  disabling Next until remount or page-size change.)
+      expect(result.current.hasNext).toBe(true);
+      expect(result.current.hasPrev).toBe(false);
+    });
+
+    it('goNext still works after the hook re-renders with new options (search-like rerender)', async () => {
+      const pages = makePages(10, 5);
+      const fetchFn = jest.fn().mockImplementation(({ pageToken }) => {
+        const idx = pageToken ? parseInt(pageToken, 10) : 0;
+        const items = pages[idx] ?? [];
+        const nextIdx = idx + 1;
+        const nextPageToken = nextIdx < pages.length ? String(nextIdx) : '';
+        return Promise.resolve({ items, nextPageToken });
+      });
+      const { result, rerender } = renderHook(
+        ({ pageSize }: { pageSize: number }) =>
+          usePaginatedFetch<Item>({ fetchFn, pageSize }),
+        { initialProps: { pageSize: 5 } },
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.hasNext).toBe(true);
+
+      // Simulate a re-render caused by a parent state update (e.g. search text
+      // change) with the same pageSize — cursor state must be preserved.
+      rerender({ pageSize: 5 });
+      expect(result.current.hasNext).toBe(true);
+
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data[0].id).toBe('6');
+      expect(result.current.hasPrev).toBe(true);
+    });
+  });
 });

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  usePaginatedFetch,
+  UsePaginatedFetchOptions,
+} from './usePaginatedFetch';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+type Item = { id: string };
+
+function makePages(total: number, pageSize: number): Item[][] {
+  const all: Item[] = Array.from({ length: total }, (_, i) => ({
+    id: String(i + 1),
+  }));
+  const pages: Item[][] = [];
+  for (let i = 0; i < all.length; i += pageSize) {
+    pages.push(all.slice(i, i + pageSize));
+  }
+  return pages;
+}
+
+function makeOptions(
+  pages: Item[][],
+  overrides?: Partial<UsePaginatedFetchOptions<Item>>,
+): UsePaginatedFetchOptions<Item> {
+  return {
+    fetchFn: jest.fn().mockImplementation(({ pageToken }) => {
+      const idx = pageToken ? parseInt(pageToken, 10) : 0;
+      const items = pages[idx] ?? [];
+      const nextIdx = idx + 1;
+      const nextPageToken = nextIdx < pages.length ? String(nextIdx) : '';
+      return Promise.resolve({ items, nextPageToken });
+    }),
+    pageSize: 5,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('usePaginatedFetch', () => {
+  describe('initial load', () => {
+    it('starts in loading state', () => {
+      const opts = makeOptions(makePages(5, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      expect(result.current.loading).toBe(true);
+    });
+
+    it('populates data after load', async () => {
+      const opts = makeOptions(makePages(5, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data).toHaveLength(5);
+      expect(result.current.hasPrev).toBe(false);
+      expect(result.current.hasNext).toBe(false);
+    });
+
+    it('exposes hasNext when more pages exist', async () => {
+      const opts = makeOptions(makePages(10, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.hasNext).toBe(true);
+      expect(result.current.hasPrev).toBe(false);
+    });
+
+    it('sets error and clears data on failure', async () => {
+      const opts = makeOptions([], {
+        fetchFn: jest.fn().mockRejectedValue(new Error('network error')),
+      });
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.error).toBe('network error');
+      expect(result.current.data).toHaveLength(0);
+    });
+  });
+
+  describe('goNext', () => {
+    it('fetches the next page and enables hasPrev', async () => {
+      const opts = makeOptions(makePages(15, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data[0].id).toBe('1');
+
+      act(() => {
+        result.current.goNext();
+      });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.data[0].id).toBe('6');
+      expect(result.current.hasPrev).toBe(true);
+      expect(result.current.hasNext).toBe(true);
+    });
+
+    it('navigating to the last page clears hasNext', async () => {
+      const opts = makeOptions(makePages(10, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.goNext();
+      });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.hasNext).toBe(false);
+      expect(result.current.hasPrev).toBe(true);
+    });
+  });
+
+  describe('goPrev', () => {
+    it('goes back to the first page', async () => {
+      const opts = makeOptions(makePages(10, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data[0].id).toBe('6');
+
+      act(() => result.current.goPrev());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.data[0].id).toBe('1');
+      expect(result.current.hasPrev).toBe(false);
+    });
+
+    it('navigates across three pages and back', async () => {
+      const opts = makeOptions(makePages(15, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data[0].id).toBe('11');
+      expect(result.current.hasNext).toBe(false);
+
+      act(() => result.current.goPrev());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data[0].id).toBe('6');
+
+      act(() => result.current.goPrev());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data[0].id).toBe('1');
+      expect(result.current.hasPrev).toBe(false);
+    });
+  });
+
+  describe('refresh', () => {
+    it('re-fetches the current page without changing cursor position', async () => {
+      const fetchFn = jest.fn().mockImplementation(({ pageToken }) => {
+        const idx = pageToken ? parseInt(pageToken, 10) : 0;
+        const pages = makePages(10, 5);
+        const items = pages[idx] ?? [];
+        const nextIdx = idx + 1;
+        const nextPageToken = nextIdx < pages.length ? String(nextIdx) : '';
+        return Promise.resolve({ items, nextPageToken });
+      });
+      const { result } = renderHook(() =>
+        usePaginatedFetch<Item>({ fetchFn, pageSize: 5 }),
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      const callCountAfterNext = fetchFn.mock.calls.length;
+
+      act(() => result.current.refresh());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(fetchFn.mock.calls).toHaveLength(callCountAfterNext + 1);
+      // Should still be on page 2 (pageToken '1')
+      expect(result.current.data[0].id).toBe('6');
+    });
+  });
+
+  describe('resetToFirstPage', () => {
+    it('resets cursor and fetches the first page', async () => {
+      const opts = makeOptions(makePages(10, 5));
+      const { result } = renderHook(() => usePaginatedFetch<Item>(opts));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.goNext());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.hasPrev).toBe(true);
+
+      act(() => result.current.resetToFirstPage());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.data[0].id).toBe('1');
+      expect(result.current.hasPrev).toBe(false);
+    });
+  });
+});

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.ts
@@ -51,12 +51,6 @@ export interface UsePaginatedFetchResult<T> {
   refresh: () => void;
   /** Resets cursor to the first page and re-fetches. */
   resetToFirstPage: () => void;
-  /**
-   * Resets only the navigation state (token stack + next token) without
-   * triggering a new API request. Use when client-side filtering changes so
-   * the cursor controls reflect "page 1" without an extra round-trip.
-   */
-  resetCursor: () => void;
 }
 
 /**
@@ -177,13 +171,6 @@ export function usePaginatedFetch<T>(
     fetch();
   }, [fetch]);
 
-  const resetCursor = useCallback(() => {
-    currentTokenRef.current = undefined;
-    tokenStackRef.current = [];
-    setTokenStack([]);
-    setNextToken('');
-  }, []);
-
   return {
     data,
     loading,
@@ -194,6 +181,5 @@ export function usePaginatedFetch<T>(
     goPrev,
     refresh,
     resetToFirstPage,
-    resetCursor,
   };
 }

--- a/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.ts
+++ b/workspaces/dcm/plugins/dcm/src/hooks/usePaginatedFetch.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { extractApiError } from '../utils/extractApiError';
+
+/** Shape that fetch functions must return. */
+export interface PaginatedPage<T> {
+  items: T[];
+  /** Opaque token for the next page, or empty/undefined when no next page exists. */
+  nextPageToken: string;
+}
+
+/** Parameters passed to the fetch function on every request. */
+export interface FetchParams {
+  pageToken: string | undefined;
+  pageSize: number;
+}
+
+export interface UsePaginatedFetchOptions<T> {
+  /** Called for every page request (initial load, Next, Previous, refresh). */
+  fetchFn: (params: FetchParams) => Promise<PaginatedPage<T>>;
+  /** Number of items to request per page. */
+  pageSize: number;
+}
+
+export interface UsePaginatedFetchResult<T> {
+  data: T[];
+  loading: boolean;
+  error: string | null;
+  /** True when the last server response included a non-empty next_page_token. */
+  hasNext: boolean;
+  /** True when we have navigated past the first page. */
+  hasPrev: boolean;
+  goNext: () => void;
+  goPrev: () => void;
+  /** Re-fetches the current page without changing the cursor position. */
+  refresh: () => void;
+  /** Resets cursor to the first page and re-fetches. */
+  resetToFirstPage: () => void;
+  /**
+   * Resets only the navigation state (token stack + next token) without
+   * triggering a new API request. Use when client-side filtering changes so
+   * the cursor controls reflect "page 1" without an extra round-trip.
+   */
+  resetCursor: () => void;
+}
+
+/**
+ * Generic cursor-based pagination hook.
+ *
+ * Maintains a stack of previously-visited page tokens so Previous navigation
+ * is possible without any extra API knowledge. The fetch function is called
+ * with `{ pageToken, pageSize }` on every page change and on `refresh()`.
+ *
+ * The token stack stores the tokens of ALL pages visited before the current
+ * one. The current page token is kept in a ref so navigation handlers can
+ * update it synchronously before the next fetch.
+ *
+ * @example
+ * const { data, loading, error, hasNext, hasPrev, goNext, goPrev } =
+ *   usePaginatedFetch({
+ *     fetchFn: ({ pageToken, pageSize }) =>
+ *       catalogApi.listServiceTypes({ page_token: pageToken, max_page_size: pageSize })
+ *         .then(r => ({ items: r.results ?? [], nextPageToken: r.next_page_token })),
+ *     pageSize,
+ *   });
+ */
+export function usePaginatedFetch<T>(
+  options: UsePaginatedFetchOptions<T>,
+): UsePaginatedFetchResult<T> {
+  // Keep a ref that always reflects the latest options so the stable `fetch`
+  // callback never closes over stale values. Assigning inline (during render)
+  // rather than inside a useEffect guarantees the ref is up-to-date when a
+  // page-size change triggers a `resetToFirstPage` in a useEffect.
+  const optsRef = useRef(options);
+  optsRef.current = options;
+
+  const [data, setData] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [nextToken, setNextToken] = useState('');
+
+  // Stack of tokens for pages BEFORE the current one. Length === number of
+  // previously-visited pages, so hasPrev = tokenStack.length > 0.
+  const [tokenStack, setTokenStack] = useState<string[]>([]);
+
+  // Ref holding the token for the CURRENT page so fetch() can read it
+  // synchronously even when navigation state hasn't re-rendered yet.
+  const currentTokenRef = useRef<string | undefined>(undefined);
+
+  // Mirrors tokenStack in a ref so goPrev can read the latest value
+  // synchronously inside the click handler (before the next render).
+  const tokenStackRef = useRef<string[]>([]);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    optsRef.current
+      .fetchFn({
+        pageToken: currentTokenRef.current,
+        pageSize: optsRef.current.pageSize,
+      })
+      .then(page => {
+        setData(page.items);
+        setNextToken(page.nextPageToken ?? '');
+      })
+      .catch(err => {
+        setError(extractApiError(err));
+        setData([]);
+        setNextToken('');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  // When pageSize changes after the initial render, reset to the first page
+  // automatically so consumers don't need to duplicate this effect.
+  const prevPageSizeRef = useRef(options.pageSize);
+  useEffect(() => {
+    if (prevPageSizeRef.current !== options.pageSize) {
+      prevPageSizeRef.current = options.pageSize;
+      currentTokenRef.current = undefined;
+      tokenStackRef.current = [];
+      setTokenStack([]);
+      setNextToken('');
+      fetch();
+    }
+  }, [options.pageSize, fetch]);
+
+  const goNext = useCallback(() => {
+    // Capture the current-page token as a plain string BEFORE mutating the ref
+    // so the setTokenStack call below closes over the right value regardless of
+    // when React schedules the state-updater function.
+    const tokenToPush = currentTokenRef.current ?? '';
+    currentTokenRef.current = nextToken || undefined;
+    tokenStackRef.current = [...tokenStackRef.current, tokenToPush];
+    setTokenStack(tokenStackRef.current);
+    fetch();
+  }, [fetch, nextToken]);
+
+  const goPrev = useCallback(() => {
+    const stack = tokenStackRef.current;
+    const prevToken = stack.at(-1);
+    currentTokenRef.current = prevToken || undefined;
+    tokenStackRef.current = stack.slice(0, -1);
+    setTokenStack(tokenStackRef.current);
+    fetch();
+  }, [fetch]);
+
+  const refresh = useCallback(() => {
+    fetch();
+  }, [fetch]);
+
+  const resetToFirstPage = useCallback(() => {
+    currentTokenRef.current = undefined;
+    tokenStackRef.current = [];
+    setTokenStack([]);
+    setNextToken('');
+    fetch();
+  }, [fetch]);
+
+  const resetCursor = useCallback(() => {
+    currentTokenRef.current = undefined;
+    tokenStackRef.current = [];
+    setTokenStack([]);
+    setNextToken('');
+  }, []);
+
+  return {
+    data,
+    loading,
+    error,
+    hasNext: Boolean(nextToken),
+    hasPrev: tokenStack.length > 0,
+    goNext,
+    goPrev,
+    refresh,
+    resetToFirstPage,
+    resetCursor,
+  };
+}

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
@@ -45,7 +45,7 @@ import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { DcmFormDialog } from '../../components/DcmFormDialog';
 import { DcmFormDialogActions } from '../../components/DcmFormDialogActions';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
-import { useCrudTab } from '../../hooks/useCrudTab';
+import { usePaginatedCrudTab } from '../../hooks/usePaginatedCrudTab';
 import { useTranslation } from '../../hooks/useTranslation';
 import emptyIllustration from '../../assets/environments-empty-state.png';
 import { InstanceFormFields } from './components/InstanceFormFields';
@@ -87,15 +87,26 @@ export function CatalogItemInstancesTabContent() {
   const [rehydrateConfirmInst, setRehydrateConfirmInst] =
     useState<CatalogItemInstance | null>(null);
 
-  const crud = useCrudTab<CatalogItemInstance, InstanceForm>({
-    loadFn: async () => {
-      const [instanceList, itemList] = await Promise.all([
-        catalogApi.listCatalogItemInstances().then(r => r.results ?? []),
-        catalogApi.listCatalogItems().then(r => r.results ?? []),
+  const crud = usePaginatedCrudTab<CatalogItemInstance, InstanceForm>({
+    loadFn: async ({ pageToken, pageSize: ps }) => {
+      const [instanceResult, itemList] = await Promise.all([
+        catalogApi
+          .listCatalogItemInstances({
+            page_token: pageToken,
+            max_page_size: ps,
+          })
+          .then(r => ({
+            items: r.results ?? [],
+            nextPageToken: r.next_page_token,
+          })),
+        catalogApi
+          .listCatalogItems({ max_page_size: 25 })
+          .then(r => r.results ?? []),
       ]);
       setCatalogItems(itemList);
-      return instanceList;
+      return instanceResult;
     },
+    storageKey: 'catalog-item-instances',
     createFn: form =>
       catalogApi.createCatalogItemInstance(formToInstance(form)),
     deleteFn: id => catalogApi.deleteCatalogItemInstance(id),
@@ -108,7 +119,6 @@ export function CatalogItemInstancesTabContent() {
     ],
     emptyForm: emptyInstanceForm,
     isValid: isInstanceFormValid,
-    storageKey: 'catalog-item-instances',
   });
 
   const { handleOpenDelete, setItems } = crud;
@@ -276,7 +286,7 @@ export function CatalogItemInstancesTabContent() {
       <DcmCrudTabLayout<CatalogItemInstance>
         items={crud.items}
         filtered={crud.filtered}
-        paginated={crud.paginated}
+        paginated={crud.filtered}
         columns={columns}
         loading={crud.loading}
         loadError={crud.loadError}
@@ -284,11 +294,8 @@ export function CatalogItemInstancesTabContent() {
         actionError={rehydrateError}
         onDismissActionError={() => setRehydrateError(null)}
         search={crud.search}
-        onSearchChange={crud.setSearch}
-        page={crud.page}
-        pageSize={crud.pageSize}
-        onPageChange={crud.onPageChange}
-        onRowsPerPageChange={crud.onRowsPerPageChange}
+        onSearchChange={crud.handleSearchChange}
+        cursorPagination={crud.cursorPagination}
         emptyTitle={t('instances.emptyTitle')}
         emptyDescription={t('instances.emptyDescription')}
         primaryActionLabel={t('instances.createButton')}

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-item-instances/CatalogItemInstancesTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TableColumn } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import {
@@ -81,31 +81,34 @@ export function CatalogItemInstancesTabContent() {
   const { t } = useTranslation();
 
   const [catalogItems, setCatalogItems] = useState<CatalogItem[]>([]);
+  const [catalogItemsError, setCatalogItemsError] = useState<string | null>(
+    null,
+  );
   const [rehydratingId, setRehydratingId] = useState<string | null>(null);
   const [rehydrateError, setRehydrateError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [rehydrateConfirmInst, setRehydrateConfirmInst] =
     useState<CatalogItemInstance | null>(null);
 
+  // Fetch catalog items once on mount; page navigation does not re-fetch.
+  useEffect(() => {
+    catalogApi
+      .listCatalogItems({ max_page_size: 100 })
+      .then(r => setCatalogItems(r.results ?? []))
+      .catch(err => setCatalogItemsError(extractApiError(err)));
+  }, [catalogApi]);
+
   const crud = usePaginatedCrudTab<CatalogItemInstance, InstanceForm>({
-    loadFn: async ({ pageToken, pageSize: ps }) => {
-      const [instanceResult, itemList] = await Promise.all([
-        catalogApi
-          .listCatalogItemInstances({
-            page_token: pageToken,
-            max_page_size: ps,
-          })
-          .then(r => ({
-            items: r.results ?? [],
-            nextPageToken: r.next_page_token,
-          })),
-        catalogApi
-          .listCatalogItems({ max_page_size: 25 })
-          .then(r => r.results ?? []),
-      ]);
-      setCatalogItems(itemList);
-      return instanceResult;
-    },
+    loadFn: ({ pageToken, pageSize: ps }) =>
+      catalogApi
+        .listCatalogItemInstances({
+          page_token: pageToken,
+          max_page_size: ps,
+        })
+        .then(r => ({
+          items: r.results ?? [],
+          nextPageToken: r.next_page_token,
+        })),
     storageKey: 'catalog-item-instances',
     createFn: form =>
       catalogApi.createCatalogItemInstance(formToInstance(form)),
@@ -291,8 +294,11 @@ export function CatalogItemInstancesTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={rehydrateError}
-        onDismissActionError={() => setRehydrateError(null)}
+        actionError={catalogItemsError ?? rehydrateError}
+        onDismissActionError={() => {
+          setCatalogItemsError(null);
+          setRehydrateError(null);
+        }}
         search={crud.search}
         onSearchChange={crud.handleSearchChange}
         cursorPagination={crud.cursorPagination}

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
@@ -74,6 +74,7 @@ import type {
   CatalogItem,
   ServiceType,
 } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
+import { extractApiError } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
 import { catalogApiRef } from '../../apis';
 import { DcmCrudTabLayout } from '../../components/DcmCrudTabLayout';
 import { DcmDeleteDialog } from '../../components/DcmDeleteDialog';
@@ -99,6 +100,9 @@ export function CatalogItemsTabContent() {
   const { t } = useTranslation();
 
   const [serviceTypes, setServiceTypes] = useState<ServiceType[]>([]);
+  const [serviceTypesError, setServiceTypesError] = useState<string | null>(
+    null,
+  );
   /** Tracks whether a submit was attempted so field-level errors show for all fields. */
   const [createSubmitAttempted, setCreateSubmitAttempted] = useState(false);
   const [editSubmitAttempted, setEditSubmitAttempted] = useState(false);
@@ -108,7 +112,7 @@ export function CatalogItemsTabContent() {
     catalogApi
       .listServiceTypes({ max_page_size: 100 })
       .then(r => setServiceTypes(r.results ?? []))
-      .catch(() => {});
+      .catch(err => setServiceTypesError(extractApiError(err)));
   }, [catalogApi]);
 
   const crud = usePaginatedCrudTab<CatalogItem, CatalogItemForm>({
@@ -333,8 +337,8 @@ export function CatalogItemsTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={null}
-        onDismissActionError={undefined}
+        actionError={serviceTypesError}
+        onDismissActionError={() => setServiceTypesError(null)}
         search={crud.search}
         onSearchChange={crud.handleSearchChange}
         cursorPagination={crud.cursorPagination}

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
@@ -80,7 +80,7 @@ import { DcmDeleteDialog } from '../../components/DcmDeleteDialog';
 import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { createEditDeleteColumn } from '../../components/dcmTabListHelpers';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
-import { useCrudTab } from '../../hooks/useCrudTab';
+import { usePaginatedCrudTab } from '../../hooks/usePaginatedCrudTab';
 import { useTranslation } from '../../hooks/useTranslation';
 import emptyIllustration from '../../assets/environments-empty-state.png';
 import { CatalogItemFormFields } from './components/CatalogItemFormFields';
@@ -103,15 +103,26 @@ export function CatalogItemsTabContent() {
   const [createSubmitAttempted, setCreateSubmitAttempted] = useState(false);
   const [editSubmitAttempted, setEditSubmitAttempted] = useState(false);
 
-  const crud = useCrudTab<CatalogItem, CatalogItemForm>({
-    loadFn: async () => {
+  const crud = usePaginatedCrudTab<CatalogItem, CatalogItemForm>({
+    loadFn: async ({ pageToken, pageSize: ps }) => {
       const [itemList, serviceTypeList] = await Promise.all([
-        catalogApi.listCatalogItems().then(r => r.results ?? []),
-        catalogApi.listServiceTypes().then(r => r.results ?? []),
+        catalogApi
+          .listCatalogItems({
+            page_token: pageToken,
+            max_page_size: ps,
+          })
+          .then(r => ({
+            items: r.results ?? [],
+            nextPageToken: r.next_page_token,
+          })),
+        catalogApi
+          .listServiceTypes({ max_page_size: 25 })
+          .then(r => r.results ?? []),
       ]);
       setServiceTypes(serviceTypeList);
       return itemList;
     },
+    storageKey: 'catalog-items',
     createFn: form => catalogApi.createCatalogItem(formToCatalogItem(form)),
     updateFn: (id, form) =>
       catalogApi.updateCatalogItem(id, formToCatalogItemForUpdate(form)),
@@ -125,7 +136,6 @@ export function CatalogItemsTabContent() {
     emptyForm: emptyCatalogItemForm,
     isValid: isCatalogItemFormValid,
     itemToForm: catalogItemToForm,
-    storageKey: 'catalog-items',
     createSuccessMessage: t('catalogItems.createSuccess'),
     editSuccessMessage: t('catalogItems.updateSuccess'),
     deleteSuccessMessage: t('catalogItems.deleteSuccess'),
@@ -321,7 +331,7 @@ export function CatalogItemsTabContent() {
       <DcmCrudTabLayout<CatalogItem>
         items={crud.items}
         filtered={crud.filtered}
-        paginated={crud.paginated}
+        paginated={crud.filtered}
         columns={columns}
         loading={crud.loading}
         loadError={crud.loadError}
@@ -329,11 +339,8 @@ export function CatalogItemsTabContent() {
         actionError={null}
         onDismissActionError={undefined}
         search={crud.search}
-        onSearchChange={crud.setSearch}
-        page={crud.page}
-        pageSize={crud.pageSize}
-        onPageChange={crud.onPageChange}
-        onRowsPerPageChange={crud.onRowsPerPageChange}
+        onSearchChange={crud.handleSearchChange}
+        cursorPagination={crud.cursorPagination}
         emptyTitle={t('catalogItems.emptyTitle')}
         emptyDescription={t('catalogItems.emptyDescription')}
         primaryActionLabel={t('catalogItems.createButton')}

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/CatalogItemsTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TableColumn } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import {
@@ -103,25 +103,22 @@ export function CatalogItemsTabContent() {
   const [createSubmitAttempted, setCreateSubmitAttempted] = useState(false);
   const [editSubmitAttempted, setEditSubmitAttempted] = useState(false);
 
+  // Fetch dropdown options once on mount; page navigation does not re-fetch.
+  useEffect(() => {
+    catalogApi
+      .listServiceTypes({ max_page_size: 100 })
+      .then(r => setServiceTypes(r.results ?? []))
+      .catch(() => {});
+  }, [catalogApi]);
+
   const crud = usePaginatedCrudTab<CatalogItem, CatalogItemForm>({
-    loadFn: async ({ pageToken, pageSize: ps }) => {
-      const [itemList, serviceTypeList] = await Promise.all([
-        catalogApi
-          .listCatalogItems({
-            page_token: pageToken,
-            max_page_size: ps,
-          })
-          .then(r => ({
-            items: r.results ?? [],
-            nextPageToken: r.next_page_token,
-          })),
-        catalogApi
-          .listServiceTypes({ max_page_size: 25 })
-          .then(r => r.results ?? []),
-      ]);
-      setServiceTypes(serviceTypeList);
-      return itemList;
-    },
+    loadFn: ({ pageToken, pageSize: ps }) =>
+      catalogApi
+        .listCatalogItems({ page_token: pageToken, max_page_size: ps })
+        .then(r => ({
+          items: r.results ?? [],
+          nextPageToken: r.next_page_token,
+        })),
     storageKey: 'catalog-items',
     createFn: form => catalogApi.createCatalogItem(formToCatalogItem(form)),
     updateFn: (id, form) =>

--- a/workspaces/dcm/plugins/dcm/src/pages/catalog-items/components/CatalogItemFormFields.test.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/catalog-items/components/CatalogItemFormFields.test.tsx
@@ -107,9 +107,9 @@ describe('CatalogItemFormFields – file import error handling', () => {
 
     await userEvent.upload(input, file);
 
-    await waitFor(() =>
-      expect(screen.getByText(/Failed to import file/i)).toBeInTheDocument(),
-    );
+    expect(
+      await screen.findByText(/Failed to import file/i),
+    ).toBeInTheDocument();
   });
 
   it('does not show an error alert when a valid JSON file is imported', async () => {
@@ -148,9 +148,9 @@ describe('CatalogItemFormFields – file import error handling', () => {
     await userEvent.upload(input, file);
 
     // Wait for error to appear
-    await waitFor(() =>
-      expect(screen.getByText(/Failed to import file/i)).toBeInTheDocument(),
-    );
+    expect(
+      await screen.findByText(/Failed to import file/i),
+    ).toBeInTheDocument();
 
     // MuiAlert renders a close button
     const closeBtn = screen.getByRole('button', { name: /close/i });

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.test.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.test.tsx
@@ -37,7 +37,9 @@ const MOCK_POLICY: Policy = {
 const UPDATED_POLICY: Policy = { ...MOCK_POLICY, enabled: false };
 
 const baseMockApi = {
-  listPolicies: jest.fn().mockResolvedValue({ policies: [MOCK_POLICY] }),
+  listPolicies: jest
+    .fn()
+    .mockResolvedValue({ policies: [MOCK_POLICY], next_page_token: undefined }),
   updatePolicy: jest.fn(),
   createPolicy: jest.fn(),
   deletePolicy: jest.fn(),
@@ -57,6 +59,84 @@ async function renderPoliciesTab(
   );
 }
 
+describe('PoliciesTabContent – pagination params', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls listPolicies with pagination params on mount', async () => {
+    const mockApi = buildMockApi();
+    await renderPoliciesTab(mockApi);
+
+    await waitFor(() => expect(mockApi.listPolicies).toHaveBeenCalledTimes(1));
+    expect(mockApi.listPolicies).toHaveBeenCalledWith(
+      expect.objectContaining({ max_page_size: expect.any(Number) }),
+    );
+  });
+});
+
+describe('PoliciesTabContent – cursor pagination', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('shows a Next button when next_page_token is returned', async () => {
+    const mockApi = buildMockApi({
+      listPolicies: jest.fn().mockResolvedValue({
+        policies: [MOCK_POLICY],
+        next_page_token: 'tok-2',
+      }),
+    });
+    await renderPoliciesTab(mockApi);
+
+    expect(
+      await screen.findByRole('button', { name: /next/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('Next button is disabled when no next_page_token', async () => {
+    const mockApi = buildMockApi({
+      listPolicies: jest
+        .fn()
+        .mockResolvedValue({ policies: [MOCK_POLICY], next_page_token: '' }),
+    });
+    await renderPoliciesTab(mockApi);
+
+    const nextBtn = await screen.findByRole('button', { name: /next/i });
+    expect(nextBtn).toBeDisabled();
+  });
+
+  it('Previous button is disabled on the first page', async () => {
+    const mockApi = buildMockApi({
+      listPolicies: jest.fn().mockResolvedValue({
+        policies: [MOCK_POLICY],
+        next_page_token: 'tok-2',
+      }),
+    });
+    await renderPoliciesTab(mockApi);
+
+    const prevBtn = await screen.findByRole('button', { name: /previous/i });
+    expect(prevBtn).toBeDisabled();
+  });
+
+  it('calls listPolicies with next_page_token after clicking Next', async () => {
+    const listPolicies = jest
+      .fn()
+      .mockResolvedValueOnce({
+        policies: [MOCK_POLICY],
+        next_page_token: 'tok-2',
+      })
+      .mockResolvedValueOnce({ policies: [MOCK_POLICY], next_page_token: '' });
+    const mockApi = buildMockApi({ listPolicies });
+    await renderPoliciesTab(mockApi);
+
+    const nextBtn = await screen.findByRole('button', { name: /next/i });
+    fireEvent.click(nextBtn);
+
+    await waitFor(() =>
+      expect(listPolicies).toHaveBeenCalledWith(
+        expect.objectContaining({ page_token: 'tok-2' }),
+      ),
+    );
+  });
+});
+
 describe('PoliciesTabContent – toggle error handling', () => {
   beforeEach(() => jest.clearAllMocks());
 
@@ -73,9 +153,7 @@ describe('PoliciesTabContent – toggle error handling', () => {
     fireEvent.click(toggleSwitch);
 
     // The snackbar should show the error text
-    await waitFor(() =>
-      expect(screen.getByText(/toggle failed/i)).toBeInTheDocument(),
-    );
+    expect(await screen.findByText(/toggle failed/i)).toBeInTheDocument();
   });
 
   it('does not show a snackbar when updatePolicy succeeds', async () => {

--- a/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/policies/PoliciesTabContent.tsx
@@ -58,7 +58,7 @@ import { DcmFormDialog } from '../../components/DcmFormDialog';
 import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { DcmFormDialogActions } from '../../components/DcmFormDialogActions';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
-import { useCrudTab } from '../../hooks/useCrudTab';
+import { usePaginatedCrudTab } from '../../hooks/usePaginatedCrudTab';
 import { useTranslation } from '../../hooks/useTranslation';
 import { extractApiError } from '../../utils/extractApiError';
 import emptyIllustration from '../../assets/environments-empty-state.png';
@@ -99,8 +99,18 @@ export function PoliciesTabContent() {
   const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
   const [toggleError, setToggleError] = useState<string | null>(null);
 
-  const crud = useCrudTab<Policy, PolicyForm>({
-    loadFn: () => policyApi.listPolicies().then(res => res.policies ?? []),
+  const crud = usePaginatedCrudTab<Policy, PolicyForm>({
+    loadFn: ({ pageToken, pageSize: ps }) =>
+      policyApi
+        .listPolicies({
+          page_token: pageToken,
+          max_page_size: ps,
+        })
+        .then(res => ({
+          items: res.policies ?? [],
+          nextPageToken: res.next_page_token,
+        })),
+    storageKey: 'policies',
     createFn: form => policyApi.createPolicy(formToPolicy(form)),
     updateFn: (id, form) => policyApi.updatePolicy(id, formToPolicy(form)),
     deleteFn: id => policyApi.deletePolicy(id),
@@ -109,7 +119,6 @@ export function PoliciesTabContent() {
     emptyForm: emptyPolicyForm,
     isValid: isPolicyFormValid,
     itemToForm: policyToForm,
-    storageKey: 'policies',
     createSuccessMessage: t('policies.createSuccess'),
     editSuccessMessage: t('policies.updateSuccess'),
     deleteSuccessMessage: t('policies.deleteSuccess'),
@@ -335,7 +344,7 @@ export function PoliciesTabContent() {
       <DcmCrudTabLayout<Policy>
         items={crud.items}
         filtered={crud.filtered}
-        paginated={crud.paginated}
+        paginated={crud.filtered}
         columns={columns}
         loading={crud.loading}
         loadError={crud.loadError}
@@ -343,11 +352,8 @@ export function PoliciesTabContent() {
         actionError={toggleError}
         onDismissActionError={() => setToggleError(null)}
         search={crud.search}
-        onSearchChange={crud.setSearch}
-        page={crud.page}
-        pageSize={crud.pageSize}
-        onPageChange={crud.onPageChange}
-        onRowsPerPageChange={crud.onRowsPerPageChange}
+        onSearchChange={crud.handleSearchChange}
+        cursorPagination={crud.cursorPagination}
         emptyTitle={t('policies.emptyTitle')}
         emptyDescription={t('policies.emptyDescription')}
         primaryActionLabel={t('policies.createButton')}

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.test.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.test.tsx
@@ -1,0 +1,293 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import type {
+  Provider,
+  ServiceType,
+} from '@red-hat-developer-hub/backstage-plugin-dcm-common';
+import { catalogApiRef, providersApiRef } from '../../apis';
+import { ProvidersTabContent } from './ProvidersTabContent';
+
+jest.mock('../../hooks/useTranslation', () => {
+  const mod = require('../../test-utils/mockTranslations');
+  return { useTranslation: mod.mockUseTranslation };
+});
+
+const MOCK_PROVIDER: Provider = {
+  id: 'provider-1',
+  name: 'my-provider',
+  display_name: 'My Provider',
+  endpoint: 'http://example.com',
+  service_type: 'vm',
+  schema_version: 'v1alpha1',
+};
+
+const MOCK_SERVICE_TYPE: ServiceType = {
+  uid: 'st-1',
+  service_type: 'vm',
+  api_version: 'v1alpha1',
+  spec: {},
+};
+
+const baseProvidersApi = {
+  listProviders: jest.fn().mockResolvedValue({
+    providers: [MOCK_PROVIDER],
+    next_page_token: undefined,
+  }),
+  createProvider: jest.fn(),
+  applyProvider: jest.fn(),
+  deleteProvider: jest.fn(),
+  getProvider: jest.fn(),
+};
+
+const baseCatalogApi = {
+  listServiceTypes: jest
+    .fn()
+    .mockResolvedValue({ results: [MOCK_SERVICE_TYPE] }),
+  listCatalogItems: jest.fn().mockResolvedValue({ results: [] }),
+  listCatalogItemInstances: jest.fn().mockResolvedValue({ results: [] }),
+  getCatalogItem: jest.fn(),
+  getCatalogItemInstance: jest.fn(),
+  getServiceType: jest.fn(),
+  createServiceType: jest.fn(),
+  createCatalogItem: jest.fn(),
+  updateCatalogItem: jest.fn(),
+  deleteCatalogItem: jest.fn(),
+  createCatalogItemInstance: jest.fn(),
+  deleteCatalogItemInstance: jest.fn(),
+  rehydrateCatalogItemInstance: jest.fn(),
+};
+
+function buildApis(
+  providerOverrides: Partial<typeof baseProvidersApi> = {},
+  catalogOverrides: Partial<typeof baseCatalogApi> = {},
+) {
+  return {
+    providers: { ...baseProvidersApi, ...providerOverrides },
+    catalog: { ...baseCatalogApi, ...catalogOverrides },
+  };
+}
+
+async function renderProvidersTab(
+  apis: ReturnType<typeof buildApis> = buildApis(),
+) {
+  return renderInTestApp(
+    <TestApiProvider
+      apis={[
+        [providersApiRef, apis.providers],
+        [catalogApiRef, apis.catalog],
+      ]}
+    >
+      <ProvidersTabContent />
+    </TestApiProvider>,
+  );
+}
+
+describe('ProvidersTabContent', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('initial load', () => {
+    it('calls listProviders with pagination params on mount', async () => {
+      const apis = buildApis();
+      await renderProvidersTab(apis);
+
+      await waitFor(() =>
+        expect(apis.providers.listProviders).toHaveBeenCalledTimes(1),
+      );
+      expect(apis.providers.listProviders).toHaveBeenCalledWith(
+        expect.objectContaining({ max_page_size: expect.any(Number) }),
+      );
+    });
+
+    it('calls listServiceTypes with max_page_size: 25 for the dropdown', async () => {
+      const apis = buildApis();
+      await renderProvidersTab(apis);
+
+      await waitFor(() =>
+        expect(apis.catalog.listServiceTypes).toHaveBeenCalledTimes(1),
+      );
+      expect(apis.catalog.listServiceTypes).toHaveBeenCalledWith({
+        max_page_size: 25,
+      });
+    });
+
+    it('shows provider name in the table after successful load', async () => {
+      const apis = buildApis();
+      await renderProvidersTab(apis);
+
+      expect(await screen.findByText('my-provider')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when no providers are returned', async () => {
+      const apis = buildApis({
+        listProviders: jest.fn().mockResolvedValue({ providers: [] }),
+      });
+      await renderProvidersTab(apis);
+
+      expect(
+        await screen.findByText(/no providers registered/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('load error', () => {
+    it('shows an error alert when listProviders rejects', async () => {
+      const apis = buildApis({
+        listProviders: jest.fn().mockRejectedValue(new Error('API down')),
+      });
+      await renderProvidersTab(apis);
+
+      expect(await screen.findByText(/API down/i)).toBeInTheDocument();
+    });
+
+    it('shows a Retry button when listProviders rejects', async () => {
+      const apis = buildApis({
+        listProviders: jest.fn().mockRejectedValue(new Error('API down')),
+      });
+      await renderProvidersTab(apis);
+
+      expect(
+        await screen.findByRole('button', { name: /retry/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('cursor pagination', () => {
+    it('shows Next button when next_page_token is returned', async () => {
+      const apis = buildApis({
+        listProviders: jest.fn().mockResolvedValue({
+          providers: [MOCK_PROVIDER],
+          next_page_token: 'tok-2',
+        }),
+      });
+      await renderProvidersTab(apis);
+
+      expect(
+        await screen.findByRole('button', { name: /next/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('Next button is disabled when no next_page_token', async () => {
+      const apis = buildApis({
+        listProviders: jest.fn().mockResolvedValue({
+          providers: [MOCK_PROVIDER],
+          next_page_token: '',
+        }),
+      });
+      await renderProvidersTab(apis);
+
+      const nextBtn = await screen.findByRole('button', { name: /next/i });
+      expect(nextBtn).toBeDisabled();
+    });
+
+    it('calls listProviders with next_page_token after clicking Next', async () => {
+      const listProviders = jest
+        .fn()
+        .mockResolvedValueOnce({
+          providers: [MOCK_PROVIDER],
+          next_page_token: 'tok-2',
+        })
+        .mockResolvedValueOnce({
+          providers: [MOCK_PROVIDER],
+          next_page_token: '',
+        });
+      const apis = buildApis({ listProviders });
+      await renderProvidersTab(apis);
+
+      const nextBtn = await screen.findByRole('button', { name: /next/i });
+      fireEvent.click(nextBtn);
+
+      await waitFor(() =>
+        expect(listProviders).toHaveBeenCalledWith(
+          expect.objectContaining({ page_token: 'tok-2' }),
+        ),
+      );
+    });
+
+    it('Previous button is disabled on the first page', async () => {
+      const apis = buildApis({
+        listProviders: jest.fn().mockResolvedValue({
+          providers: [MOCK_PROVIDER],
+          next_page_token: 'tok-2',
+        }),
+      });
+      await renderProvidersTab(apis);
+
+      const prevBtn = await screen.findByRole('button', { name: /previous/i });
+      expect(prevBtn).toBeDisabled();
+    });
+
+    it('shows the current page size in the rows-per-page selector', async () => {
+      const apis = buildApis();
+      await renderProvidersTab(apis);
+
+      await screen.findByText('my-provider');
+      // The Select renders the selected value as "5 rows" via renderValue.
+      expect(screen.getByText('5 rows')).toBeInTheDocument();
+    });
+
+    it('re-fetches with new max_page_size when the page-size option is selected', async () => {
+      const listProviders = jest
+        .fn()
+        .mockResolvedValue({ providers: [MOCK_PROVIDER], next_page_token: '' });
+      const apis = buildApis({ listProviders });
+      await renderProvidersTab(apis);
+
+      await screen.findByText('my-provider');
+      expect(listProviders).toHaveBeenCalledTimes(1);
+
+      // Open the MUI Select by clicking its trigger button (displays current size).
+      // The trigger renders as a button inside the pagination controls.
+      fireEvent.mouseDown(screen.getByRole('button', { name: /rows/i }));
+
+      // Pick "15" from the opened dropdown menu.
+      const option15 = await screen.findByRole('option', { name: '15' });
+      fireEvent.click(option15);
+
+      await waitFor(() =>
+        expect(listProviders).toHaveBeenCalledWith(
+          expect.objectContaining({ max_page_size: 15 }),
+        ),
+      );
+    });
+
+    it('Previous button is enabled after navigating to page 2', async () => {
+      const listProviders = jest
+        .fn()
+        .mockResolvedValueOnce({
+          providers: [MOCK_PROVIDER],
+          next_page_token: 'tok-2',
+        })
+        .mockResolvedValueOnce({
+          providers: [MOCK_PROVIDER],
+          next_page_token: '',
+        });
+      const apis = buildApis({ listProviders });
+      await renderProvidersTab(apis);
+
+      const nextBtn = await screen.findByRole('button', { name: /next/i });
+      fireEvent.click(nextBtn);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /previous/i }),
+        ).not.toBeDisabled(),
+      );
+    });
+  });
+});

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.test.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.test.tsx
@@ -114,7 +114,7 @@ describe('ProvidersTabContent', () => {
       );
     });
 
-    it('calls listServiceTypes with max_page_size: 25 for the dropdown', async () => {
+    it('calls listServiceTypes with max_page_size: 100 for the dropdown (once on mount)', async () => {
       const apis = buildApis();
       await renderProvidersTab(apis);
 
@@ -122,7 +122,7 @@ describe('ProvidersTabContent', () => {
         expect(apis.catalog.listServiceTypes).toHaveBeenCalledTimes(1),
       );
       expect(apis.catalog.listServiceTypes).toHaveBeenCalledWith({
-        max_page_size: 25,
+        max_page_size: 100,
       });
     });
 
@@ -255,13 +255,13 @@ describe('ProvidersTabContent', () => {
       // The trigger renders as a button inside the pagination controls.
       fireEvent.mouseDown(screen.getByRole('button', { name: /rows/i }));
 
-      // Pick "15" from the opened dropdown menu.
-      const option15 = await screen.findByRole('option', { name: '15' });
-      fireEvent.click(option15);
+      // Pick "10" from the opened dropdown menu.
+      const option10 = await screen.findByRole('option', { name: '10' });
+      fireEvent.click(option10);
 
       await waitFor(() =>
         expect(listProviders).toHaveBeenCalledWith(
-          expect.objectContaining({ max_page_size: 15 }),
+          expect.objectContaining({ max_page_size: 10 }),
         ),
       );
     });

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
@@ -49,7 +49,7 @@ import { DcmSuccessSnackbar } from '../../components/DcmSuccessSnackbar';
 import { DcmFormDialogActions } from '../../components/DcmFormDialogActions';
 import { createEditDeleteColumn } from '../../components/dcmTabListHelpers';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
-import { useCrudTab } from '../../hooks/useCrudTab';
+import { usePaginatedCrudTab } from '../../hooks/usePaginatedCrudTab';
 import { useTranslation } from '../../hooks/useTranslation';
 import emptyIllustration from '../../assets/environments-empty-state.png';
 import { CopyButton } from './components/CopyButton';
@@ -72,15 +72,26 @@ export function ProvidersTabContent() {
 
   const [serviceTypes, setServiceTypes] = useState<ServiceType[]>([]);
 
-  const crud = useCrudTab<Provider, ProviderForm>({
-    loadFn: async () => {
-      const [providerList, serviceTypeList] = await Promise.all([
-        providersApi.listProviders().then(r => r.providers ?? []),
-        catalogApi.listServiceTypes().then(r => r.results ?? []),
+  const crud = usePaginatedCrudTab<Provider, ProviderForm>({
+    loadFn: async ({ pageToken, pageSize: ps }) => {
+      const [providerResult, serviceTypeList] = await Promise.all([
+        providersApi
+          .listProviders({
+            page_token: pageToken,
+            max_page_size: ps,
+          })
+          .then(r => ({
+            items: r.providers ?? [],
+            nextPageToken: r.next_page_token,
+          })),
+        catalogApi
+          .listServiceTypes({ max_page_size: 25 })
+          .then(r => r.results ?? []),
       ]);
       setServiceTypes(serviceTypeList);
-      return providerList;
+      return providerResult;
     },
+    storageKey: 'providers',
     createFn: form => providersApi.createProvider(formToProvider(form)),
     updateFn: (id, form) =>
       providersApi.applyProvider(id, formToProvider(form)),
@@ -90,7 +101,6 @@ export function ProvidersTabContent() {
     emptyForm: emptyProviderForm,
     isValid: isProviderFormValid,
     itemToForm: providerToForm,
-    storageKey: 'providers',
     createSuccessMessage: t('providers.createSuccess'),
     editSuccessMessage: t('providers.updateSuccess'),
     deleteSuccessMessage: t('providers.deleteSuccess'),
@@ -298,7 +308,7 @@ export function ProvidersTabContent() {
       <DcmCrudTabLayout<Provider>
         items={crud.items}
         filtered={crud.filtered}
-        paginated={crud.paginated}
+        paginated={crud.filtered}
         columns={columns}
         loading={crud.loading}
         loadError={crud.loadError}
@@ -306,19 +316,14 @@ export function ProvidersTabContent() {
         actionError={null}
         onDismissActionError={undefined}
         search={crud.search}
-        onSearchChange={crud.setSearch}
-        page={crud.page}
-        pageSize={crud.pageSize}
-        onPageChange={crud.onPageChange}
-        onRowsPerPageChange={crud.onRowsPerPageChange}
+        onSearchChange={crud.handleSearchChange}
+        cursorPagination={crud.cursorPagination}
         emptyTitle={t('providers.emptyTitle')}
         emptyDescription={t('providers.emptyDescription')}
         primaryActionLabel={t('providers.registerButton')}
         onPrimaryAction={crud.handleOpenCreate}
         illustrationSrc={emptyIllustration}
         entityLabel={t('providers.entityLabel')}
-        onRefresh={crud.reload}
-        refreshing={crud.refreshing}
       />
 
       {formDialog({

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TableColumn } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { Box, Chip, Tooltip, Typography } from '@material-ui/core';
@@ -72,25 +72,22 @@ export function ProvidersTabContent() {
 
   const [serviceTypes, setServiceTypes] = useState<ServiceType[]>([]);
 
+  // Fetch dropdown options once on mount; page navigation does not re-fetch.
+  useEffect(() => {
+    catalogApi
+      .listServiceTypes({ max_page_size: 100 })
+      .then(r => setServiceTypes(r.results ?? []))
+      .catch(() => {});
+  }, [catalogApi]);
+
   const crud = usePaginatedCrudTab<Provider, ProviderForm>({
-    loadFn: async ({ pageToken, pageSize: ps }) => {
-      const [providerResult, serviceTypeList] = await Promise.all([
-        providersApi
-          .listProviders({
-            page_token: pageToken,
-            max_page_size: ps,
-          })
-          .then(r => ({
-            items: r.providers ?? [],
-            nextPageToken: r.next_page_token,
-          })),
-        catalogApi
-          .listServiceTypes({ max_page_size: 25 })
-          .then(r => r.results ?? []),
-      ]);
-      setServiceTypes(serviceTypeList);
-      return providerResult;
-    },
+    loadFn: ({ pageToken, pageSize: ps }) =>
+      providersApi
+        .listProviders({ page_token: pageToken, max_page_size: ps })
+        .then(r => ({
+          items: r.providers ?? [],
+          nextPageToken: r.next_page_token,
+        })),
     storageKey: 'providers',
     createFn: form => providersApi.createProvider(formToProvider(form)),
     updateFn: (id, form) =>

--- a/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/providers/ProvidersTabContent.tsx
@@ -41,6 +41,7 @@ import type {
   Provider,
   ServiceType,
 } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
+import { extractApiError } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
 import { catalogApiRef, providersApiRef } from '../../apis';
 import { DcmCrudTabLayout } from '../../components/DcmCrudTabLayout';
 import { DcmDeleteDialog } from '../../components/DcmDeleteDialog';
@@ -71,13 +72,16 @@ export function ProvidersTabContent() {
   const { t } = useTranslation();
 
   const [serviceTypes, setServiceTypes] = useState<ServiceType[]>([]);
+  const [serviceTypesError, setServiceTypesError] = useState<string | null>(
+    null,
+  );
 
   // Fetch dropdown options once on mount; page navigation does not re-fetch.
   useEffect(() => {
     catalogApi
       .listServiceTypes({ max_page_size: 100 })
       .then(r => setServiceTypes(r.results ?? []))
-      .catch(() => {});
+      .catch(err => setServiceTypesError(extractApiError(err)));
   }, [catalogApi]);
 
   const crud = usePaginatedCrudTab<Provider, ProviderForm>({
@@ -310,8 +314,8 @@ export function ProvidersTabContent() {
         loading={crud.loading}
         loadError={crud.loadError}
         onRetry={crud.reload}
-        actionError={null}
-        onDismissActionError={undefined}
+        actionError={serviceTypesError}
+        onDismissActionError={() => setServiceTypesError(null)}
         search={crud.search}
         onSearchChange={crud.handleSearchChange}
         cursorPagination={crud.cursorPagination}

--- a/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.test.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.test.tsx
@@ -1,0 +1,225 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import type { ServiceTypeInstance } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
+import { resourcesApiRef } from '../../apis';
+import { ResourcesTabContent } from './ResourcesTabContent';
+
+jest.mock('../../hooks/useTranslation', () => {
+  const mod = require('../../test-utils/mockTranslations');
+  return { useTranslation: mod.mockUseTranslation };
+});
+
+const MOCK_INSTANCE: ServiceTypeInstance = {
+  id: 'inst-1',
+  provider_name: 'my-provider',
+  status: 'active',
+  spec: { service_type: 'vm' },
+};
+
+const baseResourcesApi = {
+  listServiceTypeInstances: jest.fn().mockResolvedValue({
+    instances: [MOCK_INSTANCE],
+    next_page_token: undefined,
+  }),
+};
+
+function buildApi(overrides: Partial<typeof baseResourcesApi> = {}) {
+  return { ...baseResourcesApi, ...overrides };
+}
+
+async function renderResourcesTab(
+  mockApi: ReturnType<typeof buildApi> = buildApi(),
+) {
+  return renderInTestApp(
+    <TestApiProvider apis={[[resourcesApiRef, mockApi]]}>
+      <ResourcesTabContent />
+    </TestApiProvider>,
+  );
+}
+
+describe('ResourcesTabContent', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('initial load', () => {
+    it('calls listServiceTypeInstances with pagination params on mount', async () => {
+      const mockApi = buildApi();
+      await renderResourcesTab(mockApi);
+
+      await waitFor(() =>
+        expect(mockApi.listServiceTypeInstances).toHaveBeenCalledTimes(1),
+      );
+      expect(mockApi.listServiceTypeInstances).toHaveBeenCalledWith(
+        expect.objectContaining({ max_page_size: expect.any(Number) }),
+      );
+    });
+
+    it('shows instance id in the table after successful load', async () => {
+      const mockApi = buildApi();
+      await renderResourcesTab(mockApi);
+
+      expect(await screen.findByText('inst-1')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when no instances are returned', async () => {
+      const mockApi = buildApi({
+        listServiceTypeInstances: jest
+          .fn()
+          .mockResolvedValue({ instances: [] }),
+      });
+      await renderResourcesTab(mockApi);
+
+      expect(
+        await screen.findByText(/no resources found/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('load error', () => {
+    it('shows an error alert when listServiceTypeInstances rejects', async () => {
+      const mockApi = buildApi({
+        listServiceTypeInstances: jest
+          .fn()
+          .mockRejectedValue(new Error('Resources unavailable')),
+      });
+      await renderResourcesTab(mockApi);
+
+      expect(
+        await screen.findByText(/Resources unavailable/i),
+      ).toBeInTheDocument();
+    });
+
+    it('shows a Retry button when the API rejects', async () => {
+      const mockApi = buildApi({
+        listServiceTypeInstances: jest
+          .fn()
+          .mockRejectedValue(new Error('Resources unavailable')),
+      });
+      await renderResourcesTab(mockApi);
+
+      expect(
+        await screen.findByRole('button', { name: /retry/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('re-calls listServiceTypeInstances when Retry is clicked', async () => {
+      const listServiceTypeInstances = jest
+        .fn()
+        .mockRejectedValue(new Error('Resources unavailable'));
+      const mockApi = buildApi({ listServiceTypeInstances });
+      await renderResourcesTab(mockApi);
+
+      const retryBtn = await screen.findByRole('button', { name: /retry/i });
+      fireEvent.click(retryBtn);
+
+      await waitFor(() =>
+        expect(listServiceTypeInstances).toHaveBeenCalledTimes(2),
+      );
+    });
+  });
+
+  describe('cursor pagination', () => {
+    it('shows Next button when next_page_token is returned', async () => {
+      const mockApi = buildApi({
+        listServiceTypeInstances: jest.fn().mockResolvedValue({
+          instances: [MOCK_INSTANCE],
+          next_page_token: 'tok-2',
+        }),
+      });
+      await renderResourcesTab(mockApi);
+
+      expect(
+        await screen.findByRole('button', { name: /next/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('Next button is disabled when no next_page_token', async () => {
+      const mockApi = buildApi({
+        listServiceTypeInstances: jest.fn().mockResolvedValue({
+          instances: [MOCK_INSTANCE],
+          next_page_token: '',
+        }),
+      });
+      await renderResourcesTab(mockApi);
+
+      const nextBtn = await screen.findByRole('button', { name: /next/i });
+      expect(nextBtn).toBeDisabled();
+    });
+
+    it('calls listServiceTypeInstances with next_page_token after clicking Next', async () => {
+      const listServiceTypeInstances = jest
+        .fn()
+        .mockResolvedValueOnce({
+          instances: [MOCK_INSTANCE],
+          next_page_token: 'tok-2',
+        })
+        .mockResolvedValueOnce({
+          instances: [MOCK_INSTANCE],
+          next_page_token: '',
+        });
+      const mockApi = buildApi({ listServiceTypeInstances });
+      await renderResourcesTab(mockApi);
+
+      const nextBtn = await screen.findByRole('button', { name: /next/i });
+      fireEvent.click(nextBtn);
+
+      await waitFor(() =>
+        expect(listServiceTypeInstances).toHaveBeenCalledWith(
+          expect.objectContaining({ page_token: 'tok-2' }),
+        ),
+      );
+    });
+
+    it('Previous button is disabled on the first page', async () => {
+      const mockApi = buildApi({
+        listServiceTypeInstances: jest.fn().mockResolvedValue({
+          instances: [MOCK_INSTANCE],
+          next_page_token: 'tok-2',
+        }),
+      });
+      await renderResourcesTab(mockApi);
+
+      const prevBtn = await screen.findByRole('button', { name: /previous/i });
+      expect(prevBtn).toBeDisabled();
+    });
+
+    it('Previous button is enabled after navigating to page 2', async () => {
+      const listServiceTypeInstances = jest
+        .fn()
+        .mockResolvedValueOnce({
+          instances: [MOCK_INSTANCE],
+          next_page_token: 'tok-2',
+        })
+        .mockResolvedValueOnce({
+          instances: [MOCK_INSTANCE],
+          next_page_token: '',
+        });
+      const mockApi = buildApi({ listServiceTypeInstances });
+      await renderResourcesTab(mockApi);
+
+      const nextBtn = await screen.findByRole('button', { name: /next/i });
+      fireEvent.click(nextBtn);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /previous/i }),
+        ).not.toBeDisabled(),
+      );
+    });
+  });
+});

--- a/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { TableColumn, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { Box, Button, Chip, Typography } from '@material-ui/core';
@@ -47,7 +47,6 @@ export function ResourcesTabContent() {
     goNext,
     goPrev,
     resetToFirstPage,
-    resetCursor,
   } = usePaginatedFetch<ServiceTypeInstance>({
     fetchFn: ({ pageToken, pageSize: ps }) =>
       resourcesApi
@@ -58,13 +57,6 @@ export function ResourcesTabContent() {
         })),
     pageSize,
   });
-
-  // When the search query changes, reset cursor navigation state so that
-  // the Previous/Next controls reflect "page 1". No API call is needed
-  // because search filtering happens client-side on the current page.
-  useEffect(() => {
-    resetCursor();
-  }, [search, resetCursor]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return data;

--- a/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/resources/ResourcesTabContent.tsx
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TableColumn, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { Box, Button, Chip, Typography } from '@material-ui/core';
 import MuiAlert from '@material-ui/lab/Alert';
 import type { ServiceTypeInstance } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
 import { resourcesApiRef } from '../../apis';
-import { extractApiError } from '../../utils/extractApiError';
 import { DcmSearchTableCard } from '../../components/dcmTabListHelpers';
 import { useDcmStyles } from '../../components/dcmStyles';
 import emptyIllustration from '../../assets/environments-empty-state.png';
 import { DcmDataCenterTabEmptyState } from '../../components/DcmDataCenterTabEmptyState';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
 import { usePersistedPageSize } from '../../hooks/usePersistedPageSize';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { useTranslation } from '../../hooks/useTranslation';
 
 export function ResourcesTabContent() {
@@ -35,47 +35,48 @@ export function ResourcesTabContent() {
   const resourcesApi = useApi(resourcesApiRef);
   const { t } = useTranslation();
 
-  const [instances, setInstances] = useState<ServiceTypeInstance[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = usePersistedPageSize('resources');
+  const [search, setSearch] = useState('');
 
-  const load = useCallback(() => {
-    setLoading(true);
-    setLoadError(null);
-    resourcesApi
-      .listServiceTypeInstances()
-      .then(res => setInstances(res.instances ?? []))
-      .catch(err => setLoadError(extractApiError(err)))
-      .finally(() => setLoading(false));
-  }, [resourcesApi]);
+  const {
+    data,
+    loading,
+    error,
+    hasNext,
+    hasPrev,
+    goNext,
+    goPrev,
+    resetToFirstPage,
+    resetCursor,
+  } = usePaginatedFetch<ServiceTypeInstance>({
+    fetchFn: ({ pageToken, pageSize: ps }) =>
+      resourcesApi
+        .listServiceTypeInstances({ page_token: pageToken, max_page_size: ps })
+        .then(res => ({
+          items: res.instances ?? [],
+          nextPageToken: res.next_page_token ?? '',
+        })),
+    pageSize,
+  });
 
+  // When the search query changes, reset cursor navigation state so that
+  // the Previous/Next controls reflect "page 1". No API call is needed
+  // because search filtering happens client-side on the current page.
   useEffect(() => {
-    load();
-  }, [load]);
-
-  useEffect(() => {
-    setPage(0);
-  }, [search]);
+    resetCursor();
+  }, [search, resetCursor]);
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return instances;
+    if (!search.trim()) return data;
     const q = search.toLowerCase();
-    return instances.filter(
+    return data.filter(
       inst =>
         (inst.id ?? '').toLowerCase().includes(q) ||
         (inst.spec?.service_type ?? '').toLowerCase().includes(q) ||
         (inst.provider_name ?? '').toLowerCase().includes(q) ||
         (inst.status ?? '').toLowerCase().includes(q),
     );
-  }, [instances, search]);
-
-  const paginated = useMemo(() => {
-    const start = page * pageSize;
-    return filtered.slice(start, start + pageSize);
-  }, [filtered, page, pageSize]);
+  }, [data, search]);
 
   const columns = useMemo<TableColumn<ServiceTypeInstance>[]>(
     () => [
@@ -145,21 +146,21 @@ export function ResourcesTabContent() {
     [classes, t],
   );
 
-  if (loading) return <Progress />;
+  if (loading && data.length === 0) return <Progress />;
 
-  if (loadError) {
+  if (error) {
     return (
       <Box p={2}>
         <MuiAlert
           severity="error"
           variant="outlined"
           action={
-            <Button color="inherit" size="small" onClick={load}>
+            <Button color="inherit" size="small" onClick={resetToFirstPage}>
               {t('common.retry')}
             </Button>
           }
         >
-          {loadError}
+          {error}
         </MuiAlert>
       </Box>
     );
@@ -167,7 +168,7 @@ export function ResourcesTabContent() {
 
   return (
     <Box className={classes.root}>
-      {instances.length === 0 ? (
+      {data.length === 0 && !hasPrev ? (
         <DcmDataCenterTabEmptyState
           title={t('resources.emptyTitle')}
           description={t('resources.emptyDescription')}
@@ -176,15 +177,24 @@ export function ResourcesTabContent() {
       ) : (
         <DcmSearchTableCard<ServiceTypeInstance>
           title={(t as any)('resources.cardTitle', { count: filtered.length })}
-          data={paginated}
+          data={filtered}
           columns={columns}
           totalCount={filtered.length}
-          page={page}
+          page={1}
           pageSize={pageSize}
-          setPage={setPage}
+          setPage={() => {}}
           setPageSize={setPageSize}
           search={search}
           setSearch={setSearch}
+          cursorPagination={{
+            hasNext,
+            hasPrev,
+            onNext: goNext,
+            onPrev: goPrev,
+            loading,
+            pageSize,
+            onPageSizeChange: setPageSize,
+          }}
         />
       )}
     </Box>

--- a/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.test.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.test.tsx
@@ -69,9 +69,9 @@ describe('ServiceTypesTabContent', () => {
       };
       renderWith(mockApi);
 
-      await waitFor(() =>
-        expect(screen.getByText(/Service unavailable/i)).toBeInTheDocument(),
-      );
+      expect(
+        await screen.findByText(/Service unavailable/i),
+      ).toBeInTheDocument();
     });
 
     it('shows a Retry button when the API rejects', async () => {
@@ -82,11 +82,9 @@ describe('ServiceTypesTabContent', () => {
       };
       renderWith(mockApi);
 
-      await waitFor(() =>
-        expect(
-          screen.getByRole('button', { name: /retry/i }),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        await screen.findByRole('button', { name: /retry/i }),
+      ).toBeInTheDocument();
     });
 
     it('re-calls listServiceTypes when Retry is clicked', async () => {
@@ -146,11 +144,9 @@ describe('ServiceTypesTabContent', () => {
       };
       renderWith(mockApi);
 
-      await waitFor(() =>
-        expect(
-          screen.getByText(/no service types defined/i),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        await screen.findByText(/no service types defined/i),
+      ).toBeInTheDocument();
     });
 
     it('does not show an error alert when the list is empty', async () => {
@@ -159,11 +155,9 @@ describe('ServiceTypesTabContent', () => {
       };
       renderWith(mockApi);
 
-      await waitFor(() =>
-        expect(
-          screen.getByText(/no service types defined/i),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        await screen.findByText(/no service types defined/i),
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole('button', { name: /retry/i }),
       ).not.toBeInTheDocument();

--- a/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { usePersistedPageSize } from '../../hooks/usePersistedPageSize';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { TableColumn, Progress } from '@backstage/core-components';
@@ -49,7 +49,6 @@ export function ServiceTypesTabContent() {
     goNext,
     goPrev,
     resetToFirstPage,
-    resetCursor,
   } = usePaginatedFetch<ServiceType>({
     fetchFn: ({ pageToken, pageSize: ps }) =>
       catalogApi
@@ -60,13 +59,6 @@ export function ServiceTypesTabContent() {
         })),
     pageSize,
   });
-
-  // When the search query changes, reset cursor navigation state so that
-  // the Previous/Next controls reflect "page 1". No API call is needed
-  // because search filtering happens client-side on the current page.
-  useEffect(() => {
-    resetCursor();
-  }, [search, resetCursor]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return data;

--- a/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.tsx
+++ b/workspaces/dcm/plugins/dcm/src/pages/service-types/ServiceTypesTabContent.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { usePersistedPageSize } from '../../hooks/usePersistedPageSize';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { TableColumn, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { Box, Button, Chip, Typography } from '@material-ui/core';
@@ -24,7 +25,6 @@ import type { ServiceType } from '@red-hat-developer-hub/backstage-plugin-dcm-co
 import { catalogApiRef } from '../../apis';
 import { DcmSearchTableCard } from '../../components/dcmTabListHelpers';
 import { useDcmStyles } from '../../components/dcmStyles';
-import { extractApiError } from '../../utils/extractApiError';
 import emptyIllustration from '../../assets/environments-empty-state.png';
 import { DcmDataCenterTabEmptyState } from '../../components/DcmDataCenterTabEmptyState';
 import { DcmEmptyCell, TruncatedText } from '../../components/TruncatedText';
@@ -37,49 +37,47 @@ export function ServiceTypesTabContent() {
   const catalogApi = useApi(catalogApiRef);
   const { t } = useTranslation();
 
-  const [serviceTypes, setServiceTypes] = useState<ServiceType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = usePersistedPageSize('service-types');
+  const [search, setSearch] = useState('');
 
-  const load = useCallback(() => {
-    setLoading(true);
-    setLoadError(null);
-    catalogApi
-      .listServiceTypes()
-      .then(res => setServiceTypes(res.results ?? []))
-      .catch(err => {
-        setLoadError(extractApiError(err));
-        setServiceTypes([]);
-      })
-      .finally(() => setLoading(false));
-  }, [catalogApi]);
+  const {
+    data,
+    loading,
+    error,
+    hasNext,
+    hasPrev,
+    goNext,
+    goPrev,
+    resetToFirstPage,
+    resetCursor,
+  } = usePaginatedFetch<ServiceType>({
+    fetchFn: ({ pageToken, pageSize: ps }) =>
+      catalogApi
+        .listServiceTypes({ page_token: pageToken, max_page_size: ps })
+        .then(res => ({
+          items: res.results ?? [],
+          nextPageToken: res.next_page_token ?? '',
+        })),
+    pageSize,
+  });
 
+  // When the search query changes, reset cursor navigation state so that
+  // the Previous/Next controls reflect "page 1". No API call is needed
+  // because search filtering happens client-side on the current page.
   useEffect(() => {
-    load();
-  }, [load]);
-
-  useEffect(() => {
-    setPage(0);
-  }, [search]);
+    resetCursor();
+  }, [search, resetCursor]);
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return serviceTypes;
+    if (!search.trim()) return data;
     const q = search.toLowerCase();
-    return serviceTypes.filter(
+    return data.filter(
       st =>
         (st.service_type ?? '').toLowerCase().includes(q) ||
         (st.api_version ?? '').toLowerCase().includes(q) ||
         (st.uid ?? '').toLowerCase().includes(q),
     );
-  }, [serviceTypes, search]);
-
-  const paginated = useMemo(() => {
-    const start = page * pageSize;
-    return filtered.slice(start, start + pageSize);
-  }, [filtered, page, pageSize]);
+  }, [data, search]);
 
   const columns = useMemo<TableColumn<ServiceType>[]>(
     () => [
@@ -151,21 +149,21 @@ export function ServiceTypesTabContent() {
     [classes, t],
   );
 
-  if (loading) return <Progress />;
+  if (loading && data.length === 0) return <Progress />;
 
-  if (loadError) {
+  if (error) {
     return (
       <Box p={2}>
         <MuiAlert
           severity="error"
           variant="outlined"
           action={
-            <Button color="inherit" size="small" onClick={load}>
+            <Button color="inherit" size="small" onClick={resetToFirstPage}>
               {t('common.retry')}
             </Button>
           }
         >
-          {loadError}
+          {error}
         </MuiAlert>
       </Box>
     );
@@ -173,7 +171,7 @@ export function ServiceTypesTabContent() {
 
   return (
     <Box className={classes.root}>
-      {serviceTypes.length === 0 ? (
+      {data.length === 0 && !hasPrev ? (
         <DcmDataCenterTabEmptyState
           title={t('serviceTypes.emptyTitle')}
           description={t('serviceTypes.emptyDescription')}
@@ -184,15 +182,24 @@ export function ServiceTypesTabContent() {
           title={(t as any)('serviceTypes.cardTitle', {
             count: filtered.length,
           })}
-          data={paginated}
+          data={filtered}
           columns={columns}
           totalCount={filtered.length}
-          page={page}
+          page={1}
           pageSize={pageSize}
-          setPage={setPage}
+          setPage={() => {}}
           setPageSize={setPageSize}
           search={search}
           setSearch={setSearch}
+          cursorPagination={{
+            hasNext,
+            hasPrev,
+            onNext: goNext,
+            onPrev: goPrev,
+            loading,
+            pageSize,
+            onPageSizeChange: setPageSize,
+          }}
         />
       )}
     </Box>

--- a/workspaces/dcm/plugins/dcm/src/translations/de.ts
+++ b/workspaces/dcm/plugins/dcm/src/translations/de.ts
@@ -45,6 +45,8 @@ const dcmTranslationDe: TranslationMessages<
     'common.saving': 'Wird gespeichert\u2026',
     'common.close': 'Schlie\u00dfen',
     'common.rows': 'Zeilen',
+    'common.previousPage': 'Zurück',
+    'common.nextPage': 'Weiter',
     'deleteDialog.title': '{{resourceLabel}} l\u00f6schen',
     'deleteDialog.confirmButton': 'L\u00f6schen',
     'deleteDialog.cancelButton': 'Abbrechen',

--- a/workspaces/dcm/plugins/dcm/src/translations/es.ts
+++ b/workspaces/dcm/plugins/dcm/src/translations/es.ts
@@ -45,6 +45,8 @@ const dcmTranslationEs: TranslationMessages<
     'common.saving': 'Guardando\u2026',
     'common.close': 'Cerrar',
     'common.rows': 'filas',
+    'common.previousPage': 'Anterior',
+    'common.nextPage': 'Siguiente',
     'deleteDialog.title': 'Eliminar {{resourceLabel}}',
     'deleteDialog.confirmButton': 'Eliminar',
     'deleteDialog.cancelButton': 'Cancelar',

--- a/workspaces/dcm/plugins/dcm/src/translations/fr.ts
+++ b/workspaces/dcm/plugins/dcm/src/translations/fr.ts
@@ -45,6 +45,8 @@ const dcmTranslationFr: TranslationMessages<
     'common.saving': 'Enregistrement\u2026',
     'common.close': 'Fermer',
     'common.rows': 'lignes',
+    'common.previousPage': 'Précédent',
+    'common.nextPage': 'Suivant',
     'deleteDialog.title': 'Supprimer {{resourceLabel}}',
     'deleteDialog.confirmButton': 'Supprimer',
     'deleteDialog.cancelButton': 'Annuler',

--- a/workspaces/dcm/plugins/dcm/src/translations/it.ts
+++ b/workspaces/dcm/plugins/dcm/src/translations/it.ts
@@ -45,6 +45,8 @@ const dcmTranslationIt: TranslationMessages<
     'common.saving': 'Salvataggio\u2026',
     'common.close': 'Chiudi',
     'common.rows': 'righe',
+    'common.previousPage': 'Precedente',
+    'common.nextPage': 'Successivo',
     'deleteDialog.title': 'Elimina {{resourceLabel}}',
     'deleteDialog.confirmButton': 'Elimina',
     'deleteDialog.cancelButton': 'Annulla',

--- a/workspaces/dcm/plugins/dcm/src/translations/ja.ts
+++ b/workspaces/dcm/plugins/dcm/src/translations/ja.ts
@@ -48,6 +48,8 @@ const dcmTranslationJa: TranslationMessages<
     'common.saving': '\u4fdd\u5b58\u4e2d\u2026',
     'common.close': '\u9589\u3058\u308b',
     'common.rows': '\u884c',
+    'common.previousPage': '\u524d\u3078',
+    'common.nextPage': '\u6b21\u3078',
     'deleteDialog.title': '{{resourceLabel}}\u3092\u524a\u9664',
     'deleteDialog.confirmButton': '\u524a\u9664',
     'deleteDialog.cancelButton': '\u30ad\u30e3\u30f3\u30bb\u30eb',

--- a/workspaces/dcm/plugins/dcm/src/translations/ref.ts
+++ b/workspaces/dcm/plugins/dcm/src/translations/ref.ts
@@ -49,6 +49,8 @@ export const dcmMessages = {
     saving: 'Saving\u2026',
     close: 'Close',
     rows: 'rows',
+    previousPage: 'Previous',
+    nextPage: 'Next',
   },
   deleteDialog: {
     title: 'Delete {{resourceLabel}}',


### PR DESCRIPTION
## Summary

Add server-side cursor pagination to all DCM tabs.

Previously only Service Types, Catalog Items, and Instances fetched data page-by-page. Providers, Policies, and Resources loaded everything in a single call, silently dropping records beyond the first page.

### What changed

- **Providers & Policies** — converted to cursor pagination with Next/Previous controls; search resets to page 1 client-side.
- **Resources** — converted to `usePaginatedFetch` (read-only layout preserved).
- **`dcm-common`** — extracted `buildPaginationQuery` utility; `listProviders` and `listPolicies` now accept optional `PaginationParams`; `next_page_token` made optional on list response types to match real backend behaviour.
- **Dropdown calls capped at 25 items** — service-type and catalog-item selects now pass `max_page_size: 25`.
- **Tests** — added `ProvidersTabContent.test.tsx` and `ResourcesTabContent.test.tsx`; extended `PoliciesTabContent.test.tsx` with cursor navigation tests.
- **Translations** — added `common.previousPage` / `common.nextPage` to all locale files.