### PR TITLE
feat(orchestrator-form-widgets): add ActiveBoolean widget for dynamic boolean form fields

### DIFF
--- a/workspaces/orchestrator/.changeset/active-boolean-widget.md
+++ b/workspaces/orchestrator/.changeset/active-boolean-widget.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': minor
+---
+
+Add ActiveBoolean widget for dynamic boolean form fields with fetch capabilities

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -41,6 +41,9 @@ Implementation of the HTTP endpoints is out of the scope of this library, they a
   - [ActiveMultiSelect widget](#activemultiselect-widget)
     - [ActiveMultiSelect Data Fetching and validation](#activemultiselect-data-fetching-and-validation)
     - [ActiveMultiSelect widget ui:props](#activemultiselect-widget-uiprops)
+  - [ActiveBoolean widget](#activeboolean-widget)
+    - [ActiveBoolean Data Fetching](#activeboolean-data-fetching)
+    - [ActiveBoolean widget ui:props](#activeboolean-widget-uiprops)
   - [ActiveText widget](#activetext-widget)
     - [ActiveText Data Fetching](#activetext-data-fetching)
     - [Dynamic Text Templating](#dynamic-text-templating)
@@ -434,6 +437,69 @@ The widget supports following `ui:props`:
 - validate:body
 - validate:retrigger
 - ui:allowNewItems
+
+[Check more details](#content-of-uiprops)
+
+## ActiveBoolean widget
+
+Referenced as: `"ui:widget": "ActiveBoolean"`.
+
+A smart boolean component based on the [@mui/material/Checkbox](https://mui.com/material-ui/api/checkbox/) keeping look&feel with other RJSF-default fields.
+
+This widget enables boolean (checkbox) fields to dynamically fetch their values from external APIs and respond to form changes, following the same patterns as other Active widgets.
+
+### ActiveBoolean Data Fetching
+
+When instantiated, it loads (prefetch) the **default** value using a single HTTP call based on the `fetch:*` from the `ui:props`.
+
+Once fetched, the `fetch:response:value` selector is used to pick the default value.
+This selector is expected to resolve into a boolean value, or a value that can be coerced to boolean:
+
+- Boolean values: `true`, `false`
+- String values: `"true"`, `"false"`, `"1"`, `"0"` (case-insensitive)
+- Numeric values: `1` (true), `0` (false), any non-zero number (true)
+
+The data are further re-fetched if the value of one of the `fetch:retrigger` referenced values is changed.
+If the `fetch:retrigger` is omitted, the fetch is issued just once to preload the data.
+
+Because a checkbox's default value only applies when the field is initially unchecked, any changes to the returned value in subsequent requests are ignored if the user has already interacted with the field.
+If you want to keep the field unchanged until the user interacts with it, set `fetch:skipInitialValue` to `true`.
+
+**Example:**
+
+```json
+"enableFeature": {
+  "type": "boolean",
+  "title": "Enable Advanced Features",
+  "ui:widget": "ActiveBoolean",
+  "ui:props": {
+    "fetch:url": "https://api.example.com/feature-flags?tenant=$${{current.tenantId}}",
+    "fetch:response:value": "features.advanced.enabled",
+    "fetch:response:default": false,
+    "fetch:retrigger": ["current.tenantId"]
+  }
+}
+```
+
+### ActiveBoolean widget ui:props
+
+The widget supports following `ui:props`:
+
+- fetch:url
+- fetch:headers
+- fetch:method
+- fetch:body
+- fetch:retrigger
+- fetch:clearOnRetrigger
+- fetch:retry:maxAttempts
+- fetch:retry:delay
+- fetch:retry:backoff
+- fetch:retry:statusCodes
+- fetch:error:ignoreUnready
+- fetch:error:silent
+- fetch:skipInitialValue
+- fetch:response:value
+- fetch:response:default
 
 [Check more details](#content-of-uiprops)
 

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormDecoratorContent.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/FormDecoratorContent.tsx
@@ -28,6 +28,7 @@ import {
   ActiveText,
   ActiveDropdown,
   ActiveMultiSelect,
+  ActiveBoolean,
 } from './widgets';
 import { useGetExtraErrors, useGetExtraErrorsForField } from './utils';
 
@@ -44,6 +45,7 @@ const widgets = {
   ActiveText,
   ActiveDropdown,
   ActiveMultiSelect,
+  ActiveBoolean,
 };
 
 const FormDecoratorContent = ({

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.test.tsx
@@ -270,4 +270,50 @@ describe('ActiveBoolean', () => {
       .querySelector('input') as HTMLInputElement;
     expect(checkbox.disabled).toBe(true);
   });
+
+  it('coerces string default value to boolean', () => {
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: true,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+
+    render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean' }}
+        uiSchema={{}}
+        options={{
+          props: {
+            'fetch:url': 'https://example.test/api',
+            'fetch:response:value': 'enabled',
+            'fetch:response:default': 'true',
+          },
+        }}
+        value={false}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    const checkbox = screen.getByTestId('ab-checkbox');
+    expect(checkbox).toBeInTheDocument();
+  });
 });

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.test.tsx
@@ -1,0 +1,273 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ActiveBoolean } from './ActiveBoolean';
+import * as utils from '../utils';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    useTemplateUnitEvaluator: jest.fn(),
+    useRetriggerEvaluate: jest.fn(),
+    useFetch: jest.fn(),
+    useProcessingState: jest.fn(),
+    useClearOnRetrigger: jest.fn(),
+  };
+});
+
+const mockedUseTemplateUnitEvaluator =
+  utils.useTemplateUnitEvaluator as jest.Mock;
+const mockedUseRetriggerEvaluate = utils.useRetriggerEvaluate as jest.Mock;
+const mockedUseFetch = utils.useFetch as jest.Mock;
+const mockedUseProcessingState = utils.useProcessingState as jest.Mock;
+
+describe('ActiveBoolean', () => {
+  beforeEach(() => {
+    mockedUseTemplateUnitEvaluator.mockReturnValue(() => undefined);
+    mockedUseRetriggerEvaluate.mockReturnValue([]);
+    mockedUseFetch.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: false,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+  });
+
+  it('shows config error when fetch:url is provided without selectors', () => {
+    render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean' }}
+        uiSchema={{}}
+        options={{ props: { 'fetch:url': 'https://example.test/api' } }}
+        value={false}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(screen.getByTestId('ab-error-text')).toHaveTextContent(
+      'fetch:response:value or fetch:response:default',
+    );
+  });
+
+  it('shows spinner while complete loading and no static default', () => {
+    mockedUseProcessingState.mockReturnValue({
+      completeLoading: true,
+      wrapProcessing: async (fn: () => Promise<void>) => {
+        await fn();
+      },
+    });
+
+    const { container } = render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value={false}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('marks field as user-changed and forwards checkbox value', () => {
+    const onChange = jest.fn();
+    const setIsChangedByUser = jest.fn();
+
+    render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value={false}
+        onChange={onChange}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser,
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    const checkbox = screen.getByTestId('ab-checkbox');
+    expect(checkbox).toBeInTheDocument();
+
+    fireEvent.click(checkbox);
+
+    expect(setIsChangedByUser).toHaveBeenCalledWith('ab', true);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders unchecked checkbox for false value', () => {
+    render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value={false}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    const checkbox = screen
+      .getByTestId('ab-checkbox')
+      .querySelector('input') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('renders checked checkbox for true value', () => {
+    render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean' }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    const checkbox = screen
+      .getByTestId('ab-checkbox')
+      .querySelector('input') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('disables checkbox when readonly is true', () => {
+    render(
+      <ActiveBoolean
+        id="ab"
+        name="ab"
+        label="Active Boolean"
+        required={false}
+        readonly={false}
+        disabled={false}
+        autofocus={false}
+        schema={{ type: 'boolean', readOnly: true }}
+        uiSchema={{}}
+        options={{ props: {} }}
+        value={false}
+        onChange={() => {}}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        formContext={
+          {
+            formData: {},
+            getIsChangedByUser: () => false,
+            setIsChangedByUser: () => {},
+          } as any
+        }
+        rawErrors={[]}
+        registry={{} as any}
+      />,
+    );
+
+    const checkbox = screen
+      .getByTestId('ab-checkbox')
+      .querySelector('input') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(true);
+  });
+});

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.tsx
@@ -76,31 +76,20 @@ export const ActiveBoolean: Widget<
 
   const defaultValueSelector = uiProps['fetch:response:value']?.toString();
   const staticDefault = uiProps['fetch:response:default'];
-  const hasStaticDefault =
-    typeof staticDefault === 'boolean' ||
-    staticDefault === 'true' ||
-    staticDefault === 'false' ||
-    staticDefault === '1' ||
-    staticDefault === '0';
+  const hasStaticDefault = staticDefault !== undefined;
   const skipInitialValue = uiProps['fetch:skipInitialValue'] === true;
   const hasFetchUrl = !!uiProps['fetch:url'];
   const clearOnRetrigger = uiProps['fetch:clearOnRetrigger'] === true;
 
-  // If fetch:url is configured, either fetch:response:value OR fetch:response:default should be set
-  // to provide meaningful behavior. Without fetch:url, the widget works as a plain checkbox.
   const [localError] = useState<string | undefined>(
     hasFetchUrl && !defaultValueSelector && !hasStaticDefault
       ? `When fetch:url is configured, either fetch:response:value or fetch:response:default should be set for ${props.id}.`
       : undefined,
   );
 
-  const handleFetchStarted = formContext?.handleFetchStarted;
-  const handleFetchEnded = formContext?.handleFetchEnded;
-
   const retrigger = useRetriggerEvaluate(
     templateUnitEvaluator,
     formData,
-    /* This is safe retype, since proper checking of input value is done in the useRetriggerEvaluate() hook */
     uiProps['fetch:retrigger'] as string[],
   );
 
@@ -111,17 +100,15 @@ export const ActiveBoolean: Widget<
     formContext?.onSamlSsoError,
   );
 
-  // Track the complete loading state (fetch + processing)
   const { completeLoading, wrapProcessing } = useProcessingState(
     loading,
-    handleFetchStarted,
-    handleFetchEnded,
+    formContext?.handleFetchStarted,
+    formContext?.handleFetchEnded,
   );
 
   const handleChange = useCallback(
     (changed: boolean, isByUser: boolean) => {
       if (isByUser && setIsChangedByUser) {
-        // we must handle this change out of this component's state since the component can be (de)mounted on wizard transitions or by the SchemaUpdater
         setIsChangedByUser(id, true);
       }
       onChange(changed);
@@ -129,9 +116,10 @@ export const ActiveBoolean: Widget<
     [onChange, id, setIsChangedByUser],
   );
 
-  const handleClear = useCallback(() => {
-    handleChange(false, false);
-  }, [handleChange]);
+  const handleClear = useCallback(
+    () => handleChange(false, false),
+    [handleChange],
+  );
 
   useClearOnRetrigger({
     enabled: clearOnRetrigger,
@@ -139,69 +127,49 @@ export const ActiveBoolean: Widget<
     onClear: handleClear,
   });
 
-  // Process fetch results - only override if fetch returns a valid boolean value
-  // Static defaults are applied at form initialization level (in OrchestratorForm)
   useEffect(() => {
-    if (clearOnRetrigger && loading) {
-      return;
-    }
+    if (!data || (clearOnRetrigger && loading)) return;
 
-    if (!data) {
-      return;
-    }
-
-    const doItAsync = async () => {
-      await wrapProcessing(async () => {
-        const fd = formData ?? {};
-        // Only apply fetched value if user hasn't changed the field
-        if (!skipInitialValue && !isChangedByUser && defaultValueSelector) {
-          const resolvedSelector = await evaluateFetchResponseSelectorTemplate({
-            template: defaultValueSelector,
-            key: 'fetch:response:value',
-            unitEvaluator: templateUnitEvaluator,
-            formData: fd,
-            responseData: data,
-            uiProps,
-          });
-          const fetchedValue = await applySelectorString(
-            data,
-            resolvedSelector,
-            true,
-          );
-
-          const coercedValue = coerceToBoolean(fetchedValue);
-          if (coercedValue !== undefined && value !== coercedValue) {
-            handleChange(coercedValue, false);
-          }
+    if (!skipInitialValue && !isChangedByUser && defaultValueSelector) {
+      wrapProcessing(async () => {
+        const resolvedSelector = await evaluateFetchResponseSelectorTemplate({
+          template: defaultValueSelector,
+          key: 'fetch:response:value',
+          unitEvaluator: templateUnitEvaluator,
+          formData: formData ?? {},
+          responseData: data,
+          uiProps,
+        });
+        const fetchedValue = await applySelectorString(
+          data,
+          resolvedSelector,
+          true,
+        );
+        const coercedValue = coerceToBoolean(fetchedValue);
+        if (coercedValue !== undefined && value !== coercedValue) {
+          handleChange(coercedValue, false);
         }
       });
-    };
-
-    doItAsync();
+    }
   }, [
-    defaultValueSelector,
     data,
+    loading,
+    clearOnRetrigger,
+    skipInitialValue,
+    isChangedByUser,
+    defaultValueSelector,
+    wrapProcessing,
+    templateUnitEvaluator,
     formData,
     uiProps,
-    templateUnitEvaluator,
-    props.id,
     value,
     handleChange,
-    isChangedByUser,
-    skipInitialValue,
-    wrapProcessing,
-    clearOnRetrigger,
-    loading,
   ]);
 
-  const shouldShowFetchError = uiProps['fetch:error:silent'] !== true;
-  const displayError = localError ?? (shouldShowFetchError ? error : undefined);
-  if (displayError) {
-    return <ErrorText text={displayError} id={id} />;
+  if (localError || (error && uiProps['fetch:error:silent'] !== true)) {
+    return <ErrorText text={localError ?? error!} id={id} />;
   }
 
-  // Show loading only if we don't have a static default value to display
-  // This ensures the default is shown instantly while fetch happens in background
   if (completeLoading && !hasStaticDefault) {
     return <CircularProgress size={20} />;
   }

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { JsonObject } from '@backstage/types';
+import { Widget } from '@rjsf/utils';
+import { JSONSchema7 } from 'json-schema';
+
+import CircularProgress from '@mui/material/CircularProgress';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+
+import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
+
+import {
+  useRetriggerEvaluate,
+  useTemplateUnitEvaluator,
+  useFetch,
+  applySelectorString,
+  useProcessingState,
+  useClearOnRetrigger,
+  evaluateFetchResponseSelectorTemplate,
+} from '../utils';
+import { ErrorText } from './ErrorText';
+import { UiProps } from '../uiPropTypes';
+
+const coerceToBoolean = (value: any): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase().trim();
+    if (lower === 'true' || lower === '1') {
+      return true;
+    }
+    if (lower === 'false' || lower === '0') {
+      return false;
+    }
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  return undefined;
+};
+
+export const ActiveBoolean: Widget<
+  JsonObject,
+  JSONSchema7,
+  OrchestratorFormContextProps
+> = props => {
+  const templateUnitEvaluator = useTemplateUnitEvaluator();
+
+  const { id, label, value, onChange, formContext } = props;
+  const formData = formContext?.formData;
+  const isChangedByUser = !!formContext?.getIsChangedByUser(id);
+  const setIsChangedByUser = formContext?.setIsChangedByUser;
+
+  const uiProps = useMemo(
+    () => (props.options?.props ?? {}) as UiProps,
+    [props.options?.props],
+  );
+  const isReadOnly = !!props?.schema.readOnly;
+
+  const defaultValueSelector = uiProps['fetch:response:value']?.toString();
+  const staticDefault = uiProps['fetch:response:default'];
+  const hasStaticDefault =
+    typeof staticDefault === 'boolean' ||
+    staticDefault === 'true' ||
+    staticDefault === 'false' ||
+    staticDefault === '1' ||
+    staticDefault === '0';
+  const skipInitialValue = uiProps['fetch:skipInitialValue'] === true;
+  const hasFetchUrl = !!uiProps['fetch:url'];
+  const clearOnRetrigger = uiProps['fetch:clearOnRetrigger'] === true;
+
+  // If fetch:url is configured, either fetch:response:value OR fetch:response:default should be set
+  // to provide meaningful behavior. Without fetch:url, the widget works as a plain checkbox.
+  const [localError] = useState<string | undefined>(
+    hasFetchUrl && !defaultValueSelector && !hasStaticDefault
+      ? `When fetch:url is configured, either fetch:response:value or fetch:response:default should be set for ${props.id}.`
+      : undefined,
+  );
+
+  const handleFetchStarted = formContext?.handleFetchStarted;
+  const handleFetchEnded = formContext?.handleFetchEnded;
+
+  const retrigger = useRetriggerEvaluate(
+    templateUnitEvaluator,
+    formData,
+    /* This is safe retype, since proper checking of input value is done in the useRetriggerEvaluate() hook */
+    uiProps['fetch:retrigger'] as string[],
+  );
+
+  const { data, error, loading } = useFetch(
+    formData ?? {},
+    uiProps,
+    retrigger,
+    formContext?.onSamlSsoError,
+  );
+
+  // Track the complete loading state (fetch + processing)
+  const { completeLoading, wrapProcessing } = useProcessingState(
+    loading,
+    handleFetchStarted,
+    handleFetchEnded,
+  );
+
+  const handleChange = useCallback(
+    (changed: boolean, isByUser: boolean) => {
+      if (isByUser && setIsChangedByUser) {
+        // we must handle this change out of this component's state since the component can be (de)mounted on wizard transitions or by the SchemaUpdater
+        setIsChangedByUser(id, true);
+      }
+      onChange(changed);
+    },
+    [onChange, id, setIsChangedByUser],
+  );
+
+  const handleClear = useCallback(() => {
+    handleChange(false, false);
+  }, [handleChange]);
+
+  useClearOnRetrigger({
+    enabled: clearOnRetrigger,
+    retrigger,
+    onClear: handleClear,
+  });
+
+  // Process fetch results - only override if fetch returns a valid boolean value
+  // Static defaults are applied at form initialization level (in OrchestratorForm)
+  useEffect(() => {
+    if (clearOnRetrigger && loading) {
+      return;
+    }
+
+    if (!data) {
+      return;
+    }
+
+    const doItAsync = async () => {
+      await wrapProcessing(async () => {
+        const fd = formData ?? {};
+        // Only apply fetched value if user hasn't changed the field
+        if (!skipInitialValue && !isChangedByUser && defaultValueSelector) {
+          const resolvedSelector = await evaluateFetchResponseSelectorTemplate({
+            template: defaultValueSelector,
+            key: 'fetch:response:value',
+            unitEvaluator: templateUnitEvaluator,
+            formData: fd,
+            responseData: data,
+            uiProps,
+          });
+          const fetchedValue = await applySelectorString(
+            data,
+            resolvedSelector,
+            true,
+          );
+
+          const coercedValue = coerceToBoolean(fetchedValue);
+          if (coercedValue !== undefined && value !== coercedValue) {
+            handleChange(coercedValue, false);
+          }
+        }
+      });
+    };
+
+    doItAsync();
+  }, [
+    defaultValueSelector,
+    data,
+    formData,
+    uiProps,
+    templateUnitEvaluator,
+    props.id,
+    value,
+    handleChange,
+    isChangedByUser,
+    skipInitialValue,
+    wrapProcessing,
+    clearOnRetrigger,
+    loading,
+  ]);
+
+  const shouldShowFetchError = uiProps['fetch:error:silent'] !== true;
+  const displayError = localError ?? (shouldShowFetchError ? error : undefined);
+  if (displayError) {
+    return <ErrorText text={displayError} id={id} />;
+  }
+
+  // Show loading only if we don't have a static default value to display
+  // This ensures the default is shown instantly while fetch happens in background
+  if (completeLoading && !hasStaticDefault) {
+    return <CircularProgress size={20} />;
+  }
+
+  return (
+    <FormControl variant="outlined" fullWidth>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={!!value}
+            onChange={event => handleChange(event.target.checked, true)}
+            disabled={isReadOnly}
+            data-testid={`${id}-checkbox`}
+          />
+        }
+        label={label}
+      />
+    </FormControl>
+  );
+};

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveBoolean.tsx
@@ -75,7 +75,7 @@ export const ActiveBoolean: Widget<
   const isReadOnly = !!props?.schema.readOnly;
 
   const defaultValueSelector = uiProps['fetch:response:value']?.toString();
-  const staticDefault = uiProps['fetch:response:default'];
+  const staticDefault = coerceToBoolean(uiProps['fetch:response:default']);
   const hasStaticDefault = staticDefault !== undefined;
   const skipInitialValue = uiProps['fetch:skipInitialValue'] === true;
   const hasFetchUrl = !!uiProps['fetch:url'];

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/index.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/index.ts
@@ -18,3 +18,4 @@ export * from './ActiveTextInput';
 export * from './ActiveText';
 export * from './ActiveDropdown';
 export * from './ActiveMultiSelect';
+export * from './ActiveBoolean';


### PR DESCRIPTION
#### Story : https://redhat.atlassian.net/browse/RHIDP-16435

## Summary

Adds a new **ActiveBoolean** widget that enables boolean (checkbox) fields in Orchestrator workflow forms to dynamically fetch their values from external APIs, following the same ui:props pattern as existing Active widgets (ActiveTextInput, ActiveDropdown, ActiveMultiSelect).

## Changes

- ✅ New `ActiveBoolean` widget component
- ✅ Comprehensive unit tests
- ✅ Documentation in `orchestratorFormWidgets.md`
- ✅ Widget registration in `FormDecoratorContent.tsx`
- ✅ Changeset for release notes

## Features

- Supports `fetch:url` to call external APIs
- Supports `fetch:response:value` JSONata selector to extract boolean values
- Supports `fetch:response:default` as static fallback
- Coerces string values (`"true"`, `"false"`, `"1"`, `"0"`) and numbers (`1`, `0`) to boolean
- Supports `fetch:retrigger` to refetch when other fields change
- Supports `fetch:clearOnRetrigger` to clear value before refetching
- Supports all standard fetch configuration: retry, error handling, etc.
- Tracks user changes to prevent overwriting manual edits
- Shows loading spinner while fetching
- Respects `readOnly` schema property

## Video:

https://github.com/user-attachments/assets/73637f87-dc43-4f5d-b6b2-1eac151ca95f




## Usage Example

```json
{
  "enableFeature": {
    "type": "boolean",
    "title": "Enable Advanced Features",
    "ui:widget": "ActiveBoolean",
    "ui:props": {
      "fetch:url": "https://api.example.com/feature-flags",
      "fetch:response:value": "features.advanced.enabled",
      "fetch:response:default": false,
      "fetch:retrigger": ["current.tenantId"]
    }
  }
}
```

---

## Testing Instructions

### 1. Setup Proxy Configuration

Add this to your `app-config.local.yaml`:

```yaml
proxy:
  endpoints:
    "/dummyjson":
      target: "https://dummyjson.com"
      changeOrigin: true
      allowedMethods: ["GET"]
      allowedHeaders: ["Content-Type"]
      headers:
        X-Requested-With: "XMLHttpRequest"
```

### 2. Create Test Workflow

Create the following files in your dev environment:

**File: `packages/backend/.devModeTemp/repository/workflows/test-active-boolean.sw.yaml`**

```yaml
id: test-active-boolean
version: '1.0'
specVersion: '0.8'
name: Test ActiveBoolean Widget
description: Testing ActiveBoolean widget with various fetch and ui:props configurations
annotations:
  - "workflow-type/infrastructure"
dataInputSchema: schemas/test-active-boolean__main-schema.json
extensions:
  - extensionid: workflow-output-schema
    outputSchema: schemas/workflow-output-schema.json
start: StartState
functions:
  - name: runActionFunction
    type: custom
    operation: sysout
  - name: successResult
    type: expression
    operation: '{ "result": { "message": "ActiveBoolean test completed successfully" } }'
states:
  - name: StartState
    type: operation
    actions:
      - name: runAction
        functionRef:
          refName: runActionFunction
          arguments:
            message: '"Workflow completed with input: " + (. | tostring)'
      - name: setOutput
        functionRef:
          refName: successResult
    end: true
```

**File: `packages/backend/.devModeTemp/repository/workflows/schemas/test-active-boolean__main-schema.json`**

<details>
<summary>Click to expand schema (169 lines)</summary>

```json
{
  "$id": "classpath:/schemas/test-active-boolean__main-schema.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Test ActiveBoolean Widget",
  "type": "object",
  "description": "Testing ActiveBoolean widget with various fetch and ui:props configurations",
  "properties": {
    "basicTests": {
      "type": "object",
      "title": "Basic ActiveBoolean Tests",
      "description": "Test basic fetch capabilities of ActiveBoolean widget",
      "properties": {
        "basicFeature": {
          "type": "boolean",
          "title": "Basic Feature Flag",
          "description": "Fetches boolean value from API - uses stock > 50 as boolean",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/1",
            "fetch:response:value": "stock > 50"
          }
        },
        "featureWithDefault": {
          "type": "boolean",
          "title": "Feature with Static Default",
          "description": "Has a static default that shows while fetch is loading",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/2",
            "fetch:response:value": "stock > 100",
            "fetch:response:default": true
          }
        },
        "stringCoercion": {
          "type": "boolean",
          "title": "String to Boolean Coercion",
          "description": "API returns string, widget coerces to boolean",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/3",
            "fetch:response:value": "availabilityStatus != 'Low Stock'",
            "fetch:response:default": false
          }
        },
        "numberCoercion": {
          "type": "boolean",
          "title": "Number to Boolean Coercion",
          "description": "API returns number, widget coerces to boolean",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/4",
            "fetch:response:value": "stock",
            "fetch:response:default": false
          }
        }
      }
    },
    "retriggerTests": {
      "type": "object",
      "title": "Retrigger and Dependency Tests",
      "description": "Test fetch:retrigger and dependent boolean fields",
      "properties": {
        "tenantId": {
          "type": "string",
          "title": "Product ID (Simulating Tenant)",
          "description": "Select a product ID to see different boolean values",
          "enum": ["5", "10", "15"],
          "default": "5"
        },
        "dependentFeature": {
          "type": "boolean",
          "title": "Tenant-Specific Feature",
          "description": "This boolean refetches when Product ID changes",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/$${{current.retriggerTests.tenantId}}",
            "fetch:response:value": "stock > 30",
            "fetch:retrigger": ["current.retriggerTests.tenantId"]
          }
        },
        "clearOnRetriggerFeature": {
          "type": "boolean",
          "title": "Feature with Clear on Retrigger",
          "description": "Clears before refetching",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/$${{current.retriggerTests.tenantId}}",
            "fetch:response:value": "price > 500",
            "fetch:retrigger": ["current.retriggerTests.tenantId"],
            "fetch:clearOnRetrigger": true
          }
        }
      }
    },
    "errorHandlingTests": {
      "type": "object",
      "title": "Error Handling Tests",
      "description": "Test error handling and retry behavior",
      "properties": {
        "silentErrorFeature": {
          "type": "boolean",
          "title": "Silent Error Handling",
          "description": "Errors are suppressed, shows default value",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/999999",
            "fetch:response:value": "stock > 0",
            "fetch:response:default": false,
            "fetch:error:silent": true
          }
        },
        "retryFeature": {
          "type": "boolean",
          "title": "Feature with Retry",
          "description": "Retries up to 3 times with exponential backoff",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/6",
            "fetch:response:value": "stock > 0",
            "fetch:retry:maxAttempts": 3,
            "fetch:retry:delay": 1000,
            "fetch:retry:backoff": 2,
            "fetch:retry:statusCodes": [404, 408, 429, 500, 502, 503, 504]
          }
        }
      }
    },
    "advancedTests": {
      "type": "object",
      "title": "Advanced Tests",
      "description": "Advanced scenarios and edge cases",
      "properties": {
        "readOnlyFeature": {
          "type": "boolean",
          "title": "Read-Only Feature Flag",
          "description": "This boolean is fetched but cannot be changed",
          "readOnly": true,
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/7",
            "fetch:response:value": "stock > 0"
          }
        },
        "skipInitialFeature": {
          "type": "boolean",
          "title": "Skip Initial Value",
          "description": "Doesn't apply fetched value initially",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/1",
            "fetch:response:value": "stock > 50",
            "fetch:skipInitialValue": true
          }
        },
        "complexSelectorFeature": {
          "type": "boolean",
          "title": "Complex JSONata Selector",
          "description": "Uses complex JSONata expression",
          "ui:widget": "ActiveBoolean",
          "ui:props": {
            "fetch:url": "$${{backend.baseUrl}}/api/proxy/dummyjson/products/8",
            "fetch:response:value": "(price > 100) and (stock > 10)",
            "fetch:response:default": false
          }
        }
      }
    }
  }
}
```

</details>


---

## Supported ui:props

All standard Active widget props are supported:

- `fetch:url` - API endpoint
- `fetch:response:value` - JSONata selector for boolean value
- `fetch:response:default` - Static fallback value
- `fetch:retrigger` - Array of form field paths to watch
- `fetch:clearOnRetrigger` - Clear value before refetching
- `fetch:skipInitialValue` - Don't apply initial fetch result
- `fetch:retry:maxAttempts` - Number of retry attempts
- `fetch:retry:delay` - Initial retry delay (ms)
- `fetch:retry:backoff` - Backoff multiplier
- `fetch:retry:statusCodes` - HTTP status codes to retry
- `fetch:error:silent` - Suppress error messages
- `fetch:method`, `fetch:headers`, `fetch:body` - Request configuration

