### PR TITLE
test(adoption-insights): cover the NFS wiring, not just that the plugin exists

### DIFF
--- a/workspaces/adoption-insights/.changeset/eighty-carrots-repeat.md
+++ b/workspaces/adoption-insights/.changeset/eighty-carrots-repeat.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+Cover the new frontend system wiring with createExtensionTester: the page's path, title and route ref, and that both the page and the API extension are registered on the plugin. The existing alpha tests all pass against a plugin whose extensions array is empty, which is one of the two ways an NFS plugin fails silently.

--- a/workspaces/adoption-insights/plugins/adoption-insights/package.json
+++ b/workspaces/adoption-insights/plugins/adoption-insights/package.json
@@ -81,6 +81,7 @@
     "@backstage/config": "^1.3.8",
     "@backstage/core-app-api": "^1.20.2",
     "@backstage/dev-utils": "^1.1.24",
+    "@backstage/frontend-test-utils": "^0.6.1",
     "@backstage/plugin-catalog": "^2.0.6",
     "@backstage/test-utils": "^1.7.19",
     "@red-hat-developer-hub/backstage-plugin-theme": "^0.14.11",

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/alpha.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/alpha.test.tsx
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { coreExtensionData } from '@backstage/frontend-plugin-api';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+
 import plugin, { adoptionInsightsTranslationsModule } from './alpha';
 import translationsModuleDefault from './adoptionInsightsTranslationsModuleExport';
+import { rootRouteRef } from './routes';
 
 describe('adoption-insights alpha', () => {
   it('should export a valid frontend plugin', () => {
@@ -40,5 +44,29 @@ describe('adoption-insights alpha', () => {
 
   it('should export the translations module as default for NFS discovery', () => {
     expect(translationsModuleDefault).toBe(adoptionInsightsTranslationsModule);
+  });
+});
+
+describe('adoption-insights NFS wiring', () => {
+  // Everything above stays green against a plugin that contributes nothing:
+  // dropping the page from `extensions` leaves `$$type`, `id` and `routes`
+  // untouched, and the app then boots clean with no Adoption Insights anywhere
+  // — no error, no warning. These read the values the app actually resolves.
+  it('declares the path, title and route ref the app renders the page under', () => {
+    const tester = createExtensionTester(
+      plugin.getExtension('page:adoption-insights'),
+    );
+
+    expect(tester.get(coreExtensionData.routePath)).toBe('/adoption-insights');
+    expect(tester.get(coreExtensionData.title)).toBe('Adoption Insights');
+    expect(tester.get(coreExtensionData.routeRef)).toBe(rootRouteRef);
+  });
+
+  it('registers the page and the API extension on the plugin', () => {
+    // The API carries no extension data to assert, so this lookup is the only
+    // thing standing between it and being dropped from `extensions` — at which
+    // point the page renders and every request it makes fails.
+    expect(plugin.getExtension('page:adoption-insights')).toBeDefined();
+    expect(plugin.getExtension('api:adoption-insights')).toBeDefined();
   });
 });

--- a/workspaces/adoption-insights/yarn.lock
+++ b/workspaces/adoption-insights/yarn.lock
@@ -8878,6 +8878,7 @@ __metadata:
     "@backstage/core-plugin-api": "npm:^1.12.7"
     "@backstage/dev-utils": "npm:^1.1.24"
     "@backstage/frontend-plugin-api": "npm:^0.17.2"
+    "@backstage/frontend-test-utils": "npm:^0.6.1"
     "@backstage/plugin-app-react": "npm:^0.2.4"
     "@backstage/plugin-catalog": "npm:^2.0.6"
     "@backstage/plugin-catalog-react": "npm:^3.1.0"


### PR DESCRIPTION
`src/alpha.test.tsx` has five assertions and none of them fail when the plugin stops working.

Emptying `extensions` leaves `$$type`, `id` and `routes` exactly as they are, so the suite stays green while Adoption Insights disappears from the app — no error, no console warning, exit 0. That is one of the two ways an NFS plugin fails silently, and it is the one nothing here catches.

## What's added

Two tests reading what the app actually resolves off the extension:

- the page's `routePath`, `title` and `routeRef`
- that the page **and** the API extension are registered on the plugin

The API extension carries no extension data to assert, so the registration lookup is the only thing covering it — hence a separate test rather than folding it into the first.

## Mutation-verified

Each mutation applied to `src/alpha.tsx`, suite re-run, source restored:

| Mutation | Result |
|---|---|
| page dropped from `extensions` | 2 failed |
| api dropped from `extensions` | 1 failed |
| `path: '/adoption-insights'` changed | 1 failed |
| `title: 'Adoption Insights'` changed | 1 failed |
| `routeRef: rootRouteRef` removed | 1 failed |

Five for five, and the counts are what tells the two tests apart: dropping the page fails both, dropping the api fails only the second.

## Why it matters beyond this plugin

At the e2e layer this failure arrives as `heading "Adoption Insights" not found` after a ~20 minute cluster deploy, in a different repository from the code that broke. Here it fails in about a second, in the repo that owns the blueprint, naming the extension.

Across this repo there are 13 NFS test files and only two assert any wiring at all (`ScorecardLayoutBlueprint.test.tsx`, `AiCatalogFilterBlueprint.test.ts`) — both blueprint tests, neither a plugin-wiring test. The rest assert `$$type`, `pluginId` and "is defined". This is the pattern for closing that, applied to one plugin first.

## Verification

From `workspaces/adoption-insights`:

    yarn tsc          # exit 0
    yarn lint         # exit 0
    yarn prettier --check .   # clean
    yarn test --no-watch plugins/adoption-insights/src/alpha.test.tsx   # 7 passed

`@backstage/frontend-test-utils` is added at `^0.6.1` — already resolved in the lockfile, and the same range `scorecard` and `global-header` use at this manifest version, so `yarn dedupe` is unaffected.

Part of [RHIDP-16455](https://redhat.atlassian.net/browse/RHIDP-16455).