### PR TITLE
fix(quickstart): import global-header nfs exports from main

### DIFF
--- a/workspaces/quickstart/.changeset/update-global-header-v2.md
+++ b/workspaces/quickstart/.changeset/update-global-header-v2.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-quickstart': patch
+---
+
+Updated `@red-hat-developer-hub/backstage-plugin-global-header` dependency to `^2.0.0` and migrated imports from the deprecated `/alpha` subpath to the graduated main entry.

--- a/workspaces/quickstart/packages/app/package.json
+++ b/workspaces/quickstart/packages/app/package.json
@@ -44,7 +44,7 @@
     "@mui/icons-material": "5.18.0",
     "@mui/material": "5.18.0",
     "@red-hat-developer-hub/backstage-plugin-app-react": "^0.1.0",
-    "@red-hat-developer-hub/backstage-plugin-global-header": "1.21.5",
+    "@red-hat-developer-hub/backstage-plugin-global-header": "^2.0.0",
     "@red-hat-developer-hub/backstage-plugin-quickstart": "workspace:^",
     "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.11",
     "material-icons": "^1.13.14",

--- a/workspaces/quickstart/packages/app/src/App.tsx
+++ b/workspaces/quickstart/packages/app/src/App.tsx
@@ -18,7 +18,7 @@ import { appDrawerModule } from '@red-hat-developer-hub/backstage-plugin-app-rea
 import {
   globalHeaderModule,
   globalHeaderTranslationsModule,
-} from '@red-hat-developer-hub/backstage-plugin-global-header/alpha';
+} from '@red-hat-developer-hub/backstage-plugin-global-header';
 import {
   quickstartInitModule,
   quickstartTranslationsModule,

--- a/workspaces/quickstart/plugins/quickstart/package.json
+++ b/workspaces/quickstart/plugins/quickstart/package.json
@@ -46,7 +46,7 @@
     "@mui/material": "5.18.0",
     "@patternfly/react-icons": "^6.5.0",
     "@red-hat-developer-hub/backstage-plugin-app-react": "^0.1.0",
-    "@red-hat-developer-hub/backstage-plugin-global-header": "1.21.5",
+    "@red-hat-developer-hub/backstage-plugin-global-header": "^2.0.0",
     "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.11",
     "react-use": "^17.6.0"
   },

--- a/workspaces/quickstart/plugins/quickstart/report.api.md
+++ b/workspaces/quickstart/plugins/quickstart/report.api.md
@@ -6,8 +6,8 @@
 import { AppDrawerContent } from '@red-hat-developer-hub/backstage-plugin-app-react';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { FrontendModule } from '@backstage/frontend-plugin-api';
-import { GlobalHeaderMenuItemData } from '@red-hat-developer-hub/backstage-plugin-global-header/alpha';
-import { MenuItemParams } from '@red-hat-developer-hub/backstage-plugin-global-header/alpha';
+import { GlobalHeaderMenuItemData } from '@red-hat-developer-hub/backstage-plugin-global-header';
+import { MenuItemParams } from '@red-hat-developer-hub/backstage-plugin-global-header';
 import { OverridableExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { TranslationRef } from '@backstage/frontend-plugin-api';

--- a/workspaces/quickstart/plugins/quickstart/src/QuickstartHelpMenuItem.test.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/QuickstartHelpMenuItem.test.tsx
@@ -32,22 +32,19 @@ jest.mock('@red-hat-developer-hub/backstage-plugin-app-react', () => ({
   }),
 }));
 
-jest.mock(
-  '@red-hat-developer-hub/backstage-plugin-global-header/alpha',
-  () => ({
-    GlobalHeaderMenuItem: ({
-      title,
-      onClick,
-    }: {
-      title?: string;
-      onClick?: () => void;
-    }) => (
-      <button type="button" role="menuitem" onClick={onClick}>
-        {title}
-      </button>
-    ),
-  }),
-);
+jest.mock('@red-hat-developer-hub/backstage-plugin-global-header', () => ({
+  GlobalHeaderMenuItem: ({
+    title,
+    onClick,
+  }: {
+    title?: string;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitem" onClick={onClick}>
+      {title}
+    </button>
+  ),
+}));
 
 describe('QuickstartHelpMenuItem', () => {
   beforeEach(() => {

--- a/workspaces/quickstart/plugins/quickstart/src/QuickstartHelpMenuItem.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/QuickstartHelpMenuItem.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useAppDrawer } from '@red-hat-developer-hub/backstage-plugin-app-react';
-import { GlobalHeaderMenuItem } from '@red-hat-developer-hub/backstage-plugin-global-header/alpha';
+import { GlobalHeaderMenuItem } from '@red-hat-developer-hub/backstage-plugin-global-header';
 
 import { QUICKSTART_DRAWER_ID } from './const';
 

--- a/workspaces/quickstart/plugins/quickstart/src/index.tsx
+++ b/workspaces/quickstart/plugins/quickstart/src/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { TranslationBlueprint } from '@backstage/plugin-app-react';
 import { AppDrawerContentBlueprint } from '@red-hat-developer-hub/backstage-plugin-app-react/alpha';
-import { GlobalHeaderMenuItemBlueprint } from '@red-hat-developer-hub/backstage-plugin-global-header/alpha';
+import { GlobalHeaderMenuItemBlueprint } from '@red-hat-developer-hub/backstage-plugin-global-header';
 
 import { quickstartTranslations } from './translations';
 import { QUICKSTART_DRAWER_ID } from './const';

--- a/workspaces/quickstart/yarn.lock
+++ b/workspaces/quickstart/yarn.lock
@@ -9948,6 +9948,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@red-hat-developer-hub/backstage-plugin-global-header@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@red-hat-developer-hub/backstage-plugin-global-header@npm:2.0.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/core-components": "npm:^0.18.11"
+    "@backstage/core-plugin-api": "npm:^1.12.7"
+    "@backstage/frontend-plugin-api": "npm:^0.17.2"
+    "@backstage/plugin-app-react": "npm:^0.2.4"
+    "@backstage/plugin-catalog-react": "npm:^3.1.0"
+    "@backstage/plugin-notifications": "npm:^0.5.18"
+    "@backstage/plugin-notifications-common": "npm:^0.2.3"
+    "@backstage/plugin-search": "npm:^1.7.5"
+    "@backstage/plugin-search-backend": "npm:^2.1.3"
+    "@backstage/plugin-search-backend-module-catalog": "npm:^0.3.16"
+    "@backstage/plugin-search-backend-module-pg": "npm:^0.5.56"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:^0.4.15"
+    "@backstage/plugin-search-common": "npm:^1.2.24"
+    "@backstage/plugin-search-react": "npm:^1.11.5"
+    "@backstage/plugin-signals-react": "npm:^0.0.23"
+    "@backstage/plugin-user-settings": "npm:^0.9.4"
+    "@backstage/theme": "npm:^0.7.3"
+    "@mui/icons-material": "npm:5.18.0"
+    "@mui/material": "npm:5.18.0"
+    "@mui/styled-engine": "npm:5.18.0"
+    "@scalprum/react-core": "npm:0.11.3"
+    react-use: "npm:^17.5.0"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.0.0
+  checksum: 10c0/b26f78eb58bd0ee3a4bd9976569096bddf81c92fd53904dc3d0c8d1d21880ff5a4e6fa2aaed10f33f882e2b3d33771cd0572eca8852ae4ba7181f39da30e9cf8
+  languageName: node
+  linkType: hard
+
 "@red-hat-developer-hub/backstage-plugin-quickstart@workspace:^, @red-hat-developer-hub/backstage-plugin-quickstart@workspace:plugins/quickstart":
   version: 0.0.0-use.local
   resolution: "@red-hat-developer-hub/backstage-plugin-quickstart@workspace:plugins/quickstart"
@@ -9969,7 +10004,7 @@ __metadata:
     "@mui/material": "npm:5.18.0"
     "@patternfly/react-icons": "npm:^6.5.0"
     "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.1.0"
-    "@red-hat-developer-hub/backstage-plugin-global-header": "npm:1.21.5"
+    "@red-hat-developer-hub/backstage-plugin-global-header": "npm:^2.0.0"
     "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.11"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
@@ -10621,7 +10656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scalprum/core@npm:^0.9.0":
+"@scalprum/core@npm:^0.9.0, @scalprum/core@npm:^0.9.1":
   version: 0.9.3
   resolution: "@scalprum/core@npm:0.9.3"
   dependencies:
@@ -10642,6 +10677,20 @@ __metadata:
     react: ">=16.8.0 || >=17.0.0 || ^18.0.0"
     react-dom: ">=16.8.0 || >=17.0.0 || ^18.0.0"
   checksum: 10c0/61094ddfcef1547bb4f43ef794f555ee625e0aa1b5479ad1fa056fa00301fe96c7b96c53ef7c1ece8f8bc0be0859404507887f3109163c8a2025558ec30f364a
+  languageName: node
+  linkType: hard
+
+"@scalprum/react-core@npm:0.11.3":
+  version: 0.11.3
+  resolution: "@scalprum/react-core@npm:0.11.3"
+  dependencies:
+    "@openshift/dynamic-plugin-sdk": "npm:^5.0.1"
+    "@scalprum/core": "npm:^0.9.1"
+    lodash: "npm:^4.17.0"
+  peerDependencies:
+    react: ">=16.8.0 || >=17.0.0 || ^18.0.0"
+    react-dom: ">=16.8.0 || >=17.0.0 || ^18.0.0"
+  checksum: 10c0/6de3f4b624fb3e0cf1a7785154dfd6cd589809b0d44dbf0e065531729320ea918b17b673744fe60f4bdf3ef0602af87e857bf98109e03f6cc7634b4893269ff6
   languageName: node
   linkType: hard
 
@@ -14643,7 +14692,7 @@ __metadata:
     "@mui/material": "npm:5.18.0"
     "@playwright/test": "npm:1.61.1"
     "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.1.0"
-    "@red-hat-developer-hub/backstage-plugin-global-header": "npm:1.21.5"
+    "@red-hat-developer-hub/backstage-plugin-global-header": "npm:^2.0.0"
     "@red-hat-developer-hub/backstage-plugin-quickstart": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.14.11"
     "@testing-library/dom": "npm:^9.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Import global-header nfs exports from main rather than `/alpha` as global-header nfs plugin exports are now moved to the main entry point.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
