### PR TITLE
fix(theme): keep Inspect Entity dialog below the global header

### DIFF
--- a/workspaces/global-header/.changeset/quiet-harbor-nudge.md
+++ b/workspaces/global-header/.changeset/quiet-harbor-nudge.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-global-header': patch
+---
+
+Offset Backstage UI dialogs such as Inspect Entity below the sticky global header so their title and close control stay visible.

--- a/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.test.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.test.tsx
@@ -64,4 +64,16 @@ describe('GlobalHeader', () => {
 
     expect(document.getElementById('global-header')).toBeInTheDocument();
   });
+
+  it('injects BUI dialog overlay offset styles', () => {
+    render(
+      <GlobalHeaderProvider components={[]} menuItems={[]}>
+        <GlobalHeader />
+      </GlobalHeaderProvider>,
+    );
+
+    expect(
+      document.querySelector('style[data-rhdh-global-header-dialog-offset]'),
+    ).toBeInTheDocument();
+  });
 });

--- a/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.tsx
+++ b/workspaces/global-header/plugins/global-header/src/components/GlobalHeader.tsx
@@ -21,6 +21,7 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 
 import { useGlobalHeaderComponents } from '../extensions/GlobalHeaderContext';
+import { GLOBAL_HEADER_DIALOG_OFFSET_CSS } from './globalHeaderDialogOffset';
 
 /**
  * Global header bar. Reads toolbar items from GlobalHeaderContext
@@ -32,32 +33,37 @@ export const GlobalHeader = () => {
   const components = useGlobalHeaderComponents();
 
   return (
-    <AppBar
-      position="sticky"
-      component="nav"
-      id="global-header"
-      sx={{
-        width: 'auto',
-        marginRight: 'var(--docked-drawer-width, 0px)',
-        transition: 'margin-right 225ms cubic-bezier(0, 0, 0.2, 1)',
-      }}
-    >
-      <Toolbar
+    <>
+      <style data-rhdh-global-header-dialog-offset="">
+        {GLOBAL_HEADER_DIALOG_OFFSET_CSS}
+      </style>
+      <AppBar
+        position="sticky"
+        component="nav"
+        id="global-header"
         sx={{
-          gap: 1,
-          color: theme =>
-            (theme as any).rhdh?.general?.appBarForegroundColor ??
-            theme.palette.text.primary,
+          width: 'auto',
+          marginRight: 'var(--docked-drawer-width, 0px)',
+          transition: 'margin-right 225ms cubic-bezier(0, 0, 0.2, 1)',
         }}
       >
-        {components.map((item, index) => (
-          <ErrorBoundary key={`gh-component-${index}`}>
-            <Box sx={item.layout}>
-              <item.component />
-            </Box>
-          </ErrorBoundary>
-        ))}
-      </Toolbar>
-    </AppBar>
+        <Toolbar
+          sx={{
+            gap: 1,
+            color: theme =>
+              (theme as any).rhdh?.general?.appBarForegroundColor ??
+              theme.palette.text.primary,
+          }}
+        >
+          {components.map((item, index) => (
+            <ErrorBoundary key={`gh-component-${index}`}>
+              <Box sx={item.layout}>
+                <item.component />
+              </Box>
+            </ErrorBoundary>
+          ))}
+        </Toolbar>
+      </AppBar>
+    </>
   );
 };

--- a/workspaces/global-header/plugins/global-header/src/components/globalHeaderDialogOffset.test.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/globalHeaderDialogOffset.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GLOBAL_HEADER_DIALOG_OFFSET_CSS } from './globalHeaderDialogOffset';
+
+describe('GLOBAL_HEADER_DIALOG_OFFSET_CSS', () => {
+  it('offsets BUI dialog overlays below the masthead', () => {
+    expect(GLOBAL_HEADER_DIALOG_OFFSET_CSS).toContain('bui-DialogOverlay');
+    expect(GLOBAL_HEADER_DIALOG_OFFSET_CSS).toContain(
+      '--rhdh-global-header-height',
+    );
+    expect(GLOBAL_HEADER_DIALOG_OFFSET_CSS).toContain('z-index: 1300');
+  });
+});

--- a/workspaces/global-header/plugins/global-header/src/components/globalHeaderDialogOffset.ts
+++ b/workspaces/global-header/plugins/global-header/src/components/globalHeaderDialogOffset.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Sticky AppBar is z-index 1100. BUI Dialog overlay is 1000 and
+ * InspectEntityDialog uses height 100vh, so the masthead covers the
+ * title and close control (RHDHBUGS-3603).
+ *
+ * 64px fallback matches the MUI Toolbar default when
+ * --rhdh-global-header-height is unset.
+ *
+ * A raw style tag is used instead of MUI GlobalStyles so NFS demo apps
+ * and dynamic-plugin bundles pick this up without depending on a shared
+ * MUI GlobalStyles export.
+ */
+export const GLOBAL_HEADER_DIALOG_OFFSET_CSS = `
+[class*="bui-DialogOverlay"] {
+  top: var(--rhdh-global-header-height, 64px) !important;
+  height: calc(100% - var(--rhdh-global-header-height, 64px)) !important;
+  z-index: 1300;
+}
+[class*="bui-DialogOverlay"] > [class*="bui-Dialog"] {
+  height: calc(100vh - var(--rhdh-global-header-height, 64px) - 3rem) !important;
+  max-height: calc(100vh - var(--rhdh-global-header-height, 64px) - 3rem) !important;
+}
+`;

--- a/workspaces/global-header/plugins/global-header/src/legacy/components/GlobalHeaderComponent.tsx
+++ b/workspaces/global-header/plugins/global-header/src/legacy/components/GlobalHeaderComponent.tsx
@@ -21,6 +21,7 @@ import { ErrorBoundary } from '@backstage/core-components';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 
+import { GLOBAL_HEADER_DIALOG_OFFSET_CSS } from '../../components/globalHeaderDialogOffset';
 import { GlobalHeaderComponentMountPoint } from '../types';
 
 /**
@@ -47,24 +48,29 @@ export const GlobalHeaderComponent = ({
   }, [globalHeaderMountPoints]);
 
   return (
-    <AppBar position="sticky" component="nav" id="global-header">
-      <Toolbar
-        sx={{
-          gap: 1,
-          color: theme =>
-            (theme as any).rhdh?.general.appBarForegroundColor ??
-            theme.palette.text.primary,
-        }}
-      >
-        {mountPoints.map((mountPoint, index) => (
-          <ErrorBoundary key={`header-component-${index}`}>
-            <mountPoint.Component
-              {...mountPoint.config?.props}
-              layout={mountPoint.config?.layout}
-            />
-          </ErrorBoundary>
-        ))}
-      </Toolbar>
-    </AppBar>
+    <>
+      <style data-rhdh-global-header-dialog-offset="">
+        {GLOBAL_HEADER_DIALOG_OFFSET_CSS}
+      </style>
+      <AppBar position="sticky" component="nav" id="global-header">
+        <Toolbar
+          sx={{
+            gap: 1,
+            color: theme =>
+              (theme as any).rhdh?.general.appBarForegroundColor ??
+              theme.palette.text.primary,
+          }}
+        >
+          {mountPoints.map((mountPoint, index) => (
+            <ErrorBoundary key={`header-component-${index}`}>
+              <mountPoint.Component
+                {...mountPoint.config?.props}
+                layout={mountPoint.config?.layout}
+              />
+            </ErrorBoundary>
+          ))}
+        </Toolbar>
+      </AppBar>
+    </>
   );
 };

--- a/workspaces/theme/.changeset/quiet-harbor-nudge.md
+++ b/workspaces/theme/.changeset/quiet-harbor-nudge.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Offset Backstage UI dialogs such as Inspect Entity below the global header so their title and close control stay visible.

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -117,6 +117,14 @@ describe('createComponents', () => {
     );
   });
 
+  it('offsets BUI dialogs below the masthead so Inspect Entity stays visible', () => {
+    const actual = createComponents({});
+    const overrides = actual.MuiCssBaseline?.styleOverrides;
+    expect(typeof overrides).toBe('function');
+    expect(String(overrides)).toContain('bui-DialogOverlay');
+    expect(String(overrides)).toContain('--rhdh-global-header-height');
+  });
+
   it('paints BUI content Containers with mainSectionBackgroundColor', () => {
     const actual = createComponents({ palette: customDarkTheme() });
     const root = actual.BackstageSidebarPage?.styleOverrides?.root as

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -135,6 +135,14 @@ describe('createComponents', () => {
     );
   });
 
+  it('offsets BUI dialogs below the masthead so Inspect Entity stays visible', () => {
+    const actual = createComponents({});
+    const overrides = actual.MuiCssBaseline?.styleOverrides;
+    expect(typeof overrides).toBe('function');
+    expect(String(overrides)).toContain('bui-DialogOverlay');
+    expect(String(overrides)).toContain('--rhdh-global-header-height');
+  });
+
   it('paints BUI content Containers with mainSectionBackgroundColor', () => {
     const actual = createComponents({ palette: customDarkTheme() });
     const root = actual.BackstageSidebarPage?.styleOverrides?.root as

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -87,14 +87,14 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
         ...backstageStyles,
         '@font-face': redHatFontFaces,
         ':root:has(#global-header) [class*="bui-DialogOverlay"]': {
-          top: dialogMastheadOffset,
-          height: `calc(100% - ${dialogMastheadOffset})`,
+          top: `${dialogMastheadOffset} !important`,
+          height: `calc(100% - ${dialogMastheadOffset}) !important`,
           zIndex: 1300,
         },
         ':root:has(#global-header) [class*="bui-DialogOverlay"] > [class*="bui-Dialog"]':
           {
             height: `calc(100vh - ${dialogMastheadOffset} - 3rem) !important`,
-            maxHeight: `calc(100vh - ${dialogMastheadOffset} - 3rem)`,
+            maxHeight: `calc(100vh - ${dialogMastheadOffset} - 3rem) !important`,
           },
         body: {
           ...(backstageStyles.body as CSSObject),

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -77,9 +77,25 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
           ? (backstageOverrides(theme) as CSSObject)
           : (backstageOverrides as CSSObject);
 
+      // Sticky AppBar is z-index 1100. BUI Dialog overlay is 1000 and
+      // InspectEntityDialog uses height 100vh, so the masthead covers the
+      // title and close control (RHDHBUGS-3603). 64px fallback matches the
+      // MUI Toolbar default when --rhdh-global-header-height is unset.
+      const dialogMastheadOffset = 'var(--rhdh-global-header-height, 64px)';
+
       return {
         ...backstageStyles,
         '@font-face': redHatFontFaces,
+        ':root:has(#global-header) [class*="bui-DialogOverlay"]': {
+          top: dialogMastheadOffset,
+          height: `calc(100% - ${dialogMastheadOffset})`,
+          zIndex: 1300,
+        },
+        ':root:has(#global-header) [class*="bui-DialogOverlay"] > [class*="bui-Dialog"]':
+          {
+            height: `calc(100vh - ${dialogMastheadOffset} - 3rem) !important`,
+            maxHeight: `calc(100vh - ${dialogMastheadOffset} - 3rem)`,
+          },
         body: {
           ...(backstageStyles.body as CSSObject),
           fontFamily: redHatFonts.text,


### PR DESCRIPTION
## Description
Catalog Inspect Entity is a Backstage UI dialog portaled to a fixed overlay (`z-index: 1000`, `height: 100vh`). The sticky global header AppBar sits at `z-index: 1100`, so it covers the dialog title and close control.

This change offsets BUI dialog overlays below the masthead when `#global-header` is present, using `--rhdh-global-header-height` with a 64px fallback so it does not depend on the RHDHBUGS-3627 page-shell layout fix.

## Root cause
RHDHBUGS-3627 is in-flow page shell / sidebar / HeaderTabs. RHDHBUGS-3603 is overlay stacking: `InspectEntityDialog` (`@backstage/plugin-catalog-react`) uses `@backstage/ui` `Dialog` with `height="100vh"`. The overlay is `position: fixed; top: 0; z-index: 1000`, under MUI AppBar 1100.

## Fixed
- [RHDHBUGS-3603](https://redhat.atlassian.net/browse/RHDHBUGS-3603) — Catalog entity inspector header is covered by the global header and not visible

## Test Plan
- [ ] Open Catalog, select an entity, click Inspect Entity
- [ ] Confirm the inspector title, tabs, and close button are fully visible below the global header
- [ ] Confirm the dialog overlay is not sitting under the masthead
- [ ] Repeat on RHDH (Light/Dark) and Backstage (Light/Dark) themes

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.

Before
<img width="3024" height="1648" alt="image" src="https://github.com/user-attachments/assets/3e13b484-9451-443a-96d7-72e1dda192fd" />

After
<img width="3024" height="1652" alt="image" src="https://github.com/user-attachments/assets/d4d00498-4f69-4620-8076-976116077ffd" />
