### PR TITLE
test(orchestrator): cover Run as Event UX at L3 #RHIDP-16049

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.test.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { createElement, type ReactNode } from 'react';
+
+import { TestApiProvider } from '@backstage/test-utils';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { orchestratorApiRef } from '../../api';
+import { ExecuteWorkflowPage } from './ExecuteWorkflowPage';
+
+const mockNavigate = jest.fn();
+const mockExecuteWorkflow = jest.fn();
+const mockGetWorkflowDataInputSchema = jest.fn();
+const mockGetWorkflowOverview = jest.fn();
+const mockAuthenticate = jest.fn();
+let mockKafkaEnabled = true;
+let mockSearchParams = new URLSearchParams();
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('../../hooks/useKafkaEnabled', () => ({
+  useKafkaEnabled: () => mockKafkaEnabled,
+}));
+
+jest.mock('../../hooks/useOrchestratorAuth', () => ({
+  useOrchestratorAuth: () => ({
+    authenticate: (...args: unknown[]) => mockAuthenticate(...args),
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams],
+}));
+
+jest.mock('@backstage/core-components', () => {
+  const actual = jest.requireActual('@backstage/core-components');
+  const React = require('react');
+  return {
+    ...actual,
+    InfoCard: ({ children, title }: { children: ReactNode; title?: string }) =>
+      React.createElement(
+        'div',
+        null,
+        React.createElement('h2', null, title),
+        children,
+      ),
+    Progress: () => React.createElement('div', null, 'loading'),
+    ResponseErrorPanel: ({ error }: { error: Error }) =>
+      React.createElement('div', null, error.message),
+    useQueryParamState: () => [undefined],
+  };
+});
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useRouteRefParams: () => ({ workflowId: 'wf-1' }),
+    useRouteRef: () => (params: Record<string, string>) => {
+      if ('instanceId' in params && 'kind' in params) {
+        return `/catalog/${params.namespace}/${params.kind}/${params.name}/workflows/${params.workflowId}/runs/${params.instanceId}`;
+      }
+      if ('instanceId' in params) {
+        return `/orchestrator/instances/${params.instanceId}`;
+      }
+      if ('kind' in params) {
+        return `/catalog/${params.namespace}/${params.kind}/${params.name}/workflows/${params.workflowId}`;
+      }
+      return `/orchestrator/workflows/${params.workflowId}/runs`;
+    },
+  };
+});
+
+jest.mock('../ui/BaseOrchestratorPage', () => {
+  const React = require('react');
+  return {
+    BaseOrchestratorPage: ({ children }: { children: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+jest.mock('../ui/SamlSsoExpiredDialog', () => ({
+  SamlSsoExpiredDialog: () => null,
+}));
+
+jest.mock(
+  '@red-hat-developer-hub/backstage-plugin-orchestrator-form-react',
+  () => {
+    const React = require('react');
+    return {
+      SubmitButton: ({
+        children,
+        handleClick,
+        submitting,
+      }: {
+        children: ReactNode;
+        handleClick: () => void;
+        submitting?: boolean;
+      }) =>
+        React.createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: handleClick,
+            disabled: submitting ?? false,
+            'data-testid': 'submit-button',
+          },
+          children,
+        ),
+    };
+  },
+);
+
+describe('ExecuteWorkflowPage', () => {
+  const renderPage = () =>
+    render(
+      createElement(TestApiProvider, {
+        apis: [
+          [
+            orchestratorApiRef,
+            {
+              getWorkflowDataInputSchema: mockGetWorkflowDataInputSchema,
+              getWorkflowOverview: mockGetWorkflowOverview,
+              executeWorkflow: mockExecuteWorkflow,
+            },
+          ],
+        ],
+        children: createElement(ExecuteWorkflowPage),
+      }),
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockKafkaEnabled = true;
+    mockSearchParams = new URLSearchParams();
+    mockAuthenticate.mockResolvedValue([]);
+    mockGetWorkflowDataInputSchema.mockResolvedValue({ data: {} });
+    mockGetWorkflowOverview.mockResolvedValue({ data: { name: 'WF' } });
+    mockExecuteWorkflow.mockResolvedValue({ data: { id: 'kafkaEvent' } });
+  });
+
+  const waitForPage = async () => {
+    expect(
+      await screen.findByRole('button', { name: 'common.run' }),
+    ).toBeInTheDocument();
+  };
+
+  it('sends isEvent: true when Run as Event is clicked', async () => {
+    renderPage();
+    await waitForPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'workflow.buttons.runAsEvent' }),
+    );
+
+    await waitFor(() => {
+      expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowId: 'wf-1',
+          parameters: { isEvent: true },
+          authTokens: [],
+        }),
+      );
+    });
+  });
+
+  it('redirects to workflow runs with eventTriggered when response id is kafkaEvent', async () => {
+    renderPage();
+    await waitForPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'workflow.buttons.runAsEvent' }),
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/orchestrator/workflows/wf-1/runs?eventTriggered=true',
+      );
+    });
+  });
+
+  it('redirects to entity workflow runs with eventTriggered when targetEntity is set', async () => {
+    mockSearchParams = new URLSearchParams(
+      'targetEntity=component:default/my-comp',
+    );
+
+    renderPage();
+    await waitForPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'workflow.buttons.runAsEvent' }),
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/catalog/default/component/my-comp/workflows/wf-1?eventTriggered=true',
+      );
+    });
+  });
+
+  it('navigates to the instance page for a normal run', async () => {
+    mockExecuteWorkflow.mockResolvedValue({ data: { id: 'inst-1' } });
+
+    renderPage();
+    await waitForPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.run' }));
+
+    await waitFor(() => {
+      expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: {},
+        }),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/orchestrator/instances/inst-1',
+      );
+    });
+  });
+
+  it('does not render Run as Event when kafka is disabled', async () => {
+    mockKafkaEnabled = false;
+
+    renderPage();
+    await waitForPage();
+
+    expect(
+      screen.queryByRole('button', { name: 'workflow.buttons.runAsEvent' }),
+    ).toBeNull();
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.test.tsx
@@ -111,24 +111,44 @@ jest.mock(
   () => {
     const React = require('react');
     return {
-      SubmitButton: ({
-        children,
-        handleClick,
-        submitting,
+      OrchestratorForm: ({
+        handleExecute,
+        handleExecuteAsEvent,
+        executeLabel,
+        executeAsEventLabel,
+        isExecuting,
       }: {
-        children: ReactNode;
-        handleClick: () => void;
-        submitting?: boolean;
+        handleExecute: (parameters: Record<string, unknown>) => Promise<void>;
+        handleExecuteAsEvent?: (
+          parameters: Record<string, unknown>,
+        ) => Promise<void>;
+        executeLabel?: string;
+        executeAsEventLabel?: string;
+        isExecuting?: boolean;
       }) =>
         React.createElement(
-          'button',
-          {
-            type: 'button',
-            onClick: handleClick,
-            disabled: submitting ?? false,
-            'data-testid': 'submit-button',
-          },
-          children,
+          React.Fragment,
+          null,
+          React.createElement(
+            'button',
+            {
+              type: 'button',
+              onClick: () => handleExecute({}),
+              disabled: isExecuting ?? false,
+            },
+            executeLabel,
+          ),
+          handleExecuteAsEvent && executeAsEventLabel
+            ? React.createElement(
+                'button',
+                {
+                  type: 'button',
+                  onClick: () => handleExecuteAsEvent({}),
+                  disabled: isExecuting ?? false,
+                },
+                executeAsEventLabel,
+              )
+            : null,
         ),
     };
   },
@@ -157,7 +177,14 @@ describe('ExecuteWorkflowPage', () => {
     mockKafkaEnabled = true;
     mockSearchParams = new URLSearchParams();
     mockAuthenticate.mockResolvedValue([]);
-    mockGetWorkflowDataInputSchema.mockResolvedValue({ data: {} });
+    // Minimal schema so the page takes the OrchestratorForm path (primary UX),
+    // not MissingSchemaNotice (already covered in MissingSchemaNotice.test.tsx).
+    mockGetWorkflowDataInputSchema.mockResolvedValue({
+      data: {
+        inputSchema: { type: 'object', properties: {} },
+        data: {},
+      },
+    });
     mockGetWorkflowOverview.mockResolvedValue({ data: { name: 'WF' } });
     mockExecuteWorkflow.mockResolvedValue({ data: { id: 'kafkaEvent' } });
   });

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { WorkflowRunsTabContent } from './WorkflowRunsTabContent';
+
+const mockSetSearchParams = jest.fn();
+let mockSearchParams = new URLSearchParams('eventTriggered=true');
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}));
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: () => ({}),
+    useRouteRef: () => () => '/stub',
+    useRouteRefParams: () => ({}),
+  };
+});
+
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: () => ({ allowed: false, loading: false }),
+}));
+
+jest.mock('../../hooks/usePolling', () => ({
+  __esModule: true,
+  default: () => ({
+    loading: false,
+    error: undefined,
+    value: { items: [] },
+  }),
+}));
+
+jest.mock('../../hooks/useEntityFilterItems', () => ({
+  useEntityFilterItems: () => ({ items: [] }),
+}));
+
+jest.mock('../../hooks/useRunByFilterItems', () => ({
+  useRunByFilterItems: () => ({ items: [] }),
+}));
+
+jest.mock('../../hooks/useLogsEnabled', () => ({
+  useLogsEnabled: () => false,
+}));
+
+jest.mock('../ui/OrchestratorEmptyState', () => {
+  const React = require('react');
+  return {
+    OrchestratorEmptyState: () =>
+      React.createElement('div', { 'data-testid': 'empty-state' }),
+  };
+});
+
+jest.mock('../WorkflowInstancePage/VariablesDialog', () => ({
+  VariablesDialog: () => null,
+}));
+
+jest.mock('../WorkflowInstancePage/WorkflowLogsDialog', () => ({
+  WorkflowLogsDialog: () => null,
+}));
+
+jest.mock('@mui/material/Alert', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ children, onClose }: any) =>
+      React.createElement(
+        'div',
+        { role: 'alert' },
+        children,
+        onClose
+          ? React.createElement(
+              'button',
+              { type: 'button', onClick: onClose },
+              'close',
+            )
+          : null,
+      ),
+  };
+});
+
+describe('WorkflowRunsTabContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams('eventTriggered=true');
+  });
+
+  it('shows the eventTriggered alert when the query param is true', () => {
+    render(<WorkflowRunsTabContent />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'run.messages.eventTriggered',
+    );
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+
+  it('does not show the eventTriggered alert when the query param is missing', () => {
+    mockSearchParams = new URLSearchParams();
+
+    render(<WorkflowRunsTabContent />);
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+
+  it('dismisses the alert and strips eventTriggered from the query string', () => {
+    render(<WorkflowRunsTabContent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      { replace: true },
+    );
+    const nextParams = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(nextParams.get('eventTriggered')).toBeNull();
+  });
+});


### PR DESCRIPTION
Add RTL tests for isEvent execute payload, kafkaEvent redirect, and runs-tab eventTriggered alert so RHIDP-9144 regressions are caught without cluster or Kafka.
Closes RHIDP-16049