### PR TITLE
feat(x2a): changed the module page

### DIFF
--- a/workspaces/x2a/.changeset/big-poets-kneel.md
+++ b/workspaces/x2a/.changeset/big-poets-kneel.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a': patch
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+Improve module page UX

--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -709,6 +709,17 @@ case "${PHASE}" in
       ARTIFACTS+=("adversarial_report_json:$(cat /app/agent-adversarial-report.json)")
     fi
 
+    echo ""
+    echo "=== Output directory contents ==="
+    ls -la "${OUTPUT_DIR}/"
+
+    if [[ -f "${REPORT_MD}" ]]; then
+      echo ""
+      echo "=== Adversarial report (${ACTUAL_PHASE}) ==="
+      cat "${REPORT_MD}"
+      echo ""
+    fi
+
     ARTIFACTS+=("adversarial_report:${PROJECT_DIR}/modules/${MODULE_NAME}/adversarial-report-${ACTUAL_PHASE}.md")
     ;;
 

--- a/workspaces/x2a/plugins/x2a/report-alpha.api.md
+++ b/workspaces/x2a/plugins/x2a/report-alpha.api.md
@@ -240,6 +240,8 @@ export const x2aPluginTranslationRef: TranslationRef<
     readonly 'modulePage.phases.runAdversarialReview': string;
     readonly 'modulePage.phases.adversarialReview': string;
     readonly 'modulePage.phases.adversarialNoRuns': string;
+    readonly 'modulePage.phases.adversarialRunning': string;
+    readonly 'modulePage.phases.adversarialCriticalAgentsWarning': string;
     readonly 'modulePage.phases.adversarialAgentLabel': string;
     readonly 'modulePage.phases.adversarialCriticalFindings': string;
     readonly 'modulePage.phases.adversarialWarningFindings': string;

--- a/workspaces/x2a/plugins/x2a/report.api.md
+++ b/workspaces/x2a/plugins/x2a/report.api.md
@@ -146,6 +146,8 @@ export const x2aPluginTranslationRef: TranslationRef<
     readonly 'modulePage.phases.runAdversarialReview': string;
     readonly 'modulePage.phases.adversarialReview': string;
     readonly 'modulePage.phases.adversarialNoRuns': string;
+    readonly 'modulePage.phases.adversarialRunning': string;
+    readonly 'modulePage.phases.adversarialCriticalAgentsWarning': string;
     readonly 'modulePage.phases.adversarialAgentLabel': string;
     readonly 'modulePage.phases.adversarialCriticalFindings': string;
     readonly 'modulePage.phases.adversarialWarningFindings': string;

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/AdversarialAgentsSelector.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/AdversarialAgentsSelector.tsx
@@ -25,12 +25,14 @@ import { extractResponseError, isHttpSuccessResponse } from '../tools';
 interface AdversarialAgentsSelectorProps {
   selectedAgentIds: string[];
   onSelectionChange: (agentIds: string[]) => void;
+  onAgentsLoaded?: (agents: AdversarialAgent[]) => void;
   phase?: 'analyze' | 'migrate';
 }
 
 export const AdversarialAgentsSelector = ({
   selectedAgentIds,
   onSelectionChange,
+  onAgentsLoaded,
   phase,
 }: AdversarialAgentsSelectorProps) => {
   const [agents, setAgents] = useState<AdversarialAgent[]>([]);
@@ -57,7 +59,9 @@ export const AdversarialAgentsSelector = ({
           return;
         }
         const data = await response.json();
-        setAgents(data.agents || []);
+        const loaded: AdversarialAgent[] = data.agents || [];
+        setAgents(loaded);
+        onAgentsLoaded?.(loaded);
       } catch {
         setError(t('modulePage.phases.adversarialAgents.loadingError'));
       } finally {
@@ -65,7 +69,7 @@ export const AdversarialAgentsSelector = ({
       }
     };
     fetchAgents();
-  }, [client, t, phase]);
+  }, [client, t, phase, onAgentsLoaded]);
 
   if (error) {
     return <Alert severity="error">{error}</Alert>;

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/AdversarialReviewSection.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/AdversarialReviewSection.tsx
@@ -40,15 +40,13 @@ import {
   MigrationPhase,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
-import millify from 'millify';
-
 import { useTranslation } from '../../hooks/useTranslation';
 import { useLogStream } from '../../hooks/useLogStream';
 import { useClientService } from '../../ClientService';
 import { ArtifactLink } from '../ArtifactLink';
 import { ItemField } from '../ItemField';
 import { PhaseStatus } from '../PhaseStatus';
-import { PhaseTelemetry } from '../PhaseTelemetry';
+import { TelemetrySection } from '../PhaseTelemetry';
 import {
   canCancelPhase,
   downloadLogFile,
@@ -173,15 +171,6 @@ export const AdversarialReviewSection = ({
       return undefined;
     }
   }, [job]);
-
-  const tokenTotals = useMemo(() => {
-    const all = Object.values(job?.telemetry?.agents ?? {});
-    if (all.length === 0) return undefined;
-    return {
-      inputTokens: all.reduce((s, a) => s + (a.inputTokens ?? 0), 0),
-      outputTokens: all.reduce((s, a) => s + (a.outputTokens ?? 0), 0),
-    };
-  }, [job?.telemetry]);
 
   const durationSeconds = job ? getEffectiveDurationSeconds(job) : undefined;
   const duration =
@@ -408,33 +397,7 @@ export const AdversarialReviewSection = ({
                 </Grid>
               )}
 
-              {job.telemetry && (
-                <>
-                  <Grid item xs={12}>
-                    <Grid container alignItems="baseline" spacing={2}>
-                      <Grid item>
-                        <Typography variant="h6">
-                          {t('modulePage.phases.telemetry.title')}
-                        </Typography>
-                      </Grid>
-                      {tokenTotals && (
-                        <Grid item>
-                          <Typography variant="body2" color="textSecondary">
-                            {millify(tokenTotals.inputTokens)}{' '}
-                            {t('modulePage.phases.telemetry.totalInputTokens')}
-                            {' · '}
-                            {millify(tokenTotals.outputTokens)}{' '}
-                            {t('modulePage.phases.telemetry.totalOutputTokens')}
-                          </Typography>
-                        </Grid>
-                      )}
-                    </Grid>
-                  </Grid>
-                  <Grid item xs={12}>
-                    <PhaseTelemetry telemetry={job.telemetry} />
-                  </Grid>
-                </>
-              )}
+              <TelemetrySection telemetry={job.telemetry} />
             </Grid>
           )}
         </AccordionDetails>

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/AdversarialReviewSection.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/AdversarialReviewSection.tsx
@@ -26,15 +26,21 @@ import {
   ButtonGroup,
   Divider,
   Grid,
+  Tooltip,
   Typography,
   makeStyles,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import WarningIcon from '@material-ui/icons/Warning';
 import {
+  AdversarialAgent,
   ArtifactKind,
   Job,
+  JobStatus,
   MigrationPhase,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
+
+import millify from 'millify';
 
 import { useTranslation } from '../../hooks/useTranslation';
 import { useLogStream } from '../../hooks/useLogStream';
@@ -42,6 +48,7 @@ import { useClientService } from '../../ClientService';
 import { ArtifactLink } from '../ArtifactLink';
 import { ItemField } from '../ItemField';
 import { PhaseStatus } from '../PhaseStatus';
+import { PhaseTelemetry } from '../PhaseTelemetry';
 import {
   canCancelPhase,
   downloadLogFile,
@@ -79,6 +86,14 @@ const useStyles = makeStyles(theme => ({
     flex: '1 1 300px',
     minWidth: 0,
   },
+  criticalWarningIcon: {
+    color: theme.palette.warning.main ?? '#f57c00',
+    fontSize: '1.1rem',
+    verticalAlign: 'middle',
+  },
+  warningTooltip: {
+    fontSize: theme.typography.body2.fontSize,
+  },
 }));
 
 export const AdversarialReviewSection = ({
@@ -110,6 +125,10 @@ export const AdversarialReviewSection = ({
   const empty = t('module.phases.none');
   const [showLog, setShowLog] = useState(false);
   const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
+  const [hasCriticalAgents, setHasCriticalAgents] = useState(false);
+  const handleAgentsLoaded = useCallback((agents: AdversarialAgent[]) => {
+    setHasCriticalAgents(agents.some(a => a.critical));
+  }, []);
 
   const fetchLog = useCallback(
     () =>
@@ -155,6 +174,15 @@ export const AdversarialReviewSection = ({
     }
   }, [job]);
 
+  const tokenTotals = useMemo(() => {
+    const all = Object.values(job?.telemetry?.agents ?? {});
+    if (all.length === 0) return undefined;
+    return {
+      inputTokens: all.reduce((s, a) => s + (a.inputTokens ?? 0), 0),
+      outputTokens: all.reduce((s, a) => s + (a.outputTokens ?? 0), 0),
+    };
+  }, [job?.telemetry]);
+
   const durationSeconds = job ? getEffectiveDurationSeconds(job) : undefined;
   const duration =
     durationSeconds === undefined ? empty : formatDuration(t, durationSeconds);
@@ -167,202 +195,250 @@ export const AdversarialReviewSection = ({
 
   if (!job && !canRun) return null;
 
+  const jobStatus = job?.status ? JobStatus.from(job.status) : undefined;
+  const isActive = jobStatus?.isActive() ?? false;
+
   return (
-    <Accordion>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Box className={classes.accordionSummaryContent}>
-          <Typography variant="subtitle2">
-            {t('modulePage.phases.adversarialReview')}
-          </Typography>
-          {job ? (
-            <>
-              <PhaseStatus status={job.status} />
-              {reportJson && (
-                <Typography variant="body2" color="textSecondary">
-                  {reportJson.total_critical_findings}{' '}
-                  {t('modulePage.phases.adversarialCriticalFindings')} &middot;{' '}
-                  {reportJson.total_findings -
-                    reportJson.total_critical_findings}{' '}
-                  {t('modulePage.phases.adversarialWarningFindings')}
-                </Typography>
-              )}
-              <Typography variant="body2" color="textSecondary">
-                {duration}
-              </Typography>
-            </>
-          ) : (
-            <Typography variant="body2" color="textSecondary">
-              {t('modulePage.phases.adversarialNoRuns')}
+    <Box>
+      {isActive && <Progress />}
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Box className={classes.accordionSummaryContent}>
+            <Typography variant="subtitle2">
+              {t('modulePage.phases.adversarialReview')}
             </Typography>
-          )}
-        </Box>
-      </AccordionSummary>
+            {job ? (
+              <>
+                <PhaseStatus status={job.status} />
+                {reportJson && (
+                  <Typography variant="body2" color="textSecondary">
+                    {reportJson.total_critical_findings}{' '}
+                    {t('modulePage.phases.adversarialCriticalFindings')}{' '}
+                    &middot;{' '}
+                    {reportJson.total_findings -
+                      reportJson.total_critical_findings}{' '}
+                    {t('modulePage.phases.adversarialWarningFindings')}
+                  </Typography>
+                )}
+                <Typography variant="body2" color="textSecondary">
+                  {duration}
+                </Typography>
+              </>
+            ) : (
+              <>
+                <Typography variant="body2" color="textSecondary">
+                  {t('modulePage.phases.adversarialNoRuns')}
+                </Typography>
+                {canRun && hasCriticalAgents && (
+                  <Tooltip
+                    title={t(
+                      'modulePage.phases.adversarialCriticalAgentsWarning',
+                    )}
+                    classes={{ tooltip: classes.warningTooltip }}
+                  >
+                    <WarningIcon className={classes.criticalWarningIcon} />
+                  </Tooltip>
+                )}
+              </>
+            )}
+          </Box>
+        </AccordionSummary>
 
-      <AccordionDetails className={classes.accordionDetails}>
-        {onRunAdversarial && canRun && (
-          <>
-            <Box className={classes.runRow}>
-              <Box className={classes.selectorWrapper}>
-                <AdversarialAgentsSelector
-                  selectedAgentIds={selectedAgentIds}
-                  onSelectionChange={setSelectedAgentIds}
-                  phase={runPhase}
-                />
-              </Box>
-              <Button
-                variant="outlined"
-                color="default"
-                size="small"
-                disabled={selectedAgentIds.length === 0}
-                onClick={() => onRunAdversarial(runPhase, selectedAgentIds)}
-              >
-                {t('modulePage.phases.runAdversarialReview')}
-              </Button>
-            </Box>
-            {job && <Divider style={{ margin: '16px 0' }} />}
-          </>
-        )}
-
-        {job && (
-          <Grid container spacing={3}>
-            <Grid item xs={2}>
-              <ItemField
-                label={t('modulePage.phases.status')}
-                value={<PhaseStatus status={job.status} />}
-              />
-            </Grid>
-            <Grid item xs={10}>
-              <ItemField
-                label={t('modulePage.phases.errorDetails')}
-                value={job.errorDetails || empty}
-              />
-            </Grid>
-
-            <Grid item xs={3}>
-              <ItemField
-                label={t('artifact.types.adversarial_report')}
-                value={
-                  <ArtifactLink
-                    artifact={reportArtifact}
-                    targetRepoUrl={targetRepoUrl}
-                    targetRepoBranch={targetRepoBranch}
+        <AccordionDetails className={classes.accordionDetails}>
+          {onRunAdversarial && canRun && (
+            <>
+              <Box className={classes.runRow}>
+                <Box className={classes.selectorWrapper}>
+                  <AdversarialAgentsSelector
+                    selectedAgentIds={selectedAgentIds}
+                    onSelectionChange={setSelectedAgentIds}
+                    onAgentsLoaded={handleAgentsLoaded}
+                    phase={runPhase}
                   />
-                }
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.adversarialCriticalFindings')}
-                value={
-                  reportJson !== undefined
-                    ? String(reportJson.total_critical_findings)
-                    : empty
-                }
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.adversarialWarningFindings')}
-                value={
-                  reportJson !== undefined
-                    ? String(
-                        reportJson.total_findings -
-                          reportJson.total_critical_findings,
-                      )
-                    : empty
-                }
-              />
-            </Grid>
-            <Grid item xs={3} />
-
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.startedAt')}
-                value={job.startedAt ? humanizeDate(job.startedAt) : empty}
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.duration')}
-                value={duration}
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.attempts')}
-                value={String(attemptCount)}
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.totalElapsed')}
-                value={totalDuration || empty}
-              />
-            </Grid>
-
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.k8sJobName')}
-                value={job.k8sJobName || empty}
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.id')}
-                value={job.id || empty}
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <ItemField
-                label={t('modulePage.phases.commitId')}
-                value={job.commitId || empty}
-              />
-            </Grid>
-            <Grid item xs={3} />
-
-            <Grid item xs={12}>
-              <ButtonGroup>
+                </Box>
                 <Button
                   variant="outlined"
+                  color="default"
                   size="small"
-                  onClick={() => setShowLog(prev => !prev)}
+                  disabled={selectedAgentIds.length === 0}
+                  onClick={() => onRunAdversarial(runPhase, selectedAgentIds)}
                 >
-                  {showLog
-                    ? t('modulePage.phases.hideLog')
-                    : t('modulePage.phases.viewLog')}
+                  {t('modulePage.phases.runAdversarialReview')}
                 </Button>
-                {canCancelPhase(job.status) && onCancel && (
-                  <Button variant="outlined" onClick={onCancel}>
-                    {t('modulePage.phases.cancel')}
-                  </Button>
-                )}
-              </ButtonGroup>
-            </Grid>
+              </Box>
+              {job && <Divider style={{ margin: '16px 0' }} />}
+            </>
+          )}
 
-            {showLog && (
-              <Grid item xs={12}>
-                {logLoading && <Progress />}
-                {logError && (
-                  <Typography color="error">{logError.message}</Typography>
-                )}
-                {logText !== undefined && (
-                  <div className={classes.logViewerWrapper}>
-                    <LogViewer
-                      text={logViewerText}
-                      onDownloadLog={() =>
-                        downloadLogFile(
-                          logText || '',
-                          `${adversarialPhaseName}-${projectId}`,
-                        )
-                      }
-                    />
-                  </div>
-                )}
+          {job && (
+            <Grid container spacing={3}>
+              <Grid item xs={2}>
+                <ItemField
+                  label={t('modulePage.phases.status')}
+                  value={<PhaseStatus status={job.status} />}
+                />
               </Grid>
-            )}
-          </Grid>
-        )}
-      </AccordionDetails>
-    </Accordion>
+              <Grid item xs={10}>
+                <ItemField
+                  label={t('modulePage.phases.errorDetails')}
+                  value={job.errorDetails || empty}
+                />
+              </Grid>
+
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('artifact.types.adversarial_report')}
+                  value={
+                    <ArtifactLink
+                      artifact={reportArtifact}
+                      targetRepoUrl={targetRepoUrl}
+                      targetRepoBranch={targetRepoBranch}
+                    />
+                  }
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.adversarialCriticalFindings')}
+                  value={
+                    reportJson !== undefined
+                      ? String(reportJson.total_critical_findings)
+                      : empty
+                  }
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.adversarialWarningFindings')}
+                  value={
+                    reportJson !== undefined
+                      ? String(
+                          reportJson.total_findings -
+                            reportJson.total_critical_findings,
+                        )
+                      : empty
+                  }
+                />
+              </Grid>
+              <Grid item xs={3} />
+
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.startedAt')}
+                  value={job.startedAt ? humanizeDate(job.startedAt) : empty}
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.duration')}
+                  value={duration}
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.attempts')}
+                  value={String(attemptCount)}
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.totalElapsed')}
+                  value={totalDuration || empty}
+                />
+              </Grid>
+
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.k8sJobName')}
+                  value={job.k8sJobName || empty}
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.id')}
+                  value={job.id || empty}
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <ItemField
+                  label={t('modulePage.phases.commitId')}
+                  value={job.commitId || empty}
+                />
+              </Grid>
+              <Grid item xs={3} />
+
+              <Grid item xs={12}>
+                <ButtonGroup>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => setShowLog(prev => !prev)}
+                  >
+                    {showLog
+                      ? t('modulePage.phases.hideLog')
+                      : t('modulePage.phases.viewLog')}
+                  </Button>
+                  {canCancelPhase(job.status) && onCancel && (
+                    <Button variant="outlined" onClick={onCancel}>
+                      {t('modulePage.phases.cancel')}
+                    </Button>
+                  )}
+                </ButtonGroup>
+              </Grid>
+
+              {showLog && (
+                <Grid item xs={12}>
+                  {logLoading && <Progress />}
+                  {logError && (
+                    <Typography color="error">{logError.message}</Typography>
+                  )}
+                  {logText !== undefined && (
+                    <div className={classes.logViewerWrapper}>
+                      <LogViewer
+                        text={logViewerText}
+                        onDownloadLog={() =>
+                          downloadLogFile(
+                            logText || '',
+                            `${adversarialPhaseName}-${projectId}`,
+                          )
+                        }
+                      />
+                    </div>
+                  )}
+                </Grid>
+              )}
+
+              {job.telemetry && (
+                <>
+                  <Grid item xs={12}>
+                    <Grid container alignItems="baseline" spacing={2}>
+                      <Grid item>
+                        <Typography variant="h6">
+                          {t('modulePage.phases.telemetry.title')}
+                        </Typography>
+                      </Grid>
+                      {tokenTotals && (
+                        <Grid item>
+                          <Typography variant="body2" color="textSecondary">
+                            {millify(tokenTotals.inputTokens)}{' '}
+                            {t('modulePage.phases.telemetry.totalInputTokens')}
+                            {' · '}
+                            {millify(tokenTotals.outputTokens)}{' '}
+                            {t('modulePage.phases.telemetry.totalOutputTokens')}
+                          </Typography>
+                        </Grid>
+                      )}
+                    </Grid>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <PhaseTelemetry telemetry={job.telemetry} />
+                  </Grid>
+                </>
+              )}
+            </Grid>
+          )}
+        </AccordionDetails>
+      </Accordion>
+    </Box>
   );
 };

--- a/workspaces/x2a/plugins/x2a/src/components/ModulePage/PhasesCard.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/ModulePage/PhasesCard.tsx
@@ -158,7 +158,6 @@ export const PhasesCard = ({
           moduleId={moduleId}
           onRunPhase={onRunPhase}
           onCancelPhase={onCancelPhase}
-          adversarialTelemetry={adversarialAnalyzePhase?.telemetry}
         />
         {onRunAdversarial && (
           <Box mt={2}>
@@ -192,7 +191,6 @@ export const PhasesCard = ({
           moduleId={moduleId}
           onRunPhase={onRunPhase}
           onCancelPhase={onCancelPhase}
-          adversarialTelemetry={adversarialMigratePhase?.telemetry}
         />
         {onRunAdversarial && (
           <Box mt={2}>

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
@@ -32,8 +32,6 @@ import {
   Phase,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
-import millify from 'millify';
-
 import { useTranslation } from '../hooks/useTranslation';
 import { useLogStream } from '../hooks/useLogStream';
 import { useClientService } from '../ClientService';
@@ -46,7 +44,7 @@ import {
   humanizeDate,
   secondsBetween,
 } from './tools';
-import { PhaseTelemetry } from './PhaseTelemetry';
+import { TelemetrySection } from './PhaseTelemetry';
 import { PhaseStatus } from './PhaseStatus';
 
 const useStyles = makeStyles(theme => ({
@@ -205,15 +203,6 @@ export const PhaseDetails = (
 
   const canRunPhase = phase?.status !== 'running';
 
-  const tokenTotals = useMemo(() => {
-    const all = Object.values(phase?.telemetry?.agents ?? {});
-    if (all.length === 0) return undefined;
-    return {
-      inputTokens: all.reduce((s, a) => s + (a.inputTokens ?? 0), 0),
-      outputTokens: all.reduce((s, a) => s + (a.outputTokens ?? 0), 0),
-    };
-  }, [phase?.telemetry]);
-
   const fetchLog = useCallback(
     () =>
       phaseName === 'init'
@@ -352,33 +341,7 @@ export const PhaseDetails = (
         </Grid>
       )}
 
-      {phase?.telemetry && (
-        <>
-          <Grid item xs={12}>
-            <Grid container alignItems="baseline" spacing={2}>
-              <Grid item>
-                <Typography variant="h6">
-                  {t('modulePage.phases.telemetry.title')}
-                </Typography>
-              </Grid>
-              {tokenTotals && (
-                <Grid item>
-                  <Typography variant="body2" color="textSecondary">
-                    {millify(tokenTotals.inputTokens)}{' '}
-                    {t('modulePage.phases.telemetry.totalInputTokens')}
-                    {' · '}
-                    {millify(tokenTotals.outputTokens)}{' '}
-                    {t('modulePage.phases.telemetry.totalOutputTokens')}
-                  </Typography>
-                </Grid>
-              )}
-            </Grid>
-          </Grid>
-          <Grid item xs={12}>
-            <PhaseTelemetry telemetry={phase?.telemetry} />
-          </Grid>
-        </>
-      )}
+      <TelemetrySection telemetry={phase?.telemetry} />
     </Grid>
   );
 };

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseDetails.tsx
@@ -30,7 +30,6 @@ import {
   MigrationPhase,
   ModulePhase,
   Phase,
-  Telemetry,
 } from '@red-hat-developer-hub/backstage-plugin-x2a-common';
 
 import millify from 'millify';
@@ -175,7 +174,6 @@ export const PhaseDetails = (
     projectId: string;
     onRunPhase?: (phase: MigrationPhase) => void;
     onCancelPhase?: (phase: MigrationPhase) => void;
-    adversarialTelemetry?: Telemetry;
   } & OptionalModuleId,
 ) => {
   const { t } = useTranslation();
@@ -184,14 +182,7 @@ export const PhaseDetails = (
   const empty = t('module.phases.none');
   const [showLog, setShowLog] = useState(false);
 
-  const {
-    phase,
-    projectId,
-    phaseName,
-    onRunPhase,
-    onCancelPhase,
-    adversarialTelemetry,
-  } = props;
+  const { phase, projectId, phaseName, onRunPhase, onCancelPhase } = props;
   const moduleId = 'moduleId' in props ? props.moduleId : undefined;
 
   const durationSeconds = phase
@@ -215,16 +206,13 @@ export const PhaseDetails = (
   const canRunPhase = phase?.status !== 'running';
 
   const tokenTotals = useMemo(() => {
-    const all = [
-      ...Object.values(phase?.telemetry?.agents ?? {}),
-      ...Object.values(adversarialTelemetry?.agents ?? {}),
-    ];
+    const all = Object.values(phase?.telemetry?.agents ?? {});
     if (all.length === 0) return undefined;
     return {
       inputTokens: all.reduce((s, a) => s + (a.inputTokens ?? 0), 0),
       outputTokens: all.reduce((s, a) => s + (a.outputTokens ?? 0), 0),
     };
-  }, [phase?.telemetry, adversarialTelemetry]);
+  }, [phase?.telemetry]);
 
   const fetchLog = useCallback(
     () =>
@@ -364,7 +352,7 @@ export const PhaseDetails = (
         </Grid>
       )}
 
-      {(phase?.telemetry || adversarialTelemetry) && (
+      {phase?.telemetry && (
         <>
           <Grid item xs={12}>
             <Grid container alignItems="baseline" spacing={2}>
@@ -387,10 +375,7 @@ export const PhaseDetails = (
             </Grid>
           </Grid>
           <Grid item xs={12}>
-            <PhaseTelemetry
-              telemetry={phase?.telemetry}
-              adversarialTelemetry={adversarialTelemetry}
-            />
+            <PhaseTelemetry telemetry={phase?.telemetry} />
           </Grid>
         </>
       )}

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseTelemetry.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseTelemetry.tsx
@@ -70,7 +70,6 @@ const useStyles = makeStyles(theme => ({
 
 interface AgentRow extends AgentMetrics {
   id: string;
-  isAdversarial?: boolean;
 }
 
 const ToolCallsCell = ({
@@ -140,35 +139,21 @@ const AgentDetailPanel = ({ row }: { row: AgentRow }) => {
   );
 };
 
-export const PhaseTelemetry = ({
-  telemetry,
-  adversarialTelemetry,
-}: {
-  telemetry?: Telemetry;
-  adversarialTelemetry?: Telemetry;
-}) => {
+export const PhaseTelemetry = ({ telemetry }: { telemetry?: Telemetry }) => {
   const { t } = useTranslation();
   const classes = useStyles();
   const theme = useTheme();
   const [selectedAgent, setSelectedAgent] = useState<AgentRow | null>(null);
 
   const agentRows = useMemo((): AgentRow[] => {
-    const regular = telemetry?.agents
-      ? Object.entries(telemetry.agents).map(([id, metrics]) => ({
-          id,
-          ...metrics,
-          isAdversarial: false,
-        }))
-      : [];
-    const adversarial = adversarialTelemetry?.agents
-      ? Object.entries(adversarialTelemetry.agents).map(([id, metrics]) => ({
-          id: `adversarial-${id}`,
-          ...metrics,
-          isAdversarial: true,
-        }))
-      : [];
-    return [...regular, ...adversarial];
-  }, [telemetry, adversarialTelemetry]);
+    if (!telemetry?.agents) {
+      return [];
+    }
+    return Object.entries(telemetry.agents).map(([id, metrics]) => ({
+      id,
+      ...metrics,
+    }));
+  }, [telemetry]);
 
   const columns = useMemo((): TableColumn<AgentRow>[] => {
     return [
@@ -231,11 +216,6 @@ export const PhaseTelemetry = ({
             <Box className={classes.drawerHeader}>
               <Box>
                 <Typography variant="h6">{selectedAgent.name}</Typography>
-                {selectedAgent.isAdversarial && (
-                  <Typography variant="caption" color="textSecondary">
-                    {t('modulePage.phases.adversarialAgentLabel')}
-                  </Typography>
-                )}
               </Box>
               <IconButton
                 size="small"

--- a/workspaces/x2a/plugins/x2a/src/components/PhaseTelemetry.tsx
+++ b/workspaces/x2a/plugins/x2a/src/components/PhaseTelemetry.tsx
@@ -235,3 +235,53 @@ export const PhaseTelemetry = ({ telemetry }: { telemetry?: Telemetry }) => {
     </>
   );
 };
+
+/**
+ * Telemetry heading with aggregated token totals and the per-agent table.
+ * Renders as `<Grid item>` children, so it must be placed inside a
+ * `<Grid container>`. Returns null when there is no telemetry.
+ */
+export const TelemetrySection = ({ telemetry }: { telemetry?: Telemetry }) => {
+  const { t } = useTranslation();
+
+  const tokenTotals = useMemo(() => {
+    const all = Object.values(telemetry?.agents ?? {});
+    if (all.length === 0) return undefined;
+    return {
+      inputTokens: all.reduce((s, a) => s + (a.inputTokens ?? 0), 0),
+      outputTokens: all.reduce((s, a) => s + (a.outputTokens ?? 0), 0),
+    };
+  }, [telemetry]);
+
+  if (!telemetry) {
+    return null;
+  }
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <Grid container alignItems="baseline" spacing={2}>
+          <Grid item>
+            <Typography variant="h6">
+              {t('modulePage.phases.telemetry.title')}
+            </Typography>
+          </Grid>
+          {tokenTotals && (
+            <Grid item>
+              <Typography variant="body2" color="textSecondary">
+                {millify(tokenTotals.inputTokens)}{' '}
+                {t('modulePage.phases.telemetry.totalInputTokens')}
+                {' · '}
+                {millify(tokenTotals.outputTokens)}{' '}
+                {t('modulePage.phases.telemetry.totalOutputTokens')}
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+      </Grid>
+      <Grid item xs={12}>
+        <PhaseTelemetry telemetry={telemetry} />
+      </Grid>
+    </>
+  );
+};

--- a/workspaces/x2a/plugins/x2a/src/translations/de.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/de.ts
@@ -328,6 +328,9 @@ const x2aPluginTranslationDe = createTranslationMessages({
       'Adversarielle Überprüfung starten',
     'modulePage.phases.adversarialReview': 'Adversarielle Überprüfung',
     'modulePage.phases.adversarialNoRuns': 'Noch keine Läufe',
+    'modulePage.phases.adversarialRunning': 'Adversarielle Überprüfung läuft…',
+    'modulePage.phases.adversarialCriticalAgentsWarning':
+      'Kritische adversarielle Agenten sind konfiguriert, wurden aber für diese Phase noch nicht ausgeführt.',
     'modulePage.phases.adversarialAgentLabel': 'adversariell',
     'modulePage.phases.adversarialCriticalFindings': 'Kritische Befunde',
     'modulePage.phases.adversarialWarningFindings': 'Warnungsbefunde',

--- a/workspaces/x2a/plugins/x2a/src/translations/es.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/es.ts
@@ -334,6 +334,10 @@ const x2aPluginTranslationEs = createTranslationMessages({
     'modulePage.phases.runAdversarialReview': 'Ejecutar revisión adversarial',
     'modulePage.phases.adversarialReview': 'Revisión Adversarial',
     'modulePage.phases.adversarialNoRuns': 'Sin ejecuciones aún',
+    'modulePage.phases.adversarialRunning':
+      'La revisión adversarial está en curso…',
+    'modulePage.phases.adversarialCriticalAgentsWarning':
+      'Los agentes adversariales críticos están configurados pero no se han ejecutado para esta fase.',
     'modulePage.phases.adversarialAgentLabel': 'adversarial',
     'modulePage.phases.adversarialCriticalFindings': 'Hallazgos Críticos',
     'modulePage.phases.adversarialWarningFindings': 'Hallazgos de Advertencia',

--- a/workspaces/x2a/plugins/x2a/src/translations/fr.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/fr.ts
@@ -336,6 +336,10 @@ const x2aPluginTranslationFr = createTranslationMessages({
     'modulePage.phases.runAdversarialReview': 'Lancer la revue adversariale',
     'modulePage.phases.adversarialReview': 'Revue Adversariale',
     'modulePage.phases.adversarialNoRuns': 'Aucune exécution pour le moment',
+    'modulePage.phases.adversarialRunning':
+      'La révision adversariale est en cours…',
+    'modulePage.phases.adversarialCriticalAgentsWarning':
+      "Des agents adversariaux critiques sont configurés mais n'ont pas encore été exécutés pour cette phase.",
     'modulePage.phases.adversarialAgentLabel': 'adversarial',
     'modulePage.phases.adversarialCriticalFindings': 'Résultats Critiques',
     'modulePage.phases.adversarialWarningFindings': "Résultats d'Avertissement",

--- a/workspaces/x2a/plugins/x2a/src/translations/it.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/it.ts
@@ -335,6 +335,10 @@ const x2aPluginTranslationIt = createTranslationMessages({
     'modulePage.phases.runAdversarialReview': 'Esegui revisione avversariale',
     'modulePage.phases.adversarialReview': 'Revisione Avversariale',
     'modulePage.phases.adversarialNoRuns': 'Nessuna esecuzione ancora',
+    'modulePage.phases.adversarialRunning':
+      'La revisione avversariale è in corso…',
+    'modulePage.phases.adversarialCriticalAgentsWarning':
+      'Gli agenti avversariali critici sono configurati ma non sono stati ancora eseguiti per questa fase.',
     'modulePage.phases.adversarialAgentLabel': 'avversariale',
     'modulePage.phases.adversarialCriticalFindings': 'Risultati Critici',
     'modulePage.phases.adversarialWarningFindings': 'Risultati di Avviso',

--- a/workspaces/x2a/plugins/x2a/src/translations/ref.ts
+++ b/workspaces/x2a/plugins/x2a/src/translations/ref.ts
@@ -135,6 +135,9 @@ export const x2aPluginMessages = {
       runAdversarialReview: 'Run Adversarial Review',
       adversarialReview: 'Adversarial Review',
       adversarialNoRuns: 'No runs yet',
+      adversarialRunning: 'Adversarial review is running…',
+      adversarialCriticalAgentsWarning:
+        'Critical adversarial agents are configured but have not been run for this phase.',
       adversarialAgentLabel: 'adversarial',
       adversarialCriticalFindings: 'Critical Findings',
       adversarialWarningFindings: 'Warning Findings',


### PR DESCRIPTION
  Two UX improvements to the module page:

Running indicator: a progress bar appears above the adversarial accordion while a job is running, making the active state visible without needing to expand the accordion.
Critical agents warning: a warning icon (with text) appears when critical adversarial agents are configured for the phase but didn't run
Separate telemetry tables: adversarial and regular phase telemetry are shown in their own tables.  
 Adversarial job logs: the adversarial job now prints its output directory