### PR TITLE
fix(orchestrator): preserve All Runs table column order after sorting

### DIFF
--- a/workspaces/orchestrator/.changeset/fix-allruns-column-order-reset.md
+++ b/workspaces/orchestrator/.changeset/fix-allruns-column-order-reset.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator': patch
+---
+
+Fix All Runs table column order resetting to default after sorting. Dragged column positions are now preserved across sort and data refetch operations.

--- a/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator/src/components/OrchestratorPage/WorkflowRunsTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import {
@@ -492,6 +492,15 @@ export const WorkflowRunsTabContent = ({
     [runItems, orderDirection],
   );
 
+  const applyBackendSortRef = useRef(applyBackendSort);
+  applyBackendSortRef.current = applyBackendSort;
+
+  const stableApplyBackendSort = useCallback(
+    (item1: WorkflowRunDetail, item2: WorkflowRunDetail): number =>
+      applyBackendSortRef.current(item1, item2),
+    [],
+  );
+
   const columns = useMemo(
     (): TableColumn<WorkflowRunDetail>[] => [
       {
@@ -523,7 +532,7 @@ export const WorkflowRunsTabContent = ({
             {
               title: t('table.headers.workflowName'),
               field: 'processName',
-              customSort: applyBackendSort,
+              customSort: stableApplyBackendSort,
               render: (data: WorkflowRunDetail) => (
                 <Link to={workflowPageLink({ workflowId: data.workflowId })}>
                   {data.processName}
@@ -575,7 +584,7 @@ export const WorkflowRunsTabContent = ({
       {
         title: t('table.headers.started'),
         field: 'start',
-        customSort: applyBackendSort,
+        customSort: stableApplyBackendSort,
         render: (data: WorkflowRunDetail) =>
           formatStartedRelative(data.startIso),
       },
@@ -596,7 +605,7 @@ export const WorkflowRunsTabContent = ({
       workflowInstanceLink,
       workflowId,
       workflowPageLink,
-      applyBackendSort,
+      stableApplyBackendSort,
       entityInstanceLink,
       name,
       kind,
@@ -605,6 +614,32 @@ export const WorkflowRunsTabContent = ({
       logsEnabled,
       handleViewLogs,
     ],
+  );
+
+  const [columnOrder, setColumnOrder] = useState<number[] | null>(null);
+
+  useEffect(() => {
+    setColumnOrder(null);
+  }, [columns.length]);
+
+  const orderedColumns = useMemo(() => {
+    if (!columnOrder || columnOrder.length !== columns.length) return columns;
+    return columnOrder.map(i => columns[i]);
+  }, [columns, columnOrder]);
+
+  const handleColumnDragged = useCallback(
+    (sourceIndex: number, destinationIndex: number) => {
+      setColumnOrder(prev => {
+        const order =
+          prev && prev.length === columns.length
+            ? [...prev]
+            : columns.map((_, i) => i);
+        const [moved] = order.splice(sourceIndex, 1);
+        order.splice(destinationIndex, 0, moved);
+        return order;
+      });
+    },
+    [columns],
   );
 
   const actions = useMemo((): TableProps<WorkflowRunDetail>['actions'] => {
@@ -807,18 +842,19 @@ export const WorkflowRunsTabContent = ({
               <OverrideBackstageTable
                 removeOutline
                 isLoading={loading}
-                columns={columns}
+                columns={orderedColumns}
                 data={filteredData}
                 actions={actions}
                 options={{
                   paging: false,
-                  actionsColumnIndex: columns.length,
+                  actionsColumnIndex: orderedColumns.length,
                 }}
+                onColumnDragged={handleColumnDragged}
                 onOrderChange={(
                   orderBy_: number,
                   orderDirection_: 'asc' | 'desc',
                 ) => {
-                  const field = columns[orderBy_].field;
+                  const field = orderedColumns[orderBy_].field;
                   if (!field) {
                     throw new Error(`Failed to find column number ${orderBy_}`);
                   }


### PR DESCRIPTION
#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3600

## Summary

- Fixes the All Runs page table where dragging columns to reorder them would revert to the original sequence after clicking a column header to sort.

## Root Cause

Two layers caused the column order reset:

1. **Unstable `columns` memo**: The `columns` useMemo depended on `applyBackendSort`, which was recreated on every sort/data change (it closes over `orderDirection` and `runItems`). Each recreation produced a new columns array reference, causing material-table to reset its internal column order state.

2. **material-table loses column order on data changes**: Even with a stable `columns` reference, sorting triggers a backend data refetch producing a new `data` prop. material-table's `componentDidUpdate` detects this and calls `setColumns` to reconcile column state. It tries to preserve column order by matching columns via a top-level `id` property — but Backstage's `Table` component runs columns through `convertColumns()`, which creates new objects without `id`. The match always fails, so `columnOrder` resets to `[0, 1, 2, ...]`.

The Workflow List page is unaffected because it uses client-side sorting with no `onOrderChange`, no sorting state, and no data refetching on sort.

## Fix

- **Layer 1 — Stabilize the `columns` memo**: Wrapped `applyBackendSort` in a ref-based stable callback so the columns memo isn't recreated on sort/data changes.
- **Layer 2 — Manage column order in React state**: Track drag-and-drop order via `columnOrder` state and reorder the columns array before passing it to material-table. When material-table resets its internal `columnOrder` to `[0, 1, 2, ...]` after a data change, the columns are already in the user's desired visual order, making the reset a no-op.

### Video:


https://github.com/user-attachments/assets/7502902a-8602-4a9a-b9e4-7e52bd0c59e7



## Test plan

- [ ] Navigate to Orchestrator → All Runs tab
- [ ] Drag a column header to a different position
- [ ] Click a sortable column header (e.g., Started, Workflow Name) to sort
- [ ] Verify the dragged column order is preserved after sorting
- [ ] Verify sorting still works correctly with reordered columns
- [ ] Verify the Workflow List tab still works as before