### PR TITLE
fix(install-dynamic-plugins): resolve ref:// before the pre-merge disabled pass

### DIFF
--- a/workspaces/install-dynamic-plugins/.changeset/fix-ref-pre-merge-disabled.md
+++ b/workspaces/install-dynamic-plugins/.changeset/fix-ref-pre-merge-disabled.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/cli-module-install-dynamic-plugins': patch
+---
+
+Fix `ref://` plugin references being ignored when the referenced plugin is disabled by default

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer.ts
@@ -45,13 +45,15 @@ import {
 } from './merger';
 import { computePluginHash } from './plugin-hash';
 import { Skopeo } from './skopeo';
-import { isLocalPath, isOciUrl } from './protocols';
+import { extractPluginName } from './plugin-name';
+import { isLocalPath, isOciUrl, isRefUrl, REF_PROTO } from './protocols';
 import {
   CONFIG_HASH_FILE,
   DPDY_FILENAME,
   type DynamicPluginsConfig,
   effectivePullPolicy,
   GLOBAL_CONFIG_FILENAME,
+  type IncludePluginList,
   isPluginDisabled,
   LOCK_FILENAME,
   type Plugin,
@@ -232,6 +234,57 @@ async function loadDynamicPluginsConfig(
   return content;
 }
 
+/**
+ * Resolve `ref://` entries in the main plugin list to their full package URLs
+ * by matching the ref name against entries in the include lists.
+ *
+ * This must run before the pre-merge pass so that resolved entries are visible
+ * as standard OCI URLs and level overrides apply correctly.
+ *
+ * Mutates `plugin.package` in place for each resolved entry:
+ *
+ * @example
+ * // ref://backstage-plugin-foo → oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc
+ */
+export function resolveRefPlugins(
+  mainPlugins: PluginSpec[],
+  includeLists: IncludePluginList[],
+): void {
+  const pluginsWithRef = mainPlugins.filter(p => isRefUrl(p.package));
+  if (pluginsWithRef.length === 0) return;
+
+  const nameToPackage = new Map<string, string>();
+
+  for (const [, plugins] of includeLists) {
+    for (const plugin of plugins) {
+      const name = extractPluginName(plugin.package);
+      if (name && !nameToPackage.has(name)) {
+        nameToPackage.set(name, plugin.package);
+      }
+    }
+  }
+
+  for (const plugin of pluginsWithRef) {
+    const refName = plugin.package.slice(REF_PROTO.length);
+
+    if (!refName) {
+      throw new InstallException(
+        'Invalid ref:// reference: empty plugin name in ref://',
+      );
+    }
+
+    const resolved = nameToPackage.get(refName);
+
+    if (!resolved) {
+      throw new InstallException(
+        `Cannot resolve ref:// reference: no plugin named '${refName}' found in included plugins`,
+      );
+    }
+
+    plugin.package = resolved;
+  }
+}
+
 /** Resolve include paths, substitute the catalog-index placeholder, merge
  * everything into a single `PluginMap`, and compute change-detection hashes.
  *
@@ -256,7 +309,7 @@ async function loadAllPlugins(
     catalogDpdy,
   );
 
-  const includeLists: Array<[string, PluginSpec[]]> = [];
+  const includeLists: IncludePluginList[] = [];
   for (const inc of includes) {
     if (!(await fileExists(inc))) {
       log(`WARNING: include file ${inc} not found, skipping`);
@@ -278,6 +331,8 @@ async function loadAllPlugins(
     includeLists.push([inc, plugins]);
   }
   const mainPlugins = content.plugins ?? [];
+
+  resolveRefPlugins(mainPlugins, includeLists);
 
   const disabledRegistries = preMergeOciDisabledState(
     includeLists,

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { InstallException } from './errors';
-import { deepMerge, mergePlugin, resolveRefPlugin } from './merger';
+import { deepMerge, mergePlugin } from './merger';
 import type { PluginMap } from './types';
 
 describe('deepMerge', () => {
@@ -136,82 +136,5 @@ describe('mergePlugin — NPM', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mergePlugin({ package: 123 as any }, all, 'cfg.yaml', 0),
     ).rejects.toThrow(/must be a string/);
-  });
-});
-
-describe('mergePlugin — ref://', () => {
-  it('resolves ref to an OCI plugin by name', async () => {
-    const all: PluginMap = {};
-    await mergePlugin(
-      {
-        package:
-          'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123!backstage-plugin-foo',
-      },
-      all,
-      'inc.yaml',
-      0,
-    );
-    await mergePlugin(
-      { package: 'ref://backstage-plugin-foo' },
-      all,
-      'cfg.yaml',
-      1,
-    );
-    const key = 'oci://quay.io/rhdh/backstage-plugin-foo:!backstage-plugin-foo';
-    expect(all[key]?.package).toBe(
-      'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123!backstage-plugin-foo',
-    );
-  });
-});
-
-describe('resolveRefPlugin', () => {
-  it('resolves ref to an OCI plugin', () => {
-    const all: PluginMap = {
-      key: {
-        package:
-          'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123!backstage-plugin-foo',
-      },
-    };
-    expect(resolveRefPlugin('ref://backstage-plugin-foo', all)).toBe(
-      'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123!backstage-plugin-foo',
-    );
-  });
-
-  it('resolves ref to an HTTP tarball plugin', () => {
-    const all: PluginMap = {
-      key: {
-        package: 'https://example.com/plugins/backstage-plugin-bar-1.2.3.tgz',
-      },
-    };
-    expect(resolveRefPlugin('ref://backstage-plugin-bar', all)).toBe(
-      'https://example.com/plugins/backstage-plugin-bar-1.2.3.tgz',
-    );
-  });
-
-  it('resolves ref to a local plugin', () => {
-    const all: PluginMap = {
-      key: { package: './dynamic-plugins/dist/backstage-plugin-baz' },
-    };
-    expect(resolveRefPlugin('ref://backstage-plugin-baz', all)).toBe(
-      './dynamic-plugins/dist/backstage-plugin-baz',
-    );
-  });
-
-  it('throws on unknown plugin name', () => {
-    const all: PluginMap = {
-      key: {
-        package:
-          'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123!backstage-plugin-foo',
-      },
-    };
-    expect(() => resolveRefPlugin('ref://unknown-plugin', all)).toThrow(
-      "Cannot resolve ref:// reference: no plugin named 'unknown-plugin' found in included plugins",
-    );
-  });
-
-  it('throws on empty ref', () => {
-    expect(() => resolveRefPlugin('ref://', {})).toThrow(
-      'Invalid ref:// reference: empty plugin name in ref://',
-    );
   });
 });

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.ts
@@ -24,10 +24,10 @@ import {
   type ParsedOciKey,
   tryParseOciRegistryAndPath,
 } from './oci-key';
-import { extractPluginName } from './plugin-name';
-import { isOciUrl, isRefUrl, OCI_PROTO, REF_PROTO } from './protocols';
+import { isOciUrl, OCI_PROTO } from './protocols';
 import {
   type DynamicPluginsConfig,
+  type IncludePluginList,
   isPluginDisabled,
   type Plugin,
   type PluginMap,
@@ -126,23 +126,6 @@ export async function mergePluginsFromFile(
   }
 }
 
-export function resolveRefPlugin(pkg: string, allPlugins: PluginMap): string {
-  const refName = pkg.slice(REF_PROTO.length);
-  if (!refName) {
-    throw new InstallException(
-      `Invalid ref:// reference: empty plugin name in ref://`,
-    );
-  }
-  for (const entry of Object.values(allPlugins)) {
-    if (extractPluginName(entry.package) === refName) {
-      return entry.package;
-    }
-  }
-  throw new InstallException(
-    `Cannot resolve ref:// reference: no plugin named '${refName}' found in included plugins`,
-  );
-}
-
 export async function mergePlugin(
   plugin: Plugin,
   allPlugins: PluginMap,
@@ -154,9 +137,6 @@ export async function mergePlugin(
     throw new InstallException(
       `content of the 'plugins.package' field must be a string in ${configFile}`,
     );
-  }
-  if (isRefUrl(plugin.package)) {
-    plugin.package = resolveRefPlugin(plugin.package, allPlugins);
   }
   if (isOciUrl(plugin.package)) {
     await mergeOciPlugin(plugin, allPlugins, configFile, level, imageCache);
@@ -351,11 +331,6 @@ function isObjectEqual(
   if (keysA.length !== Object.keys(b).length) return false;
   return keysA.every(k => isEqual(a[k], b[k]));
 }
-
-type IncludePluginList = readonly [
-  file: string,
-  plugins: readonly PluginSpec[],
-];
 
 type EntryState = { disabled: boolean; level: number };
 

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/resolve-ref-plugins.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/resolve-ref-plugins.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { resolveRefPlugins } from './installer';
+import type { IncludePluginList, PluginSpec } from './types';
+
+describe('resolveRefPlugins', () => {
+  it('resolves ref:// entries across include files and package types', () => {
+    const main: PluginSpec[] = [
+      { package: 'ref://backstage-plugin-foo', enabled: true },
+      { package: 'ref://backstage-plugin-bar' },
+      { package: 'ref://backstage-plugin-baz' },
+      { package: 'oci://quay.io/rhdh/already-resolved@sha256:fff' },
+    ];
+    const includes: IncludePluginList[] = [
+      [
+        'dpdy.yaml',
+        [
+          {
+            package: 'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123',
+            enabled: false,
+          },
+          { package: './dynamic-plugins/dist/backstage-plugin-bar' },
+        ],
+      ],
+      [
+        'extra.yaml',
+        [
+          {
+            package:
+              'https://example.com/plugins/backstage-plugin-baz-1.2.3.tgz',
+          },
+        ],
+      ],
+    ];
+
+    resolveRefPlugins(main, includes);
+
+    expect(main[0]!.package).toBe(
+      'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123',
+    );
+    expect(main[1]!.package).toBe(
+      './dynamic-plugins/dist/backstage-plugin-bar',
+    );
+    expect(main[2]!.package).toBe(
+      'https://example.com/plugins/backstage-plugin-baz-1.2.3.tgz',
+    );
+    expect(main[3]!.package).toBe(
+      'oci://quay.io/rhdh/already-resolved@sha256:fff',
+    );
+  });
+
+  it('throws on unknown plugin name', () => {
+    const main: PluginSpec[] = [{ package: 'ref://unknown-plugin' }];
+    const includes: IncludePluginList[] = [
+      [
+        'dpdy.yaml',
+        [
+          {
+            package: 'oci://quay.io/rhdh/backstage-plugin-foo@sha256:abc123',
+          },
+        ],
+      ],
+    ];
+    expect(() => resolveRefPlugins(main, includes)).toThrow(
+      "Cannot resolve ref:// reference: no plugin named 'unknown-plugin' found in included plugins",
+    );
+  });
+
+  it('throws on empty ref', () => {
+    const main: PluginSpec[] = [{ package: 'ref://' }];
+    const includes: IncludePluginList[] = [['dpdy.yaml', []]];
+    expect(() => resolveRefPlugins(main, includes)).toThrow(
+      'Invalid ref:// reference: empty plugin name in ref://',
+    );
+  });
+
+  it('resolves to the first match when duplicate names exist across includes', () => {
+    const main: PluginSpec[] = [{ package: 'ref://backstage-plugin-foo' }];
+    const includes: IncludePluginList[] = [
+      [
+        'dpdy.yaml',
+        [
+          {
+            package: 'oci://quay.io/rhdh/backstage-plugin-foo@sha256:first',
+          },
+        ],
+      ],
+      [
+        'extra.yaml',
+        [
+          {
+            package: 'oci://quay.io/other/backstage-plugin-foo@sha256:second',
+          },
+        ],
+      ],
+    ];
+    resolveRefPlugins(main, includes);
+    expect(main[0]!.package).toBe(
+      'oci://quay.io/rhdh/backstage-plugin-foo@sha256:first',
+    );
+  });
+});

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/types.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/types.ts
@@ -65,6 +65,12 @@ export type Plugin = PluginSpec & {
 
 export type PluginMap = Record<string, Plugin>;
 
+/** A parsed include file: its path and the plugin entries it declares. */
+export type IncludePluginList = readonly [
+  file: string,
+  plugins: readonly PluginSpec[],
+];
+
 export type DynamicPluginsConfig = {
   includes?: string[];
   plugins?: PluginSpec[];


### PR DESCRIPTION
The pre-merge pass only inspects `oci://` entries to determine which plugins can be skipped. A `ref://` entry with `enabled: true` was invisible to this pass, so it could not prevent a disabled DPDY entry from being filtered out. This caused the later `resolveRefPlugin` call in `mergePlugin` to fail with "no plugin named … found in included plugins" because the target entry had already been removed.

This moves `ref://` resolution earlier in `loadAllPlugins`, before the pre-merge pass runs. Once resolved, the entries are standard `oci://` URLs and the level-override logic works correctly. The old `resolveRefPlugin` function and its call in `mergePlugin` are removed since resolution now happens up front.

Also extracts `IncludePluginList` into `types.ts` as a shared type.

[RHIDP-13226](https://redhat.atlassian.net/browse/RHIDP-13226)