### PR TITLE
fix(theme): prevent app remount on theme switch

### DIFF
--- a/workspaces/theme/.changeset/shared-theme-provider.md
+++ b/workspaces/theme/.changeset/shared-theme-provider.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Added `createSharedThemeProvider` utility that creates a single shared Provider for multiple themes, preventing full application remount when switching themes. All built-in RHDH themes now share one Provider. Exported `createSharedThemeProvider` and `SharedThemeEntry` for use by custom theme authors.

--- a/workspaces/theme/.changeset/shared-theme-provider.md
+++ b/workspaces/theme/.changeset/shared-theme-provider.md
@@ -2,4 +2,4 @@
 '@red-hat-developer-hub/backstage-plugin-theme': patch
 ---
 
-Added `createSharedThemeProvider` utility that creates a single shared Provider for multiple themes, preventing full application remount when switching themes. All built-in RHDH themes now share one Provider. Exported `createSharedThemeProvider` and `SharedThemeEntry` for use by custom theme authors.
+Added `createSharedThemeProvider` internal utility that creates a single shared Provider for multiple themes, preventing full application remount when switching themes. All built-in RHDH themes now share one Provider.

--- a/workspaces/theme/plugins/theme/src/components/ThemeProvider.test.tsx
+++ b/workspaces/theme/plugins/theme/src/components/ThemeProvider.test.tsx
@@ -57,6 +57,13 @@ const mockAppThemeApi = (activeThemeId?: string) => {
   });
 };
 
+const createMockTheme = (secondaryColor: string) =>
+  ({
+    getTheme: () => ({
+      palette: { text: { secondary: secondaryColor } },
+    }),
+  }) as any;
+
 describe('createSharedThemeProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -69,7 +76,6 @@ describe('createSharedThemeProvider', () => {
       'backstage-light': { theme: themes.light },
     });
 
-    // The return value is a single function, not one per entry
     expect(typeof provider).toBe('function');
     expect(provider.name).toBe('RHDHSharedThemeProvider');
   });
@@ -90,7 +96,26 @@ describe('createSharedThemeProvider', () => {
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
-  it('falls back to light theme when no explicit theme is selected and system prefers light', () => {
+  it('resolves the correct entry when activeId matches a key', () => {
+    mockAppThemeApi('dark');
+
+    const Provider = createSharedThemeProvider({
+      light: { theme: createMockTheme('#light-marker') },
+      dark: { theme: createMockTheme('#dark-marker') },
+    });
+
+    const { container } = render(
+      <Provider>
+        <span>content</span>
+      </Provider>,
+    );
+
+    const style = container.querySelector('style');
+    expect(style?.textContent).toContain('#dark-marker');
+    expect(style?.textContent).not.toContain('#light-marker');
+  });
+
+  it('resolves to light entry when system prefers light', () => {
     mockAppThemeApi(undefined);
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
@@ -98,17 +123,78 @@ describe('createSharedThemeProvider', () => {
     });
 
     const Provider = createSharedThemeProvider({
-      light: { name: 'light' },
-      dark: { name: 'dark' },
+      light: { theme: createMockTheme('#light-marker') },
+      dark: { theme: createMockTheme('#dark-marker') },
     });
 
-    render(
+    const { container } = render(
       <Provider>
         <span>Light fallback</span>
       </Provider>,
     );
 
-    expect(screen.getByText('Light fallback')).toBeInTheDocument();
+    const style = container.querySelector('style');
+    expect(style?.textContent).toContain('#light-marker');
+    expect(style?.textContent).not.toContain('#dark-marker');
+  });
+
+  it('resolves to dark entry when system prefers dark', () => {
+    mockAppThemeApi(undefined);
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({ matches: true }),
+    });
+
+    const Provider = createSharedThemeProvider({
+      light: { theme: createMockTheme('#light-marker') },
+      dark: { theme: createMockTheme('#dark-marker') },
+    });
+
+    const { container } = render(
+      <Provider>
+        <span>Dark fallback</span>
+      </Provider>,
+    );
+
+    const style = container.querySelector('style');
+    expect(style?.textContent).toContain('#dark-marker');
+    expect(style?.textContent).not.toContain('#light-marker');
+  });
+
+  it('falls back to dark entry for unknown activeId containing "dark"', () => {
+    mockAppThemeApi('custom-dark-theme');
+
+    const Provider = createSharedThemeProvider({
+      light: { theme: createMockTheme('#light-marker') },
+      dark: { theme: createMockTheme('#dark-marker') },
+    });
+
+    const { container } = render(
+      <Provider>
+        <span>content</span>
+      </Provider>,
+    );
+
+    const style = container.querySelector('style');
+    expect(style?.textContent).toContain('#dark-marker');
+  });
+
+  it('falls back to light entry for unknown activeId without "dark"', () => {
+    mockAppThemeApi('unknown-theme');
+
+    const Provider = createSharedThemeProvider({
+      light: { theme: createMockTheme('#light-marker') },
+      dark: { theme: createMockTheme('#dark-marker') },
+    });
+
+    const { container } = render(
+      <Provider>
+        <span>content</span>
+      </Provider>,
+    );
+
+    const style = container.querySelector('style');
+    expect(style?.textContent).toContain('#light-marker');
   });
 
   it('handles pre-built theme entries', () => {

--- a/workspaces/theme/plugins/theme/src/components/ThemeProvider.test.tsx
+++ b/workspaces/theme/plugins/theme/src/components/ThemeProvider.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { useApi } from '@backstage/core-plugin-api';
+import { themes } from '@backstage/theme';
+import { createSharedThemeProvider } from './ThemeProvider';
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: jest.fn(),
+}));
+
+jest.mock('@backstage/theme', () => ({
+  ...jest.requireActual('@backstage/theme'),
+  UnifiedThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@mui/material/styles', () => ({
+  ...jest.requireActual('@mui/material/styles'),
+  StyledEngineProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('../hooks/useThemeConfig', () => ({
+  useThemeConfig: (name: string) => ({
+    mode: name.includes('dark') ? 'dark' : 'light',
+  }),
+}));
+
+jest.mock('../hooks/useTheme', () => ({
+  useTheme: () => themes.light,
+}));
+
+const mockAppThemeApi = (activeThemeId?: string) => {
+  (useApi as jest.Mock).mockReturnValue({
+    getActiveThemeId: () => activeThemeId,
+  });
+};
+
+describe('createSharedThemeProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the same Provider function reference for all entries', () => {
+    const provider = createSharedThemeProvider({
+      light: { name: 'light' },
+      dark: { name: 'dark' },
+      'backstage-light': { theme: themes.light },
+    });
+
+    // The return value is a single function, not one per entry
+    expect(typeof provider).toBe('function');
+    expect(provider.name).toBe('RHDHSharedThemeProvider');
+  });
+
+  it('renders children when a matching theme ID is active', () => {
+    mockAppThemeApi('dark');
+    const Provider = createSharedThemeProvider({
+      light: { name: 'light' },
+      dark: { name: 'dark' },
+    });
+
+    render(
+      <Provider>
+        <span>Hello</span>
+      </Provider>,
+    );
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('falls back to light theme when no explicit theme is selected and system prefers light', () => {
+    mockAppThemeApi(undefined);
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({ matches: false }),
+    });
+
+    const Provider = createSharedThemeProvider({
+      light: { name: 'light' },
+      dark: { name: 'dark' },
+    });
+
+    render(
+      <Provider>
+        <span>Light fallback</span>
+      </Provider>,
+    );
+
+    expect(screen.getByText('Light fallback')).toBeInTheDocument();
+  });
+
+  it('handles pre-built theme entries', () => {
+    mockAppThemeApi('backstage-light');
+    const Provider = createSharedThemeProvider({
+      'backstage-light': { theme: themes.light },
+      'backstage-dark': { theme: themes.dark },
+    });
+
+    render(
+      <Provider>
+        <span>Backstage theme</span>
+      </Provider>,
+    );
+
+    expect(screen.getByText('Backstage theme')).toBeInTheDocument();
+  });
+
+  it('renders when appThemeApi is unavailable', () => {
+    (useApi as jest.Mock).mockImplementation(() => {
+      throw new Error('No API context');
+    });
+
+    const Provider = createSharedThemeProvider({
+      light: { name: 'light' },
+      dark: { name: 'dark' },
+    });
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({ matches: false }),
+    });
+
+    render(
+      <Provider>
+        <span>No API</span>
+      </Provider>,
+    );
+
+    expect(screen.getByText('No API')).toBeInTheDocument();
+  });
+});

--- a/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
+++ b/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
@@ -16,9 +16,9 @@
 
 import type { ReactNode } from 'react';
 import {
-  AppTheme,
+  type AppTheme,
   appThemeApiRef,
-  AppThemeApi,
+  type AppThemeApi,
   useApi,
 } from '@backstage/core-plugin-api';
 import { UnifiedTheme, UnifiedThemeProvider } from '@backstage/theme';

--- a/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
+++ b/workspaces/theme/plugins/theme/src/components/ThemeProvider.tsx
@@ -15,7 +15,12 @@
  */
 
 import type { ReactNode } from 'react';
-import { AppTheme } from '@backstage/core-plugin-api';
+import {
+  AppTheme,
+  appThemeApiRef,
+  AppThemeApi,
+  useApi,
+} from '@backstage/core-plugin-api';
 import { UnifiedTheme, UnifiedThemeProvider } from '@backstage/theme';
 
 import {
@@ -89,3 +94,57 @@ export const createThemeProviderForThemeName = (
     const theme = useTheme(themeConfig);
     return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
   };
+
+const resolveActiveKey = (
+  activeId: string | undefined,
+  keys: string[],
+): string => {
+  if (activeId && keys.includes(activeId)) {
+    return activeId;
+  }
+  const prefersDark = activeId
+    ? activeId.includes('dark')
+    : window.matchMedia?.('(prefers-color-scheme: dark)')?.matches;
+  return prefersDark
+    ? (keys.find(n => n.includes('dark')) ?? keys[0])
+    : (keys.find(n => !n.includes('dark')) ?? keys[0]);
+};
+
+const useActiveThemeId = (): string | undefined => {
+  let appThemeApi: AppThemeApi | undefined;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    appThemeApi = useApi<AppThemeApi>(appThemeApiRef); // NOSONAR
+  } catch {
+    // appThemeApi may not be available during createApp initialization
+  }
+  return appThemeApi?.getActiveThemeId();
+};
+
+export type SharedThemeEntry = {
+  name?: string;
+  config?: ThemeConfig;
+  theme?: UnifiedTheme;
+};
+
+export const createSharedThemeProvider = (
+  entries: Record<string, SharedThemeEntry>,
+): AppTheme['Provider'] => {
+  const keys = Object.keys(entries);
+
+  function RHDHSharedThemeProvider({ children }: { children: ReactNode }) {
+    const activeId = useActiveThemeId();
+    const key = resolveActiveKey(activeId, keys);
+    const entry = entries[key];
+
+    // Always call hooks unconditionally (Rules of Hooks).
+    // For entries that don't need them the results are simply unused.
+    const configFromName = useThemeConfig(entry.name ?? key);
+    const resolvedConfig = entry.config ?? configFromName;
+    const themeFromHook = useTheme(resolvedConfig);
+
+    const theme = entry.theme ?? themeFromHook;
+    return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  }
+  return RHDHSharedThemeProvider;
+};

--- a/workspaces/theme/plugins/theme/src/themes.tsx
+++ b/workspaces/theme/plugins/theme/src/themes.tsx
@@ -22,17 +22,40 @@ import LightIcon from '@mui/icons-material/WbSunnyRounded';
 import DarkIcon from '@mui/icons-material/Brightness2Rounded';
 import { createTheme } from '@mui/material/styles';
 
-import {
-  createThemeProvider,
-  createThemeProviderForThemeName,
-  createThemeProviderForThemeConfig,
-} from './components/ThemeProvider';
+import { createSharedThemeProvider } from './components/ThemeProvider';
 import * as backstage from './backstage';
 import * as rhdh from './rhdh';
 
-export const lightThemeProvider = createThemeProviderForThemeName('light');
+const sharedProvider = createSharedThemeProvider({
+  light: { name: 'light' },
+  dark: { name: 'dark' },
+  'light-customized': {
+    config: {
+      mode: 'light',
+      variant: 'rhdh',
+      palette: {
+        primary: { main: '#ff0000' },
+        secondary: { main: '#00ff00' },
+      },
+    },
+  },
+  'dark-customized': {
+    config: {
+      mode: 'dark',
+      variant: 'rhdh',
+      palette: {
+        primary: { main: '#ff0000' },
+        secondary: { main: '#00ff00' },
+      },
+    },
+  },
+  'backstage-light': { theme: themes.light },
+  'backstage-dark': { theme: themes.dark },
+});
 
-export const darkThemeProvider = createThemeProviderForThemeName('dark');
+export const lightThemeProvider = sharedProvider;
+
+export const darkThemeProvider = sharedProvider;
 
 export const getAllThemes = (): AppTheme[] => {
   return [
@@ -41,56 +64,42 @@ export const getAllThemes = (): AppTheme[] => {
       title: 'RHDH Light (latest)',
       variant: 'light',
       icon: <LightIcon />,
-      Provider: createThemeProviderForThemeName('light'),
+      Provider: sharedProvider,
     },
     {
       id: 'dark',
       title: 'RHDH Dark (latest)',
       variant: 'dark',
       icon: <DarkIcon />,
-      Provider: createThemeProviderForThemeName('dark'),
+      Provider: sharedProvider,
     },
     {
       id: 'light-customized',
       title: 'RHDH Light (customized)',
       variant: 'light',
       icon: <LightIcon />,
-      Provider: createThemeProviderForThemeConfig({
-        mode: 'light',
-        variant: 'rhdh',
-        palette: {
-          primary: { main: '#ff0000' },
-          secondary: { main: '#00ff00' },
-        },
-      }),
+      Provider: sharedProvider,
     },
     {
       id: 'dark-customized',
       title: 'RHDH Dark (customized)',
       variant: 'dark',
       icon: <DarkIcon />,
-      Provider: createThemeProviderForThemeConfig({
-        mode: 'dark',
-        variant: 'rhdh',
-        palette: {
-          primary: { main: '#ff0000' },
-          secondary: { main: '#00ff00' },
-        },
-      }),
+      Provider: sharedProvider,
     },
     {
       id: 'backstage-light',
       title: 'Backstage Light',
       variant: 'light',
       icon: <LightIcon />,
-      Provider: createThemeProvider(themes.light),
+      Provider: sharedProvider,
     },
     {
       id: 'backstage-dark',
       title: 'Backstage Dark',
       variant: 'dark',
       icon: <DarkIcon />,
-      Provider: createThemeProvider(themes.dark),
+      Provider: sharedProvider,
     },
   ];
 };
@@ -106,14 +115,14 @@ export const getThemes = (): AppTheme[] => {
       title: 'Light',
       variant: 'light',
       icon: <LightIcon />,
-      Provider: createThemeProviderForThemeName('light'),
+      Provider: sharedProvider,
     },
     {
       id: 'dark',
       title: 'Dark',
       variant: 'dark',
       icon: <DarkIcon />,
-      Provider: createThemeProviderForThemeName('dark'),
+      Provider: sharedProvider,
     },
   ];
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: [RHDHBUGS-3650](https://redhat.atlassian.net/browse/RHDHBUGS-3650)

 Switching themes in RHDH caused a full React subtree remount instead of a re-render, losing all component state and
  re-firing all API calls

**Root Cause:**
  Each theme previously had its own Provider function created by createThemeProviderForThemeName(). React's reconciliation treats different function references as different component types, triggering a full unmount/remount of the entire tree below the provider on every theme switch.


**Fix:**

 All built-in themes now share a single Provider component via `createSharedThemeProvider`, so React re-renders in place instead of remounting


## Screenshots


https://github.com/user-attachments/assets/f96f1c7c-85f3-44e3-86d0-0040e29bfe8f

# Verification: 

When you switch between themes: 
  - No extra API calls in network tab.
  - Elements tab, shows that components are not re-mounted.



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
