### PR TITLE
FLPATH-4764 | [dcm-ui] Helm-deployed dcm-ui crashloops on OpenShift due to /app directory permissions (mode 700)

### DIFF
--- a/workspaces/dcm/Dockerfile
+++ b/workspaces/dcm/Dockerfile
@@ -76,8 +76,12 @@ COPY --from=build /app/plugins/dcm-backend/config.d.ts plugins/dcm-backend/confi
 COPY --from=build /app/packages/app/dist packages/app/dist
 COPY app-config.yaml app-config.production.yaml ./
 
-RUN chown -R node:node /app
-USER node
+# Fix OpenShift arbitrary UID compatibility:
+# Set GID to 0 (root group) and mirror user permissions to group permissions (g=u)
+RUN chown -R node:0 /app && \
+    chmod -R g=u /app
+
+USER 1000
 
 EXPOSE 7007
 

--- a/workspaces/dcm/Dockerfile
+++ b/workspaces/dcm/Dockerfile
@@ -76,10 +76,10 @@ COPY --from=build /app/plugins/dcm-backend/config.d.ts plugins/dcm-backend/confi
 COPY --from=build /app/packages/app/dist packages/app/dist
 COPY app-config.yaml app-config.production.yaml ./
 
-# Fix OpenShift arbitrary UID compatibility:
-# Set GID to 0 (root group) and mirror user permissions to group permissions (g=u)
+# OpenShift arbitrary UID compatibility:
+# Set GID to 0 (root group) and allow group read/directory traversal (g+rX)
 RUN chown -R node:0 /app && \
-    chmod -R g=u /app
+    chmod -R g+rX /app
 
 USER 1000
 


### PR DESCRIPTION
- chown -R node:0 /app: Changes group ownership from node (GID 1000) to root (GID 0).

- chmod -R g=u /app: Ensures every file and directory has identical permissions for group members as the node  user. Directories become drwxrwxr-x, allowing OpenShift’s random UID in GID 0 to enter /app and load modules.

- USER 1000: Explicit UIDs (instead of the named string USER node) are standard for OCI containers, though both work once GID 0 permissions are in place.