### PR TITLE
fix(theme): fill NFS catalog entity tab content well

### DIFF
--- a/workspaces/theme/.changeset/bui-main-flex.md
+++ b/workspaces/theme/.changeset/bui-main-flex.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Make NFS BUI catalog entity `<main>` a flex column so Topology and Scorecard fill the content well instead of leaving a gap below short tab content (RHDHBUGS-3543).

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -117,6 +117,24 @@ describe('createComponents', () => {
     );
   });
 
+  it('makes NFS BUI main a flex column so nested Containers can grow', () => {
+    const actual = createComponents({ palette: customDarkTheme() });
+    const root = actual.BackstageSidebarPage?.styleOverrides?.root as
+      | Record<string, unknown>
+      | undefined;
+    const desktop = root?.['@media (min-width: 600px)'] as
+      | Record<string, unknown>
+      | undefined;
+    expect(desktop?.['& > main:not([data-backstage-core-page])']).toEqual(
+      expect.objectContaining({
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+      }),
+    );
+  });
+
   it('paints BUI content Containers with mainSectionBackgroundColor', () => {
     const actual = createComponents({ palette: customDarkTheme() });
     const root = actual.BackstageSidebarPage?.styleOverrides?.root as

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -789,6 +789,18 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
               // Prevent overflow in the main container due to the margin
               maxHeight: `calc(100vh - 2 * ${general.pageInset})`,
             },
+            // NFS BUI entity pages wrap PluginHeader + tabs + Container in a
+            // classless <main>. BUI Container is flex: 1 1 0% but that only
+            // grows when main is a flex column — otherwise Topology / Scorecard
+            // stay content-height inside a tall well (RHDHBUGS-3543). Do not
+            // override Backstage Page, which uses display:grid on <main>.
+            '& > main:not([data-backstage-core-page])': {
+              display: 'flex',
+              flexDirection: 'column',
+              flex: 1,
+              minHeight: 0,
+              maxHeight: `calc(100% - 2 * ${general.pageInset})`,
+            },
             // NFS / BUI pages use Container instead of <main>. Match the content
             // well color (same token as BackstageContent) and rely on flex: 1
             // from BUI rather than 100vh so PluginHeader siblings are not overflowed.


### PR DESCRIPTION
## Description
On NFS catalog entity pages, Topology and Scorecard sat in a short BUI `Container` inside a tall `<main>`, leaving an empty band in the page well. Theme 1.0.2 already sized `SidebarPage > main`, but `main` stayed `display: block`, so the nested container’s `flex: 1` never grew.

This makes classless BUI `<main>` (not Backstage `Page`, which uses `display: grid`) a flex column so those tabs fill the well.

## Fixed
- [RHDHBUGS-3543](https://redhat.atlassian.net/browse/RHDHBUGS-3543) — [NFS] Empty gap below #root on Catalog entity tabs (Topology / Scorecard)

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)


Verified on app-next, via https://github.com/redhat-developer/rhdh/pull/5115:
<img width="3024" height="1812" alt="image" src="https://github.com/user-attachments/assets/1072a5df-7fc6-41c2-b85d-478dfca363eb" />
