### PR TITLE
fix(orchestrator): center empty state content on wide viewports

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-empty-state-alignment.md
+++ b/workspaces/orchestrator/.changeset/fix-empty-state-alignment.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix Orchestrator empty state layout on wide viewports by targeting MuiGrid selectors instead of deprecated BackstageEmptyState class names.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/ui/OrchestratorEmptyState.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/ui/OrchestratorEmptyState.tsx
@@ -31,8 +31,13 @@ const useStyles = makeStyles()(theme => ({
   root: {
     width: '100%',
     containerType: 'inline-size',
-    '& [class*="BackstageEmptyState-root"]': {
-      alignItems: 'center',
+    // Prefer MuiGrid selectors: in newer Backstage/JSS builds, EmptyState's
+    // `BackstageEmptyState-root` sheet name is not present on the DOM node
+    // (only hashed classes like `jss4-…`), so attribute selectors on that
+    // prefix never match. The outer EmptyState node is always a Grid container.
+    '& > [class*="MuiGrid-container"]': {
+      // EmptyState sets alignItems="flex-start" via a generated MuiGrid class.
+      alignItems: 'center !important',
       padding: theme.spacing(4),
     },
     '& [class*="MuiTypography-h5"]': {
@@ -44,19 +49,21 @@ const useStyles = makeStyles()(theme => ({
       color: theme.palette.text.secondary,
     },
     '@container (max-width: 899px)': {
-      '& [class*="BackstageEmptyState-root"]': {
+      '& > [class*="MuiGrid-container"]': {
         textAlign: 'center',
       },
-      '& [class*="MuiGrid-grid-md-6"]': {
+      '& > [class*="MuiGrid-container"] > [class*="MuiGrid-grid-md-6"]': {
         maxWidth: '100%',
         flexBasis: '100%',
       },
-      '& [class*="BackstageEmptyState-imageContainer"]': {
-        order: -1,
-        display: 'flex',
-        justifyContent: 'center',
-        marginBottom: theme.spacing(-4),
-      },
+      // Image column is the second md-6 item (text first, illustration second).
+      '& > [class*="MuiGrid-container"] > [class*="MuiGrid-grid-md-6"]:last-child':
+        {
+          order: -1,
+          display: 'flex',
+          justifyContent: 'center',
+          marginBottom: theme.spacing(-4),
+        },
     },
   },
   illustration: {


### PR DESCRIPTION
#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3568

## Summary

- Fix misaligned Orchestrator empty states ("No workflows added yet" / "No runs yet") on wide viewports
- Replace CSS selectors targeting `BackstageEmptyState-*` class names (no longer present in newer Backstage/JSS builds) with stable `MuiGrid` selectors
- Vertically center empty-state text and illustration for both Workflows and All runs tabs

## Before

On wide viewports, empty-state text sits top-left and the illustration is pushed to the side — the CSS override never applied because hashed JSS classes replaced the old `BackstageEmptyState-root` selector.

<img width="1728" height="1102" alt="Screenshot 2026-08-04 at 11 55 02 AM" src="https://github.com/user-attachments/assets/4aa2274f-bb7c-4b14-a9e4-34eea61bb36a" />


## After

Text and illustration are vertically centered together using `& > [class*="MuiGrid-container"]` with `align-items: center`.

<img width="1728" height="1043" alt="Screenshot 2026-08-04 at 12 27 41 PM" src="https://github.com/user-attachments/assets/a8e08fca-47ce-4053-a860-e5a29b46dd56" />


## Test plan

- [ ] Open Orchestrator → Workflows tab with no workflows — empty state text and illustration are vertically aligned
- [ ] Open Orchestrator → All runs tab with no runs — same alignment
- [ ] Resize to narrow viewport — responsive empty-state layout still stacks correctly with illustration on top
