### PR TITLE
Add SQLite3 build natively and no cache on build

### DIFF
--- a/workspaces/dcm/Dockerfile
+++ b/workspaces/dcm/Dockerfile
@@ -54,17 +54,13 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 COPY --from=build /app/package.json /app/yarn.lock /app/.yarnrc.yml ./
 COPY --from=build /app/.yarn ./.yarn
 
-# FIX 2: REMOVED the inline Node script that was muting postinstall scripts.
-# FIX 3: Run production install allowing native C++ compilation to happen naturally.
 RUN YARN_ENABLE_IMMUTABLE_INSTALLS=false \
     YARN_CACHE_FOLDER=/root/.yarn/berry/cache \
     yarn workspaces focus --all --production
 
-# FIX 4: Explicitly force a targeted native compilation for your runtime environment
-RUN yarn workspace backend exec node-gyp rebuild || true
-
-# Clean up yarn cache after native build is done
-RUN rm -rf "$(yarn cache dir)"
+# Purge build tools and yarn cache — no longer needed at runtime
+RUN apt-get purge -y --auto-remove python3 make g++ \
+    && rm -rf /var/lib/apt/lists/* "$(yarn cache dir)"
 
 COPY --from=build /app/packages/app/package.json packages/app/package.json
 RUN ln -sf ../packages/app node_modules/app

--- a/workspaces/dcm/Dockerfile
+++ b/workspaces/dcm/Dockerfile
@@ -60,8 +60,8 @@ RUN YARN_ENABLE_IMMUTABLE_INSTALLS=false \
     YARN_CACHE_FOLDER=/root/.yarn/berry/cache \
     yarn workspaces focus --all --production
 
-# FIX 4: Explicitly force a targeted native compilation for your runtime environment
-RUN yarn workspace backend exec node-gyp rebuild || true
+# Rebuild better-sqlite3 native addon for the container's architecture
+RUN npm rebuild better-sqlite3
 
 # Clean up yarn cache after native build is done
 RUN rm -rf "$(yarn cache dir)"

--- a/workspaces/dcm/package.json
+++ b/workspaces/dcm/package.json
@@ -58,6 +58,11 @@
     "prettier": "^2.3.2",
     "typescript": "~5.3.0"
   },
+  "dependenciesMeta": {
+    "better-sqlite3": {
+      "built": true
+    }
+  },
   "resolutions": {
     "isolated-vm": "6.1.2",
     "better-sqlite3": "^12.0.0",

--- a/workspaces/dcm/scripts/generate-image.sh
+++ b/workspaces/dcm/scripts/generate-image.sh
@@ -31,7 +31,7 @@ function _usage {
 Usage:
   $script_name clean
   VERSION=<semver> $script_name [oci|tgz|push]
-  VERSION=<semver> $script_name backstage-image [--push]
+  VERSION=<semver> $script_name backstage-image [--push] [--no-cache]
 
 Environment variables:
   VERSION         Required. The plugin version; also used to tag the container image.
@@ -196,10 +196,13 @@ function backstage-image {
 
   local image_tag="$REGISTRY_URL/$ORG_ID/$REPO:$VERSION"
   local do_push=false
+  local no_cache=false
 
   for arg in "${@:1}"; do
     if [[ "$arg" == "--push" ]]; then
       do_push=true
+    elif [[ "$arg" == "--no-cache" ]]; then
+      no_cache=true
     fi
   done
 
@@ -215,8 +218,14 @@ function backstage-image {
     volume_args=("--volume" "$yarn_cache_dir:/root/.yarn/berry/cache:Z")
   fi
 
+  local cache_args=()
+  if $no_cache; then
+    cache_args=("--no-cache")
+  fi
+
   echo "Building Backstage app image: $image_tag"
   "$_pocker" build \
+    "${cache_args[@]+"${cache_args[@]}"}" \
     "${volume_args[@]+"${volume_args[@]}"}" \
     --tag "$image_tag" \
     --tag "$REGISTRY_URL/$ORG_ID/$REPO:main" \

--- a/workspaces/dcm/scripts/generate-image.sh
+++ b/workspaces/dcm/scripts/generate-image.sh
@@ -217,6 +217,7 @@ function backstage-image {
 
   echo "Building Backstage app image: $image_tag"
   "$_pocker" build \
+    --no-cache \
     "${volume_args[@]+"${volume_args[@]}"}" \
     --tag "$image_tag" \
     --tag "$REGISTRY_URL/$ORG_ID/$REPO:main" \

--- a/workspaces/dcm/scripts/generate-image.sh
+++ b/workspaces/dcm/scripts/generate-image.sh
@@ -236,7 +236,8 @@ function backstage-image {
     "$_pocker" push "$image_tag"
     "$_pocker" push "$REGISTRY_URL/$ORG_ID/$REPO:main"
   else
-    echo "Image built. Run with --push to push to the registry, or use:"
+    echo "Image built. Pass --push to push to the registry, --no-cache to rebuild layers from scratch."
+    echo "  Or push manually with:"
     echo "  $_pocker push $image_tag"
   fi
   return 0

--- a/workspaces/dcm/yarn.lock
+++ b/workspaces/dcm/yarn.lock
@@ -6659,6 +6659,9 @@ __metadata:
     prettier: "npm:^2.3.2"
     typescript: "npm:~5.3.0"
     yup: "npm:^1.7.1"
+  dependenciesMeta:
+    better-sqlite3:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Fixes two issues with the Docker image build that caused:
1. Stale UI being served from the container (local changes not reflected in the built image)
2. `better-sqlite3` native addon missing at runtime, breaking all database-backed plugins (catalog, permission, dcm, search)

## Problem

### 1. Docker layer caching serves stale frontend

The `generate-image.sh` script runs `podman build` / `docker build` without `--no-cache`. When source files in `plugins/` or `packages/` change, the build engine may reuse cached layers for the `yarn workspace app build` step, producing an image with an outdated frontend bundle.

### 2. `better-sqlite3` native binary not compiled

The production stage of the Dockerfile ran:

```dockerfile
RUN yarn workspace backend exec node-gyp rebuild || true
```

This executes `node-gyp rebuild` in the **backend package directory** (`packages/backend/`), which has no `binding.gyp` — so it silently does nothing. The `|| true` swallows the failure. As a result, `better-sqlite3` never gets its `.node` native addon compiled, and at runtime every plugin that uses SQLite fails with:

```
Could not locate the bindings file. Tried:
  → /app/node_modules/better-sqlite3/build/better_sqlite3.node
  → ...
```

## Solution

### 1. Disable build cache (`generate-image.sh`)

Added `--no-cache` to the `podman build` / `docker build` invocation to ensure every layer is rebuilt from scratch, guaranteeing the latest source is always compiled into the image.

### 2. Rebuild `better-sqlite3` native addon for the container's architecture

Replaced the no-op `node-gyp rebuild` with:

```dockerfile
RUN npm rebuild better-sqlite3
```

This runs `node-gyp` inside the `better-sqlite3` package where `binding.gyp` lives, correctly producing the native `.node` binary for the container's architecture. Removed `|| true` so the build fails loudly if compilation breaks.
