### PR TITLE
fix(app-defaults): pin electron-to-chromium for hermetic Konflux

### DIFF
--- a/workspaces/app-defaults/package.json
+++ b/workspaces/app-defaults/package.json
@@ -54,7 +54,8 @@
   "resolutions": {
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@backstage/plugin-catalog-react": "^3.1.0"
+    "@backstage/plugin-catalog-react": "^3.1.0",
+    "electron-to-chromium": "1.5.349"
   },
   "prettier": "@backstage/cli/config/prettier"
 }

--- a/workspaces/app-defaults/yarn.lock
+++ b/workspaces/app-defaults/yarn.lock
@@ -17893,7 +17893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.328":
+"electron-to-chromium@npm:1.5.349":
   version: 1.5.349
   resolution: "electron-to-chromium@npm:1.5.349"
   checksum: 10c0/5acd94d9c70b91383f95bc9c04f39b6f92263ef2b232f4f0d4c71d17dcd3db49ef480cd025c379f6d58b534cf568ca5cb566b0f9be238f057b9a5773d76760ec


### PR DESCRIPTION
## Summary
- Pin `electron-to-chromium` to `1.5.349` via workspace `resolutions` so Hermeto/Konflux cannot float to freshly published versions (e.g. `1.5.402`) that 404 on the cluster npm proxy.
- Refresh `workspaces/app-defaults/yarn.lock` to an exact descriptor (`electron-to-chromium@npm:1.5.349`).

## Context
Downstream Konflux builds fail with:
```
YN0035: electron-to-chromium@npm:1.5.402: Package not found (404)
```
Public npm has the tarball; the artifact-registry proxy does not yet. `browserslist` depends on `^1.5.328`, which floats daily.

## Follow-ups (after merge)
1. Overlays: bump `workspaces/app-defaults/source.json` `repo-ref` to this merge SHA.
2. Catalog midstream: sync `overlay-repo/` + `workspaces/` so Hermeto picks up the pin.

## Test plan
- [ ] CI green on this PR
- [ ] After overlays + catalog sync: Hermeto prefetch for app-defaults no longer 404s on `electron-to-chromium`

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16097
