### PR TITLE
feat(e2e): add backward step navigation e2e test in multi-step form for orchestrator

### DIFF
--- a/workspaces/orchestrator/e2e-tests/orchestrator.test.ts
+++ b/workspaces/orchestrator/e2e-tests/orchestrator.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { test, expect, Page, type BrowserContext } from '@playwright/test';
-import { Orchestrator } from './pages/orchestrator';
+import {
+  Orchestrator,
+  type NewComponentInputs,
+  type JavaMetadata,
+} from './pages/orchestrator';
 import { runAccessibilityTests } from './utils/accessibility';
 import { OrchestratorHelper } from './utils/helper';
 import { OrchestratorMessages, getTranslations } from './utils/translations';
@@ -247,6 +251,74 @@ test.describe('Orchestrator workflow runs', () => {
         .click();
       await orchestratorHelper.clickButton(translations.workflow.buttons.run);
       await orchestratorHelper.verifyBreadcrumbLink('Hello World Workflow');
+    });
+
+    test('Backward navigation in multi-step stepper', async () => {
+      const workflowName = 'Quarkus Backend application';
+      const newComponentInputs: NewComponentInputs = {
+        organizationName: 'test-name',
+        repositoryName: 'test-repo',
+        description: 'test-description',
+        owner: 'test-owner',
+        system: 'test-system',
+        port: '8000',
+      };
+      const javaMetadata: JavaMetadata = {
+        groupId: 'test-group',
+        artifactId: 'test-artifact',
+        javaPackageNamespace: 'test-package',
+        version: '1.0.0',
+      };
+
+      await orchestrator.searchWorkflow(workflowName);
+      await orchestrator.openWorkflowFromTable(workflowName);
+      await orchestrator.verifyWorkflowDetails();
+      await orchestrator.clickRunWorkflowFromDetails();
+      await orchestrator.fillNewComponentInputs(newComponentInputs);
+      await orchestratorHelper.clickButton(translations.common.next);
+      await expect(
+        sharedPage.getByRole('button', {
+          name: 'Step 1 Provide information about the new component',
+        }),
+      ).toBeEnabled();
+      await orchestrator.fillJavaMetadata(javaMetadata);
+      await sharedPage
+        .getByRole('button', {
+          name: 'Step 1 Provide information about the new component',
+        })
+        .click();
+      await orchestrator.verifyNewComponentInputs(newComponentInputs);
+      await expect(
+        sharedPage.getByRole('button', {
+          name: 'Step 2 Provide information about the Java metadata',
+        }),
+      ).not.toBeVisible();
+      await expect(
+        sharedPage.getByLabel(
+          'Step 2 Provide information about the Java metadata',
+        ),
+      ).toBeVisible();
+      await orchestratorHelper.clickButton(translations.common.next);
+      await expect(
+        sharedPage.getByLabel(
+          'Step 2 Provide information about the Java metadata',
+        ),
+      ).not.toHaveClass(/Mui-disabled/);
+      await orchestratorHelper.clickButton(translations.common.next);
+      await orchestratorHelper.clickButton(translations.common.back);
+      await orchestrator.verifyJavaMetadata(javaMetadata);
+      await orchestratorHelper.clickButton(translations.common.next);
+      await expect(
+        sharedPage.getByLabel(`Step 4 ${translations.common.review}`),
+      ).toHaveClass(/Mui-disabled/);
+      await orchestratorHelper.clickButton(translations.common.next);
+      await expect(
+        sharedPage.getByLabel(`Step 4 ${translations.common.review}`),
+      ).not.toHaveClass(/Mui-disabled/);
+      for (const input of Object.values(newComponentInputs) &&
+        Object.values(javaMetadata)) {
+        await expect(sharedPage.getByText(input)).toBeVisible();
+      }
     });
   });
 

--- a/workspaces/orchestrator/e2e-tests/orchestrator.test.ts
+++ b/workspaces/orchestrator/e2e-tests/orchestrator.test.ts
@@ -315,8 +315,11 @@ test.describe('Orchestrator workflow runs', () => {
       await expect(
         sharedPage.getByLabel(`Step 4 ${translations.common.review}`),
       ).not.toHaveClass(/Mui-disabled/);
-      for (const input of Object.values(newComponentInputs) &&
-        Object.values(javaMetadata)) {
+      const allInputs = [
+        ...Object.values(newComponentInputs),
+        ...Object.values(javaMetadata),
+      ];
+      for (const input of allInputs) {
         await expect(sharedPage.getByText(input)).toBeVisible();
       }
     });

--- a/workspaces/orchestrator/e2e-tests/pages/orchestrator.ts
+++ b/workspaces/orchestrator/e2e-tests/pages/orchestrator.ts
@@ -32,6 +32,22 @@ export type UiPropsWorkflowInputs = {
   objectExample: string;
 };
 
+export type NewComponentInputs = {
+  organizationName: string;
+  repositoryName: string;
+  description: string;
+  owner: string;
+  system: string;
+  port: string;
+};
+
+export type JavaMetadata = {
+  groupId: string;
+  artifactId: string;
+  javaPackageNamespace: string;
+  version: string;
+};
+
 type SampleRetryHits = {
   allProps: number;
   statusCodesNoMatch: number;
@@ -124,6 +140,74 @@ export class Orchestrator {
       .getByRole('textbox', { name: 'Object Type Example' })
       .fill(inputs.objectExample);
     await this.orchestratorHelper.clickButton(this.translations.common.next);
+  }
+
+  async fillNewComponentInputs(inputs: NewComponentInputs) {
+    await this.page
+      .getByRole('textbox', { name: 'Organization Name' })
+      .fill(inputs.organizationName);
+    await this.page
+      .getByRole('textbox', { name: 'Repository Name' })
+      .fill(inputs.repositoryName);
+    await this.page
+      .getByRole('textbox', { name: 'Description' })
+      .fill(inputs.description);
+    await this.page.getByRole('textbox', { name: 'Owner' }).fill(inputs.owner);
+    await this.page
+      .getByRole('textbox', { name: 'System' })
+      .fill(inputs.system);
+    await this.page.getByRole('spinbutton', { name: 'Port' }).fill(inputs.port);
+  }
+
+  async fillJavaMetadata(inputs: JavaMetadata) {
+    await this.page
+      .getByRole('textbox', { name: 'Group ID' })
+      .fill(inputs.groupId);
+    await this.page
+      .getByRole('textbox', { name: 'Artifact ID' })
+      .fill(inputs.artifactId);
+    await this.page
+      .getByRole('textbox', { name: 'Java Package Namespace' })
+      .fill(inputs.javaPackageNamespace);
+    await this.page
+      .getByRole('textbox', { name: 'Version' })
+      .fill(inputs.version);
+  }
+
+  async verifyNewComponentInputs(inputs: NewComponentInputs) {
+    await expect(
+      this.page.getByRole('textbox', { name: 'Organization Name' }),
+    ).toHaveValue(inputs.organizationName);
+    await expect(
+      this.page.getByRole('textbox', { name: 'Repository Name' }),
+    ).toHaveValue(inputs.repositoryName);
+    await expect(
+      this.page.getByRole('textbox', { name: 'Description' }),
+    ).toHaveValue(inputs.description);
+    await expect(this.page.getByRole('textbox', { name: 'Owner' })).toHaveValue(
+      inputs.owner,
+    );
+    await expect(
+      this.page.getByRole('textbox', { name: 'System' }),
+    ).toHaveValue(inputs.system);
+    await expect(
+      this.page.getByRole('spinbutton', { name: 'Port' }),
+    ).toHaveValue(inputs.port);
+  }
+
+  async verifyJavaMetadata(inputs: JavaMetadata) {
+    await expect(
+      this.page.getByRole('textbox', { name: 'Group ID' }),
+    ).toHaveValue(inputs.groupId);
+    await expect(
+      this.page.getByRole('textbox', { name: 'Artifact ID' }),
+    ).toHaveValue(inputs.artifactId);
+    await expect(
+      this.page.getByRole('textbox', { name: 'Java Package Namespace' }),
+    ).toHaveValue(inputs.javaPackageNamespace);
+    await expect(
+      this.page.getByRole('textbox', { name: 'Version' }),
+    ).toHaveValue(inputs.version);
   }
 
   async submitWorkflowRunFromReview() {
@@ -403,7 +487,9 @@ export class Orchestrator {
       }),
     ).toBeVisible();
     await expect(this.page.locator('pre').first()).toBeVisible();
-    await expect(this.page.getByRole('button', { name: 'Copy' })).toBeVisible();
+    await expect(
+      this.page.getByRole('button', { name: 'Copy' }).first(),
+    ).toBeVisible();
   }
 
   async verifyWorkflowRunsTabHeading(runsCount?: number) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
https://redhat.atlassian.net/browse/RHIDP-15559 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
<img width="1271" height="630" alt="Screenshot 2026-08-18 at 5 24 34 PM" src="https://github.com/user-attachments/assets/15f1ef3e-8696-4a29-b28c-c4c000720bda" />
