### PR TITLE
fix(ai-integrations): switch ai-model-server and ai-resource-agent from addModelSource to addProcessor

### DIFF
--- a/workspaces/ai-integrations/.changeset/fruity-tables-wonder.md
+++ b/workspaces/ai-integrations/.changeset/fruity-tables-wonder.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-ai-resource-agent': minor
+'@red-hat-developer-hub/backstage-plugin-catalog-backend-module-ai-model-server': minor
+---
+
+switch ai-model-server and ai-resource-agent from catalog model layer's addModelSource to addProcessor

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/report.api.md
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/report.api.md
@@ -4,6 +4,16 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { Entity } from '@backstage/catalog-model';
+
+// @public
+export class AiModelServerApiProcessor implements CatalogProcessor {
+  // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
+  validateEntityKind(entity: Entity): Promise<boolean>;
+}
 
 // @public
 const catalogModuleAiModelServer: BackendFeature;

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/AiModelServerApiProcessor.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/AiModelServerApiProcessor.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { AiModelServerApiProcessor } from './AiModelServerApiProcessor';
+
+function makeAiModelServerApi(overrides?: Partial<Entity['spec']>): Entity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'AiModelServerAPI',
+    metadata: { name: 'test-ai-model-server' },
+    spec: {
+      type: 'ai-model-server',
+      lifecycle: 'experimental',
+      owner: 'backstage',
+      serverType: 'openai-v1',
+      serverUrl: 'https://api.openai.com/v1',
+      ...overrides,
+    },
+  } as Entity;
+}
+
+describe('AiModelServerApiProcessor', () => {
+  let processor: AiModelServerApiProcessor;
+
+  beforeEach(() => {
+    processor = new AiModelServerApiProcessor();
+  });
+
+  it('should return processor name', () => {
+    expect(processor.getProcessorName()).toBe('AiModelServerApiProcessor');
+  });
+
+  describe('validateEntityKind', () => {
+    it('should return true for a valid AiModelServerAPI entity', async () => {
+      const result = await processor.validateEntityKind(makeAiModelServerApi());
+      expect(result).toBe(true);
+    });
+
+    it('should return false for a Component entity', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'my-component' },
+        spec: { type: 'service', lifecycle: 'production', owner: 'team-a' },
+      };
+      const result = await processor.validateEntityKind(entity);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for an AiResource entity', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiResource',
+        metadata: { name: 'my-agent' },
+        spec: { type: 'agent', lifecycle: 'production', owner: 'team-a' },
+      };
+      const result = await processor.validateEntityKind(entity);
+      expect(result).toBe(false);
+    });
+
+    it('should reject an AiModelServerAPI entity missing required fields', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiModelServerAPI',
+        metadata: { name: 'bad-entity' },
+        spec: {
+          type: 'ai-model-server',
+          lifecycle: 'production',
+          owner: 'team',
+        },
+      } as Entity;
+      await expect(processor.validateEntityKind(entity)).rejects.toThrow(
+        /serverType/,
+      );
+    });
+  });
+});

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/AiModelServerApiProcessor.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/AiModelServerApiProcessor.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { Entity } from '@backstage/catalog-model';
+import { aiModelServerApiEntityValidator } from '@red-hat-developer-hub/backstage-plugin-catalog-model-ai-model-server';
+
+/**
+ * A CatalogProcessor that validates AiModelServerAPI entities.
+ *
+ * Uses `validateEntityKind` so the catalog's `BuiltinKindsEntityProcessor`
+ * remains active for standard kinds (User, Group, Component, etc.).
+ * This avoids the pitfall of `addModelSource`, which replaces the
+ * built-in kind processor entirely.
+ *
+ * @public
+ */
+export class AiModelServerApiProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'AiModelServerApiProcessor';
+  }
+
+  async validateEntityKind(entity: Entity): Promise<boolean> {
+    if (entity.kind !== 'AiModelServerAPI') {
+      return false;
+    }
+    return aiModelServerApiEntityValidator.check(entity);
+  }
+}

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/index.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/index.ts
@@ -20,3 +20,4 @@
  * @packageDocumentation
  */
 export { catalogModuleAiModelServer as default } from './module';
+export { AiModelServerApiProcessor } from './AiModelServerApiProcessor';

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/module.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-model-server/src/module.ts
@@ -15,16 +15,18 @@
  */
 
 import { createBackendModule } from '@backstage/backend-plugin-api';
-import type { CatalogModelSource } from '@backstage/catalog-model/alpha';
-import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { aiModelServerApiEntityModel } from '@red-hat-developer-hub/backstage-plugin-catalog-model-ai-model-server';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+
+import { AiModelServerApiProcessor } from './AiModelServerApiProcessor';
 
 /**
  * Registers the AiModelServerAPI kind in the catalog.
  *
- * Uses a dedicated kind to avoid colliding with the upstream API kind.
- * When backstage/backstage#34476 merges, this module can be replaced
- * by the upstream `@backstage/plugin-catalog-backend-module-ai-model`.
+ * Uses `addProcessor` so the catalog's built-in kind processor
+ * (`BuiltinKindsEntityProcessor`) remains active for standard kinds.
+ * The previous `addModelSource` approach caused the built-in processor
+ * to be replaced entirely, breaking validation of User, Group,
+ * Component, and other standard entity kinds.
  *
  * @public
  */
@@ -34,15 +36,10 @@ export const catalogModuleAiModelServer = createBackendModule({
   register(reg) {
     reg.registerInit({
       deps: {
-        model: catalogModelExtensionPoint,
+        catalog: catalogProcessingExtensionPoint,
       },
-      async init({ model }) {
-        const source: CatalogModelSource = {
-          async *read() {
-            yield { data: [{ layer: aiModelServerApiEntityModel }] };
-          },
-        };
-        model.addModelSource(source);
+      async init({ catalog }) {
+        catalog.addProcessor(new AiModelServerApiProcessor());
       },
     });
   },

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/README.md
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/README.md
@@ -1,8 +1,11 @@
 # @red-hat-developer-hub/backstage-plugin-catalog-backend-module-ai-resource-agent
 
-A Backstage catalog backend module that registers the agent-shaped
-`AiResource` catalog model and validates agent-specific fields at
-ingestion.
+A Backstage catalog backend module that validates agent-shaped
+`AiResource` entities at ingestion time.
+
+Uses `catalogProcessingExtensionPoint.addProcessor()` so the catalog's
+built-in kind processor (`BuiltinKindsEntityProcessor`) remains active
+for standard kinds (User, Group, Component, etc.).
 
 This package is intentionally separate from
 `catalog-backend-module-ai-resource-extensions`, which owns shared RHDH
@@ -10,12 +13,11 @@ extensions such as `spec.scope` and OCI `source-location` checks.
 
 ## What it registers
 
-On init the module:
+On init the module registers `AiResourceAgentProcessor`, which:
 
-1. Adds the agent catalog model source (`agentAiResourceEntityModel`) for
-   `kind: AiResource`, `spec.type: agent`
-2. Registers `AiResourceAgentProcessor` for agent field validation during
-   catalog processing
+1. Validates `kind: AiResource`, `spec.type: agent` entities via
+   `validateEntityKind`
+2. Validates agent-specific fields via `preProcessEntity`
 
 ## Validation
 
@@ -49,7 +51,7 @@ companion `catalog-model-ai-resource-agent` package.
 | Package                                                   | Responsibility                                     |
 | --------------------------------------------------------- | -------------------------------------------------- |
 | `catalog-model-ai-resource-agent`                         | Types, JSON schema, KindValidator                  |
-| `catalog-backend-module-ai-resource-agent` (this package) | Model registration + agent processor               |
+| `catalog-backend-module-ai-resource-agent` (this package) | Agent kind validation + field-level processor      |
 | `catalog-backend-module-ai-resource-extensions`           | RHDH `spec.scope` + OCI source-location validation |
 
 ## Examples
@@ -59,7 +61,7 @@ for router + specialist agent catalog entities.
 
 ## Public API
 
-| Export                                   | Description                                                 |
-| ---------------------------------------- | ----------------------------------------------------------- |
-| `catalogModuleAiResourceAgent` (default) | Backend module that registers the agent model and processor |
-| `AiResourceAgentProcessor`               | `CatalogProcessor` for agent-specific field validation      |
+| Export                                   | Description                                            |
+| ---------------------------------------- | ------------------------------------------------------ |
+| `catalogModuleAiResourceAgent` (default) | Backend module that registers the agent processor      |
+| `AiResourceAgentProcessor`               | `CatalogProcessor` for agent-specific field validation |

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/report.api.md
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/report.api.md
@@ -19,6 +19,8 @@ export class AiResourceAgentProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<Entity>;
+  // (undocumented)
+  validateEntityKind(entity: Entity): Promise<boolean>;
 }
 
 // @public

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/src/AiResourceAgentProcessor.test.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/src/AiResourceAgentProcessor.test.ts
@@ -208,6 +208,49 @@ describe('AiResourceAgentProcessor', () => {
     });
   });
 
+  describe('validateEntityKind', () => {
+    it('should return true for a valid AiResource agent entity', async () => {
+      const entity = makeAiResource({
+        type: 'agent',
+        lifecycle: 'production',
+        owner: 'ai-platform-team',
+        instructions: 'You are a test agent.',
+      });
+      const result = await processor.validateEntityKind(entity);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for a non-AiResource kind', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'my-component' },
+        spec: { type: 'service', lifecycle: 'production', owner: 'team-a' },
+      };
+      const result = await processor.validateEntityKind(entity);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for AiResource with non-agent spec.type', async () => {
+      const entity = makeAiResource({
+        type: 'skill',
+        lifecycle: 'production',
+        owner: 'team',
+      });
+      const result = await processor.validateEntityKind(entity);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for AiResource with no spec.type', async () => {
+      const entity = makeAiResource({
+        lifecycle: 'production',
+        owner: 'team',
+      });
+      const result = await processor.validateEntityKind(entity);
+      expect(result).toBe(false);
+    });
+  });
+
   describe('non-AiResource entities', () => {
     it('should pass through Component entities unchanged', async () => {
       const entity: Entity = {

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/src/AiResourceAgentProcessor.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/src/AiResourceAgentProcessor.ts
@@ -20,13 +20,20 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { Entity } from '@backstage/catalog-model';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { agentAiResourceEntityV1alpha1Validator } from '@red-hat-developer-hub/backstage-plugin-catalog-model-ai-resource-agent';
 import { collectAgentErrors } from './collectAgentErrors';
 
 /**
  * A CatalogProcessor that validates agent-specific fields on
  * AiResource entities with `spec.type: 'agent'`.
  *
- * Validates:
+ * Implements `validateEntityKind` so the catalog's built-in kind
+ * processor remains active for standard kinds. The previous
+ * `addModelSource` approach caused the built-in processor to be
+ * replaced entirely, breaking validation of User, Group, Component,
+ * and other standard entity kinds.
+ *
+ * Also validates via `preProcessEntity`:
  * - `spec.instructions`: optional; must be a string if present
  * - `spec.handoffs` / `spec.tools`: must be arrays if present
  * - `spec.resetToolChoice`: must be boolean if present
@@ -44,6 +51,13 @@ import { collectAgentErrors } from './collectAgentErrors';
 export class AiResourceAgentProcessor implements CatalogProcessor {
   getProcessorName(): string {
     return 'AiResourceAgentProcessor';
+  }
+
+  async validateEntityKind(entity: Entity): Promise<boolean> {
+    if (entity.kind !== 'AiResource' || entity.spec?.type !== 'agent') {
+      return false;
+    }
+    return agentAiResourceEntityV1alpha1Validator.check(entity);
   }
 
   async preProcessEntity(

--- a/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/src/module.ts
+++ b/workspaces/ai-integrations/plugins/catalog-backend-module-ai-resource-agent/src/module.ts
@@ -15,18 +15,18 @@
  */
 
 import { createBackendModule } from '@backstage/backend-plugin-api';
-import type { CatalogModelSource } from '@backstage/catalog-model/alpha';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
-import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { agentAiResourceEntityModel } from '@red-hat-developer-hub/backstage-plugin-catalog-model-ai-resource-agent';
+
 import { AiResourceAgentProcessor } from './AiResourceAgentProcessor';
 
 /**
  * Registers the agent specType for the AiResource kind in the catalog.
  *
- * Follows the upstream pattern established by
- * `@backstage/plugin-catalog-backend-module-ai-model` which registers
- * skill/rule via `catalogModelExtensionPoint.addModelSource`.
+ * Uses `addProcessor` so the catalog's built-in kind processor
+ * (`BuiltinKindsEntityProcessor`) remains active for standard kinds.
+ * The previous `addModelSource` approach caused the built-in processor
+ * to be replaced entirely, breaking validation of User, Group,
+ * Component, and other standard entity kinds.
  *
  * @public
  */
@@ -36,16 +36,9 @@ export const catalogModuleAiResourceAgent = createBackendModule({
   register(reg) {
     reg.registerInit({
       deps: {
-        model: catalogModelExtensionPoint,
         catalog: catalogProcessingExtensionPoint,
       },
-      async init({ model, catalog }) {
-        const source: CatalogModelSource = {
-          async *read() {
-            yield { data: [{ layer: agentAiResourceEntityModel }] };
-          },
-        };
-        model.addModelSource(source);
+      async init({ catalog }) {
         catalog.addProcessor(new AiResourceAgentProcessor());
       },
     });


### PR DESCRIPTION
Both plugins used `catalogModelExtensionPoint.addModelSource()` which causes `CatalogBuilder` to replace `BuiltinKindsEntityProcessor` with `ModelProcessor`. Since neither included `defaultCatalogEntityModel`, all standard entity kinds (User, Group, Component, etc.) were rejected, breaking SSO login and catalog ingestion.

Switch both to `catalogProcessingExtensionPoint.addProcessor()` with `validateEntityKind()` so the built-in kind processor stays active.

Does not appear as readily in 1.10 vs. 2.x when running in the RHDH pod (diffs in how the base entity kinds are pulled in made this benign with testing on 1.10)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [n/a] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or Updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
