### PR TITLE
OCPBUGS-96718: Upgrade CVEs: basic-ftp and js-cookie

### DIFF
--- a/workspaces/dcm/package.json
+++ b/workspaces/dcm/package.json
@@ -70,7 +70,9 @@
     "@types/react-dom": "^18",
     "fsevents": "~2.3.2",
     "@backstage/backend-app-api": "1.4.1",
-    "@backstage/backend-plugin-api": "1.6.2"
+    "@backstage/backend-plugin-api": "1.6.2",
+    "basic-ftp": "^5.3.1",
+    "js-cookie": "^3.0.7"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/workspaces/dcm/yarn.lock
+++ b/workspaces/dcm/yarn.lock
@@ -16734,10 +16734,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.1.0
-  resolution: "basic-ftp@npm:5.1.0"
-  checksum: 10/49cdc2e0282487131520bbcd9b72215d6f66064799cdbbd3aecc6c1df06635e603dd9a2b8e940a4f7e6045f94486dee51143adb82c13a9d5d866f2fd987438b9
+"basic-ftp@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10/9232ee155114efafadf5adee86a6750208653a9071e53e9803dceac61a66b3ba3974771ff2490ff28f1a118fdfb806ffcc488f64609e61a9cedb52480b312843
   languageName: node
   linkType: hard
 
@@ -24003,10 +24003,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 10/4387f5f5691cb96ca9ff8852c589d3012b53f484fda68630a39e20cabc6c5b740f09225e23233ba56cd9de6ebe300a23d20b2c7315f10c309ad5a89fd8c4990b
+"js-cookie@npm:^3.0.7":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10/6bc10dc1ef0ad4780cd43a0413702d0b8d9d8d167c4fb605ae66c388270dece6b4cad4c8944654cc67b6e0e7639da379a7b48e7b7ad8711a80f60aba6a915548
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Upgrades dependencies to patch known vulnerabilities and secure the project.

### 🛡️ Dependency Updates
* **`basic-ftp`**: Upgraded from `5.1.0` to `^5.3.1`
* **`js-cookie`**: Upgraded from `2.2.1` to `^3.0.7` *(Patches prototype pollution vulnerability)*
