### PR TITLE
feat: declare remaining e2e-* coverage flags in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -162,12 +162,27 @@ flag_management:
     - name: e2e-adoption-insights
       paths:
         - workspaces/adoption-insights/
+    - name: e2e-app-defaults
+      paths:
+        - workspaces/app-defaults/
+    - name: e2e-bulk-import
+      paths:
+        - workspaces/bulk-import/
+    - name: e2e-extensions
+      paths:
+        - workspaces/extensions/
     - name: e2e-global-header
       paths:
         - workspaces/global-header/
     - name: e2e-homepage
       paths:
         - workspaces/homepage/
+    - name: e2e-intelligent-assistant
+      paths:
+        - workspaces/intelligent-assistant/
+    - name: e2e-orchestrator
+      paths:
+        - workspaces/orchestrator/
     - name: e2e-quickstart
       paths:
         - workspaces/quickstart/


### PR DESCRIPTION
## Summary

Eleven overlay workspaces both source from this repository and have E2E tests, but only six of their `e2e-*` flags were declared under `flag_management.individual_flags`. This PR adds the five missing declarations:

| Flag | Path |
| --- | --- |
| `e2e-app-defaults` | `workspaces/app-defaults/` |
| `e2e-bulk-import` | `workspaces/bulk-import/` |
| `e2e-extensions` | `workspaces/extensions/` |
| `e2e-intelligent-assistant` | `workspaces/intelligent-assistant/` |
| `e2e-orchestrator` | `workspaces/orchestrator/` |

Entries follow the shape and the alphabetical ordering already used inside the `e2e-*` block. Nothing else is touched: `ignore:`, `component_management` (generated) and `coverage.status` are unchanged, and no workflow is added or modified — the upload pipeline lives in `rhdh-plugin-export-overlays`, not here.

## Why this matters

The declaration is **not** what makes an upload succeed. `e2e-intelligent-assistant` was accepted and reported by Codecov while still undeclared. What the declaration does is scope the flag to its workspace path and control its statuses, so it matters for **display correctness** on the Flags page, not for upload acceptance.

## Context

Follow-up to #2997, which added the first `e2e-*` flags for the cross-repo uploads coming from the overlay E2E pipeline (RHIDP-13411). The overlay runs E2E tests against dynamic plugins built from this repo's source and uploads the resulting coverage here, so it is browsable per file against the code it actually measured.

## Validation

```
$ curl --data-binary @codecov.yml https://codecov.io/validate
Valid!
```

End-to-end behaviour was previously confirmed against the commit pinned by the overlay's `workspaces/intelligent-assistant/source.json` (`20a7215d`), where the `e2e-intelligent-assistant` flag reports 99 files / 46.74% / 2490 lines, browsable per file.

## Note on where E2E coverage is visible

Each overlay workspace pins its own `repo-ref` commit, and coverage is attributed to **that** commit — not to the head of `main`. Measurements on the public API confirm these flags do not propagate forward to `main`'s head via carryforward; that is a separate discussion and is not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)