### PR TITLE
feat(orchestrator): support nested objects in rjsf-widgets config

### DIFF
--- a/workspaces/orchestrator/.changeset/nested-rjsf-widgets-config.md
+++ b/workspaces/orchestrator/.changeset/nested-rjsf-widgets-config.md
@@ -1,6 +1,5 @@
 ---
 '@red-hat-developer-hub/backstage-plugin-orchestrator-common': minor
-'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': minor
 ---
 
 Support nested objects in `orchestrator.rjsf-widgets` configuration for hierarchical widget parameter organization.

--- a/workspaces/orchestrator/.changeset/nested-rjsf-widgets-config.md
+++ b/workspaces/orchestrator/.changeset/nested-rjsf-widgets-config.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-orchestrator-common': minor
+'@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets': minor
+---
+
+Support nested objects in `orchestrator.rjsf-widgets` configuration for hierarchical widget parameter organization.

--- a/workspaces/orchestrator/docs/orchestratorFormWidgets.md
+++ b/workspaces/orchestrator/docs/orchestratorFormWidgets.md
@@ -863,6 +863,52 @@ orchestrator:
 
 All values in this namespace are exposed to the frontend and must not contain secrets.
 
+#### Nested Configuration
+
+You can organize related parameters using nested objects (supported since v2.0+):
+
+```yaml
+orchestrator:
+  rjsf-widgets:
+    # Nested structures for widget-specific config
+    app-registration:
+      xParams:
+        name: app-registration
+        version: 0.21.0
+      environment: production
+
+    cloud-run:
+      xParams:
+        name: cloud-run
+        version: 1.0.0
+      region: us-central1
+
+    # Flat keys still work (backward compatible)
+    globalTimeout: '30s'
+    defaultEnvironment: production
+```
+
+**Accessing nested values in workflow schemas:**
+
+Access nested configuration using dot-path notation in templates:
+
+```json
+{
+  "ui:widget": "ActiveText",
+  "ui:props": {
+    "ui:text": "Deploying $${{rjsfConfig.app-registration.xParams.name}} v$${{rjsfConfig.app-registration.xParams.version}}"
+  }
+}
+```
+
+**Important notes:**
+
+- Templates resolve **leaf values only** (primitive strings, numbers, booleans)
+- Numbers and booleans are converted to strings: `version: 0.21.0` → `"0.21.0"`
+- Missing paths return `undefined` without crashing the form
+- Existing flat configurations continue to work
+- You can mix flat and nested keys in the same section
+
 |                                 Key Family                                  |                                                      Key                                                       |                                                                                                                                                                                                                                     Value of at runtime\<br\>(skipping promises for simplicity)                                                                                                                                                                                                                                     |
 | :-------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                   current                                   |                                           \[whatever property name\]                                           |                                                                                                                    Value of other field/property of the form. The properties build hierarchy separated by `.` (dots) matching the structure of fields/objects defined by the data input schema. Arrays or branches of a complex object structure can be passed as well, data are encoded into JSON in that case.                                                                                                                    |
@@ -875,7 +921,7 @@ All values in this namespace are exposed to the frontend and must not contain se
 | atlassianAuthApi githubAuthApi microsoftAuthApi gitlabAuthApi googleAuthApi |                                                  profileEmail                                                  |                                                                                                                                                                                                                                             ProfileInfoApi.getProfile(undefined).email                                                                                                                                                                                                                                              |
 | atlassianAuthApi githubAuthApi microsoftAuthApi gitlabAuthApi googleAuthApi |                                                  profileName                                                   |                                                                                                                                                                                                                                          ProfileInfoApi.getProfile(undefined).displayName                                                                                                                                                                                                                                           |
 |                                customAuthApi                                | One of: openIdToken, token, profileEmail, profileName (availability depends on custom-provided implementation) | Encapsulated access to custom-implemented authentication provider API. The provider API id must match its ApiRef id (as passed to `createApiRef()` when building the API). Full format: `[KEY_FAMILY].[PLUGIN_ID].[KEY]`. Example: `customAuthApi.my.auth.github-two.token` to access `OAuthApi.getAccessToken()` (if implemented) via custom apiRef created by: `createApiRef({id: 'my.auth.github-two'})`. See more info about [custom-provider implementation](https://backstage.io/docs/auth/#custom-scmauthapi-implementation) |
-|                                 rjsfConfig                                  |                                         orchestrator.\[whatever key\]                                          |                                                                                                                                                                                                                           configApi.getOptionalString(\`${orchestrator.rjsf-widgets.\[whatever key\]}\`)                                                                                                                                                                                                                            |
+|                                 rjsfConfig                                  |                                        \[whatever key or nested.path\]                                         |                                                                                                                                                                                       configApi.getOptionalString(\`orchestrator.rjsf-widgets.${key}\`). Supports dot-path notation for nested config (e.g., `app-registration.xParams.name`)                                                                                                                                                                                       |
 |                                   backend                                   |                                                    baseUrl                                                     |                                                                                                                                                                                                             configApi.getString('backend.baseUrl') - useful for building URLs with proxy without hardcoding the backend                                                                                                                                                                                                             |
 
 ## Retrieving Data from Backstage Catalog

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -86,11 +86,12 @@ export interface Config {
     /**
      * Public values available to form widget templates through `rjsfConfig.<key>`.
      * Supports both flat strings and nested objects for organizing widget-specific parameters.
+     * Values must be strings or objects - other types (numbers, booleans) will cause form errors.
      * Do not store secrets in this configuration because workflow authors can access every value.
      * @deepVisibility frontend
      */
     'rjsf-widgets'?: {
-      [key: string]: any;
+      [key: string]: string | { [key: string]: any };
     };
     /**
      * Kafka configuration for event-triggered workflows (KafkaJS-style).

--- a/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
+++ b/workspaces/orchestrator/plugins/orchestrator-common/config.d.ts
@@ -84,12 +84,13 @@ export interface Config {
       url: string;
     };
     /**
-     * Public string values available to form widget templates through `rjsfConfig.<key>`.
+     * Public values available to form widget templates through `rjsfConfig.<key>`.
+     * Supports both flat strings and nested objects for organizing widget-specific parameters.
      * Do not store secrets in this configuration because workflow authors can access every value.
      * @deepVisibility frontend
      */
     'rjsf-widgets'?: {
-      [key: string]: string;
+      [key: string]: any;
     };
     /**
      * Kafka configuration for event-triggered workflows (KafkaJS-style).

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
@@ -132,6 +132,80 @@ describe('useTemplateUnitEvaluator', () => {
     );
   });
 
+  it('evaluates rjsfConfig.* with nested paths', async () => {
+    configApi.getOptionalString.mockImplementation((path: string) => {
+      const configs: Record<string, string> = {
+        'orchestrator.rjsf-widgets.app-registration.xParams.name':
+          'app-registration',
+        'orchestrator.rjsf-widgets.app-registration.xParams.version': '0.21.0',
+        'orchestrator.rjsf-widgets.cloud-run.xParams.name': 'cloud-run',
+      };
+      return configs[path];
+    });
+
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('rjsfConfig.app-registration.xParams.name', {} as any),
+    ).resolves.toBe('app-registration');
+    expect(configApi.getOptionalString).toHaveBeenCalledWith(
+      'orchestrator.rjsf-widgets.app-registration.xParams.name',
+    );
+
+    await expect(
+      result.current('rjsfConfig.app-registration.xParams.version', {} as any),
+    ).resolves.toBe('0.21.0');
+    expect(configApi.getOptionalString).toHaveBeenCalledWith(
+      'orchestrator.rjsf-widgets.app-registration.xParams.version',
+    );
+  });
+
+  it('evaluates rjsfConfig.* with multiple nested widget namespaces', async () => {
+    configApi.getOptionalString.mockImplementation((path: string) => {
+      const configs: Record<string, string> = {
+        'orchestrator.rjsf-widgets.cloud-run.xParams.name': 'cloud-run',
+      };
+      return configs[path];
+    });
+
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('rjsfConfig.cloud-run.xParams.name', {} as any),
+    ).resolves.toBe('cloud-run');
+  });
+
+  it('returns undefined for missing nested paths in rjsfConfig', async () => {
+    configApi.getOptionalString.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('rjsfConfig.nonexistent.path', {} as any),
+    ).resolves.toBeUndefined();
+  });
+
+  it('supports mixed flat and nested keys in rjsfConfig', async () => {
+    configApi.getOptionalString.mockImplementation((path: string) => {
+      const configs: Record<string, string> = {
+        'orchestrator.rjsf-widgets.defaultEnvironment': 'production',
+        'orchestrator.rjsf-widgets.app-registration.xParams.name':
+          'app-registration',
+      };
+      return configs[path];
+    });
+
+    const { result } = renderHook(() => useTemplateUnitEvaluator());
+
+    await expect(
+      result.current('rjsfConfig.defaultEnvironment', {} as any),
+    ).resolves.toBe('production');
+
+    await expect(
+      result.current('rjsfConfig.app-registration.xParams.name', {} as any),
+    ).resolves.toBe('app-registration');
+  });
+
   it('evaluates fetch response selector units', async () => {
     mockedApplySelectorString.mockResolvedValue('resolved-value');
     const { result } = renderHook(() => useTemplateUnitEvaluator());

--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/utils/useTemplateUnitEvaluator.test.tsx
@@ -133,15 +133,18 @@ describe('useTemplateUnitEvaluator', () => {
   });
 
   it('evaluates rjsfConfig.* with nested paths', async () => {
-    configApi.getOptionalString.mockImplementation((path: string) => {
-      const configs: Record<string, string> = {
-        'orchestrator.rjsf-widgets.app-registration.xParams.name':
-          'app-registration',
-        'orchestrator.rjsf-widgets.app-registration.xParams.version': '0.21.0',
-        'orchestrator.rjsf-widgets.cloud-run.xParams.name': 'cloud-run',
-      };
-      return configs[path];
-    });
+    (configApi.getOptionalString as jest.Mock).mockImplementation(
+      (path: string) => {
+        const configs: Record<string, string> = {
+          'orchestrator.rjsf-widgets.app-registration.xParams.name':
+            'app-registration',
+          'orchestrator.rjsf-widgets.app-registration.xParams.version':
+            '0.21.0',
+          'orchestrator.rjsf-widgets.cloud-run.xParams.name': 'cloud-run',
+        };
+        return configs[path];
+      },
+    );
 
     const { result } = renderHook(() => useTemplateUnitEvaluator());
 
@@ -161,12 +164,14 @@ describe('useTemplateUnitEvaluator', () => {
   });
 
   it('evaluates rjsfConfig.* with multiple nested widget namespaces', async () => {
-    configApi.getOptionalString.mockImplementation((path: string) => {
-      const configs: Record<string, string> = {
-        'orchestrator.rjsf-widgets.cloud-run.xParams.name': 'cloud-run',
-      };
-      return configs[path];
-    });
+    (configApi.getOptionalString as jest.Mock).mockImplementation(
+      (path: string) => {
+        const configs: Record<string, string> = {
+          'orchestrator.rjsf-widgets.cloud-run.xParams.name': 'cloud-run',
+        };
+        return configs[path];
+      },
+    );
 
     const { result } = renderHook(() => useTemplateUnitEvaluator());
 
@@ -176,7 +181,7 @@ describe('useTemplateUnitEvaluator', () => {
   });
 
   it('returns undefined for missing nested paths in rjsfConfig', async () => {
-    configApi.getOptionalString.mockReturnValue(undefined);
+    (configApi.getOptionalString as jest.Mock).mockReturnValue(undefined);
 
     const { result } = renderHook(() => useTemplateUnitEvaluator());
 
@@ -186,14 +191,16 @@ describe('useTemplateUnitEvaluator', () => {
   });
 
   it('supports mixed flat and nested keys in rjsfConfig', async () => {
-    configApi.getOptionalString.mockImplementation((path: string) => {
-      const configs: Record<string, string> = {
-        'orchestrator.rjsf-widgets.defaultEnvironment': 'production',
-        'orchestrator.rjsf-widgets.app-registration.xParams.name':
-          'app-registration',
-      };
-      return configs[path];
-    });
+    (configApi.getOptionalString as jest.Mock).mockImplementation(
+      (path: string) => {
+        const configs: Record<string, string> = {
+          'orchestrator.rjsf-widgets.defaultEnvironment': 'production',
+          'orchestrator.rjsf-widgets.app-registration.xParams.name':
+            'app-registration',
+        };
+        return configs[path];
+      },
+    );
 
     const { result } = renderHook(() => useTemplateUnitEvaluator());
 


### PR DESCRIPTION
#### Story - https://redhat.atlassian.net/browse/RHIDP-16437

## Summary

Adds support for nested objects in `orchestrator.rjsf-widgets` configuration, enabling Platform Engineers to organize widget parameters hierarchically.

## Changes

- **Config Schema**: Updated `config.d.ts` to accept `[key: string]: any` instead of `[key: string]: string`
- **Tests**: Added comprehensive test coverage for nested path resolution
- **Documentation**: Updated `orchestratorFormWidgets.md` with nested configuration examples
- **Backward Compatible**: Existing flat string keys continue to work and can be mixed with nested structures

## Video

https://github.com/user-attachments/assets/db239554-378e-4fd1-9673-c32f184b2873




## Example Configuration

```yaml
orchestrator:
  rjsf-widgets:
    # Nested structure
    app-registration:
      xParams:
        name: app-registration
        version: 0.21.0
    # Flat keys still work
    defaultEnvironment: production
```

## How to Test

### 1. Add Configuration

Add to your `app-config.local.yaml`:

```yaml
orchestrator:
  rjsf-widgets:
    app-registration:
      xParams:
        name: app-registration
        version: 0.21.0
      environment: dev
    cloud-run:
      xParams:
        name: cloud-run
        version: 1.0.0
    defaultEnvironment: production
```

### 2. Create Test Workflow

**Workflow**: `test-nested-config.sw.yaml`

```yaml
id: test-nested-config
version: "1.0"
specVersion: "0.8"
name: Test Nested rjsf-widgets Configuration
description: "Demonstrates nested and flat config values"
dataInputSchema: schemas/test-nested-config__main-schema.json
start: StartState
functions:
  - name: successResult
    type: expression
    operation: '{ "result": { "message": "Config test completed" } }'
states:
  - name: StartState
    type: operation
    actions:
      - name: setOutput
        functionRef:
          refName: successResult
    end: true
```

**Schema**: `schemas/test-nested-config__main-schema.json`

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Test Nested Config",
  "type": "object",
  "properties": {
    "flatConfig": {
      "type": "string",
      "title": "Flat Config Value",
      "ui:widget": "ActiveText",
      "ui:props": {
        "ui:text": "**Environment:** $${{rjsfConfig.defaultEnvironment}}"
      }
    },
    "nestedConfig": {
      "type": "string",
      "title": "Nested Config Values",
      "ui:widget": "ActiveText",
      "ui:props": {
        "ui:text": "## App Registration\n\n- **Name:** $${{rjsfConfig.app-registration.xParams.name}}\n- **Version:** $${{rjsfConfig.app-registration.xParams.version}}\n- **Env:** $${{rjsfConfig.app-registration.environment}}"
      }
    },
    "mixedExample": {
      "type": "string",
      "title": "Mixed Config Summary",
      "ui:widget": "ActiveText",
      "ui:props": {
        "ui:text": "# Summary\n\nGlobal: **$${{rjsfConfig.defaultEnvironment}}**\n\nWidgets:\n- $${{rjsfConfig.app-registration.xParams.name}} v$${{rjsfConfig.app-registration.xParams.version}}\n- $${{rjsfConfig.cloud-run.xParams.name}} v$${{rjsfConfig.cloud-run.xParams.version}}"
      }
    }
  }
}
```

### 3. Run Tests

```bash
yarn workspace @red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets test useTemplateUnitEvaluator
```

All 10 tests should pass, including new tests for:
- Nested path resolution
- Multiple widget namespaces
- Mixed flat and nested keys
- Missing paths return undefined

### 4. Test in UI

1. Start backend: `yarn dev`
2. Navigate to Orchestrator → Workflows
3. Run "Test Nested rjsf-widgets Configuration" workflow
4. Verify the form displays:
   - Flat config: `defaultEnvironment` → "production"
   - Nested config: `app-registration.xParams.name` → "app-registration"
   - All values rendered as markdown in ActiveText widgets

## Customer Request

Resolves customer feature request for hierarchical widget parameter organization (xParams configuration).
