### PR TITLE
fix: correct release_workspace.yml condition to unblock npm publish

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Update Version Packages (${{ inputs.workspace }}) PR
         id: changesets-pr
-        if: steps.release_check.outputs.needs_release != 'true' || inputs.force_release != true
+        if: steps.release_check.outputs.needs_release != 'true' && inputs.force_release != true
         uses: backstage/changesets-action@a39baf18913e669734ffb00c2fd9900472cfa240 # v2.3.2
         with:
           title: Version Packages (${{ inputs.workspace }})


### PR DESCRIPTION
The `changesets-pr` step's `if` condition used `||` (OR) instead of `&&` (AND), causing the backstage/changesets-action to run even when `needs_release=true` — i.e., when a Version Packages PR has just been merged and the release job should run instead.

The condition was:

  needs_release != 'true' || force_release != true

Since `force_release` defaults to false (not set), the right side (`false != true`) is ALWAYS true, making the entire OR expression true regardless of `needs_release`. This means the changesets-action step runs unconditionally. When a Version Packages PR merge leaves zero unconsumed changesets for the workspace, the action finds nothing to do, attempts to create an empty PR, and fails with:

  "No commits between main and changesets-release/<workspace>/main"

An example failure can be seen at https://github.com/redhat-developer/rhdh-plugins/actions/runs/31861654161/job/95193449174

Because the `changesets-pr` job fails, the `release` job (which has `needs: changesets-pr`) is skipped by GitHub Actions — so the npm publish never happens.

The fix changes `||` to `&&`:

  needs_release != 'true' && force_release != true

Now when `needs_release=true`: `false && true` = `false` → the changesets-action step is skipped → the job succeeds → the release job runs → packages are published to npm.

This bug was not previously observed because it only surfaces when a Version Packages PR merge leaves zero remaining changesets for the affected workspace. If other changesets are pending, the action finds them and succeeds, masking the logic error.

Immediate impact: the ai-integrations workspace packages `catalog-backend-module-ai-model-server@0.3.0` and `catalog-backend-module-ai-resource-agent@0.4.0` (from PR #4320, switching from addModelSource to addProcessor) were version-bumped by Version Packages PR #4332 but never published to npm. A patch changeset is included to trigger a new version cycle that will publish these packages once this fix lands.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [/] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or Updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
