### PR TITLE
chore(app-defaults): add fixed changeset group for app-defaults and app-react

### DIFF
--- a/workspaces/app-defaults/.changeset/config.json
+++ b/workspaces/app-defaults/.changeset/config.json
@@ -2,6 +2,12 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
+  "fixed": [
+    [
+      "@red-hat-developer-hub/backstage-plugin-app-defaults",
+      "@red-hat-developer-hub/backstage-plugin-app-react"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
- Adds a `fixed` group to the changeset config so that `@red-hat-developer-hub/backstage-plugin-app-defaults` and `@red-hat-developer-hub/backstage-plugin-app-react` are always released together with the same version number.

## Test plan
- [ ] Verify the changeset config is valid JSON
- [ ] Confirm that future changeset version bumps apply to both packages simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)