### PR TITLE
fix(global-header): resolve accessibility violations in nested interactive controls

### DIFF
--- a/workspaces/global-header/.changeset/gentle-rocks-shine.md
+++ b/workspaces/global-header/.changeset/gentle-rocks-shine.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Fix accessibility violations: resolve nested interactive controls in search results and starred dropdown, add missing accessible names, and fix aria-expanded attribute

--- a/workspaces/global-header/e2e-tests/globalHeader.test.ts
+++ b/workspaces/global-header/e2e-tests/globalHeader.test.ts
@@ -218,8 +218,16 @@ test('Verify Starred items functionality', async () => {
         - menuitem "example-website COMPONENT":
           - paragraph: example-website
           - paragraph: COMPONENT
-        - button "${translations.starred.removeTooltip}"
     `);
+
+  const starredMenuItem = page.getByRole('menuitem', {
+    name: 'example-website COMPONENT',
+  });
+  await starredMenuItem.hover();
+  await expect(
+    page.getByRole('button', { name: translations.starred.removeTooltip }),
+  ).toBeVisible();
+
   await page.keyboard.press('Escape');
 });
 

--- a/workspaces/global-header/e2e-tests/globalHeader.test.ts
+++ b/workspaces/global-header/e2e-tests/globalHeader.test.ts
@@ -105,7 +105,7 @@ test('Verify Global header to be visible', async ({
     - link "${translations.notifications.title}":
       - /url: /notifications
     `);
-  await runAccessibilityTests(page, testInfo);
+  await runAccessibilityTests(page, testInfo, undefined, '#global-header');
 });
 
 test('Verify Hover texts to be visible', async () => {
@@ -147,16 +147,18 @@ test('Verify Search functionality and results', async () => {
   const searchQuery = 'example-website';
   const expectedUrl = /\/example-website/;
 
-  await search.fill(searchQuery);
-
-  // Wait for search results to appear
-  await expect(page.getByRole('listbox')).toBeVisible();
-
-  // Click the result link and verify navigation
-  const resultLink = page
+  const resultOption = page
     .getByRole('listbox')
-    .getByRole('link', { name: searchQuery });
-  await resultLink.click();
+    .getByRole('option', { name: searchQuery });
+
+  // Retry search until indexed results appear (search index may not be ready immediately)
+  await expect(async () => {
+    await search.clear();
+    await search.fill(searchQuery);
+    await expect(resultOption).toBeVisible();
+  }).toPass({ timeout: 30000, intervals: [2000] });
+
+  await resultOption.click();
   await expect(page).toHaveURL(expectedUrl);
   await expect(page.locator('h1')).toContainText(searchQuery);
 });
@@ -187,9 +189,11 @@ test('Verify Starred items functionality', async () => {
   await expect(page.getByRole('menu')).toMatchAriaSnapshot(`
     - menu:
       - text: ${translations.starred.title}
-      - menuitem "example-website COMPONENT":
-        - paragraph: example-website
-        - paragraph: COMPONENT
+      - listitem:
+        - menuitem "example-website COMPONENT":
+          - paragraph: example-website
+          - paragraph: COMPONENT
+        - button "${translations.starred.removeTooltip}"
     `);
   await page.keyboard.press('Escape');
 });

--- a/workspaces/global-header/e2e-tests/globalHeader.test.ts
+++ b/workspaces/global-header/e2e-tests/globalHeader.test.ts
@@ -146,21 +146,46 @@ test('Verify Search functionality and results', async () => {
   const { search } = getHeaderElements();
   const searchQuery = 'example-website';
   const expectedUrl = /\/example-website/;
+  const resultLocation = `/catalog/default/component/${searchQuery}`;
 
-  const resultOption = page
-    .getByRole('listbox')
-    .getByRole('option', { name: searchQuery });
+  // Stub search so this header UI test is not coupled to collator indexing.
+  await page.route('**/api/search/query**', async route => {
+    const term = new URL(route.request().url()).searchParams.get('term') ?? '';
+    if (!term.includes(searchQuery)) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      json: {
+        results: [
+          {
+            type: 'software-catalog',
+            document: {
+              title: searchQuery,
+              text: searchQuery,
+              location: resultLocation,
+            },
+          },
+        ],
+      },
+    });
+  });
 
-  // Retry search until indexed results appear (search index may not be ready immediately)
-  await expect(async () => {
-    await search.clear();
+  try {
     await search.fill(searchQuery);
-    await expect(resultOption).toBeVisible();
-  }).toPass({ timeout: 30000, intervals: [2000] });
 
-  await resultOption.click();
-  await expect(page).toHaveURL(expectedUrl);
-  await expect(page.locator('h1')).toContainText(searchQuery);
+    const resultOption = page
+      .getByRole('listbox')
+      .getByRole('option', { name: searchQuery });
+
+    await expect(resultOption).toBeVisible();
+    await resultOption.click();
+    await expect(page).toHaveURL(expectedUrl);
+    await expect(page.locator('h1')).toContainText(searchQuery);
+  } finally {
+    await page.unroute('**/api/search/query**');
+  }
 });
 
 test('Verify Self-service functionality', async () => {

--- a/workspaces/global-header/e2e-tests/utils/accessibility.ts
+++ b/workspaces/global-header/e2e-tests/utils/accessibility.ts
@@ -21,11 +21,20 @@ export async function runAccessibilityTests(
   page: Page,
   testInfo: TestInfo,
   attachName = 'accessibility-scan-results.json',
+  includeSelector?: string,
 ) {
-  const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-    .disableRules(['nested-interactive'])
-    .analyze();
+  let builder = new AxeBuilder({ page }).withTags([
+    'wcag2a',
+    'wcag2aa',
+    'wcag21a',
+    'wcag21aa',
+  ]);
+
+  if (includeSelector) {
+    builder = builder.include(includeSelector);
+  }
+
+  const accessibilityScanResults = await builder.analyze();
 
   await testInfo.attach(attachName, {
     body: JSON.stringify(accessibilityScanResults, null, 2),

--- a/workspaces/global-header/e2e-tests/utils/globalHeaderHelper.ts
+++ b/workspaces/global-header/e2e-tests/utils/globalHeaderHelper.ts
@@ -50,6 +50,6 @@ export async function switchToLocale(
     await page.getByRole('menuitem', { name: 'Settings' }).click();
     await page.getByRole('button', { name: 'English' }).click();
     await page.getByRole('option', { name: displayName }).click();
-    await page.locator('a').filter({ hasText: 'Home' }).click();
+    await page.goto('/');
   }
 }

--- a/workspaces/global-header/plugins/global-header/src/components/CompanyLogo/DefaultLogo.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/CompanyLogo/DefaultLogo.tsx
@@ -29,6 +29,7 @@ const RedHatDeveloperHubSVG = ({
     viewBox="0 0 931.8 244"
     height={40}
     width={150}
+    aria-hidden="true"
   >
     <path
       fill="#e00"

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/HeaderDropdownComponent.tsx
@@ -95,7 +95,7 @@ export const HeaderDropdownComponent: FC<HeaderDropdownProps> = ({
     },
     'aria-haspopup': true,
     'aria-controls': menuId,
-    'aria-expanded': anchorEl ? true : undefined,
+    'aria-expanded': Boolean(anchorEl),
     'aria-label': tooltip,
   };
 

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
@@ -86,7 +86,7 @@ const StarredItem: FC<SectionComponentProps> = ({
         </Tooltip>
       }
       sx={{
-        '&:hover .star-icon, &:focus-within .star-icon': {
+        '&:hover .star-icon, &:has(:focus-visible) .star-icon': {
           visibility: 'visible',
         },
       }}
@@ -98,7 +98,7 @@ const StarredItem: FC<SectionComponentProps> = ({
         disableRipple
         disableTouchRipple
         role="menuitem"
-        sx={{ py: 0.5 }}
+        sx={{ py: 0.5, pr: 6 }}
       >
         {Icon && (
           <ListItemIcon sx={{ minWidth: 36 }}>

--- a/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/HeaderDropdownComponent/StarredDropdown.tsx
@@ -28,11 +28,12 @@ import {
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import Star from '@mui/icons-material/Star';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 
 import { useTheme } from '@mui/material/styles';
-import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
@@ -67,50 +68,54 @@ const StarredItem: FC<SectionComponentProps> = ({
   const rhdhPalette = (theme.palette as any).rhdh;
 
   return (
-    <MenuItem
-      component={Link}
-      to={`/catalog/${namespace || 'default'}/${kind}/${name}`}
-      onClick={handleClose}
-      disableRipple
-      disableTouchRipple
+    <ListItem
+      disablePadding
+      secondaryAction={
+        <Tooltip title={t('starred.removeTooltip')}>
+          <IconButton
+            className="star-icon"
+            onClick={() => toggleStarredEntity(entityRef)}
+            aria-label={t('starred.removeTooltip')}
+            sx={{
+              visibility: 'hidden',
+              color: rhdhPalette?.general?.starredItemsColor ?? '#F3BA37',
+            }}
+          >
+            <AppIcon id="star" Fallback={Star} />
+          </IconButton>
+        </Tooltip>
+      }
       sx={{
-        '&:hover .star-icon, &:focus-visible .star-icon': {
+        '&:hover .star-icon, &:focus-within .star-icon': {
           visibility: 'visible',
         },
       }}
     >
-      {Icon && (
-        <ListItemIcon sx={{ minWidth: 36 }}>
-          <Icon />
-        </ListItemIcon>
-      )}
-      <ListItemText
-        primary={
-          <Typography sx={{ color: theme.palette.text.primary }}>
-            {primaryTitle || secondaryTitle}
-          </Typography>
-        }
-        secondary={kind.toLocaleUpperCase()}
-        // inset={!Icon}
-        sx={{ ml: 1, mr: 1 }}
-      />
-      <Tooltip title={t('starred.removeTooltip')}>
-        <IconButton
-          className="star-icon"
-          onClick={e => {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleStarredEntity(entityRef);
-          }}
-          sx={{
-            visibility: 'hidden',
-            color: rhdhPalette?.general?.starredItemsColor ?? '#F3BA37',
-          }}
-        >
-          <AppIcon id="star" Fallback={Star} />
-        </IconButton>
-      </Tooltip>
-    </MenuItem>
+      <ListItemButton
+        component={Link}
+        to={`/catalog/${namespace || 'default'}/${kind}/${name}`}
+        onClick={handleClose}
+        disableRipple
+        disableTouchRipple
+        role="menuitem"
+        sx={{ py: 0.5 }}
+      >
+        {Icon && (
+          <ListItemIcon sx={{ minWidth: 36 }}>
+            <Icon />
+          </ListItemIcon>
+        )}
+        <ListItemText
+          primary={
+            <Typography sx={{ color: theme.palette.text.primary }}>
+              {primaryTitle || secondaryTitle}
+            </Typography>
+          }
+          secondary={kind.toLocaleUpperCase()}
+          sx={{ ml: 1, mr: 1 }}
+        />
+      </ListItemButton>
+    </ListItem>
   );
 };
 

--- a/workspaces/global-header/plugins/global-header/src/components/ProfileDropdown.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/ProfileDropdown.tsx
@@ -118,13 +118,17 @@ const ProfileButtonContent = () => {
  *
  * @internal
  */
-export const ProfileDropdown = () => (
-  <GlobalHeaderDropdown
-    target="profile"
-    buttonContent={<ProfileButtonContent />}
-    buttonProps={{
-      color: 'inherit',
-      sx: { display: 'flex', alignItems: 'center' },
-    }}
-  />
-);
+export const ProfileDropdown = () => {
+  const { t } = useTranslation();
+  return (
+    <GlobalHeaderDropdown
+      target="profile"
+      buttonContent={<ProfileButtonContent />}
+      tooltip={t('profile.settings')}
+      buttonProps={{
+        color: 'inherit',
+        sx: { display: 'flex', alignItems: 'center' },
+      }}
+    />
+  );
+};

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchBar.tsx
@@ -132,6 +132,7 @@ export const SearchBar = (props: SearchBarProps) => {
                 results={results}
                 renderProps={renderProps}
                 searchLink={searchLink}
+                noResultsText={t('search.noResults')}
               />
             )}
             ListboxProps={{

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchOption.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchOption.tsx
@@ -33,6 +33,7 @@ interface SearchOptionProps {
   results: Result<SearchDocument>[];
   renderProps: any;
   searchLink: string;
+  noResultsText?: string;
 }
 
 export const SearchOption = ({
@@ -43,6 +44,7 @@ export const SearchOption = ({
   results,
   renderProps,
   searchLink,
+  noResultsText,
 }: SearchOptionProps) => {
   const { t } = useTranslation();
 
@@ -50,20 +52,21 @@ export const SearchOption = ({
     return (
       <Box key="all-results" id="all-results">
         <Divider sx={{ my: 0.5 }} />
-        <Link to={searchLink} underline="none">
-          <ListItem
-            {...renderProps}
-            sx={{ my: 0 }}
-            className="allResultsOption"
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <Typography sx={{ flexGrow: 1 }}>
-                {t('search.allResults')}
-              </Typography>
-              <ArrowForwardIcon fontSize="small" />
-            </Box>
-          </ListItem>
-        </Link>
+        <ListItem
+          {...renderProps}
+          component={Link}
+          to={searchLink}
+          underline="none"
+          sx={{ my: 0 }}
+          className="allResultsOption"
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography sx={{ flexGrow: 1 }}>
+              {t('search.allResults')}
+            </Typography>
+            <ArrowForwardIcon fontSize="small" />
+          </Box>
+        </ListItem>
       </Box>
     );
   }
@@ -76,6 +79,7 @@ export const SearchOption = ({
       query={query}
       result={result}
       renderProps={renderProps}
+      noResultsText={noResultsText}
     />
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { Link } from '@backstage/core-components';
 import ListItem from '@mui/material/ListItem';
 import Box from '@mui/material/Box';
@@ -28,6 +29,7 @@ interface SearchResultItemProps {
   query: SearchResultProps['query'];
   result: Result<SearchDocument> | undefined;
   renderProps: any;
+  noResultsText?: string;
 }
 
 export const SearchResultItem = ({
@@ -35,25 +37,32 @@ export const SearchResultItem = ({
   query,
   result,
   renderProps,
+  noResultsText,
 }: SearchResultItemProps) => {
-  const isNoResultsFound = option === 'No results found';
+  const isNoResultsFound = option === (noResultsText ?? 'No results found');
   const analytics = useAnalytics();
 
   return (
     <Box
-      component={isNoResultsFound ? 'div' : Link}
-      to={result?.document.location}
-      underline="none"
       sx={{ width: '100%', ...(isNoResultsFound ? {} : { cursor: 'pointer' }) }}
     >
       <ListItem
         {...renderProps}
+        {...(isNoResultsFound
+          ? {}
+          : {
+              component: Link,
+              to: result?.document.location,
+              underline: 'none',
+            })}
         sx={{ py: 1 }}
-        onClick={e => {
-          analytics.captureEvent('discover', result?.document.title ?? '', {
-            attributes: { to: result?.document.location ?? '#' },
-            value: result?.rank,
-          });
+        onClick={(e: React.MouseEvent) => {
+          if (!isNoResultsFound) {
+            analytics.captureEvent('discover', result?.document.title ?? '', {
+              attributes: { to: result?.document.location ?? '#' },
+              value: result?.rank,
+            });
+          }
           renderProps?.onClick?.(e);
         }}
       >

--- a/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/SearchComponent/SearchResultItem.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import { MouseEvent } from 'react';
 import { Link } from '@backstage/core-components';
 import ListItem from '@mui/material/ListItem';
 import Box from '@mui/material/Box';
@@ -56,7 +56,7 @@ export const SearchResultItem = ({
               underline: 'none',
             })}
         sx={{ py: 1 }}
-        onClick={(e: React.MouseEvent) => {
+        onClick={(e: MouseEvent) => {
           if (!isNoResultsFound) {
             analytics.captureEvent('discover', result?.document.title ?? '', {
               attributes: { to: result?.document.location ?? '#' },


### PR DESCRIPTION
## Description

Fixes accessibility violations in the Global Header plugin, primarily the `nested-interactive` axe-core rule violation (WCAG 2.1 AA). Search result items and starred dropdown items had interactive elements (links) nested inside other interactive elements (buttons/links). Additionally fixes missing accessible names, improper `aria-expanded` values, and a decorative SVG missing `aria-hidden`.

**Changes:**
- **SearchResultItem/SearchOption**: Merged `Link` wrapper into `ListItem` via `component={Link}` prop to eliminate nested interactive controls in search results
- **StarredDropdown**: Replaced `MenuItem component={Link}` containing `IconButton` with `ListItem` + `secondaryAction` + `ListItemButton component={Link}` pattern to separate navigation from star/unstar action
- **HeaderDropdownComponent**: Fixed `aria-expanded` to use `Boolean(anchorEl)` instead of `true | undefined`
- **DefaultLogo**: Added `aria-hidden="true"` to decorative SVG (parent link already has `aria-label="Home"`)
- **ProfileDropdown**: Added accessible `tooltip` prop to `GlobalHeaderDropdown` for the Settings button
- **SearchBar**: Pass i18n-safe `noResultsText` prop to avoid hardcoded string comparison
- **E2e tests**: Re-enabled `nested-interactive` rule in axe scans (scoped to `#global-header`), updated aria snapshots and selectors to match new DOM structure

## Fixed
- [RHDHBUGS-2247](https://redhat.atlassian.net/browse/RHDHBUGS-2247) — Accessibility Violation in Global Header – Nested Interactive Controls

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.