### PR TITLE
docs(RHIDP-15201): add openspec artifacts for K8s config migration

### DIFF
--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/.openspec.yaml
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-05
+status: draft

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
@@ -209,7 +209,7 @@ const url = await this.discovery.getBaseUrl(this.name);
 
 **Implementation:**
 
-- `ReconcilerConfig` in `types.ts` gains: `clusterName?`, `url?`, `serviceAccountToken?`, `skipTLSVerify?`, `caData?` (K8s connection); keeps `catalogUrl?`, `defaultOwner?`, `defaultLifecycle?` as optional (was required, now optional with defaults applied in `setupInformer`). `clusterName` comes from the `name` field in the cluster sub-config and is used in `loadFromOptions` for KubeConfig cluster/context naming.
+- `ReconcilerConfig` in `types.ts` gains: `clusterName?`, `url?`, `serviceAccountToken?`, `skipTLSVerify?`, `caData?` (K8s connection); changes `catalogUrl?`, `defaultOwner?`, `defaultLifecycle?` from required to optional (defaults applied in `setupInformer`). `clusterName` comes from the `name` field in the cluster sub-config and is used in `loadFromOptions` for KubeConfig cluster/context naming.
 - The existing `k8sToken` field is **removed** from `ReconcilerConfig`. The new `serviceAccountToken` field replaces it as the single token field — `setupInformer` populates it with the resolved token regardless of source (app-config, `K8S_TOKEN` env var, or kubeconfig extraction). All code reading `config.k8sToken` (e.g., `fetchModelCardViaAnnotations`) is updated to read `config.serviceAccountToken`.
   Note: `defaultOwner` and `defaultLifecycle` change from required `string` to optional `string` (`?: string`) on the type — `setupInformer` continues to apply defaults (`process.env.OWNER || 'default-owner'` and `process.env.LIFECYCLE || 'production'`) before any code that depends on them.
 - `ConnectorConfig` interface and its export in `InformerService.ts` are removed.
@@ -321,7 +321,8 @@ Also remove `baseUrl` from the connector-level fields (per D2).
 
 **Choice:** The following precedence order determines how the KubeConfig is built:
 
-1. **kubernetesPluginRef** (found): If set AND the referenced cluster is found in `kubernetes.clusterLocatorMethods`, use its `url`, `serviceAccountToken`, `skipTLSVerify`, `caData`.
+1. **kubernetesPluginRef** (found, complete): If set AND the referenced cluster is found in `kubernetes.clusterLocatorMethods` with both `url` and `serviceAccountToken`, use its K8s fields.
+   1b. **kubernetesPluginRef** (found, incomplete): If the matched cluster is missing `url` or `serviceAccountToken`, log a warning, clear any stale fields, and fall through to step 3.
 2. **kubernetesPluginRef** (not found): If set but the referenced cluster is NOT found, log a warning and fall through to step 3 (do NOT skip to `loadFromDefault`).
 3. **Direct config**: If `url` and `serviceAccountToken` are present in the cluster sub-config, use them.
 4. **Local dev — loadFromDefault()**: If none of the above, use `loadFromDefault()` which supports three local dev options:

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
@@ -183,7 +183,7 @@ When `kubernetesPluginRef` is set and the referenced cluster is found, its K8s f
 
 **Choice:** Remove `baseUrl` from `ModelCatalogConfig`, `readModelCatalogApiEntityConfig`, and `ModelCatalogResourceEntityProvider`. Also remove `baseUrl` from `config.d.ts`.
 
-**Rationale:** The entity provider uses `DiscoveryService.getBaseUrl()` to resolve the connector's URL at runtime (line 169 of `ModelCatalogResourceEntityProvider.ts`). The `baseUrl` field was a manual override — if `baseUrl` was set, it took priority over discovery. But if discovery fails, the `auth.getPluginRequestToken()` call (line 174) also fails because it depends on the same plugin registration. So `baseUrl` is either redundant (discovery works) or insufficient (discovery broken). Removing it simplifies config and eliminates confusion.
+**Rationale:** The entity provider uses `DiscoveryService.getBaseUrl()` to resolve the connector's URL at runtime (line 169 of `ModelCatalogResourceEntityProvider.ts`). The `baseUrl` field was a manual override — if `baseUrl` was set, it took priority over discovery. But a hardcoded `baseUrl` cannot help when the connector service is unreachable: the subsequent HTTP call to fetch the model catalog will fail regardless. So `baseUrl` is either redundant (discovery works and the service is reachable) or insufficient (service is down). Removing it simplifies config and eliminates confusion.
 
 **Impact:** The `run()` method in `ModelCatalogResourceEntityProvider.ts` simplifies from:
 
@@ -210,6 +210,7 @@ const url = await this.discovery.getBaseUrl(this.name);
 **Implementation:**
 
 - `ReconcilerConfig` in `types.ts` gains: `clusterName?`, `url?`, `serviceAccountToken?`, `skipTLSVerify?`, `caData?` (K8s connection); keeps `catalogUrl?`, `defaultOwner?`, `defaultLifecycle?` as optional (was required, now optional with defaults applied in `setupInformer`). `clusterName` comes from the `name` field in the cluster sub-config and is used in `loadFromOptions` for KubeConfig cluster/context naming.
+- The existing `k8sToken` field is **removed** from `ReconcilerConfig`. The new `serviceAccountToken` field replaces it as the single token field — `setupInformer` populates it with the resolved token regardless of source (app-config, `K8S_TOKEN` env var, or kubeconfig extraction). All code reading `config.k8sToken` (e.g., `fetchModelCardViaAnnotations`) is updated to read `config.serviceAccountToken`.
   Note: `defaultOwner` and `defaultLifecycle` change from required `string` to optional `string` (`?: string`) on the type — `setupInformer` continues to apply defaults (`process.env.OWNER || 'default-owner'` and `process.env.LIFECYCLE || 'production'`) before any code that depends on them.
 - `ConnectorConfig` interface and its export in `InformerService.ts` are removed.
 - `plugin.ts` builds a `ReconcilerConfig` directly (minus the runtime K8s objects, which `setupInformer` populates).
@@ -250,11 +251,16 @@ if (config.url && config.serviceAccountToken) {
     currentContext: clusterName,
   });
 } else {
+  if (config.url || config.serviceAccountToken) {
+    logger.warn(
+      'Partial K8s config: both url and serviceAccountToken are required for config-based auth; falling back to loadFromDefault()',
+    );
+  }
   kc.loadFromDefault();
 }
 ```
 
-Note: `clusterName` comes from the `name` field in the cluster sub-config (e.g., `name: my-k8s-cluster`). OCM uses the same pattern — its `hubApiClient()` passes the cluster name from config to `loadFromOptions`.
+Note: `clusterName` comes from the `name` field in the cluster sub-config (e.g., `name: my-k8s-cluster`). OCM uses the same pattern — its `hubApiClient()` passes the cluster name from config to `loadFromOptions`. If only one of `url` or `serviceAccountToken` is present, a warning is logged before falling back to `loadFromDefault()` — this helps catch partial config mistakes.
 
 **Rationale:** `loadFromDefault()` reads from `KUBECONFIG` env var or `~/.kube/config` — appropriate for local dev but not for deployed Backstage instances where config should come from `app-config.yaml`. `loadFromOptions()` builds the KubeConfig programmatically from the exact fields we control. The `K8S_TOKEN` env var override in the current code becomes unnecessary when credentials come from config.
 

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
@@ -1,0 +1,389 @@
+# Design: Migrate K8s Credentials and Plugin Config to app-config.yaml
+
+## Canonical Touchpoints
+
+- Parent design: `openspec/changes/transition-oai-connector-to-kserve-plugin/design.md` — Decision 2
+- Jira: [RHIDP-15201](https://redhat.atlassian.net/browse/RHIDP-15201)
+
+## Context
+
+The connector plugin (`kserve-kubeflow-connector-backend`) creates K8s clients in `setupInformer` (InformerService.ts) using `KubeConfig.loadFromDefault()`, which reads from the `KUBECONFIG` env var or the default kubeconfig file path. The token is then optionally overridden by a `K8S_TOKEN` env var. This is a prototype pattern — Backstage plugins should read cluster credentials from `app-config.yaml`.
+
+The [OCM plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm#setting-up-the-ocm-backend-package) provides the reference pattern with two config approaches:
+
+**Approach 1 — Direct config**: K8s fields directly in the provider config:
+
+```yaml
+catalog:
+  providers:
+    ocm:
+      env:
+        name: hub-cluster
+        url: https://api.hub.example.com:6443
+        serviceAccountToken: ${HUB_TOKEN}
+        skipTLSVerify: false
+        caData: ${HUB_CA_DATA:-}
+```
+
+**Approach 2 — kubernetesPluginRef**: Reference a cluster from the Backstage K8s plugin config:
+
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - name: hub-cluster
+          url: https://api.hub.example.com:6443
+          serviceAccountToken: ${HUB_TOKEN}
+
+catalog:
+  providers:
+    ocm:
+      env:
+        kubernetesPluginRef: hub-cluster # matches cluster name above
+```
+
+When `kubernetesPluginRef` is provided, it takes precedence over direct K8s fields. The Backstage kubernetes plugin does NOT need to be installed — only its config section in `app-config.yaml` is required.
+
+**OCM reference implementation** (local clones for cross-reference):
+
+- Config reading: `/home/gmontero/go/src/github.com/backstage/community-plugins/workspaces/ocm/plugins/ocm-backend/src/helpers/config.ts` — `deferToKubernetesPlugin()`, `getHubClusterFromKubernetesConfig()`, `getHubClusterFromOcmConfig()`
+- K8s client creation: `/home/gmontero/go/src/github.com/backstage/community-plugins/workspaces/ocm/plugins/ocm-backend/src/helpers/kubernetes.ts` — `hubApiClient()` uses `loadFromOptions()`
+- Backstage K8s plugin config schema: `/home/gmontero/go/src/github.com/backstage/backstage/plugins/kubernetes-backend/config.d.ts`
+
+### Current config structure
+
+```yaml
+catalog:
+  providers:
+    modelCatalog:
+      kserve-kubeflow-connector: # entity provider ID / connector plugin ID
+        schedule: # read by entity provider (ModelCatalogConfig.schedule)
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
+        cluster-1: # cluster sub-key — read by connector plugin
+          name: my-k8s-cluster
+          kubeflow-model-catalog-url: '${KUBEFLOW_MODEL_CATALOG_URL:-}'
+          default-owner: '${OWNER:-default-owner}'
+          default-lifecycle: '${LIFECYCLE:-production}'
+```
+
+### Target config structure
+
+```yaml
+catalog:
+  providers:
+    modelCatalog:
+      kserve-kubeflow-connector:
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
+        cluster-1:
+          name: my-k8s-cluster
+          # K8s connection — direct approach
+          url: '${K8S_CLUSTER_URL}'
+          serviceAccountToken: '${K8S_SA_TOKEN}'
+          skipTLSVerify: false
+          caData: '${K8S_CA_DATA:-}'
+          # Plugin-specific fields
+          kubeflow-model-catalog-url: '${KUBEFLOW_MODEL_CATALOG_URL:-}'
+          default-owner: '${OWNER:-default-owner}'
+          default-lifecycle: '${LIFECYCLE:-production}'
+```
+
+Or using `kubernetesPluginRef`:
+
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - name: my-k8s-cluster
+          url: '${K8S_CLUSTER_URL}'
+          serviceAccountToken: '${K8S_SA_TOKEN}'
+          skipTLSVerify: false
+          caData: '${K8S_CA_DATA:-}'
+
+catalog:
+  providers:
+    modelCatalog:
+      kserve-kubeflow-connector:
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
+        cluster-1:
+          kubernetesPluginRef: my-k8s-cluster # matches cluster name above
+          kubeflow-model-catalog-url: '${KUBEFLOW_MODEL_CATALOG_URL:-}'
+          default-owner: '${OWNER:-default-owner}'
+          default-lifecycle: '${LIFECYCLE:-production}'
+```
+
+### Current type hierarchy
+
+```
+plugin.ts reads app-config
+  → creates ConnectorConfig { catalogUrl?, defaultOwner?, defaultLifecycle? }
+  → calls setupInformer(connectorConfig)
+    → setupInformer builds ReconcilerConfig {
+        catalogRoute?, catalogUrl?, defaultLifecycle, defaultOwner,
+        k8sToken?, routeClient?, coreClient?, informer?
+      }
+    → KubeConfig via loadFromDefault() (reads KUBECONFIG env var, ~/.kube/config from oc login, or K8S_TOKEN env var override)
+```
+
+### Target type hierarchy
+
+```
+plugin.ts reads app-config + optional kubernetes config
+  → builds ReconcilerConfig directly (no ConnectorConfig intermediate)
+  → calls setupInformer(reconcilerConfig)
+    → setupInformer receives KubeConfig-ready fields
+    → KubeConfig via loadFromOptions() when config fields present,
+      loadFromDefault() as fallback for local dev
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- K8s credentials read from `app-config.yaml` (direct or via kubernetesPluginRef)
+- Config-based credentials take precedence over local dev options (`K8S_TOKEN` env var, `KUBECONFIG` env var, `~/.kube/config` from `oc login`)
+- `baseUrl` removed from entity provider `ModelCatalogConfig`
+- `ConnectorConfig` merged into `ReconcilerConfig`
+- ServiceAccount auth only
+- `config.d.ts` declares K8s connection fields
+- Example K8s RBAC YAML for ServiceAccount setup
+- `yarn build:all`, `yarn tsc`, unit tests, prettier, and lint pass
+
+**Non-Goals:**
+
+- OIDC, Google SA, or other auth methods beyond serviceAccount
+- Frontend-level config (all new fields are `@visibility backend`)
+- Multi-cluster support (single cluster per provider instance)
+- Changes to url-reader plugin or entity provider's entity generation logic
+
+## Decisions
+
+### D1 — Two config approaches following OCM pattern
+
+**Choice:** Support two approaches for K8s cluster credentials, matching the OCM plugin:
+
+1. **Direct fields** in the cluster sub-config: `url`, `serviceAccountToken`, `skipTLSVerify`, `caData`
+2. **kubernetesPluginRef** referencing a cluster name from `kubernetes.clusterLocatorMethods`
+
+When `kubernetesPluginRef` is set and the referenced cluster is found, its K8s fields take precedence over any direct K8s fields in the cluster sub-config. If the referenced cluster is NOT found, direct K8s fields are used as fallback (see D7 for the full precedence chain). Plugin-specific fields (`kubeflow-model-catalog-url`, `default-owner`, `default-lifecycle`) are always read from the cluster sub-config regardless.
+
+**Rationale:** This is the established Backstage pattern used by the OCM plugin. It allows platform engineers to either centralize cluster config (via the kubernetes plugin section) or keep it self-contained in the provider config. The Backstage kubernetes plugin does NOT need to be installed — only its config section in `app-config.yaml` is needed when using `kubernetesPluginRef`.
+
+### D2 — Remove baseUrl from ModelCatalogConfig
+
+**Choice:** Remove `baseUrl` from `ModelCatalogConfig`, `readModelCatalogApiEntityConfig`, and `ModelCatalogResourceEntityProvider`. Also remove `baseUrl` from `config.d.ts`.
+
+**Rationale:** The entity provider uses `DiscoveryService.getBaseUrl()` to resolve the connector's URL at runtime (line 169 of `ModelCatalogResourceEntityProvider.ts`). The `baseUrl` field was a manual override — if `baseUrl` was set, it took priority over discovery. But if discovery fails, the `auth.getPluginRequestToken()` call (line 174) also fails because it depends on the same plugin registration. So `baseUrl` is either redundant (discovery works) or insufficient (discovery broken). Removing it simplifies config and eliminates confusion.
+
+**Impact:** The `run()` method in `ModelCatalogResourceEntityProvider.ts` simplifies from:
+
+```typescript
+const svcUrl = await this.discovery.getBaseUrl(this.name);
+let url = this.baseUrl;
+if (svcUrl.length > 0 && url.length === 0) {
+  url = svcUrl;
+}
+```
+
+to:
+
+```typescript
+const url = await this.discovery.getBaseUrl(this.name);
+```
+
+### D3 — Merge ConnectorConfig into ReconcilerConfig
+
+**Choice:** Eliminate the `ConnectorConfig` interface. Move its fields (`catalogUrl?`, `defaultOwner?`, `defaultLifecycle?`) and the new K8s connection fields into `ReconcilerConfig`. The config-derived fields remain optional strings (matching `ConnectorConfig`'s signature); defaults are applied in `setupInformer`.
+
+**Rationale:** `ConnectorConfig` is a thin intermediate that `setupInformer` immediately unpacks into `ReconcilerConfig`. The two types have overlapping fields with different optionality (`ConnectorConfig.defaultOwner?: string` vs `ReconcilerConfig.defaultOwner: string`). With the K8s config migration adding more fields, maintaining two types adds complexity without value.
+
+**Implementation:**
+
+- `ReconcilerConfig` in `types.ts` gains: `clusterName?`, `url?`, `serviceAccountToken?`, `skipTLSVerify?`, `caData?` (K8s connection); keeps `catalogUrl?`, `defaultOwner?`, `defaultLifecycle?` as optional (was required, now optional with defaults applied in `setupInformer`). `clusterName` comes from the `name` field in the cluster sub-config and is used in `loadFromOptions` for KubeConfig cluster/context naming.
+  Note: `defaultOwner` and `defaultLifecycle` change from required `string` to optional `string` (`?: string`) on the type — `setupInformer` continues to apply defaults (`process.env.OWNER || 'default-owner'` and `process.env.LIFECYCLE || 'production'`) before any code that depends on them.
+- `ConnectorConfig` interface and its export in `InformerService.ts` are removed.
+- `plugin.ts` builds a `ReconcilerConfig` directly (minus the runtime K8s objects, which `setupInformer` populates).
+- `setupInformer` signature changes from `(connectorConfig?: ConnectorConfig)` to `(config: ReconcilerConfig, logger: LoggerService)`.
+
+### D4 — Build KubeConfig from config fields via loadFromOptions
+
+**Choice:** When K8s connection fields (`url`, `serviceAccountToken`) are available in `ReconcilerConfig`, build the KubeConfig using `kc.loadFromOptions()` instead of `kc.loadFromDefault()`. Fall back to `loadFromDefault()` when no config fields are present (local dev with kubeconfig file).
+
+**Implementation** (matches OCM's `hubApiClient()` pattern in `ocm-backend/src/helpers/kubernetes.ts`):
+
+```typescript
+const kc = new k8s.KubeConfig();
+const clusterName = config.clusterName || 'target-cluster';
+if (config.url && config.serviceAccountToken) {
+  kc.loadFromOptions({
+    clusters: [
+      {
+        name: clusterName,
+        server: config.url,
+        skipTLSVerify: config.skipTLSVerify ?? false,
+        caData: config.caData,
+      },
+    ],
+    users: [
+      {
+        name: 'backstage-sa',
+        token: config.serviceAccountToken,
+      },
+    ],
+    contexts: [
+      {
+        name: clusterName,
+        cluster: clusterName,
+        user: 'backstage-sa',
+      },
+    ],
+    currentContext: clusterName,
+  });
+} else {
+  kc.loadFromDefault();
+}
+```
+
+Note: `clusterName` comes from the `name` field in the cluster sub-config (e.g., `name: my-k8s-cluster`). OCM uses the same pattern — its `hubApiClient()` passes the cluster name from config to `loadFromOptions`.
+
+**Rationale:** `loadFromDefault()` reads from `KUBECONFIG` env var or `~/.kube/config` — appropriate for local dev but not for deployed Backstage instances where config should come from `app-config.yaml`. `loadFromOptions()` builds the KubeConfig programmatically from the exact fields we control. The `K8S_TOKEN` env var override in the current code becomes unnecessary when credentials come from config.
+
+**Local dev fallback:** After building the KubeConfig (either way), the token extraction logic is simplified. When config fields are present, `config.serviceAccountToken` IS the token — no need to dig through the KubeConfig's user list. When falling back to `loadFromDefault()`, the following local dev options are supported:
+
+- **`~/.kube/config`** — default kubeconfig from `oc login` / `kubectl login`; `loadFromDefault()` reads this automatically
+- **`KUBECONFIG` env var** — explicit path to a kubeconfig file; `loadFromDefault()` reads this automatically
+- **`K8S_TOKEN` env var** — override token extracted from the kubeconfig; keep the existing token extraction logic (currentUser → users list) and this override for backwards compatibility
+
+### D5 — ServiceAccount auth only
+
+**Choice:** Only support `serviceAccount` authentication. Do not implement OIDC, Google SA, or other auth providers from the Backstage K8s plugin config.
+
+**Rationale:** The connector uses long-lived K8s informers and periodic polling — it needs a stable service account token, not a user-scoped OAuth token. The Backstage K8s plugin's `authProvider` field supports 8 strategies (`serviceAccount`, `aks`, `aws`, `azure`, `google`, `googleServiceAccount`, `oidc`, `localKubectlProxy`), but the non-serviceAccount types are designed for user-initiated K8s API requests. The connector runs as a backend daemon and should use a dedicated ServiceAccount. This matches the OCM plugin's approach — OCM also only supports `serviceAccount` and validates this when using `kubernetesPluginRef` (see `ocm-backend/src/helpers/config.ts:61-63`).
+
+**Validation:** When `kubernetesPluginRef` is used and the referenced cluster has an `authProvider` field, log a warning if it is not `serviceAccount` but proceed anyway — the `serviceAccountToken` field is what matters for the connection.
+
+### D6 — Config.d.ts: K8s fields in entity provider's existing config.d.ts
+
+**Choice:** Add the K8s connection fields (`url`, `serviceAccountToken`, `skipTLSVerify`, `caData`, `kubernetesPluginRef`) to the cluster sub-key type in the entity provider's existing `catalog-backend-module-model-catalog/config.d.ts`. Do NOT create a separate `config.d.ts` in the connector plugin.
+
+**Rationale:** The entire `catalog.providers.modelCatalog` config tree is already declared in the entity provider's `config.d.ts`. Adding the K8s fields there keeps all schema declarations for this config path in one place. Backstage merges config schemas across plugins, so a separate connector `config.d.ts` would also work, but splitting the schema for the same config path across two files is harder to maintain.
+
+**Schema update:**
+
+```typescript
+[clusterKey: string]:
+  | {
+      /** @visibility backend */
+      name?: string;
+      /** @visibility backend */
+      url?: string;
+      /** @visibility secret */
+      serviceAccountToken?: string;
+      /** @visibility backend */
+      skipTLSVerify?: boolean;
+      /** @visibility secret */
+      caData?: string;
+      /** @visibility backend */
+      kubernetesPluginRef?: string;
+      /** @visibility backend */
+      'kubeflow-model-catalog-url'?: string;
+      /** @visibility backend */
+      'default-owner'?: string;
+      /** @visibility backend */
+      'default-lifecycle'?: string;
+    }
+  | string
+  | SchedulerServiceTaskScheduleDefinitionConfig
+  | undefined;
+```
+
+Note: `serviceAccountToken` and `caData` use `@visibility secret` — they must never be exposed to the frontend.
+
+Also remove `baseUrl` from the connector-level fields (per D2).
+
+### D7 — Precedence: kubernetesPluginRef > direct config > env vars > loadFromDefault
+
+**Choice:** The following precedence order determines how the KubeConfig is built:
+
+1. **kubernetesPluginRef** (found): If set AND the referenced cluster is found in `kubernetes.clusterLocatorMethods`, use its `url`, `serviceAccountToken`, `skipTLSVerify`, `caData`.
+2. **kubernetesPluginRef** (not found): If set but the referenced cluster is NOT found, log a warning and fall through to step 3 (do NOT skip to `loadFromDefault`).
+3. **Direct config**: If `url` and `serviceAccountToken` are present in the cluster sub-config, use them.
+4. **Local dev — loadFromDefault()**: If none of the above, use `loadFromDefault()` which supports three local dev options:
+   - `~/.kube/config` from `oc login` / `kubectl login` (read automatically)
+   - `KUBECONFIG` env var pointing to a custom kubeconfig file (read automatically)
+   - `K8S_TOKEN` env var to override the token extracted from the kubeconfig (backward compatibility)
+
+**Reading kubernetesPluginRef:** In `plugin.ts`, when `kubernetesPluginRef` is present in the cluster sub-config:
+
+```typescript
+const k8sConfig = config.getOptionalConfig('kubernetes');
+if (k8sConfig) {
+  const locators =
+    k8sConfig.getOptionalConfigArray('clusterLocatorMethods') ?? [];
+  for (const locator of locators) {
+    if (locator.getOptionalString('type') !== 'config') continue;
+    const clusters = locator.getOptionalConfigArray('clusters') ?? [];
+    for (const cluster of clusters) {
+      if (cluster.getOptionalString('name') === kubernetesPluginRef) {
+        // Found matching cluster — extract url, serviceAccountToken, skipTLSVerify, caData
+      }
+    }
+  }
+}
+```
+
+**Rationale:** This precedence follows the OCM pattern (kubernetesPluginRef > own config > defaults) while preserving backward compatibility with existing local dev setups (`oc login` kubeconfig, `KUBECONFIG` env var, `K8S_TOKEN` env var). Platform engineers deploying to production will use approach 1 or 2; dev setups will fall through to loadFromDefault.
+
+### D8 — K8s RBAC example YAML
+
+**Choice:** Provide an example YAML file at `examples/k8s-rbac.yaml` with ServiceAccount, ClusterRole, and ClusterRoleBinding resources. The ClusterRole grants the minimum permissions the connector needs.
+
+**Permissions required** (derived from `InformerService.ts` and `Catalog.ts`):
+
+| Resource            | API Group            | Verbs            | Used by                                     |
+| ------------------- | -------------------- | ---------------- | ------------------------------------------- |
+| `inferenceservices` | `serving.kserve.io`  | get, watch, list | K8s Informer in `setupInformer`             |
+| `routes`            | `route.openshift.io` | get, watch, list | `setupCatalogRoute` in `Catalog.ts`         |
+| `serviceaccounts`   | `""` (core)          | get, list        | `getAuthentication` in `InformerService.ts` |
+
+**Rationale:** Platform engineers need to know what RBAC to set up before the connector can function. This is the same pattern OCM follows in its README (showing the ClusterRole rules). The example YAML is more maintainable than inline documentation and can be applied directly with `kubectl apply`.
+
+## Cross-Change Reconciliation
+
+- **`remove-kfmr-client-code` (D3, D7)**: That change simplified `ReconcilerConfig` and added `catalogUrl`. This change further modifies `ReconcilerConfig` by adding K8s connection fields and merging `ConnectorConfig` into it. Both changes are sequential — `remove-kfmr-client-code` landed first (already merged), so this change builds on its result. No conflict.
+- **`techdocs-modelcard-finalization` (D5)**: That change added the `[clusterKey: string]` index signature to `config.d.ts`. This change extends the same union type with K8s connection fields. Both modify the same type declaration but add different fields — merge is additive. No conflict.
+
+## Risks / Trade-offs
+
+| Risk                                                                                                                                   | Mitigation                                                                                                                                                               |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `kubernetesPluginRef` lookup fails silently if the referenced cluster doesn't exist                                                    | Log a warning and fall back to direct config or loadFromDefault; document the expected cluster name format                                                               |
+| `loadFromOptions` with wrong `caData` or `url` produces cryptic K8s client errors                                                      | Log the cluster name and url (NOT the token) when building the KubeConfig to help diagnosis                                                                              |
+| Removing `baseUrl` breaks deployments that depend on it                                                                                | Extremely unlikely — `baseUrl` was only useful when discovery works for auth but fails for URL resolution, which is contradictory. Document the removal in the changelog |
+| Local dev options (`K8S_TOKEN`, `KUBECONFIG` env vars, `~/.kube/config` from `oc login`) still work but are undocumented going forward | Keep backward compat silently; don't encourage env vars in documentation                                                                                                 |
+| `serviceAccountToken` in config is a secret value                                                                                      | Use `@visibility secret` in config.d.ts; Backstage config system masks secrets in logs                                                                                   |
+| Config validation rejects new fields if `config.d.ts` is not picked up                                                                 | Verify that Backstage loads the schema — the entity provider's `config.d.ts` is already active                                                                           |
+
+## Verification
+
+After all changes:
+
+1. `yarn tsc` passes with no errors
+2. `yarn build:all` succeeds
+3. Existing unit tests pass (no test changes expected — tests don't exercise K8s connection)
+4. Prettier and lint checks pass
+5. Plugin starts with direct K8s config in `app-config.yaml` (url + serviceAccountToken)
+6. Plugin starts with `kubernetesPluginRef` referencing a cluster in `kubernetes.clusterLocatorMethods`
+7. Plugin starts with no K8s config (falls back to `loadFromDefault()` for local dev)
+8. Connector discovers and watches InferenceServices using config-based credentials
+9. Local dev options still work as backward-compatible fallback: `~/.kube/config` from `oc login`, `KUBECONFIG` env var, and `K8S_TOKEN` env var override

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
@@ -332,6 +332,7 @@ Also remove `baseUrl` from the connector-level fields (per D2).
 **Reading kubernetesPluginRef:** In `plugin.ts`, when `kubernetesPluginRef` is present in the cluster sub-config:
 
 ```typescript
+let matched = false;
 const k8sConfig = config.getOptionalConfig('kubernetes');
 if (k8sConfig) {
   const locators =
@@ -340,10 +341,12 @@ if (k8sConfig) {
     if (locator.getOptionalString('type') !== 'config') continue;
     const clusters = locator.getOptionalConfigArray('clusters') ?? [];
     for (const cluster of clusters) {
-      if (cluster.getOptionalString('name') === kubernetesPluginRef) {
-        // Found matching cluster — extract url, serviceAccountToken, skipTLSVerify, caData
+      if (safeGetOptionalString(cluster, 'name') === kubernetesPluginRef) {
+        matched = true;
+        // Extract url, serviceAccountToken, skipTLSVerify, caData
       }
     }
+    if (matched) break;
   }
 }
 ```

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
@@ -47,11 +47,11 @@ catalog:
 
 When `kubernetesPluginRef` is provided, it takes precedence over direct K8s fields. The Backstage kubernetes plugin does NOT need to be installed — only its config section in `app-config.yaml` is required.
 
-**OCM reference implementation** (local clones for cross-reference):
+**OCM reference implementation**:
 
-- Config reading: `/home/gmontero/go/src/github.com/backstage/community-plugins/workspaces/ocm/plugins/ocm-backend/src/helpers/config.ts` — `deferToKubernetesPlugin()`, `getHubClusterFromKubernetesConfig()`, `getHubClusterFromOcmConfig()`
-- K8s client creation: `/home/gmontero/go/src/github.com/backstage/community-plugins/workspaces/ocm/plugins/ocm-backend/src/helpers/kubernetes.ts` — `hubApiClient()` uses `loadFromOptions()`
-- Backstage K8s plugin config schema: `/home/gmontero/go/src/github.com/backstage/backstage/plugins/kubernetes-backend/config.d.ts`
+- Config reading: [`ocm-backend/src/helpers/config.ts`](https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/src/helpers/config.ts) — `deferToKubernetesPlugin()`, `getHubClusterFromKubernetesConfig()`, `getHubClusterFromOcmConfig()`
+- K8s client creation: [`ocm-backend/src/helpers/kubernetes.ts`](https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/src/helpers/kubernetes.ts) — `hubApiClient()` uses `loadFromOptions()`
+- Backstage K8s plugin config schema: [`kubernetes-backend/config.d.ts`](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/config.d.ts)
 
 ### Current config structure
 
@@ -274,7 +274,7 @@ Note: `clusterName` comes from the `name` field in the cluster sub-config (e.g.,
 
 ### D6 — Config.d.ts: K8s fields in entity provider's existing config.d.ts
 
-**Choice:** Add the K8s connection fields (`url`, `serviceAccountToken`, `skipTLSVerify`, `caData`, `kubernetesPluginRef`) to the cluster sub-key type in the entity provider's existing `catalog-backend-module-model-catalog/config.d.ts`. Do NOT create a separate `config.d.ts` in the connector plugin.
+**Choice:** Add the K8s connection fields (`url`, `serviceAccountToken`, `skipTLSVerify`, `caData`, `kubernetesPluginRef`) to the cluster sub-key type in the entity provider's existing `plugins/catalog-backend-module-model-catalog/config.d.ts`. Do NOT create a separate `config.d.ts` in the connector plugin.
 
 **Rationale:** The entire `catalog.providers.modelCatalog` config tree is already declared in the entity provider's `config.d.ts`. Adding the K8s fields there keeps all schema declarations for this config path in one place. Backstage merges config schemas across plugins, so a separate connector `config.d.ts` would also work, but splitting the schema for the same config path across two files is harder to maintain.
 

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/design.md
@@ -311,7 +311,7 @@ Note: `serviceAccountToken` and `caData` use `@visibility secret` — they must 
 
 Also remove `baseUrl` from the connector-level fields (per D2).
 
-### D7 — Precedence: kubernetesPluginRef > direct config > env vars > loadFromDefault
+### D7 — Precedence: kubernetesPluginRef > direct config > loadFromDefault (local dev)
 
 **Choice:** The following precedence order determines how the KubeConfig is built:
 
@@ -353,7 +353,7 @@ if (k8sConfig) {
 | Resource            | API Group            | Verbs            | Used by                                     |
 | ------------------- | -------------------- | ---------------- | ------------------------------------------- |
 | `inferenceservices` | `serving.kserve.io`  | get, watch, list | K8s Informer in `setupInformer`             |
-| `routes`            | `route.openshift.io` | get, watch, list | `setupCatalogRoute` in `Catalog.ts`         |
+| `routes`            | `route.openshift.io` | get, list        | `setupCatalogRoute` in `Catalog.ts`         |
 | `serviceaccounts`   | `""` (core)          | get, list        | `getAuthentication` in `InformerService.ts` |
 
 **Rationale:** Platform engineers need to know what RBAC to set up before the connector can function. This is the same pattern OCM follows in its README (showing the ClusterRole rules). The example YAML is more maintainable than inline documentation and can be applied directly with `kubectl apply`.

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
@@ -1,0 +1,73 @@
+# Proposal: Migrate K8s Credentials and Plugin Config to app-config.yaml
+
+## Why
+
+The `kserve-kubeflow-connector-backend` plugin creates its K8s clients via `KubeConfig.loadFromDefault()`, which reads from `~/.kube/config` (e.g., after `oc login`) or the `KUBECONFIG` env var, and optionally overrides the token with a `K8S_TOKEN` environment variable. This works for local development but does not follow Backstage conventions — platform engineers expect to configure K8s cluster access through `app-config.yaml`, not environment variables. The [OCM plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm) provides the reference pattern: cluster credentials either directly in the provider config or via a `kubernetesPluginRef` that references a cluster defined in the Backstage kubernetes plugin's `kubernetes.clusterLocatorMethods` config.
+
+Additionally, two type-level issues have accumulated:
+
+1. `ModelCatalogConfig.baseUrl` in the entity provider is unused in practice — if the Backstage `DiscoveryService` cannot resolve the connector, nothing else works either (auth tokens, endpoint calls), so the fallback adds complexity without value.
+2. `ConnectorConfig` and `ReconcilerConfig` in the connector plugin are redundant — `ConnectorConfig` exists solely to be unpacked into `ReconcilerConfig` five lines later in `setupInformer`.
+
+## Starting Point
+
+- Connector plugin (`kserve-kubeflow-connector-backend`) uses `kc.loadFromDefault()` in `InformerService.ts` (reads `~/.kube/config` or `KUBECONFIG` env var) with optional `K8S_TOKEN` env var token override
+- `ModelCatalogConfig` in `catalog-backend-module-model-catalog/src/providers/types.ts` contains `baseUrl`, `id`, `schedule`
+- `ConnectorConfig` (InformerService.ts:556) is a thin wrapper with `catalogUrl?`, `defaultOwner?`, `defaultLifecycle?`
+- `ReconcilerConfig` (types.ts:113) merges those fields with runtime K8s objects (`routeClient`, `coreClient`, `informer`, `k8sToken`)
+- Entity provider's `config.d.ts` declares cluster sub-key fields but not K8s connection fields
+- Connector plugin has no `config.d.ts` of its own
+
+## What Changes
+
+- **K8s connection via config**: Add `url`, `serviceAccountToken`, `skipTLSVerify`, `caData` fields to the cluster sub-config under `catalog.providers.modelCatalog.<connector>.<cluster>`
+- **kubernetesPluginRef**: Add optional `kubernetesPluginRef` field to the cluster sub-config, referencing a cluster by name in `kubernetes.clusterLocatorMethods` — follows the OCM plugin pattern
+- **KubeConfig from config**: Replace `kc.loadFromDefault()` with `kc.loadFromOptions()` when config fields are present; fall back to `loadFromDefault()` for local dev when no config is set
+- **Remove baseUrl**: Drop `baseUrl` from `ModelCatalogConfig`, `readModelCatalogApiEntityConfig`, and `ModelCatalogResourceEntityProvider`
+- **Merge ConnectorConfig → ReconcilerConfig**: Eliminate the intermediate `ConnectorConfig` type; pass K8s connection fields and plugin-specific config directly through `ReconcilerConfig`
+- **Config schema**: Extend the entity provider's `config.d.ts` with K8s connection fields under the cluster sub-key
+- **K8s RBAC example**: Provide example YAML for ServiceAccount, ClusterRole, and ClusterRoleBinding so the connector's K8s clients can access InferenceServices, Routes, and ServiceAccounts
+- **App-config example**: Update `app-config.yaml` with both config approaches (direct and kubernetesPluginRef)
+
+## Capabilities
+
+### New Capabilities
+
+- `config-based-k8s-auth`: K8s cluster credentials configured via `app-config.yaml` instead of environment variables, supporting direct fields or cross-reference to the Backstage kubernetes plugin
+- `k8s-rbac-example`: Example YAML for ServiceAccount setup with appropriate ClusterRole permissions
+
+### Modified Capabilities
+
+- `reconciler-config`: `ConnectorConfig` merged into `ReconcilerConfig`; K8s connection fields (`url`, `serviceAccountToken`, `skipTLSVerify`, `caData`) added
+- `kubeconfig-init`: `setupInformer` builds KubeConfig from config fields via `loadFromOptions()` when available; `loadFromDefault()` is the fallback for local dev
+- `entity-provider-config`: `baseUrl` removed from `ModelCatalogConfig` — entity provider relies on `DiscoveryService` exclusively
+
+## Non-goals
+
+- Frontend-level config — all new config is backend-only (`@visibility backend`)
+- Auth providers other than `serviceAccount` — no OIDC, Google SA, or other auth methods in this iteration
+- Multi-cluster support — single cluster per provider instance, same as today (TODO comment for future)
+- Merging the connector plugin with the entity provider plugin
+- Changes to the `catalog-techdoc-url-reader-backend` plugin
+
+## Canonical Touchpoints
+
+- **Parent openspec**: `openspec/changes/transition-oai-connector-to-kserve-plugin/` — Decision 2
+- **Jira**: [RHIDP-15201](https://redhat.atlassian.net/browse/RHIDP-15201)
+- **Reference**: [OCM plugin setup](https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm#setting-up-the-ocm-backend-package), [Backstage K8s plugin config](https://backstage.io/docs/features/kubernetes/configuration), [Backstage K8s plugin auth](https://backstage.io/docs/features/kubernetes/authentication)
+- **Local refs**: Backstage K8s plugin at `/home/gmontero/go/src/github.com/backstage/backstage/plugins/kubernetes*`, OCM plugin at `/home/gmontero/go/src/github.com/backstage/community-plugins/workspaces/ocm`
+
+**Change type**: feature
+
+## Impact
+
+- `plugins/kserve-kubeflow-connector-backend/src/services/types.ts` — `ReconcilerConfig` gains K8s connection fields; `ConnectorConfig` removed
+- `plugins/kserve-kubeflow-connector-backend/src/services/InformerService.ts` — `setupInformer` signature and KubeConfig creation rewritten; `ConnectorConfig` type removed
+- `plugins/kserve-kubeflow-connector-backend/src/plugin.ts` — reads K8s fields from cluster config and `kubernetes.clusterLocatorMethods`; passes directly to `ReconcilerConfig`
+- `plugins/catalog-backend-module-model-catalog/src/providers/types.ts` — `baseUrl` removed from `ModelCatalogConfig`
+- `plugins/catalog-backend-module-model-catalog/src/providers/config.ts` — `baseUrl` reading removed
+- `plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.ts` — `baseUrl` field and fallback logic in `run()` removed
+- `plugins/catalog-backend-module-model-catalog/config.d.ts` — K8s connection fields added to cluster sub-key schema
+- `app-config.yaml` — updated with K8s connection example
+- New: `examples/k8s-rbac.yaml` — ServiceAccount, ClusterRole, ClusterRoleBinding example
+- Net change: ~+180 lines, -90 lines across 9 files

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
@@ -42,7 +42,7 @@ Additionally, two type-level issues have accumulated:
 - `kubeconfig-init`: `setupInformer` builds KubeConfig from config fields via `loadFromOptions()` when available; `loadFromDefault()` is the fallback for local dev
 - `entity-provider-config`: `baseUrl` removed from `ModelCatalogConfig` — entity provider relies on `DiscoveryService` exclusively
 
-## Non-goals
+## Non-Goals
 
 - Frontend-level config — all new config is backend-only (`@visibility backend`)
 - Auth providers other than `serviceAccount` — no OIDC, Google SA, or other auth methods in this iteration

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
@@ -12,7 +12,7 @@ Additionally, two type-level issues have accumulated:
 ## Starting Point
 
 - Connector plugin (`kserve-kubeflow-connector-backend`) uses `kc.loadFromDefault()` in `InformerService.ts` (reads `~/.kube/config` or `KUBECONFIG` env var) with optional `K8S_TOKEN` env var token override
-- `ModelCatalogConfig` in `catalog-backend-module-model-catalog/src/providers/types.ts` contains `baseUrl`, `id`, `schedule`
+- `ModelCatalogConfig` in `plugins/catalog-backend-module-model-catalog/src/providers/types.ts` contains `baseUrl`, `id`, `schedule`
 - `ConnectorConfig` (InformerService.ts:556) is a thin wrapper with `catalogUrl?`, `defaultOwner?`, `defaultLifecycle?`
 - `ReconcilerConfig` (types.ts:113) merges those fields with runtime K8s objects (`routeClient`, `coreClient`, `informer`, `k8sToken`)
 - Entity provider's `config.d.ts` declares cluster sub-key fields but not K8s connection fields
@@ -54,8 +54,7 @@ Additionally, two type-level issues have accumulated:
 
 - **Parent openspec**: `openspec/changes/transition-oai-connector-to-kserve-plugin/` — Decision 2
 - **Jira**: [RHIDP-15201](https://redhat.atlassian.net/browse/RHIDP-15201)
-- **Reference**: [OCM plugin setup](https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm#setting-up-the-ocm-backend-package), [Backstage K8s plugin config](https://backstage.io/docs/features/kubernetes/configuration), [Backstage K8s plugin auth](https://backstage.io/docs/features/kubernetes/authentication)
-- **Local refs**: Backstage K8s plugin at `/home/gmontero/go/src/github.com/backstage/backstage/plugins/kubernetes*`, OCM plugin at `/home/gmontero/go/src/github.com/backstage/community-plugins/workspaces/ocm`
+- **Reference**: [OCM plugin setup](https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm#setting-up-the-ocm-backend-package), [Backstage K8s plugin config](https://backstage.io/docs/features/kubernetes/configuration), [Backstage K8s plugin auth](https://backstage.io/docs/features/kubernetes/authentication), [Backstage K8s plugin config.d.ts](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/config.d.ts), [OCM config helper](https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/src/helpers/config.ts)
 
 **Change type**: feature
 

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/proposal.md
@@ -42,7 +42,7 @@ Additionally, two type-level issues have accumulated:
 - `kubeconfig-init`: `setupInformer` builds KubeConfig from config fields via `loadFromOptions()` when available; `loadFromDefault()` is the fallback for local dev
 - `entity-provider-config`: `baseUrl` removed from `ModelCatalogConfig` — entity provider relies on `DiscoveryService` exclusively
 
-## Non-Goals
+## Non-goals
 
 - Frontend-level config — all new config is backend-only (`@visibility backend`)
 - Auth providers other than `serviceAccount` — no OIDC, Google SA, or other auth methods in this iteration

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
@@ -1,0 +1,271 @@
+## K8s Config — Direct Fields
+
+### Requirement: Connector builds KubeConfig from direct config fields
+
+When the cluster sub-config contains `url` and `serviceAccountToken`, the connector SHALL build a KubeConfig using `loadFromOptions()` instead of `loadFromDefault()`.
+
+#### Scenario: Direct config with all fields
+
+- **GIVEN** `app-config.yaml` has `catalog.providers.modelCatalog.kserve-kubeflow-connector.cluster-1` with:
+  - `url: https://api.my-cluster.example.com:6443`
+  - `serviceAccountToken: eyJhbG...`
+  - `skipTLSVerify: true`
+  - `caData: LS0tLS1C...`
+- **WHEN** the connector plugin initializes
+- **THEN** `KubeConfig.loadFromOptions()` is called with one cluster, one user, and one context
+- **AND** the cluster's `server` is `https://api.my-cluster.example.com:6443`
+- **AND** the user's `token` is the serviceAccountToken value
+- **AND** `skipTLSVerify` is `true`
+- **AND** `caData` is `LS0tLS1C...`
+- **AND** `loadFromDefault()` is NOT called
+
+#### Scenario: Direct config with minimum fields
+
+- **GIVEN** `cluster-1` has only `url` and `serviceAccountToken` (no `skipTLSVerify`, no `caData`)
+- **WHEN** the connector plugin initializes
+- **THEN** `KubeConfig.loadFromOptions()` is called
+- **AND** `skipTLSVerify` defaults to `false`
+- **AND** `caData` is `undefined`
+
+#### Scenario: Direct config missing serviceAccountToken
+
+- **GIVEN** `cluster-1` has `url` but no `serviceAccountToken`
+- **WHEN** the connector plugin initializes
+- **THEN** `loadFromDefault()` is used as fallback
+- **AND** the plugin logs that it fell back to default KubeConfig
+
+---
+
+## K8s Config — kubernetesPluginRef
+
+### Requirement: Connector resolves K8s credentials from Backstage kubernetes plugin config
+
+When `kubernetesPluginRef` is set in the cluster sub-config, the connector SHALL look up the matching cluster in `kubernetes.clusterLocatorMethods` and use its K8s connection fields.
+
+#### Scenario: kubernetesPluginRef matches a cluster
+
+- **GIVEN** `cluster-1` has `kubernetesPluginRef: my-k8s-cluster`
+- **AND** `kubernetes.clusterLocatorMethods` contains a `type: config` entry with a cluster named `my-k8s-cluster` having `url` and `serviceAccountToken`
+- **WHEN** the connector plugin initializes
+- **THEN** the K8s connection fields are read from the kubernetes plugin config (NOT from `cluster-1`)
+- **AND** `KubeConfig.loadFromOptions()` is called with the kubernetes plugin cluster's fields
+- **AND** plugin-specific fields (`kubeflow-model-catalog-url`, `default-owner`, `default-lifecycle`) are still read from `cluster-1`
+
+#### Scenario: kubernetesPluginRef takes precedence over direct fields
+
+- **GIVEN** `cluster-1` has both `kubernetesPluginRef: my-k8s-cluster` AND `url: https://other.example.com`
+- **AND** the referenced kubernetes plugin cluster has `url: https://kubernetes-plugin.example.com`
+- **WHEN** the connector plugin initializes
+- **THEN** `url` from the kubernetes plugin config (`https://kubernetes-plugin.example.com`) is used
+- **AND** the direct `url` in `cluster-1` is ignored for K8s connection
+
+#### Scenario: kubernetesPluginRef not found — falls through to direct config
+
+- **GIVEN** `cluster-1` has `kubernetesPluginRef: nonexistent-cluster`
+- **AND** no cluster with that name exists in `kubernetes.clusterLocatorMethods`
+- **AND** `cluster-1` also has `url` and `serviceAccountToken` fields
+- **WHEN** the connector plugin initializes
+- **THEN** a warning is logged: `kubernetesPluginRef 'nonexistent-cluster' not found`
+- **AND** the direct config fields (`url`, `serviceAccountToken`) are used instead (per D7 precedence)
+
+#### Scenario: kubernetesPluginRef not found and no direct config
+
+- **GIVEN** `cluster-1` has `kubernetesPluginRef: nonexistent-cluster`
+- **AND** no cluster with that name exists in `kubernetes.clusterLocatorMethods`
+- **AND** `cluster-1` has no `url` or `serviceAccountToken` fields
+- **WHEN** the connector plugin initializes
+- **THEN** a warning is logged
+- **AND** `loadFromDefault()` is used as final fallback
+
+#### Scenario: kubernetesPluginRef without kubernetes config section
+
+- **GIVEN** `cluster-1` has `kubernetesPluginRef: my-cluster`
+- **AND** there is no `kubernetes` section in `app-config.yaml`
+- **AND** `cluster-1` has no direct `url` or `serviceAccountToken` fields
+- **WHEN** the connector plugin initializes
+- **THEN** a warning is logged
+- **AND** `loadFromDefault()` is used as final fallback
+
+---
+
+## Config Precedence
+
+### Requirement: Config fields take precedence over environment variables
+
+K8s credentials from `app-config.yaml` SHALL take precedence over local dev options (`K8S_TOKEN` env var, `KUBECONFIG` env var, `~/.kube/config` from `oc login`).
+
+#### Scenario: Config fields override K8S_TOKEN
+
+- **GIVEN** `cluster-1` has `url` and `serviceAccountToken` configured
+- **AND** `K8S_TOKEN` env var is also set to a different token
+- **WHEN** the connector plugin initializes
+- **THEN** the `serviceAccountToken` from config is used
+- **AND** the `K8S_TOKEN` env var is ignored
+
+#### Scenario: Config fields override kubeconfig from oc login
+
+- **GIVEN** `cluster-1` has `url` and `serviceAccountToken` configured
+- **AND** `~/.kube/config` exists from a previous `oc login` to a different cluster
+- **WHEN** the connector plugin initializes
+- **THEN** the config fields are used (via `loadFromOptions`)
+- **AND** `~/.kube/config` is NOT read
+
+#### Scenario: No config fields — K8S_TOKEN env var used as fallback
+
+- **GIVEN** `cluster-1` has no `url` or `serviceAccountToken`
+- **AND** no `kubernetesPluginRef` is set
+- **AND** `K8S_TOKEN` env var is set
+- **WHEN** the connector plugin initializes
+- **THEN** `loadFromDefault()` is used for the KubeConfig
+- **AND** the token is overridden with `K8S_TOKEN` env var value
+
+#### Scenario: No config fields — KUBECONFIG env var used as fallback
+
+- **GIVEN** `cluster-1` has no `url` or `serviceAccountToken`
+- **AND** no `kubernetesPluginRef` is set
+- **AND** `KUBECONFIG` env var points to a valid kubeconfig file
+- **WHEN** the connector plugin initializes
+- **THEN** `loadFromDefault()` reads the kubeconfig from the path in `KUBECONFIG`
+
+#### Scenario: No config fields — ~/.kube/config from oc login used as fallback
+
+- **GIVEN** `cluster-1` has no `url` or `serviceAccountToken`
+- **AND** no `kubernetesPluginRef` is set
+- **AND** `~/.kube/config` exists from `oc login` / `kubectl login`
+- **WHEN** the connector plugin initializes
+- **THEN** `loadFromDefault()` reads `~/.kube/config` automatically
+
+#### Scenario: No config, no env vars, no kubeconfig — loadFromDefault fails gracefully
+
+- **GIVEN** `cluster-1` has no K8s connection fields
+- **AND** no `kubernetesPluginRef` is set
+- **AND** no `K8S_TOKEN` or `KUBECONFIG` env vars are set
+- **AND** `~/.kube/config` does not exist
+- **WHEN** the connector plugin initializes
+- **THEN** `loadFromDefault()` is called and fails with a K8s client error
+
+---
+
+## baseUrl Removal
+
+### Requirement: Entity provider uses DiscoveryService exclusively
+
+The entity provider SHALL use `DiscoveryService.getBaseUrl()` to resolve the connector's URL. The `baseUrl` config field SHALL be removed.
+
+#### Scenario: Entity provider run() uses discovery
+
+- **WHEN** `ModelCatalogResourceEntityProvider.run()` executes
+- **THEN** it calls `this.discovery.getBaseUrl(this.name)` to get the connector URL
+- **AND** no `baseUrl` field exists on the entity provider instance
+- **AND** no fallback logic for `baseUrl` vs `svcUrl` exists
+
+#### Scenario: baseUrl in app-config is ignored
+
+- **GIVEN** `app-config.yaml` has `baseUrl: http://localhost:7007` at the connector level
+- **WHEN** the entity provider reads config
+- **THEN** `baseUrl` is not read from config
+- **AND** the config.d.ts schema does not include `baseUrl`
+
+---
+
+## ConnectorConfig / ReconcilerConfig Merge
+
+### Requirement: Single config type for connector plugin
+
+The connector plugin SHALL use a single `ReconcilerConfig` type. The `ConnectorConfig` interface SHALL be removed.
+
+#### Scenario: plugin.ts builds ReconcilerConfig directly
+
+- **WHEN** `plugin.ts` reads cluster config from `app-config.yaml`
+- **THEN** it constructs a `ReconcilerConfig` object directly
+- **AND** no `ConnectorConfig` type is referenced anywhere in the codebase
+
+#### Scenario: Optional fields have defaults
+
+- **GIVEN** `ReconcilerConfig.defaultOwner` is `undefined`
+- **WHEN** `setupInformer` processes the config
+- **THEN** `defaultOwner` is set to `process.env.OWNER || 'default-owner'`
+- **AND** the same pattern applies to `defaultLifecycle` (`process.env.LIFECYCLE || 'production'`)
+
+---
+
+## Config Schema
+
+### Requirement: config.d.ts declares K8s connection fields
+
+The config schema SHALL declare K8s connection fields in the cluster sub-key type so Backstage config validation does not strip them.
+
+#### Scenario: K8s fields pass config validation
+
+- **WHEN** `app-config.yaml` contains `url`, `serviceAccountToken`, `skipTLSVerify`, `caData` under a cluster sub-key
+- **THEN** Backstage config validation preserves these fields
+- **AND** the connector plugin can read them via `config.getOptionalString('url')`, etc.
+
+#### Scenario: Secret visibility
+
+- **WHEN** `serviceAccountToken` or `caData` values are present in config
+- **THEN** they are annotated with `@visibility secret` in `config.d.ts`
+- **AND** Backstage's config system masks them in logs and frontend exposure
+
+#### Scenario: kubernetesPluginRef field passes validation
+
+- **WHEN** `app-config.yaml` contains `kubernetesPluginRef` under a cluster sub-key
+- **THEN** the field passes config validation
+- **AND** its value is readable via `config.getOptionalString('kubernetesPluginRef')`
+
+---
+
+## K8s RBAC
+
+### Requirement: Example RBAC YAML grants minimum required permissions
+
+The example K8s RBAC YAML SHALL grant exactly the permissions the connector needs — no more, no less.
+
+#### Scenario: InferenceService access
+
+- **GIVEN** the ClusterRole from the example RBAC YAML is applied
+- **WHEN** the connector's informer watches InferenceServices
+- **THEN** the watch, list, and get operations succeed
+
+#### Scenario: Route access (OpenShift only)
+
+- **GIVEN** the ClusterRole is applied on an OpenShift cluster
+- **WHEN** `setupCatalogRoute` lists routes by label
+- **THEN** the list operation succeeds
+
+#### Scenario: ServiceAccount listing
+
+- **GIVEN** the ClusterRole is applied
+- **WHEN** `getAuthentication` lists ServiceAccounts in a namespace
+- **THEN** the list and get operations succeed
+
+---
+
+## Build and Quality
+
+### Requirement: All quality gates pass
+
+#### Scenario: TypeScript compilation
+
+- **WHEN** `yarn tsc` is run from the workspace root
+- **THEN** it completes with zero errors
+
+#### Scenario: Full build
+
+- **WHEN** `yarn build:all` is run
+- **THEN** it completes with zero errors
+
+#### Scenario: Unit tests
+
+- **WHEN** `yarn test:all` is run
+- **THEN** all existing tests pass (no new test failures introduced)
+
+#### Scenario: Code formatting
+
+- **WHEN** `yarn prettier` is run
+- **THEN** no formatting changes are needed
+
+#### Scenario: Lint
+
+- **WHEN** `yarn lint:all` is run
+- **THEN** no lint errors are reported

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
@@ -31,8 +31,15 @@ When the cluster sub-config contains `url` and `serviceAccountToken`, the connec
 
 - **GIVEN** `cluster-1` has `url` but no `serviceAccountToken`
 - **WHEN** the connector plugin initializes
-- **THEN** `loadFromDefault()` is used as fallback
-- **AND** the plugin logs that it fell back to default KubeConfig
+- **THEN** a warning is logged: partial K8s config (both `url` and `serviceAccountToken` are required)
+- **AND** `loadFromDefault()` is used as fallback
+
+#### Scenario: Direct config missing url
+
+- **GIVEN** `cluster-1` has `serviceAccountToken` but no `url`
+- **WHEN** the connector plugin initializes
+- **THEN** a warning is logged: partial K8s config (both `url` and `serviceAccountToken` are required)
+- **AND** `loadFromDefault()` is used as fallback
 
 ---
 

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
@@ -86,6 +86,15 @@ When `kubernetesPluginRef` is set in the cluster sub-config, the connector SHALL
 - **THEN** a warning is logged
 - **AND** `loadFromDefault()` is used as final fallback
 
+#### Scenario: kubernetesPluginRef cluster uses non-serviceAccount authProvider
+
+- **GIVEN** `cluster-1` has `kubernetesPluginRef: my-k8s-cluster`
+- **AND** the referenced cluster in `kubernetes.clusterLocatorMethods` has `authProvider: oidc`
+- **AND** the referenced cluster also has a valid `serviceAccountToken`
+- **WHEN** the connector plugin initializes
+- **THEN** a warning is logged indicating `authProvider 'oidc'` is not supported and only `serviceAccount` is used
+- **AND** the `serviceAccountToken` is still used for the connection (per D5)
+
 ---
 
 ## Config Precedence

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
@@ -7,16 +7,16 @@ When the cluster sub-config contains `url` and `serviceAccountToken`, the connec
 #### Scenario: Direct config with all fields
 
 - **GIVEN** `app-config.yaml` has `catalog.providers.modelCatalog.kserve-kubeflow-connector.cluster-1` with:
-  - `url: https://api.my-cluster.example.com:6443`
-  - `serviceAccountToken: eyJhbG...`
-  - `skipTLSVerify: true`
-  - `caData: LS0tLS1C...`
+  - `url` set to a cluster API endpoint
+  - `serviceAccountToken` set to a valid token
+  - `skipTLSVerify: false`
+  - `caData` set to a base64-encoded CA certificate
 - **WHEN** the connector plugin initializes
 - **THEN** `KubeConfig.loadFromOptions()` is called with one cluster, one user, and one context
-- **AND** the cluster's `server` is `https://api.my-cluster.example.com:6443`
-- **AND** the user's `token` is the serviceAccountToken value
-- **AND** `skipTLSVerify` is `true`
-- **AND** `caData` is `LS0tLS1C...`
+- **AND** the cluster's `server` is the configured `url` value
+- **AND** the user's `token` is the configured `serviceAccountToken` value
+- **AND** `skipTLSVerify` is `false`
+- **AND** `caData` is the configured `caData` value
 - **AND** `loadFromDefault()` is NOT called
 
 #### Scenario: Direct config with minimum fields

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
@@ -99,8 +99,10 @@ When `kubernetesPluginRef` is set in the cluster sub-config, the connector SHALL
 - **AND** the referenced cluster in `kubernetes.clusterLocatorMethods` has `url` but no `serviceAccountToken`
 - **AND** `cluster-1` has no direct K8s connection fields
 - **WHEN** the connector plugin initializes
-- **THEN** a warning is logged that the matched cluster has no url or incomplete fields
-- **AND** `loadFromDefault()` is used as fallback (per D4 partial-config warning → D7 step 4)
+- **THEN** a warning is logged that the matched cluster has incomplete K8s fields (url: true, serviceAccountToken: false)
+- **AND** the stale K8s fields from the matched cluster are cleared (per D7 step 1b)
+- **AND** direct config fallback is attempted but finds no fields (per D7 step 3)
+- **AND** `loadFromDefault()` is used as final fallback (per D7 step 4)
 
 #### Scenario: kubernetesPluginRef cluster uses non-serviceAccount authProvider
 
@@ -167,7 +169,8 @@ K8s credentials from `app-config.yaml` SHALL take precedence over local dev opti
 - **AND** no `K8S_TOKEN` or `KUBECONFIG` env vars are set
 - **AND** `~/.kube/config` does not exist
 - **WHEN** the connector plugin initializes
-- **THEN** `loadFromDefault()` is called and fails with a K8s client error
+- **THEN** `loadFromDefault()` is called and loads an empty KubeConfig (no throw at init time)
+- **AND** the first K8s API call fails with a connection error (failure is deferred to connection time, not initialization)
 
 ---
 

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/specs/k8s-config/spec.md
@@ -93,6 +93,15 @@ When `kubernetesPluginRef` is set in the cluster sub-config, the connector SHALL
 - **THEN** a warning is logged
 - **AND** `loadFromDefault()` is used as final fallback
 
+#### Scenario: kubernetesPluginRef matches but cluster has incomplete K8s fields
+
+- **GIVEN** `cluster-1` has `kubernetesPluginRef: my-k8s-cluster`
+- **AND** the referenced cluster in `kubernetes.clusterLocatorMethods` has `url` but no `serviceAccountToken`
+- **AND** `cluster-1` has no direct K8s connection fields
+- **WHEN** the connector plugin initializes
+- **THEN** a warning is logged that the matched cluster has no url or incomplete fields
+- **AND** `loadFromDefault()` is used as fallback (per D4 partial-config warning → D7 step 4)
+
 #### Scenario: kubernetesPluginRef cluster uses non-serviceAccount authProvider
 
 - **GIVEN** `cluster-1` has `kubernetesPluginRef: my-k8s-cluster`

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
@@ -141,10 +141,14 @@ Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString
       logger.warn(
         `kubernetesPluginRef '${kubernetesPluginRef}' not found in kubernetes.clusterLocatorMethods, falling through to direct config`,
       );
-    } else if (!reconcilerConfig.url) {
+    } else if (!reconcilerConfig.url || !reconcilerConfig.serviceAccountToken) {
       logger.warn(
-        `kubernetesPluginRef '${kubernetesPluginRef}' matched but cluster has no url, falling through to direct config`,
+        `kubernetesPluginRef '${kubernetesPluginRef}' matched but cluster has incomplete K8s fields (url: ${!!reconcilerConfig.url}, serviceAccountToken: ${!!reconcilerConfig.serviceAccountToken}), falling through to direct config`,
       );
+      reconcilerConfig.url = undefined;
+      reconcilerConfig.serviceAccountToken = undefined;
+      reconcilerConfig.skipTLSVerify = undefined;
+      reconcilerConfig.caData = undefined;
     }
   }
   ```
@@ -157,9 +161,9 @@ Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString
     );
   }
   ```
-- [ ] 5.4 If `kubernetesPluginRef` is NOT set OR if `kubernetesPluginRef` lookup failed (no `url` resolved), read K8s fields directly from the cluster sub-config (per D7 fall-through precedence):
+- [ ] 5.4 If `kubernetesPluginRef` is NOT set OR if `kubernetesPluginRef` lookup failed (incomplete K8s fields), read K8s fields directly from the cluster sub-config (per D7 fall-through precedence):
   ```typescript
-  if (!reconcilerConfig.url) {
+  if (!reconcilerConfig.url || !reconcilerConfig.serviceAccountToken) {
     reconcilerConfig.url = safeGetOptionalString(clusterConfig, 'url');
     reconcilerConfig.serviceAccountToken = safeGetOptionalString(
       clusterConfig,

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
@@ -112,6 +112,7 @@ Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString
 - [ ] 5.2 If `kubernetesPluginRef` is set, look up the cluster in `kubernetes.clusterLocatorMethods`:
   ```typescript
   if (kubernetesPluginRef) {
+    let matched = false;
     const k8sConfig = config.getOptionalConfig('kubernetes');
     if (k8sConfig) {
       const locators =
@@ -120,8 +121,8 @@ Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString
         if (locator.getOptionalString('type') !== 'config') continue;
         const clusters = locator.getOptionalConfigArray('clusters') ?? [];
         for (const cluster of clusters) {
-          if (cluster.getOptionalString('name') === kubernetesPluginRef) {
-            // Extract K8s connection fields from kubernetes plugin config
+          if (safeGetOptionalString(cluster, 'name') === kubernetesPluginRef) {
+            matched = true;
             reconcilerConfig.url = safeGetOptionalString(cluster, 'url');
             reconcilerConfig.serviceAccountToken = safeGetOptionalString(
               cluster,
@@ -133,12 +134,16 @@ Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString
             break;
           }
         }
-        if (reconcilerConfig.url) break;
+        if (matched) break;
       }
     }
-    if (!reconcilerConfig.url) {
+    if (!matched) {
       logger.warn(
         `kubernetesPluginRef '${kubernetesPluginRef}' not found in kubernetes.clusterLocatorMethods, falling through to direct config`,
+      );
+    } else if (!reconcilerConfig.url) {
+      logger.warn(
+        `kubernetesPluginRef '${kubernetesPluginRef}' matched but cluster has no url, falling through to direct config`,
       );
     }
   }

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
@@ -1,0 +1,284 @@
+# Tasks: Migrate K8s Credentials and Plugin Config to app-config.yaml
+
+## 1. Remove baseUrl from Entity Provider
+
+- [ ] 1.1 In `catalog-backend-module-model-catalog/src/providers/types.ts`, remove `baseUrl` from `ModelCatalogConfig`
+- [ ] 1.2 In `catalog-backend-module-model-catalog/src/providers/config.ts`, remove `baseUrl` reading from `readModelCatalogApiEntityConfig` (remove the `if (config.has('baseUrl'))` block and the `baseUrl` field from the returned object)
+- [ ] 1.3 In `catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.ts`:
+  - Remove `private readonly baseUrl: string` field
+  - Remove `this.baseUrl = config.baseUrl` from constructor
+  - Simplify `run()` method: replace the `baseUrl`/`svcUrl` fallback logic (lines 169-173) with `const url = await this.discovery.getBaseUrl(this.name)`
+- [ ] 1.4 In `catalog-backend-module-model-catalog/config.d.ts`, remove `baseUrl?: string` from the connector-level fields
+- [ ] 1.5 Verify `yarn tsc` passes
+
+## 2. Merge ConnectorConfig into ReconcilerConfig
+
+- [ ] 2.1 In `kserve-kubeflow-connector-backend/src/services/types.ts`, update `ReconcilerConfig`:
+  - Change `defaultLifecycle: string` → `defaultLifecycle?: string`
+  - Change `defaultOwner: string` → `defaultOwner?: string`
+  - These are now optional because defaults are applied in `setupInformer`, not at the type level
+- [ ] 2.2 In `kserve-kubeflow-connector-backend/src/services/InformerService.ts`:
+  - Remove the `ConnectorConfig` interface (lines 556-560)
+  - Remove the `ConnectorConfig` export
+  - Update `setupInformer` signature from `(connectorConfig?: ConnectorConfig)` to `(config: ReconcilerConfig, logger: LoggerService)` — the caller (`plugin.ts`) now builds `ReconcilerConfig` directly
+  - Inside `setupInformer`, remove the code that builds `ReconcilerConfig` from `ConnectorConfig` fields (lines 587-599) — the config is now passed in pre-built
+  - Keep the `loadFromDefault()` / K8s client creation and informer setup logic but adapt to receive the KubeConfig-ready config
+  - Apply defaults for `defaultOwner` and `defaultLifecycle` if not already set:
+    ```
+    config.defaultOwner = config.defaultOwner || process.env.OWNER || 'default-owner';
+    config.defaultLifecycle = config.defaultLifecycle || process.env.LIFECYCLE || 'production';
+    ```
+- [ ] 2.3 In `kserve-kubeflow-connector-backend/src/plugin.ts`:
+  - Remove the `ConnectorConfig` import
+  - Import `ReconcilerConfig` from `./services/types`
+  - Update the config-reading code to build a `ReconcilerConfig` directly (without K8s fields for now — those are added in Task 3)
+  - Update the `setupInformer` call to pass the `ReconcilerConfig` and `logger` (from `init` deps)
+- [ ] 2.4 Update any re-exports of `ConnectorConfig` in `InformerService.ts` (the existing `export type { ReconcilerConfig }` stays)
+- [ ] 2.5 Verify `yarn tsc` passes
+
+## 3. Add K8s Connection Fields to ReconcilerConfig
+
+- [ ] 3.1 In `kserve-kubeflow-connector-backend/src/services/types.ts`, add to `ReconcilerConfig`:
+  ```typescript
+  clusterName?: string;
+  url?: string;
+  serviceAccountToken?: string;
+  skipTLSVerify?: boolean;
+  caData?: string;
+  ```
+  `clusterName` comes from the `name` field in the cluster sub-config and is used in `loadFromOptions` for KubeConfig cluster/context naming (matches OCM's pattern in `hubApiClient()`).
+- [ ] 3.2 Verify `yarn tsc` passes
+
+## 4. Implement KubeConfig from Config Fields
+
+- [ ] 4.1 In `kserve-kubeflow-connector-backend/src/services/InformerService.ts`, update `setupInformer` to build KubeConfig from config fields when available (matches OCM's `hubApiClient()` pattern):
+  ```typescript
+  const kc = new k8s.KubeConfig();
+  const clusterName = config.clusterName || 'target-cluster';
+  if (config.url && config.serviceAccountToken) {
+    kc.loadFromOptions({
+      clusters: [
+        {
+          name: clusterName,
+          server: config.url,
+          skipTLSVerify: config.skipTLSVerify ?? false,
+          caData: config.caData,
+        },
+      ],
+      users: [
+        {
+          name: 'backstage-sa',
+          token: config.serviceAccountToken,
+        },
+      ],
+      contexts: [
+        {
+          name: clusterName,
+          cluster: clusterName,
+          user: 'backstage-sa',
+        },
+      ],
+      currentContext: clusterName,
+    });
+    logger.info(
+      `KubeConfig built from app-config fields for cluster '${clusterName}'`,
+    );
+  } else {
+    kc.loadFromDefault();
+    logger.info('KubeConfig loaded from default (kubeconfig file / env)');
+  }
+  ```
+- [ ] 4.2 Simplify the token extraction: when config fields are present, `config.serviceAccountToken` is the token — skip the currentUser/users list scanning. When falling back to `loadFromDefault()`, keep the existing extraction logic (currentUser → users list) and `K8S_TOKEN` env var override. Note: `loadFromDefault()` also supports `KUBECONFIG` env var and `~/.kube/config` from `oc login` / `kubectl login` — these are valid local dev options that work automatically.
+- [ ] 4.3 Store the resolved token on `config.k8sToken` so the rest of the code (e.g., `fetchModelCardViaAnnotations`) can use it unchanged.
+- [ ] 4.4 Add logging: log the cluster URL (NOT the token) and whether config or loadFromDefault was used.
+- [ ] 4.5 Verify `yarn tsc` passes
+
+## 5. Implement kubernetesPluginRef Lookup in plugin.ts
+
+Note: Use `safeGetOptionalString` (already defined in `catalog-techdoc-url-reader-backend/src/plugin.ts`, see AGENTS.md `ConfigReader getOptionalString() edge case`) for all optional string config reads from cluster sub-config and kubernetes plugin config. Backstage's `getOptionalString` throws TypeError on empty env var substitution (e.g., `${K8S_CLUSTER_URL:-}`). Either import the existing helper or duplicate it locally in the connector's `plugin.ts`.
+
+- [ ] 5.1 In `kserve-kubeflow-connector-backend/src/plugin.ts`, when reading cluster sub-config, check for `kubernetesPluginRef`:
+  ```typescript
+  const kubernetesPluginRef = clusterConfig.getOptionalString(
+    'kubernetesPluginRef',
+  );
+  ```
+- [ ] 5.2 If `kubernetesPluginRef` is set, look up the cluster in `kubernetes.clusterLocatorMethods`:
+  ```typescript
+  if (kubernetesPluginRef) {
+    const k8sConfig = config.getOptionalConfig('kubernetes');
+    if (k8sConfig) {
+      const locators =
+        k8sConfig.getOptionalConfigArray('clusterLocatorMethods') ?? [];
+      for (const locator of locators) {
+        if (locator.getOptionalString('type') !== 'config') continue;
+        const clusters = locator.getOptionalConfigArray('clusters') ?? [];
+        for (const cluster of clusters) {
+          if (cluster.getOptionalString('name') === kubernetesPluginRef) {
+            // Extract K8s connection fields from kubernetes plugin config
+            reconcilerConfig.url = safeGetOptionalString(cluster, 'url');
+            reconcilerConfig.serviceAccountToken = safeGetOptionalString(
+              cluster,
+              'serviceAccountToken',
+            );
+            reconcilerConfig.skipTLSVerify =
+              cluster.getOptionalBoolean('skipTLSVerify');
+            reconcilerConfig.caData = safeGetOptionalString(cluster, 'caData');
+            break;
+          }
+        }
+        if (reconcilerConfig.url) break;
+      }
+    }
+    if (!reconcilerConfig.url) {
+      logger.warn(
+        `kubernetesPluginRef '${kubernetesPluginRef}' not found in kubernetes.clusterLocatorMethods, falling through to direct config`,
+      );
+    }
+  }
+  ```
+- [ ] 5.3 If `kubernetesPluginRef` is NOT set OR if `kubernetesPluginRef` lookup failed (no `url` resolved), read K8s fields directly from the cluster sub-config (per D7 fall-through precedence):
+  ```typescript
+  if (!reconcilerConfig.url) {
+    reconcilerConfig.url = safeGetOptionalString(clusterConfig, 'url');
+    reconcilerConfig.serviceAccountToken = safeGetOptionalString(
+      clusterConfig,
+      'serviceAccountToken',
+    );
+    reconcilerConfig.skipTLSVerify =
+      clusterConfig.getOptionalBoolean('skipTLSVerify');
+    reconcilerConfig.caData = safeGetOptionalString(clusterConfig, 'caData');
+  }
+  ```
+- [ ] 5.4 Verify `yarn tsc` passes
+
+## 6. Update config.d.ts Schema
+
+- [ ] 6.1 In `catalog-backend-module-model-catalog/config.d.ts`, add K8s connection fields to the cluster sub-key type within the `[clusterKey: string]` union:
+  ```typescript
+  /** @visibility backend */
+  url?: string;
+  /** @visibility secret */
+  serviceAccountToken?: string;
+  /** @visibility backend */
+  skipTLSVerify?: boolean;
+  /** @visibility secret */
+  caData?: string;
+  /** @visibility backend */
+  kubernetesPluginRef?: string;
+  ```
+- [ ] 6.2 Remove `baseUrl?: string` from the connector-level fields (done in Task 1.4, verify it persisted)
+- [ ] 6.3 Verify `yarn tsc` passes
+
+## 7. Update app-config.yaml
+
+- [ ] 7.1 Update the `catalog.providers.modelCatalog.kserve-kubeflow-connector.cluster-1` section in `app-config.yaml` with K8s connection fields:
+  ```yaml
+  cluster-1:
+    name: my-k8s-cluster
+    url: '${K8S_CLUSTER_URL:-}'
+    serviceAccountToken: '${K8S_SA_TOKEN:-}'
+    skipTLSVerify: false
+    caData: '${K8S_CA_DATA:-}'
+    kubeflow-model-catalog-url: '${KUBEFLOW_MODEL_CATALOG_URL:-}'
+    default-owner: '${OWNER:-default-owner}'
+    default-lifecycle: '${LIFECYCLE:-production}'
+  ```
+- [ ] 7.2 Add a commented-out `kubernetesPluginRef` alternative showing the reference approach:
+  ```yaml
+  # Alternative: reference a cluster from the Backstage kubernetes plugin config:
+  # cluster-1:
+  #   kubernetesPluginRef: my-k8s-cluster  # must match a name in kubernetes.clusterLocatorMethods
+  #   kubeflow-model-catalog-url: '${KUBEFLOW_MODEL_CATALOG_URL:-}'
+  #   default-owner: '${OWNER:-default-owner}'
+  #   default-lifecycle: '${LIFECYCLE:-production}'
+  ```
+- [ ] 7.3 Add a commented-out `kubernetes` section showing the Backstage K8s plugin config (for use with `kubernetesPluginRef`):
+  ```yaml
+  # Required when using kubernetesPluginRef above:
+  # kubernetes:
+  #   serviceLocatorMethod:
+  #     type: 'multiTenant'
+  #   clusterLocatorMethods:
+  #     - type: 'config'
+  #       clusters:
+  #         - name: my-k8s-cluster
+  #           url: '${K8S_CLUSTER_URL}'
+  #           serviceAccountToken: '${K8S_SA_TOKEN}'
+  #           skipTLSVerify: false
+  #           caData: '${K8S_CA_DATA:-}'
+  ```
+
+## 8. Add K8s RBAC Example YAML
+
+- [ ] 8.1 Create `examples/k8s-rbac.yaml` with ServiceAccount, ClusterRole, and ClusterRoleBinding:
+  ```yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: backstage-kserve-connector
+    namespace: backstage
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: backstage-kserve-connector
+  rules:
+    - apiGroups:
+        - serving.kserve.io
+      resources:
+        - inferenceservices
+      verbs:
+        - get
+        - watch
+        - list
+    - apiGroups:
+        - route.openshift.io
+      resources:
+        - routes
+      verbs:
+        - get
+        - watch
+        - list
+    - apiGroups:
+        - ''
+      resources:
+        - serviceaccounts
+      verbs:
+        - get
+        - list
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: backstage-kserve-connector
+  subjects:
+    - kind: ServiceAccount
+      name: backstage-kserve-connector
+      namespace: backstage
+  roleRef:
+    kind: ClusterRole
+    name: backstage-kserve-connector
+    apiGroup: rbac.authorization.k8s.io
+  ```
+- [ ] 8.2 Verify the RBAC rules match the actual K8s API calls in `InformerService.ts` (Informer on InferenceServices), `Catalog.ts` (Routes listing), and `InformerService.ts` (ServiceAccount listing in `getAuthentication`)
+
+## 9. Replace console.log with logger in setupInformer
+
+- [ ] 9.1 Since `setupInformer` now receives `logger: LoggerService`, replace `console.log` / `console.error` calls inside `setupInformer` and its helper functions with `logger.info` / `logger.error` / `logger.debug` as appropriate. This is a natural follow-on since we're already changing the function signature.
+      Note: do NOT change logging in functions called by the informer event handlers (`reconcileInferenceService`, `innerStart`, etc.) unless they also receive the logger — those can remain as `console.log` for now.
+- [ ] 9.2 Verify `yarn tsc` passes
+
+## 10. Verification
+
+- [ ] 10.1 `yarn tsc` passes with no errors
+- [ ] 10.2 `yarn build:all` succeeds
+- [ ] 10.3 Existing unit tests pass (`yarn test:all` or `yarn test -- --watchAll=false` in affected plugins)
+- [ ] 10.4 Prettier checks pass (`yarn prettier`)
+- [ ] 10.5 Lint checks pass (`yarn lint:all`)
+- [ ] 10.6 Plugin starts with direct K8s config in `app-config.yaml` and connects to cluster
+- [ ] 10.7 Plugin starts with `kubernetesPluginRef` and connects to cluster
+- [ ] 10.8 Plugin starts with no K8s config (falls back to `loadFromDefault()`) — verify with `~/.kube/config` from `oc login`
+- [ ] 10.9 Plugin starts with `KUBECONFIG` env var pointing to a custom kubeconfig file
+- [ ] 10.10 `K8S_TOKEN` env var still works as token override when using `loadFromDefault()`
+- [ ] 10.11 Connector discovers and watches InferenceServices using config-based credentials

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
@@ -84,12 +84,17 @@
       `KubeConfig built from app-config fields for cluster '${clusterName}'`,
     );
   } else {
+    if (config.url || config.serviceAccountToken) {
+      logger.warn(
+        'Partial K8s config: both url and serviceAccountToken are required for config-based auth; falling back to loadFromDefault()',
+      );
+    }
     kc.loadFromDefault();
     logger.info('KubeConfig loaded from default (kubeconfig file / env)');
   }
   ```
 - [ ] 4.2 Simplify the token extraction: when config fields are present, `config.serviceAccountToken` is the token — skip the currentUser/users list scanning. When falling back to `loadFromDefault()`, keep the existing extraction logic (currentUser → users list) and `K8S_TOKEN` env var override. Note: `loadFromDefault()` also supports `KUBECONFIG` env var and `~/.kube/config` from `oc login` / `kubectl login` — these are valid local dev options that work automatically.
-- [ ] 4.3 Store the resolved token on `config.k8sToken` so the rest of the code (e.g., `fetchModelCardViaAnnotations`) can use it unchanged.
+- [ ] 4.3 Store the resolved token on `config.serviceAccountToken` (NOT `config.k8sToken`). Remove the `k8sToken` field from `ReconcilerConfig` entirely — `serviceAccountToken` is the single token field regardless of source. Update all code that reads `config.k8sToken` (e.g., `fetchModelCardViaAnnotations` in InformerService.ts) to read `config.serviceAccountToken` instead.
 - [ ] 4.4 Add logging: log the cluster URL (NOT the token) and whether config or loadFromDefault was used.
 - [ ] 4.5 Verify `yarn tsc` passes
 

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
@@ -95,11 +95,12 @@
 
 ## 5. Implement kubernetesPluginRef Lookup in plugin.ts
 
-Note: Use `safeGetOptionalString` (already defined in `catalog-techdoc-url-reader-backend/src/plugin.ts`, see AGENTS.md `ConfigReader getOptionalString() edge case`) for all optional string config reads from cluster sub-config and kubernetes plugin config. Backstage's `getOptionalString` throws TypeError on empty env var substitution (e.g., `${K8S_CLUSTER_URL:-}`). Either import the existing helper or duplicate it locally in the connector's `plugin.ts`.
+Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString() edge case`) for all optional string config reads from cluster sub-config and kubernetes plugin config. Backstage's `getOptionalString` throws TypeError on empty env var substitution (e.g., `${K8S_CLUSTER_URL:-}`). Duplicate the helper locally in the connector's `plugin.ts` using the AGENTS.md pattern (returns `undefined` on error, NOT empty string). The existing helper in `catalog-techdoc-url-reader-backend/src/plugin.ts` returns `''` on error — do NOT import that variant, as empty string passes truthiness checks (e.g., `if (config.url)`) and would cause `loadFromOptions` to receive an empty URL.
 
 - [ ] 5.1 In `kserve-kubeflow-connector-backend/src/plugin.ts`, when reading cluster sub-config, check for `kubernetesPluginRef`:
   ```typescript
-  const kubernetesPluginRef = clusterConfig.getOptionalString(
+  const kubernetesPluginRef = safeGetOptionalString(
+    clusterConfig,
     'kubernetesPluginRef',
   );
   ```
@@ -137,7 +138,16 @@ Note: Use `safeGetOptionalString` (already defined in `catalog-techdoc-url-reade
     }
   }
   ```
-- [ ] 5.3 If `kubernetesPluginRef` is NOT set OR if `kubernetesPluginRef` lookup failed (no `url` resolved), read K8s fields directly from the cluster sub-config (per D7 fall-through precedence):
+- [ ] 5.3 When `kubernetesPluginRef` lookup succeeds, check the matched cluster's `authProvider` field. If it is set and is not `serviceAccount`, log a warning (per D5) but proceed — the `serviceAccountToken` field is what matters:
+  ```typescript
+  const authProvider = safeGetOptionalString(cluster, 'authProvider');
+  if (authProvider && authProvider !== 'serviceAccount') {
+    logger.warn(
+      `kubernetesPluginRef '${kubernetesPluginRef}' uses authProvider '${authProvider}' — only serviceAccount is supported; proceeding with serviceAccountToken`,
+    );
+  }
+  ```
+- [ ] 5.4 If `kubernetesPluginRef` is NOT set OR if `kubernetesPluginRef` lookup failed (no `url` resolved), read K8s fields directly from the cluster sub-config (per D7 fall-through precedence):
   ```typescript
   if (!reconcilerConfig.url) {
     reconcilerConfig.url = safeGetOptionalString(clusterConfig, 'url');
@@ -150,7 +160,7 @@ Note: Use `safeGetOptionalString` (already defined in `catalog-techdoc-url-reade
     reconcilerConfig.caData = safeGetOptionalString(clusterConfig, 'caData');
   }
   ```
-- [ ] 5.4 Verify `yarn tsc` passes
+- [ ] 5.5 Verify `yarn tsc` passes
 
 ## 6. Update config.d.ts Schema
 
@@ -238,7 +248,6 @@ Note: Use `safeGetOptionalString` (already defined in `catalog-techdoc-url-reade
         - routes
       verbs:
         - get
-        - watch
         - list
     - apiGroups:
         - ''

--- a/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
+++ b/workspaces/ai-integrations/openspec/changes/k8s-config-migration/tasks.md
@@ -2,22 +2,22 @@
 
 ## 1. Remove baseUrl from Entity Provider
 
-- [ ] 1.1 In `catalog-backend-module-model-catalog/src/providers/types.ts`, remove `baseUrl` from `ModelCatalogConfig`
-- [ ] 1.2 In `catalog-backend-module-model-catalog/src/providers/config.ts`, remove `baseUrl` reading from `readModelCatalogApiEntityConfig` (remove the `if (config.has('baseUrl'))` block and the `baseUrl` field from the returned object)
-- [ ] 1.3 In `catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.ts`:
+- [ ] 1.1 In `plugins/catalog-backend-module-model-catalog/src/providers/types.ts`, remove `baseUrl` from `ModelCatalogConfig`
+- [ ] 1.2 In `plugins/catalog-backend-module-model-catalog/src/providers/config.ts`, remove `baseUrl` reading from `readModelCatalogApiEntityConfig` (remove the `if (config.has('baseUrl'))` block and the `baseUrl` field from the returned object)
+- [ ] 1.3 In `plugins/catalog-backend-module-model-catalog/src/providers/ModelCatalogResourceEntityProvider.ts`:
   - Remove `private readonly baseUrl: string` field
   - Remove `this.baseUrl = config.baseUrl` from constructor
   - Simplify `run()` method: replace the `baseUrl`/`svcUrl` fallback logic (lines 169-173) with `const url = await this.discovery.getBaseUrl(this.name)`
-- [ ] 1.4 In `catalog-backend-module-model-catalog/config.d.ts`, remove `baseUrl?: string` from the connector-level fields
+- [ ] 1.4 In `plugins/catalog-backend-module-model-catalog/config.d.ts`, remove `baseUrl?: string` from the connector-level fields
 - [ ] 1.5 Verify `yarn tsc` passes
 
 ## 2. Merge ConnectorConfig into ReconcilerConfig
 
-- [ ] 2.1 In `kserve-kubeflow-connector-backend/src/services/types.ts`, update `ReconcilerConfig`:
+- [ ] 2.1 In `plugins/kserve-kubeflow-connector-backend/src/services/types.ts`, update `ReconcilerConfig`:
   - Change `defaultLifecycle: string` → `defaultLifecycle?: string`
   - Change `defaultOwner: string` → `defaultOwner?: string`
   - These are now optional because defaults are applied in `setupInformer`, not at the type level
-- [ ] 2.2 In `kserve-kubeflow-connector-backend/src/services/InformerService.ts`:
+- [ ] 2.2 In `plugins/kserve-kubeflow-connector-backend/src/services/InformerService.ts`:
   - Remove the `ConnectorConfig` interface (lines 556-560)
   - Remove the `ConnectorConfig` export
   - Update `setupInformer` signature from `(connectorConfig?: ConnectorConfig)` to `(config: ReconcilerConfig, logger: LoggerService)` — the caller (`plugin.ts`) now builds `ReconcilerConfig` directly
@@ -28,7 +28,7 @@
     config.defaultOwner = config.defaultOwner || process.env.OWNER || 'default-owner';
     config.defaultLifecycle = config.defaultLifecycle || process.env.LIFECYCLE || 'production';
     ```
-- [ ] 2.3 In `kserve-kubeflow-connector-backend/src/plugin.ts`:
+- [ ] 2.3 In `plugins/kserve-kubeflow-connector-backend/src/plugin.ts`:
   - Remove the `ConnectorConfig` import
   - Import `ReconcilerConfig` from `./services/types`
   - Update the config-reading code to build a `ReconcilerConfig` directly (without K8s fields for now — those are added in Task 3)
@@ -38,7 +38,7 @@
 
 ## 3. Add K8s Connection Fields to ReconcilerConfig
 
-- [ ] 3.1 In `kserve-kubeflow-connector-backend/src/services/types.ts`, add to `ReconcilerConfig`:
+- [ ] 3.1 In `plugins/kserve-kubeflow-connector-backend/src/services/types.ts`, add to `ReconcilerConfig`:
   ```typescript
   clusterName?: string;
   url?: string;
@@ -51,7 +51,7 @@
 
 ## 4. Implement KubeConfig from Config Fields
 
-- [ ] 4.1 In `kserve-kubeflow-connector-backend/src/services/InformerService.ts`, update `setupInformer` to build KubeConfig from config fields when available (matches OCM's `hubApiClient()` pattern):
+- [ ] 4.1 In `plugins/kserve-kubeflow-connector-backend/src/services/InformerService.ts`, update `setupInformer` to build KubeConfig from config fields when available (matches OCM's `hubApiClient()` pattern):
   ```typescript
   const kc = new k8s.KubeConfig();
   const clusterName = config.clusterName || 'target-cluster';
@@ -95,9 +95,9 @@
 
 ## 5. Implement kubernetesPluginRef Lookup in plugin.ts
 
-Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString() edge case`) for all optional string config reads from cluster sub-config and kubernetes plugin config. Backstage's `getOptionalString` throws TypeError on empty env var substitution (e.g., `${K8S_CLUSTER_URL:-}`). Duplicate the helper locally in the connector's `plugin.ts` using the AGENTS.md pattern (returns `undefined` on error, NOT empty string). The existing helper in `catalog-techdoc-url-reader-backend/src/plugin.ts` returns `''` on error — do NOT import that variant, as empty string passes truthiness checks (e.g., `if (config.url)`) and would cause `loadFromOptions` to receive an empty URL.
+Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString() edge case`) for all optional string config reads from cluster sub-config and kubernetes plugin config. Backstage's `getOptionalString` throws TypeError on empty env var substitution (e.g., `${K8S_CLUSTER_URL:-}`). Duplicate the helper locally in the connector's `plugin.ts` using the AGENTS.md pattern (returns `undefined` on error, NOT empty string). The existing helper in `plugins/catalog-techdoc-url-reader-backend/src/plugin.ts` returns `''` on error — do NOT import that variant, as empty string passes truthiness checks (e.g., `if (config.url)`) and would cause `loadFromOptions` to receive an empty URL.
 
-- [ ] 5.1 In `kserve-kubeflow-connector-backend/src/plugin.ts`, when reading cluster sub-config, check for `kubernetesPluginRef`:
+- [ ] 5.1 In `plugins/kserve-kubeflow-connector-backend/src/plugin.ts`, when reading cluster sub-config, check for `kubernetesPluginRef`:
   ```typescript
   const kubernetesPluginRef = safeGetOptionalString(
     clusterConfig,
@@ -164,7 +164,7 @@ Note: Use `safeGetOptionalString` (see AGENTS.md `ConfigReader getOptionalString
 
 ## 6. Update config.d.ts Schema
 
-- [ ] 6.1 In `catalog-backend-module-model-catalog/config.d.ts`, add K8s connection fields to the cluster sub-key type within the `[clusterKey: string]` union:
+- [ ] 6.1 In `plugins/catalog-backend-module-model-catalog/config.d.ts`, add K8s connection fields to the cluster sub-key type within the `[clusterKey: string]` union:
   ```typescript
   /** @visibility backend */
   url?: string;


### PR DESCRIPTION
Add proposal, design, tasks, and behavioral spec for migrating K8s credentials and plugin config to app-config.yaml in the kserve-kubeflow-connector-backend plugin.

a) Original artifacts:
   - proposal.md: Why, starting point, what changes, capabilities, non-goals, impact (~+180/-90 lines across 9 files)
   - design.md: 8 decisions (D1-D8) — two config approaches following OCM pattern, remove baseUrl, merge ConnectorConfig into ReconcilerConfig, loadFromOptions, serviceAccount-only auth, config.d.ts schema, precedence chain, K8s RBAC example
   - tasks.md: 10 task groups covering removal, merge, K8s fields, KubeConfig implementation, kubernetesPluginRef lookup, schema, app-config example, RBAC YAML, logger, verification
   - spec.md: behavioral specs for direct config, kubernetesPluginRef, config precedence, baseUrl removal, ConnectorConfig merge, config schema, K8s RBAC, build quality

b) Fixes from openspec-audit-change adversarial audit (15 findings):
   - Fixed kubernetesPluginRef fallback contradiction (CRITICAL): design D7, spec scenarios, and tasks 5.2-5.3 now show fall-through to direct config when ref lookup fails
   - Fixed safeGetOptionalString usage (CRITICAL): tasks 5.2/5.3 now use safeGetOptionalString for all K8s config reads per AGENTS.md ConfigReader edge case
   - Fixed optionality syntax (CRITICAL): normalized to '?: string' consistently between design.md and tasks.md
   - Added cross-change reconciliation section to design.md for remove-kfmr-client-code and techdocs-modelcard-finalization
   - Clarified task 2.3 logger source (from init deps)
   - Softened D1 'ignored' wording to 'takes precedence' with D7 cross-reference for kubernetesPluginRef fallback behavior
   - Removed redundant '?? undefined' on getOptionalBoolean in task 5.3

c) Fixes from author review:
   - Added KUBECONFIG env var and ~/.kube/config (from oc login) as peer local dev options alongside K8S_TOKEN across all four files
   - Expanded D7 precedence to merge env var steps into single 'local dev — loadFromDefault()' step with three sub-bullets
   - Added spec scenarios for KUBECONFIG env var, ~/.kube/config from oc login, config overriding kubeconfig, and no-config failure
   - Added verification task 10.9 for KUBECONFIG env var

Assisted-by: Claude Opus 4.6

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [n/a] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [/] Added or Updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
