### PR TITLE
fix(homepage): use service-to-service auth for catalog entity lookup

### DIFF
--- a/workspaces/homepage/.changeset/fix-homepage-service-auth.md
+++ b/workspaces/homepage/.changeset/fix-homepage-service-auth.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-homepage-backend': patch
+---
+
+Use service-to-service auth for catalog entity lookup so group-based widget visibility works even when RBAC prevents the user from reading their own catalog entity.

--- a/workspaces/homepage/plugins/homepage-backend/src/defaultWidgets/buildUserContext.ts
+++ b/workspaces/homepage/plugins/homepage-backend/src/defaultWidgets/buildUserContext.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  AuthService,
   BackstageCredentials,
   BackstageUserPrincipal,
   LoggerService,
@@ -31,19 +32,27 @@ import { homepageDefaultWidgetsReadPermission } from '@red-hat-developer-hub/bac
 import { UserContext } from './types';
 
 export async function buildUserContext(opts: {
-  credentials: BackstageCredentials<BackstageUserPrincipal>;
+  auth: AuthService;
   catalog: CatalogService;
   permissions: PermissionsService;
   referencedPermissions: Set<string>;
   logger: LoggerService;
+  userCredentials: BackstageCredentials<BackstageUserPrincipal>;
 }): Promise<UserContext> {
-  const { credentials, catalog, permissions, referencedPermissions, logger } =
-    opts;
+  const {
+    auth,
+    catalog,
+    permissions,
+    referencedPermissions,
+    logger,
+    userCredentials,
+  } = opts;
 
   // user ref
-  const userEntityRef = credentials.principal.userEntityRef;
+  const userEntityRef = userCredentials.principal.userEntityRef;
+  const serviceCredentials = await auth.getOwnServiceCredentials();
   const userEntity = await catalog.getEntityByRef(userEntityRef, {
-    credentials,
+    credentials: serviceCredentials,
   });
 
   if (!userEntity) {
@@ -78,7 +87,7 @@ export async function buildUserContext(opts: {
 
   const [defaultWidgetsReadDecision, ...otherConditionalDecisions] =
     await permissions.authorizeConditional(conditionalPermissionRequests, {
-      credentials,
+      credentials: userCredentials,
     });
 
   const otherPolicyDecisions = new Map<string, PolicyDecision>();

--- a/workspaces/homepage/plugins/homepage-backend/src/router.ts
+++ b/workspaces/homepage/plugins/homepage-backend/src/router.ts
@@ -29,8 +29,10 @@ export async function createRouter({
   router.use(express.json());
 
   router.get('/default-widgets', async (req, res) => {
-    const credentials = await httpAuth.credentials(req, { allow: ['user'] });
-    const result = await defaultWidgets.getDefaultWidgets({ credentials });
+    const userCredentials = await httpAuth.credentials(req, {
+      allow: ['user'],
+    });
+    const result = await defaultWidgets.getDefaultWidgets({ userCredentials });
     res.json(result);
   });
 

--- a/workspaces/homepage/plugins/homepage-backend/src/services/DefaultWidgetsService.ts
+++ b/workspaces/homepage/plugins/homepage-backend/src/services/DefaultWidgetsService.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  AuthService,
   BackstageCredentials,
   BackstageUserPrincipal,
   LoggerService,
@@ -38,19 +39,21 @@ import {
 
 export interface DefaultWidgetsService {
   getDefaultWidgets(options: {
-    credentials: BackstageCredentials<BackstageUserPrincipal>;
+    userCredentials: BackstageCredentials<BackstageUserPrincipal>;
   }): Promise<DefaultWidgetsResponse>;
 }
 
 export class DefaultWidgetsServiceImpl implements DefaultWidgetsService {
   readonly #tree: DefaultWidgetNode[] | undefined;
   readonly #referencedPermissions: Set<string>;
+  readonly #auth: AuthService;
   readonly #catalog: typeof catalogServiceRef.T;
   readonly #permissions: PermissionsService;
   readonly #logger: LoggerService;
 
   static create(options: {
     config: RootConfigService;
+    auth: AuthService;
     catalog: typeof catalogServiceRef.T;
     permissions: PermissionsService;
     logger: LoggerService;
@@ -67,6 +70,7 @@ export class DefaultWidgetsServiceImpl implements DefaultWidgetsService {
     return new DefaultWidgetsServiceImpl(
       tree,
       referencedPermissions,
+      options.auth,
       options.catalog,
       options.permissions,
       options.logger,
@@ -76,31 +80,34 @@ export class DefaultWidgetsServiceImpl implements DefaultWidgetsService {
   private constructor(
     tree: DefaultWidgetNode[] | undefined,
     referencedPermissions: Set<string>,
+    auth: AuthService,
     catalog: typeof catalogServiceRef.T,
     permissions: PermissionsService,
     logger: LoggerService,
   ) {
     this.#tree = tree;
     this.#referencedPermissions = referencedPermissions;
+    this.#auth = auth;
     this.#catalog = catalog;
     this.#permissions = permissions;
     this.#logger = logger;
   }
 
   async getDefaultWidgets({
-    credentials,
+    userCredentials,
   }: {
-    credentials: BackstageCredentials<BackstageUserPrincipal>;
+    userCredentials: BackstageCredentials<BackstageUserPrincipal>;
   }): Promise<DefaultWidgetsResponse> {
     if (!this.#tree) {
       return {};
     }
     const ctx = await buildUserContext({
-      credentials,
+      auth: this.#auth,
       catalog: this.#catalog,
       permissions: this.#permissions,
       referencedPermissions: this.#referencedPermissions,
       logger: this.#logger,
+      userCredentials,
     });
     return {
       items: filterToVisibleLeaves(this.#tree, ctx),
@@ -116,6 +123,7 @@ export const defaultWidgetsServiceRef = createServiceRef<DefaultWidgetsService>(
         service,
         deps: {
           config: coreServices.rootConfig,
+          auth: coreServices.auth,
           catalog: catalogServiceRef,
           permissions: coreServices.permissions,
           logger: coreServices.logger,


### PR DESCRIPTION
## Summary
- **RHDHBUGS-3339**: Group-based default widget visibility failed when RBAC prevented the user from reading their own catalog entity
- Uses `AuthService.getOwnServiceCredentials()` for the `getEntityByRef` call so the backend always resolves the user entity, regardless of the caller's catalog permissions
- Permission checks (`authorizeConditional`) still use the original user credentials to correctly evaluate RBAC policies

## Test plan
- [ ] Configure default widgets with group-based visibility (`if.groups`)
- [ ] Enable RBAC and remove catalog read access for a test user
- [ ] Verify the user can see group-targeted widgets on the homepage
- [ ] Verify permission-based widget visibility still works correctly

Fixes: [RHDHBUGS-3339](https://issues.redhat.com/browse/RHDHBUGS-3339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)