### PR TITLE
feat(intelligent-assistant): apply behavior-linked MCP tools permissions model

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/mcp-tools-permissions.md
+++ b/workspaces/intelligent-assistant/.changeset/mcp-tools-permissions.md
@@ -1,0 +1,18 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': major
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common': major
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': major
+---
+
+Breaking changes to MCP permissions using behavior-linked vocabulary rather than CRUD-linked vocabulary:
+
+| Before (Lightspeed)     | Before (Intelligent Assistant)     | After              |
+| ----------------------- | ---------------------------------- | ------------------ |
+| `lightspeed.mcp.read`   | `intelligent-assistant.mcp.read`   | `mcp.tools.use`    |
+| `lightspeed.mcp.manage` | `intelligent-assistant.mcp.manage` | `mcp.tools.manage` |
+
+Removed permission CRUD action attributes; RBAC entries for these permission sets now use the generic `use` action.
+
+Permission variable renamed from `iaMcpReadPermission` to `iaMcpUsePermission`; `iaMcpManagePermission` keeps its name.
+
+Plugin documentation and example RBAC policy CSV updated to reflect the new MCP permission names.

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/README.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/README.md
@@ -89,8 +89,8 @@ Update permission names in your `rbac-policy.csv`:
 | `lightspeed.chat.update`   | `intelligent-assistant.chat.manage`      |
 | `lightspeed.notebooks.use` | `intelligent-assistant.notebooks.use`    |
 |                            | `intelligent-assistant.notebooks.manage` |
-| `lightspeed.mcp.read`      | `intelligent-assistant.mcp.read`         |
-| `lightspeed.mcp.manage`    | `intelligent-assistant.mcp.manage`       |
+| `lightspeed.mcp.read`      | `mcp.tools.use`                          |
+| `lightspeed.mcp.manage`    | `mcp.tools.manage`                       |
 
 #### 5. OFS dynamic plugin configuration
 
@@ -342,8 +342,8 @@ p, role:default/team_a, intelligent-assistant.notebooks.use, use, allow
 p, role:default/team_a, intelligent-assistant.notebooks.manage, use, allow
 
 # Required for MCP server management (if configured)
-p, role:default/team_a, intelligent-assistant.mcp.read, read, allow
-p, role:default/team_a, intelligent-assistant.mcp.manage, update, allow
+p, role:default/team_a, mcp.tools.use, use, allow
+p, role:default/team_a, mcp.tools.manage, use, allow
 
 # Required for saved prompts
 p, role:default/team_a, intelligent-assistant.saved-prompts.manage, update, allow

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
@@ -32,7 +32,7 @@ import {
   iaChatManagePermission,
   iaChatUsePermission,
   iaMcpManagePermission,
-  iaMcpReadPermission,
+  iaMcpUsePermission,
   iaNotebooksUsePermission,
   iaPermissions,
   iaSavedPromptsManagePermission,
@@ -319,7 +319,7 @@ export async function createRouter(
   router.get(
     '/mcp-servers',
     generalRateLimiter,
-    requirePermission(iaMcpReadPermission),
+    requirePermission(iaMcpUsePermission),
     async (req, res) => {
       try {
         const { userEntityRef } = getIdentity(req);
@@ -360,7 +360,7 @@ export async function createRouter(
   router.post(
     '/mcp-servers/validate',
     generalRateLimiter,
-    requirePermission(iaMcpReadPermission),
+    requirePermission(iaMcpUsePermission),
     async (req, res) => {
       try {
         const { url, token } = req.body;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/report.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/report.api.md
@@ -18,7 +18,7 @@ export const iaChatUsePermission: BasicPermission;
 export const iaMcpManagePermission: BasicPermission;
 
 // @public
-export const iaMcpReadPermission: BasicPermission;
+export const iaMcpUsePermission: BasicPermission;
 
 // @public
 export const iaNotebooksManagePermission: BasicPermission;

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/src/permissions.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/src/permissions.ts
@@ -40,24 +40,20 @@ export const iaChatManagePermission = createPermission({
   attributes: {},
 });
 
-/** This permission is used to list configured MCP servers
+/** This permission is used to use MCP tooling
  * @public
  */
-export const iaMcpReadPermission = createPermission({
-  name: 'intelligent-assistant.mcp.read',
-  attributes: {
-    action: 'read',
-  },
+export const iaMcpUsePermission = createPermission({
+  name: 'mcp.tools.use',
+  attributes: {},
 });
 
-/** This permission is used to add, update, delete, and validate MCP servers
+/** This permission is used to manage MCP tooling
  * @public
  */
 export const iaMcpManagePermission = createPermission({
-  name: 'intelligent-assistant.mcp.manage',
-  attributes: {
-    action: 'update',
-  },
+  name: 'mcp.tools.manage',
+  attributes: {},
 });
 
 /** This permission is used to access, create, and query intelligent-assistant notebooks
@@ -103,7 +99,7 @@ export const iaPermissions = [
   iaChatAccessPermission,
   iaChatManagePermission,
   iaChatUsePermission,
-  iaMcpReadPermission,
+  iaMcpUsePermission,
   iaMcpManagePermission,
   iaNotebooksManagePermission,
   iaNotebooksUsePermission,

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/README.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/README.md
@@ -46,8 +46,8 @@ p, role:default/team_a, intelligent-assistant.notebooks.use, use, allow
 p, role:default/team_a, intelligent-assistant.notebooks.manage, use, allow
 
 # Required for MCP server management (if configured)
-p, role:default/team_a, intelligent-assistant.mcp.read, read, allow
-p, role:default/team_a, intelligent-assistant.mcp.manage, update, allow
+p, role:default/team_a, mcp.tools.use, use, allow
+p, role:default/team_a, mcp.tools.manage, use, allow
 
 # Required for saved prompts
 p, role:default/team_a, intelligent-assistant.saved-prompts.manage, update, allow

--- a/workspaces/intelligent-assistant/rbac-policy.csv
+++ b/workspaces/intelligent-assistant/rbac-policy.csv
@@ -9,8 +9,8 @@
 p, role:default/intelligent-assistant-user, intelligent-assistant.chat.access, use, allow
 p, role:default/intelligent-assistant-user, intelligent-assistant.chat.use, use, allow
 p, role:default/intelligent-assistant-user, intelligent-assistant.chat.manage, use, allow
-p, role:default/intelligent-assistant-user, intelligent-assistant.mcp.read, read, allow
-p, role:default/intelligent-assistant-user, intelligent-assistant.mcp.manage, update, allow
+p, role:default/intelligent-assistant-user, mcp.tools.use, use, allow
+p, role:default/intelligent-assistant-user, mcp.tools.manage, use, allow
 p, role:default/intelligent-assistant-user, intelligent-assistant.notebooks.use, use, allow
 p, role:default/intelligent-assistant-user, intelligent-assistant.notebooks.manage, use, allow
 p, role:default/intelligent-assistant-user, intelligent-assistant.skills.access, use, allow


### PR DESCRIPTION
## Description
Aligns MCP permissions with the behavior-linked model used for chat and notebooks. Renames `intelligent-assistant.mcp.read` / `intelligent-assistant.mcp.manage` to `mcp.tools.use` / `mcp.tools.manage`, removes CRUD action attributes in favor of the generic `use` RBAC action, and updates backend wiring plus docs/policy examples.

## Fixed
- https://redhat.atlassian.net/browse/RHIDP-15930
- https://redhat.atlassian.net/browse/RHIDP-15931

## ✔️ Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)


Made with [Cursor](https://cursor.com)