### PR TITLE
chore(app-defaults): add changeset for electron-to-chromium pin

### DIFF
--- a/workspaces/app-defaults/.changeset/pin-electron-to-chromium.md
+++ b/workspaces/app-defaults/.changeset/pin-electron-to-chromium.md
@@ -1,0 +1,8 @@
+---
+'@red-hat-developer-hub/backstage-plugin-app-defaults': patch
+'@red-hat-developer-hub/backstage-plugin-app-auth': patch
+'@red-hat-developer-hub/backstage-plugin-app-integrations': patch
+'@red-hat-developer-hub/backstage-plugin-app-react': patch
+---
+
+Pin `electron-to-chromium` to `1.5.349` via Yarn resolutions so hermetic Konflux/Hermeto builds do not float to freshly published versions that 404 on the cluster npm proxy.


### PR DESCRIPTION
## Summary
- Add patch changeset for the four app-defaults packages after [#4203](https://github.com/redhat-developer/rhdh-plugins/pull/4203) (pin `electron-to-chromium` for hermetic Konflux).

## Test plan
- [ ] Changeset validation / CI green
- [ ] Version Packages PR picks up the patch bumps

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16097
