### PR TITLE
fix(intelligent-assistant): chat UI squashed when opening drawer in overlay/docked modes

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/fix-drawer-squash-overlay-docked.md
+++ b/workspaces/intelligent-assistant/.changeset/fix-drawer-squash-overlay-docked.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': patch
+---
+
+Fixed chat UI being squashed when opening the chat history drawer in overlay and docked display modes. The drawer now correctly overlays the content instead of rendering inline.

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/LightSpeedChat.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/LightSpeedChat.tsx
@@ -2076,7 +2076,7 @@ export const LightspeedChat = ({
                 style: drawerPanelStyle,
               }}
               reverseButtonOrder
-              displayMode={ChatbotDisplayMode.embedded}
+              displayMode={displayMode}
               onDrawerToggle={onChatHistoryDrawerToggle}
               title=""
               navTitleIcon={null}


### PR DESCRIPTION
## Summary


#### fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3575 
- Fixes the chat history drawer rendering inline in overlay and docked display modes, which squashed the chat content area to ~55% of its width (overlay) or hid it entirely (docked)
- Root cause: `ChatbotConversationHistoryNav` was hardcoded to `displayMode={ChatbotDisplayMode.embedded}`, which tells PatternFly to render the drawer panel **inline** (side-by-side). In overlay/docked modes it should use the actual `displayMode` so the drawer renders as a floating **overlay** with a backdrop instead
- One-line fix: pass `displayMode={displayMode}` instead of the hardcoded value

## Before / After

| Mode | Before (bug) | After (fix) |
|------|-------------|-------------|
| **Overlay** | Drawer opens inline, squashing footer from 480px → 264px. Suggestion cards and input text truncated | Drawer overlays with backdrop. Chat content stays full width (480px) |
| **Docked** | Drawer replaces chat content entirely — no chat visible | Drawer overlays with backdrop. Chat content visible behind |

## Test plan

- [x] Reproduction test confirms footer width drops to 55% when drawer opens (fails before fix, passes after)
- [x] All 980 unit tests pass (73 suites, zero failures)
- [x] Before/after video recordings captured
- [ ] Manual verification: open chatbot in overlay mode → click hamburger → drawer should float over content
- [ ] Manual verification: switch to docked mode → click hamburger → drawer should float over content
- [ ] Manual verification: fullscreen mode → click expand history → drawer should still render inline (unchanged behavior)

Resolves: [RHDHBUGS-3575](https://redhat.atlassian.net/browse/RHDHBUGS-3575)

🤖 Generated with [Claude Code](https://claude.com/claude-code)