### PR TITLE
fix(codecov): republish orchestrator E2E coverage under a live flag

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -188,7 +188,11 @@ flag_management:
     # UI surface, so orchestrator's E2E coverage was invisible on this
     # dashboard. The suffix is not a plugin version — it exists only because the
     # plain name is burned. Uploaded by rhdh-plugin-export-overlays'
-    # scripts/upload-coverage-upstream.sh, which carries the matching override.
+    # scripts/upload-coverage-upstream.sh, which carries the matching override
+    # (redhat-developer/rhdh-plugin-export-overlays#3360). Land this entry
+    # BEFORE that one: without it the flag still publishes, it just falls back
+    # to default_rules and registers here permanently unscoped, and a flag
+    # registered on this project cannot be removed by the overlay side.
     - name: e2e-orchestrator-plugin
       paths:
         - workspaces/orchestrator/

--- a/codecov.yml
+++ b/codecov.yml
@@ -180,7 +180,16 @@ flag_management:
     - name: e2e-intelligent-assistant
       paths:
         - workspaces/intelligent-assistant/
-    - name: e2e-orchestrator
+    # Replaces e2e-orchestrator, which was deleted on this project some time
+    # after 2026-08-17. Codecov flag deletion is a soft delete with no inverse:
+    # the API exposes deleteFlag and nothing to undo it, the UI offers no
+    # restore, and the name cannot be reused. The old flag's data is still in
+    # the report (142 files, 49.51% at main HEAD b37abc01) but hidden from every
+    # UI surface, so orchestrator's E2E coverage was invisible on this
+    # dashboard. The suffix is not a plugin version — it exists only because the
+    # plain name is burned. Uploaded by rhdh-plugin-export-overlays'
+    # scripts/upload-coverage-upstream.sh, which carries the matching override.
+    - name: e2e-orchestrator-plugin
       paths:
         - workspaces/orchestrator/
     - name: e2e-quickstart


### PR DESCRIPTION
## What

Registers `e2e-orchestrator-plugin` in `flag_management.individual_flags` and drops `e2e-orchestrator`.

## Why

The `e2e-orchestrator` flag on this project has been deleted, so orchestrator's E2E coverage is invisible on the dashboard — it does not even appear in the flag picker.

The deletion is a soft delete with no way back: the GraphQL API exposes `deleteFlag` and [nothing that undoes it](https://github.com/codecov/codecov-api/blob/main/graphql_api/types/mutation/mutation.py), the UI offers no restore, and [Codecov documents the name as unusable afterwards](https://docs.codecov.com/docs/flags).

The data itself never went anywhere. At main HEAD `b37abc014bb13dba9159cb00d4f20cc20c5a195d` the report still carries 142 files and 3397 lines under that flag, all under `workspaces/orchestrator/`, and the v2 REST listing still returns it at 49.51%. Only the UI hides it, because the resolver behind every UI surface filters `deleted__isnot=True` ([`graphql_api/actions/flags.py`](https://github.com/codecov/codecov-api/blob/main/graphql_api/actions/flags.py)) while REST does not.

The two listings disagree on exactly one name, which is how this was found — both endpoints are public, no token needed:

```
# GraphQL — what the dashboard shows: 34 flags
curl -s -X POST https://api.codecov.io/graphql/gh -H 'Content-Type: application/json' \
  -d '{"query":"query { owner(username:\"redhat-developer\"){ repository(name:\"rhdh-plugins\"){ ... on Repository { coverageAnalytics { flags(first:100){ edges{node{name}} } } } } } }"}'

# REST v2 — everything, deleted included: 35 flags
curl -s "https://api.codecov.io/api/v2/github/redhat-developer/repos/rhdh-plugins/flags/?page=2"
```

The only difference is `e2e-orchestrator`.

## Notes

- **The suffix is not a plugin version.** It has nothing to do with orchestrator 6.0.0. It exists only because the plain name is burned.
- **The old entry is dropped, not kept alongside.** A flag nothing can ever upload to again is not configuration.
- **This project's own `orchestrator` flag is untouched.** That one is from the unit tests here and is perfectly healthy.
- **The matching override** lives in `rhdh-plugin-export-overlays` (`scripts/upload-coverage-upstream.sh`), which is what publishes this flag: redhat-developer/rhdh-plugin-export-overlays#3360. That PR is what makes uploads start using the new name; this one is what gives the flag its path scoping. Either order works, but coverage only reappears once both are in.

## Worth knowing

If someone here deleted the flag deliberately — for example not wanting cross-repo E2E flags on this dashboard — say so and I will close this instead. The other eight `e2e-*` flags are untouched, which is why this reads as accidental. If it was an accident, it is worth finding out how, because those eight are exposed to the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
