### PR TITLE
RHINENG-29740: Replace quarantined es5-ext with @unes/es5-ext

### DIFF
--- a/workspaces/cost-management/package.json
+++ b/workspaces/cost-management/package.json
@@ -88,7 +88,8 @@
     "prismjs": "1.30.0",
     "@backstage-community/plugin-rbac-backend/@backstage/plugin-permission-backend": "0.6.0",
     "fast-xml-parser": "5.10.1",
-    "casbin/minimatch": "7.4.9"
+    "casbin/minimatch": "7.4.9",
+    "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/cost-management/yarn.lock
+++ b/workspaces/cost-management/yarn.lock
@@ -20225,15 +20225,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.46, es5-ext@npm:^0.10.53, es5-ext@npm:^0.10.62, es5-ext@npm:^0.10.64, es5-ext@npm:~0.10.14, es5-ext@npm:~0.10.2, es5-ext@npm:~0.10.46":
-  version: 0.10.64
-  resolution: "es5-ext@npm:0.10.64"
+"es5-ext@npm:@unes/es5-ext@0.10.64-1":
+  version: 0.10.64-1
+  resolution: "@unes/es5-ext@npm:0.10.64-1"
   dependencies:
     es6-iterator: "npm:^2.0.3"
     es6-symbol: "npm:^3.1.3"
     esniff: "npm:^2.0.1"
     next-tick: "npm:^1.1.0"
-  checksum: 10c0/4459b6ae216f3c615db086e02437bdfde851515a101577fd61b19f9b3c1ad924bab4d197981eb7f0ccb915f643f2fc10ff76b97a680e96cbb572d15a27acd9a3
+  checksum: 10c0/14127a539c0b7a73fdde8d9e54fe52e862e344207b5103b7d8fec79bd24fe5f1c8d06210532ae414de658424436fea561f381ef19a5cf719f48a28ce99294527
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Konflux hermetic prefetch fails with 403 because Sonatype Firewall quarantines es5-ext@0.10.64. Alias it to the cleaned fork via Yarn resolutions so midstream builds can fetch dependencies.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
