### PR TITLE
fix(scorecard): score first in-window DORA deploys using the prior production deployment

### DIFF
--- a/workspaces/scorecard/.changeset/dora-first-in-window-deploys.md
+++ b/workspaces/scorecard/.changeset/dora-first-in-window-deploys.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-dora': minor
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-github': patch
+---
+
+Include the first in-window successful production deployment in DORA median lead time and change failure rate by using the latest prior successful production deployment as the pair/interval start. GitHub deployment collectors accept an optional fetchItemsLimit so that predecessor lookup stays capped.

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/docs/metrics/change-failure-rate.md
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/docs/metrics/change-failure-rate.md
@@ -8,16 +8,28 @@
 Change Failure Rate measures how often production deployments lead to failures that require incident response.
 
 The metric computes the percentage of successful production deployment intervals that contain at least one incident, out of all evaluated successful production deployment intervals.
-Only successful production deployments that happen within the metric's 30-day computation window are evaluated.
+The 30-day window decides which successful production deployments are **in-window**.
 Deployments are processed as chronological pairs (`deployment` -> `nextDeployment`), and each pair defines an interval:
 `[deployment.createdAt, nextDeployment.createdAt)`.
 
 For each interval, if at least one incident has `createdAt` in that interval, the deployment is treated as failed.
 The result is: `(deploymentsWithIncidents / evaluatedDeployments) * 100`.
 
-The metric is **deployment-interval based**, not incident-window based: only incidents that fall between two successful production deployments are scored. An incident after the latest successful production deployment in the 30-day window is not counted in that run, even if it was created within the DORA 30-day window. It is attributed in a later DORA calculation to the interval closed by the next successful production deployment (the first deployment that follows).
+### Pre-window predecessor
 
-If fewer than two successful production deployments exist in the window, or there are no evaluable intervals (adjacent deployments share the same `createdAt`), calculation fails with an error.
+To attribute incidents that fall **before** the first in-window deployment, the metric also loads the latest successful production deployment **before** the window start (`windowFrom`) from the deployments collector.
+
+That predecessor is the start of the interval that **ends** at the first in-window deploy: `[predecessor.createdAt, firstInWindow.createdAt)`.
+When a predecessor exists, incidents are collected from `predecessor.createdAt` (not only from `windowFrom`), so incidents in that leading gap are counted.
+
+- Predecessor exists: one in-window successful production deployment is enough to form that interval.
+- No predecessor: behavior is unchanged. Two successful production deployments in the 30-day window are still required, and incident collection starts at `windowFrom`.
+
+The predecessor lookup is a second deployments-collector call with `from` at `1970-01-01T00:00:00.000Z` and `to` immediately before `windowFrom`, plus optional `fetchItemsLimit` (100). Default GitHub collectors honor that cap and keep the newest in-range rows. If those rows are all failed or non-production, the predecessor is omitted. Custom collectors that ignore the cap may return a larger history.
+
+The metric is **deployment-interval based**, not incident-window based: only incidents that fall between two successful production deployments are scored. An incident **after** the latest successful production deployment in the 30-day window is still not counted in that run, even if it was created within the DORA 30-day window. It is attributed in a later DORA calculation to the interval closed by the next successful production deployment (the first deployment that follows).
+
+If there is no measurable interval (no predecessor and fewer than two successful production deployments in the window, or adjacent deployments share the same `createdAt`), calculation fails with an error.
 
 ## Scope and limitation
 
@@ -90,6 +102,8 @@ Required input:
 - `from: string` (ISO datetime)
 - `to: string` (ISO datetime)
 
+The metric may call this collector twice: once for the 30-day window, and once for the pre-window predecessor range. Extra input fields (for example `fetchItemsLimit`) are allowed; they do not replace `from` / `to`.
+
 Required output:
 
 - `deployments: Array<{ id: string; commitSha: string; environment?: string; createdAt: string; result: 'success' | 'failure' | '' }>`
@@ -128,6 +142,8 @@ Required input:
 
 - `from: string` (ISO datetime)
 - `to: string` (ISO datetime)
+
+When a pre-window predecessor exists, `from` is that deployment's `createdAt` (which can be earlier than the 30-day window start). Otherwise `from` is the window start.
 
 Required output:
 

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/docs/metrics/median-lead-time-for-changes.md
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/docs/metrics/median-lead-time-for-changes.md
@@ -8,15 +8,27 @@
 Median Lead Time for Changes measures how long changes typically take to move from code to production.
 
 The metric computes lead time for changes from pull request first commit timestamp to production deployment timestamp, then returns the median.
+The 30-day window decides which successful production deployments are **in-window** (the deployments whose lead time is scored as the pair _head_).
 Deployments are processed as chronological pairs (`previousDeployment` -> `currentDeployment`), and pull requests are resolved for the commit range between those two deployment SHAs.
 For each pull request in that range, lead time is `currentDeployment.createdAt - pullRequest.firstCommitAt` in hours.
 The result is: `median(leadTimeHours)`.
+
+### Pre-window predecessor
+
+To score the **first** in-window deployment, the metric also loads the latest successful production deployment **before** the window start (`windowFrom`) from the deployments collector.
+
+That predecessor is used only as `baseCommitSha` for pull requests into the first in-window deploy. It is not counted as an in-window scored head.
+
+- Predecessor exists: one in-window successful production deployment is enough to form a pair.
+- No predecessor: behavior is unchanged. Two successful production deployments in the 30-day window are still required. With two or more in-window deploys, pairs are formed among those deploys only (the first in-window deploy is only a base for the next pair).
+
+The predecessor lookup is a second deployments-collector call with `from` at `1970-01-01T00:00:00.000Z` and `to` immediately before `windowFrom`, plus optional `fetchItemsLimit` (100). Default GitHub collectors honor that cap and keep the newest in-range rows. If those rows are all failed or non-production, the predecessor is omitted (same as no predecessor). Custom collectors that ignore the cap may return a larger history.
 
 ## Scope and limitation
 
 This metric assumes deployments form a single chronological stream for the entity. If deployments from multiple branches or release trains are mixed in the same stream, `previousDeployment` and `currentDeployment` can belong to different branches, which may produce incorrect lead-time pairing and noisy results.
 
-If fewer than two successful production deployments exist in the window, or no pull requests with a measurable lead time are found between deployments, calculation fails with an error for now.
+If there is no measurable pair (no predecessor and fewer than two successful production deployments in the window, or no pull requests with a measurable lead time), calculation fails with an error for now.
 
 ## Options
 
@@ -91,6 +103,8 @@ Required input:
 
 - `from: string` (ISO datetime)
 - `to: string` (ISO datetime)
+
+The metric may call this collector twice: once for the 30-day window, and once for the pre-window predecessor range. Extra input fields (for example `fetchItemsLimit`) are allowed; they do not replace `from` / `to`.
 
 Required output:
 

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/constants.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/constants.ts
@@ -20,3 +20,20 @@ export const DORA_DEFAULT_DEPLOYMENT_PULL_REQUESTS_COLLECTOR_ID =
 export const DORA_DEFAULT_INCIDENTS_COLLECTOR_ID = 'jira:incidents';
 export const DORA_TIME_WINDOW_DAYS = 30;
 export const DORA_DEFAULT_PRODUCTION_ENVIRONMENTS = ['production'];
+
+/**
+ * Max deployments to request for the pre-window predecessor collect.
+ *
+ * We take the latest successful production deploy in that capped batch. That can
+ * miss a real predecessor when the newest pre-window rows are all failed or
+ * non-prod.
+ *
+ * Paging until a successful prod deploy is found would close that gap, but it
+ * is a bad default: a repo with a long staging/failed burst (or a collector
+ * that ignores the cap) would walk unbounded GitHub/Jira history per metric
+ * run — rate limits, latency, and timeout risk on every catalog entity.
+ */
+export const DORA_PRE_WINDOW_DEPLOYMENT_FETCH_CAP = 100;
+
+/** Inclusive collector `from` for unbounded predecessor lookback. */
+export const DORA_PREDECESSOR_COLLECT_FROM = '1970-01-01T00:00:00.000Z';

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraChangeFailureRateProvider.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraChangeFailureRateProvider.test.ts
@@ -42,6 +42,7 @@ describe('DoraChangeFailureRateProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
     deploymentsCollector = buildMockDeploymentsCollector({
       deployments: [
         {
@@ -262,6 +263,7 @@ describe('DoraChangeFailureRateProvider', () => {
       await expect(provider.calculateMetrics(mockEntity)).rejects.toThrow(
         /need at least 2 successful production deployments/,
       );
+      expect(deploymentsCollector.collect).toHaveBeenCalledTimes(1);
       expect(incidentsCollector.collect).not.toHaveBeenCalled();
     });
 
@@ -447,6 +449,131 @@ describe('DoraChangeFailureRateProvider', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('non-increasing createdAt'),
       );
+    });
+
+    it('should count an incident between a predecessor and the first in-window deployment', async () => {
+      jest.useFakeTimers({ now: new Date('2026-08-25T00:00:00.000Z') });
+      deploymentsCollector = buildMockDeploymentsCollector({
+        deployments: [
+          {
+            id: '101',
+            commitSha: 'sha-first',
+            environment: 'production',
+            createdAt: '2026-08-05T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        preWindowDeployments: [
+          {
+            id: '99',
+            commitSha: 'sha-predecessor',
+            environment: 'production',
+            createdAt: '2026-07-10T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        collectorId: DORA_DEFAULT_DEPLOYMENTS_COLLECTOR_ID,
+      });
+      incidentsCollector = buildMockIncidentsCollector({
+        incidents: [
+          {
+            id: 'INC-GAP',
+            createdAt: '2026-07-28T00:00:00.000Z',
+            resolutionAt: null,
+          },
+        ],
+        collectorId: DORA_DEFAULT_INCIDENTS_COLLECTOR_ID,
+      });
+      ({ collectorsService, collect } = buildMockCollectorsService({
+        collectors: [deploymentsCollector, incidentsCollector],
+      }));
+      provider = DoraChangeFailureRateProvider.fromConfig(
+        new ConfigReader({}),
+        {
+          collectorsService,
+          logger: mockLogger,
+        },
+      );
+
+      const results = await provider.calculateMetrics(mockEntity);
+
+      expect(results.get('dora.changeFailureRate')).toBe(100);
+      expect(collect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collectorId: DORA_DEFAULT_INCIDENTS_COLLECTOR_ID,
+          input: expect.objectContaining({
+            from: '2026-07-10T00:00:00.000Z',
+          }),
+        }),
+      );
+    });
+
+    it('should count an incident after the predecessor and before windowFrom', async () => {
+      jest.useFakeTimers({ now: new Date('2026-08-25T00:00:00.000Z') });
+      deploymentsCollector = buildMockDeploymentsCollector({
+        deployments: [
+          {
+            id: '101',
+            commitSha: 'sha-first',
+            environment: 'production',
+            createdAt: '2026-08-05T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        preWindowDeployments: [
+          {
+            id: '99',
+            commitSha: 'sha-predecessor',
+            environment: 'production',
+            createdAt: '2026-07-10T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        collectorId: DORA_DEFAULT_DEPLOYMENTS_COLLECTOR_ID,
+      });
+      incidentsCollector = buildMockIncidentsCollector({
+        incidents: [
+          {
+            id: 'INC-PRE-WINDOW',
+            createdAt: '2026-07-15T00:00:00.000Z',
+            resolutionAt: null,
+          },
+        ],
+        collectorId: DORA_DEFAULT_INCIDENTS_COLLECTOR_ID,
+      });
+      ({ collectorsService } = buildMockCollectorsService({
+        collectors: [deploymentsCollector, incidentsCollector],
+      }));
+      provider = DoraChangeFailureRateProvider.fromConfig(
+        new ConfigReader({}),
+        {
+          collectorsService,
+          logger: mockLogger,
+        },
+      );
+
+      const results = await provider.calculateMetrics(mockEntity);
+
+      expect(results.get('dora.changeFailureRate')).toBe(100);
+    });
+
+    it('should throw when a single in-window deployment has no predecessor', async () => {
+      jest.mocked(deploymentsCollector.collect).mockResolvedValueOnce({
+        deployments: [
+          {
+            id: '101',
+            commitSha: 'sha-1',
+            environment: 'production',
+            createdAt: '2026-06-10T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+      });
+
+      await expect(provider.calculateMetrics(mockEntity)).rejects.toThrow(
+        /need at least 2 successful production deployments.*found 1/,
+      );
+      expect(incidentsCollector.collect).not.toHaveBeenCalled();
     });
   });
 });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraChangeFailureRateProvider.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraChangeFailureRateProvider.ts
@@ -24,10 +24,6 @@ import {
 } from '@red-hat-developer-hub/backstage-plugin-scorecard-node';
 import { DORA_TIME_WINDOW_DAYS } from '../constants';
 import {
-  deploymentsCollectorInputSchema,
-  deploymentsCollectorOutputSchema,
-} from './schemas/deploymentSchemas';
-import {
   incidentsCollectorInputSchema,
   incidentsCollectorOutputSchema,
 } from './schemas/incidentSchemas';
@@ -36,7 +32,11 @@ import {
   type DoraChangeFailureRateConfig,
   parseDoraChangeFailureRateConfig,
 } from './DoraConfig';
-import { isSuccessfulProductionDeployment } from './utils/deploymentFilterUtils';
+import {
+  collectSuccessfulProductionDeploymentsWithPreWindowBoundary,
+  getChangeFailureRateIncidentFrom,
+  insufficientSuccessfulProductionDeploymentsMessage,
+} from './utils/preWindowDeploymentUtils';
 import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 
 type DoraChangeFailureRateProviderOptions = {
@@ -110,34 +110,28 @@ export class DoraChangeFailureRateProvider implements MetricProvider<'number'> {
     const from = new Date();
     from.setDate(to.getDate() - DORA_TIME_WINDOW_DAYS);
 
-    const deploymentsCollected = await this.collectorsService.collect<
-      typeof deploymentsCollectorInputSchema,
-      typeof deploymentsCollectorOutputSchema
-    >({
+    const {
+      inWindow,
+      predecessor,
+      deployments: successfulProductionDeployments,
+    } = await collectSuccessfulProductionDeploymentsWithPreWindowBoundary({
+      collectorsService: this.collectorsService,
       collectorId: this.config.deploymentsCollector.id,
-      contract: {
-        inputSchema: deploymentsCollectorInputSchema,
-        outputSchema: deploymentsCollectorOutputSchema,
-      },
+      collectorInput: this.config.deploymentsCollector.input,
       entity,
-      input: {
-        ...this.config.deploymentsCollector.input,
-        from: from.toISOString(),
-        to: to.toISOString(),
-      },
+      windowFrom: from,
+      windowTo: to,
+      productionEnvironments: this.config.productionEnvironments,
+      logger: this.logger,
+      metricProviderId: this.getProviderId(),
     });
 
-    const successfulProductionDeployments =
-      deploymentsCollected.deployments.filter(deployment =>
-        isSuccessfulProductionDeployment(
-          deployment,
-          this.config.productionEnvironments,
-        ),
-      );
-
-    if (successfulProductionDeployments.length < 2) {
+    if (inWindow.length === 0 || successfulProductionDeployments.length < 2) {
       throw new Error(
-        `Unable to calculate change failure rate: need at least 2 successful production deployments in the last ${DORA_TIME_WINDOW_DAYS} days, found ${successfulProductionDeployments.length}`,
+        insufficientSuccessfulProductionDeploymentsMessage(
+          'change failure rate',
+          inWindow.length,
+        ),
       );
     }
 
@@ -153,7 +147,7 @@ export class DoraChangeFailureRateProvider implements MetricProvider<'number'> {
       entity,
       input: {
         ...this.config.incidentsCollector.input,
-        from: from.toISOString(),
+        from: getChangeFailureRateIncidentFrom(from, predecessor),
         to: to.toISOString(),
       },
     });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraMedianLeadTimeForChangesProvider.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraMedianLeadTimeForChangesProvider.test.ts
@@ -73,6 +73,7 @@ describe('DoraMedianLeadTimeForChangesProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
     deploymentsCollector = buildMockDeploymentsCollector({
       deployments,
       collectorId: DORA_DEFAULT_DEPLOYMENTS_COLLECTOR_ID,
@@ -192,7 +193,7 @@ describe('DoraMedianLeadTimeForChangesProvider', () => {
 
       await customProvider.calculateMetrics(mockEntity);
 
-      expect(customCollect).toHaveBeenCalledTimes(2);
+      expect(customCollect).toHaveBeenCalledTimes(3);
       expect(customCollect).toHaveBeenCalledWith(
         expect.objectContaining({
           collectorId: customDeploymentsCollectorId,
@@ -220,6 +221,7 @@ describe('DoraMedianLeadTimeForChangesProvider', () => {
       const results = await provider.calculateMetrics(mockEntity);
 
       expect(results.get('dora.medianLeadTimeForChanges')).toBe(48);
+      expect(deploymentPullRequestsCollector.collect).toHaveBeenCalledTimes(1);
     });
 
     it('should calculate median with multiple pull requests across multiple deployment ranges', async () => {
@@ -294,6 +296,7 @@ describe('DoraMedianLeadTimeForChangesProvider', () => {
       await expect(provider.calculateMetrics(mockEntity)).rejects.toThrow(
         /need at least 2 successful production deployments/,
       );
+      expect(deploymentsCollector.collect).toHaveBeenCalledTimes(1);
       expect(deploymentPullRequestsCollector.collect).not.toHaveBeenCalled();
     });
 
@@ -471,6 +474,146 @@ describe('DoraMedianLeadTimeForChangesProvider', () => {
 
       await expect(provider.calculateMetrics(mockEntity)).rejects.toThrow(
         'Deployments must be sorted in ascending order by createdAt',
+      );
+    });
+
+    it('should throw when a single in-window deployment has no predecessor', async () => {
+      jest.mocked(deploymentsCollector.collect).mockResolvedValueOnce({
+        deployments: [
+          {
+            id: '101',
+            commitSha: 'sha-current',
+            environment: 'production',
+            createdAt: '2026-06-08T12:00:00.000Z',
+            result: 'success',
+          },
+        ],
+      });
+
+      await expect(provider.calculateMetrics(mockEntity)).rejects.toThrow(
+        /need at least 2 successful production deployments.*found 1/,
+      );
+      expect(deploymentPullRequestsCollector.collect).not.toHaveBeenCalled();
+    });
+
+    it('should measure lead time into the first in-window deployment using a predecessor', async () => {
+      jest.useFakeTimers({ now: new Date('2026-08-25T00:00:00.000Z') });
+      deploymentsCollector = buildMockDeploymentsCollector({
+        deployments: [
+          {
+            id: '101',
+            commitSha: 'sha-current',
+            environment: 'production',
+            createdAt: '2026-08-08T12:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        preWindowDeployments: [
+          {
+            id: '99',
+            commitSha: 'sha-predecessor',
+            environment: 'production',
+            createdAt: '2026-07-10T12:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        collectorId: DORA_DEFAULT_DEPLOYMENTS_COLLECTOR_ID,
+      });
+      deploymentPullRequestsCollector =
+        buildMockDeploymentPullRequestsCollector({
+          pullRequests: [
+            { id: '123', firstCommitAt: '2026-08-05T12:00:00.000Z' }, // 72h
+            { id: '124', firstCommitAt: '2026-08-07T12:00:00.000Z' }, // 24h
+          ],
+          collectorId: DORA_DEFAULT_DEPLOYMENT_PULL_REQUESTS_COLLECTOR_ID,
+        });
+      ({ collectorsService } = buildMockCollectorsService({
+        collectors: [deploymentsCollector, deploymentPullRequestsCollector],
+      }));
+      provider = DoraMedianLeadTimeForChangesProvider.fromConfig(
+        new ConfigReader({}),
+        { collectorsService, logger: mockLogger },
+      );
+
+      const results = await provider.calculateMetrics(mockEntity);
+
+      expect(results.get('dora.medianLeadTimeForChanges')).toBe(48);
+      expect(deploymentPullRequestsCollector.collect).toHaveBeenCalledTimes(1);
+      expect(deploymentPullRequestsCollector.collect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            baseCommitSha: 'sha-predecessor',
+            headCommitSha: 'sha-current',
+          }),
+        }),
+      );
+    });
+
+    it('should add a predecessor interval in front of existing in-window pairs', async () => {
+      jest.useFakeTimers({ now: new Date('2026-08-25T00:00:00.000Z') });
+      deploymentsCollector = buildMockDeploymentsCollector({
+        deployments: [
+          {
+            id: '101',
+            commitSha: 'sha-1',
+            environment: 'production',
+            createdAt: '2026-08-05T00:00:00.000Z',
+            result: 'success',
+          },
+          {
+            id: '102',
+            commitSha: 'sha-2',
+            environment: 'production',
+            createdAt: '2026-08-10T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        preWindowDeployments: [
+          {
+            id: '99',
+            commitSha: 'sha-predecessor',
+            environment: 'production',
+            createdAt: '2026-07-10T00:00:00.000Z',
+            result: 'success',
+          },
+        ],
+        collectorId: DORA_DEFAULT_DEPLOYMENTS_COLLECTOR_ID,
+      });
+      deploymentPullRequestsCollector =
+        buildMockDeploymentPullRequestsCollector({
+          pullRequests: [
+            { id: '501', firstCommitAt: '2026-08-04T12:00:00.000Z' },
+          ],
+          collectorId: DORA_DEFAULT_DEPLOYMENT_PULL_REQUESTS_COLLECTOR_ID,
+        });
+      ({ collectorsService } = buildMockCollectorsService({
+        collectors: [deploymentsCollector, deploymentPullRequestsCollector],
+      }));
+      provider = DoraMedianLeadTimeForChangesProvider.fromConfig(
+        new ConfigReader({}),
+        { collectorsService, logger: mockLogger },
+      );
+
+      await provider.calculateMetrics(mockEntity);
+
+      expect(deploymentPullRequestsCollector.collect).toHaveBeenCalledTimes(2);
+      expect(deploymentPullRequestsCollector.collect).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          input: expect.objectContaining({
+            baseCommitSha: 'sha-predecessor',
+            headCommitSha: 'sha-1',
+          }),
+        }),
+      );
+      expect(deploymentPullRequestsCollector.collect).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          input: expect.objectContaining({
+            baseCommitSha: 'sha-1',
+            headCommitSha: 'sha-2',
+          }),
+        }),
       );
     });
   });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraMedianLeadTimeForChangesProvider.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/DoraMedianLeadTimeForChangesProvider.ts
@@ -27,18 +27,17 @@ import {
   deploymentPullRequestsCollectorInputSchema,
   deploymentPullRequestsCollectorOutputSchema,
 } from './schemas/pullRequestSchemas';
-import {
-  deploymentsCollectorInputSchema,
-  deploymentsCollectorOutputSchema,
-} from './schemas/deploymentSchemas';
 import { calculateMedian } from './utils/calculationUtils';
 import {
   DEFAULT_DORA_MEDIAN_LEAD_TIME_THRESHOLDS,
   type DoraMedianLeadTimeForChangesConfig,
   parseDoraMedianLeadTimeForChangesConfig,
 } from './DoraConfig';
+import {
+  collectSuccessfulProductionDeploymentsWithPreWindowBoundary,
+  insufficientSuccessfulProductionDeploymentsMessage,
+} from './utils/preWindowDeploymentUtils';
 import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
-import { isSuccessfulProductionDeployment } from './utils/deploymentFilterUtils';
 
 type DoraMedianLeadTimeForChangesProviderOptions = {
   collectorsService: ScorecardCollectorsService;
@@ -113,34 +112,25 @@ export class DoraMedianLeadTimeForChangesProvider
     const from = new Date();
     from.setDate(to.getDate() - DORA_TIME_WINDOW_DAYS);
 
-    const deploymentsCollected = await this.collectorsService.collect<
-      typeof deploymentsCollectorInputSchema,
-      typeof deploymentsCollectorOutputSchema
-    >({
-      collectorId: this.config.deploymentsCollector.id,
-      contract: {
-        inputSchema: deploymentsCollectorInputSchema,
-        outputSchema: deploymentsCollectorOutputSchema,
-      },
-      entity,
-      input: {
-        ...this.config.deploymentsCollector.input,
-        from: from.toISOString(),
-        to: to.toISOString(),
-      },
-    });
+    const { inWindow, deployments } =
+      await collectSuccessfulProductionDeploymentsWithPreWindowBoundary({
+        collectorsService: this.collectorsService,
+        collectorId: this.config.deploymentsCollector.id,
+        collectorInput: this.config.deploymentsCollector.input,
+        entity,
+        windowFrom: from,
+        windowTo: to,
+        productionEnvironments: this.config.productionEnvironments,
+        logger: this.logger,
+        metricProviderId: this.getProviderId(),
+      });
 
-    // Deployments are expected to be returned sorted ascending by createdAt.
-    const deployments = deploymentsCollected.deployments.filter(deployment =>
-      isSuccessfulProductionDeployment(
-        deployment,
-        this.config.productionEnvironments,
-      ),
-    );
-
-    if (deployments.length < 2) {
+    if (inWindow.length === 0 || deployments.length < 2) {
       throw new Error(
-        `Unable to calculate median lead time for changes: need at least 2 successful production deployments in the last ${DORA_TIME_WINDOW_DAYS} days, found ${deployments.length}`,
+        insufficientSuccessfulProductionDeploymentsMessage(
+          'median lead time for changes',
+          inWindow.length,
+        ),
       );
     }
 

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/__fixtures__/mockCollectors.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/__fixtures__/mockCollectors.ts
@@ -15,6 +15,7 @@
  */
 
 import { Collector } from '@red-hat-developer-hub/backstage-plugin-scorecard-node';
+import { DORA_PREDECESSOR_COLLECT_FROM } from '../../constants';
 import {
   Deployment,
   deploymentsCollectorInputSchema,
@@ -33,18 +34,31 @@ import {
 
 export function buildMockDeploymentsCollector(options: {
   deployments: Deployment[];
+  preWindowDeployments?: Deployment[];
   collectorId?: string;
 }): Collector {
-  const { deployments, collectorId = 'github:deployments' } = options;
+  const {
+    deployments,
+    preWindowDeployments = [],
+    collectorId = 'github:deployments',
+  } = options;
 
   return {
     getCollectorId: () => collectorId,
     getCollectorDescription: () => 'mock deployments collector',
     getInputSchema: () => deploymentsCollectorInputSchema,
     getOutputSchema: () => deploymentsCollectorOutputSchema,
-    collect: jest.fn(async () => ({
-      deployments,
-    })),
+    collect: jest.fn(async ({ input }) => {
+      if (
+        typeof input === 'object' &&
+        input !== null &&
+        'from' in input &&
+        input.from === DORA_PREDECESSOR_COLLECT_FROM
+      ) {
+        return { deployments: preWindowDeployments };
+      }
+      return { deployments };
+    }),
   };
 }
 

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/utils/preWindowDeploymentUtils.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/utils/preWindowDeploymentUtils.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DORA_PREDECESSOR_COLLECT_FROM,
+  DORA_PRE_WINDOW_DEPLOYMENT_FETCH_CAP,
+} from '../../constants';
+import type { Deployment } from '../schemas/deploymentSchemas';
+import {
+  getChangeFailureRateIncidentFrom,
+  getPredecessorCollectorRange,
+  mergeSuccessfulProductionDeploymentsWithPredecessor,
+} from './preWindowDeploymentUtils';
+
+const productionEnvironments = ['production'];
+const windowFrom = new Date('2026-08-01T00:00:00.000Z');
+
+function deployment(
+  overrides: Partial<Deployment> & Pick<Deployment, 'id' | 'createdAt'>,
+): Deployment {
+  return {
+    commitSha: `sha-${overrides.id}`,
+    environment: 'production',
+    result: 'success',
+    ...overrides,
+  };
+}
+
+describe('getPredecessorCollectorRange', () => {
+  it('uses epoch from, 1ms exclusive to, and the fetch cap', () => {
+    expect(getPredecessorCollectorRange(windowFrom)).toEqual({
+      from: DORA_PREDECESSOR_COLLECT_FROM,
+      to: '2026-07-31T23:59:59.999Z',
+      fetchItemsLimit: DORA_PRE_WINDOW_DEPLOYMENT_FETCH_CAP,
+    });
+  });
+});
+
+describe('getChangeFailureRateIncidentFrom', () => {
+  it('starts at predecessor createdAt when present', () => {
+    const predecessor = deployment({
+      id: 'pre',
+      createdAt: '2026-07-20T12:00:00.000Z',
+    });
+
+    expect(getChangeFailureRateIncidentFrom(windowFrom, predecessor)).toBe(
+      '2026-07-20T12:00:00.000Z',
+    );
+  });
+
+  it('falls back to windowFrom when there is no predecessor', () => {
+    expect(getChangeFailureRateIncidentFrom(windowFrom, undefined)).toBe(
+      windowFrom.toISOString(),
+    );
+  });
+});
+
+describe('mergeSuccessfulProductionDeploymentsWithPredecessor', () => {
+  const inWindowFirst = deployment({
+    id: 'in-1',
+    createdAt: '2026-08-05T00:00:00.000Z',
+  });
+  const inWindowSecond = deployment({
+    id: 'in-2',
+    createdAt: '2026-08-10T00:00:00.000Z',
+  });
+
+  it('returns only filtered in-window deployments when there is no predecessor', () => {
+    const result = mergeSuccessfulProductionDeploymentsWithPredecessor({
+      inWindowDeployments: [
+        inWindowFirst,
+        deployment({
+          id: 'failed',
+          createdAt: '2026-08-06T00:00:00.000Z',
+          result: 'failure',
+        }),
+      ],
+      preWindowDeployments: [],
+      windowFrom,
+      productionEnvironments,
+    });
+
+    expect(result.inWindow).toEqual([inWindowFirst]);
+    expect(result.predecessor).toBeUndefined();
+    expect(result.deployments).toEqual([inWindowFirst]);
+  });
+
+  it('prepends the latest successful production deploy before windowFrom', () => {
+    const older = deployment({
+      id: 'pre-older',
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    const latest = deployment({
+      id: 'pre-latest',
+      createdAt: '2026-07-20T00:00:00.000Z',
+    });
+
+    const result = mergeSuccessfulProductionDeploymentsWithPredecessor({
+      inWindowDeployments: [inWindowFirst, inWindowSecond],
+      preWindowDeployments: [older, latest],
+      windowFrom,
+      productionEnvironments,
+    });
+
+    expect(result.predecessor).toEqual(latest);
+    expect(result.deployments).toEqual([latest, inWindowFirst, inWindowSecond]);
+  });
+
+  it('skips failed and non-production pre-window deploys', () => {
+    const failed = deployment({
+      id: 'pre-failed',
+      createdAt: '2026-07-25T00:00:00.000Z',
+      result: 'failure',
+    });
+    const staging = deployment({
+      id: 'pre-staging',
+      createdAt: '2026-07-24T00:00:00.000Z',
+      environment: 'staging',
+    });
+    const production = deployment({
+      id: 'pre-prod',
+      createdAt: '2026-07-10T00:00:00.000Z',
+    });
+
+    const result = mergeSuccessfulProductionDeploymentsWithPredecessor({
+      inWindowDeployments: [inWindowFirst],
+      preWindowDeployments: [production, staging, failed],
+      windowFrom,
+      productionEnvironments,
+    });
+
+    expect(result.predecessor).toEqual(production);
+  });
+
+  it('ignores pre-window rows that are still on or after windowFrom', () => {
+    const atBoundary = deployment({
+      id: 'at-from',
+      createdAt: windowFrom.toISOString(),
+    });
+    const after = deployment({
+      id: 'after-from',
+      createdAt: '2026-08-02T00:00:00.000Z',
+    });
+    const before = deployment({
+      id: 'before-from',
+      createdAt: '2026-07-31T23:59:59.000Z',
+    });
+
+    const result = mergeSuccessfulProductionDeploymentsWithPredecessor({
+      inWindowDeployments: [inWindowFirst],
+      preWindowDeployments: [before, atBoundary, after],
+      windowFrom,
+      productionEnvironments,
+    });
+
+    expect(result.predecessor).toEqual(before);
+  });
+
+  it('does not prepend a deploy that is already in the in-window list', () => {
+    const result = mergeSuccessfulProductionDeploymentsWithPredecessor({
+      inWindowDeployments: [inWindowFirst],
+      preWindowDeployments: [inWindowFirst],
+      windowFrom,
+      productionEnvironments,
+    });
+
+    expect(result.predecessor).toBeUndefined();
+    expect(result.deployments).toEqual([inWindowFirst]);
+  });
+
+  it('returns empty in-window without inventing a scored deploy from predecessor only', () => {
+    const predecessor = deployment({
+      id: 'pre-only',
+      createdAt: '2026-07-20T00:00:00.000Z',
+    });
+
+    const result = mergeSuccessfulProductionDeploymentsWithPredecessor({
+      inWindowDeployments: [],
+      preWindowDeployments: [predecessor],
+      windowFrom,
+      productionEnvironments,
+    });
+
+    expect(result.inWindow).toEqual([]);
+    expect(result.predecessor).toEqual(predecessor);
+    expect(result.deployments).toEqual([predecessor]);
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/utils/preWindowDeploymentUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/metricProviders/utils/preWindowDeploymentUtils.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { JsonValue } from '@backstage/types';
+import { stringifyEntityRef, type Entity } from '@backstage/catalog-model';
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import type { ScorecardCollectorsService } from '@red-hat-developer-hub/backstage-plugin-scorecard-node';
+import {
+  DORA_PREDECESSOR_COLLECT_FROM,
+  DORA_PRE_WINDOW_DEPLOYMENT_FETCH_CAP,
+  DORA_TIME_WINDOW_DAYS,
+} from '../../constants';
+import {
+  deploymentsCollectorInputSchema,
+  deploymentsCollectorOutputSchema,
+  type Deployment,
+} from '../schemas/deploymentSchemas';
+import { isSuccessfulProductionDeployment } from './deploymentFilterUtils';
+
+export type PredecessorCollectorRange = {
+  from: string;
+  to: string;
+  /**
+   * Hint for collectors that honor a fetch cap (e.g. GitHub). Custom
+   * collectors that strip unknown keys still receive from/to only.
+   */
+  fetchItemsLimit: number;
+};
+
+export type DeploymentsWithPreWindowBoundary = {
+  inWindow: Deployment[];
+  predecessor: Deployment | undefined;
+  deployments: Deployment[];
+};
+
+/**
+ * Inclusive `to` for the predecessor collect so a deploy at exactly
+ * `windowFrom` is not returned twice (deployments contract is inclusive).
+ */
+export function getPredecessorCollectorRange(
+  windowFrom: Date,
+): PredecessorCollectorRange {
+  return {
+    from: DORA_PREDECESSOR_COLLECT_FROM,
+    to: new Date(windowFrom.getTime() - 1).toISOString(),
+    fetchItemsLimit: DORA_PRE_WINDOW_DEPLOYMENT_FETCH_CAP,
+  };
+}
+
+/**
+ * Incidents for CFR must cover `[predecessor, firstInWindow)` when a
+ * pre-window deploy exists; otherwise the usual metric window start.
+ */
+export function getChangeFailureRateIncidentFrom(
+  windowFrom: Date,
+  predecessor: Deployment | undefined,
+): string {
+  return predecessor?.createdAt ?? windowFrom.toISOString();
+}
+
+export function mergeSuccessfulProductionDeploymentsWithPredecessor(options: {
+  inWindowDeployments: Deployment[];
+  preWindowDeployments: Deployment[];
+  windowFrom: Date;
+  productionEnvironments: string[];
+}): DeploymentsWithPreWindowBoundary {
+  const { windowFrom, productionEnvironments } = options;
+  const windowFromTimestamp = windowFrom.getTime();
+
+  const inWindow = options.inWindowDeployments.filter(deployment =>
+    isSuccessfulProductionDeployment(deployment, productionEnvironments),
+  );
+
+  const predecessor = findLatestSuccessfulProductionPredecessor(
+    options.preWindowDeployments,
+    windowFromTimestamp,
+    productionEnvironments,
+    new Set(inWindow.map(deployment => deployment.id)),
+  );
+
+  return {
+    inWindow,
+    predecessor,
+    deployments: predecessor ? [predecessor, ...inWindow] : inWindow,
+  };
+}
+
+function findLatestSuccessfulProductionPredecessor(
+  preWindowDeployments: Deployment[],
+  windowFromTimestamp: number,
+  productionEnvironments: string[],
+  inWindowIds: Set<string>,
+): Deployment | undefined {
+  let predecessor: Deployment | undefined;
+
+  for (const deployment of preWindowDeployments) {
+    if (inWindowIds.has(deployment.id)) {
+      continue;
+    }
+
+    const createdAtTimestamp = new Date(deployment.createdAt).getTime();
+    if (
+      Number.isNaN(createdAtTimestamp) ||
+      createdAtTimestamp >= windowFromTimestamp
+    ) {
+      continue;
+    }
+
+    if (!isSuccessfulProductionDeployment(deployment, productionEnvironments)) {
+      continue;
+    }
+
+    if (
+      !predecessor ||
+      createdAtTimestamp > new Date(predecessor.createdAt).getTime()
+    ) {
+      predecessor = deployment;
+    }
+  }
+
+  return predecessor;
+}
+
+export function insufficientSuccessfulProductionDeploymentsMessage(
+  metricLabel: string,
+  inWindowCount: number,
+): string {
+  return `Unable to calculate ${metricLabel}: need at least 2 successful production deployments in the last ${DORA_TIME_WINDOW_DAYS} days, or 1 in that window plus a prior successful production deployment, found ${inWindowCount}`;
+}
+
+export async function collectSuccessfulProductionDeploymentsWithPreWindowBoundary(options: {
+  collectorsService: ScorecardCollectorsService;
+  collectorId: string;
+  collectorInput?: Record<string, JsonValue>;
+  entity: Entity;
+  windowFrom: Date;
+  windowTo: Date;
+  productionEnvironments: string[];
+  logger: LoggerService;
+  metricProviderId: string;
+}): Promise<DeploymentsWithPreWindowBoundary> {
+  const inWindowCollected = await options.collectorsService.collect<
+    typeof deploymentsCollectorInputSchema,
+    typeof deploymentsCollectorOutputSchema
+  >({
+    collectorId: options.collectorId,
+    contract: {
+      inputSchema: deploymentsCollectorInputSchema,
+      outputSchema: deploymentsCollectorOutputSchema,
+    },
+    entity: options.entity,
+    input: {
+      ...options.collectorInput,
+      from: options.windowFrom.toISOString(),
+      to: options.windowTo.toISOString(),
+    },
+  });
+
+  const inWindowOnly = mergeSuccessfulProductionDeploymentsWithPredecessor({
+    inWindowDeployments: inWindowCollected.deployments,
+    preWindowDeployments: [],
+    windowFrom: options.windowFrom,
+    productionEnvironments: options.productionEnvironments,
+  });
+
+  if (inWindowOnly.inWindow.length === 0) {
+    return inWindowOnly;
+  }
+
+  const predecessorRange = getPredecessorCollectorRange(options.windowFrom);
+  let preWindowDeployments: Deployment[] = [];
+  try {
+    const preWindowCollected = await options.collectorsService.collect<
+      typeof deploymentsCollectorInputSchema,
+      typeof deploymentsCollectorOutputSchema
+    >({
+      collectorId: options.collectorId,
+      contract: {
+        inputSchema: deploymentsCollectorInputSchema,
+        outputSchema: deploymentsCollectorOutputSchema,
+      },
+      entity: options.entity,
+      input: {
+        ...options.collectorInput,
+        from: predecessorRange.from,
+        to: predecessorRange.to,
+        fetchItemsLimit: predecessorRange.fetchItemsLimit,
+      },
+    });
+    preWindowDeployments = preWindowCollected.deployments;
+  } catch (error) {
+    options.logger.warn(
+      `Skipping pre-window deployment lookup for ${stringifyEntityRef(
+        options.entity,
+      )} while calculating ${options.metricProviderId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return inWindowOnly;
+  }
+
+  return mergeSuccessfulProductionDeploymentsWithPredecessor({
+    inWindowDeployments: inWindowCollected.deployments,
+    preWindowDeployments,
+    windowFrom: options.windowFrom,
+    productionEnvironments: options.productionEnvironments,
+  });
+}

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/README.md
@@ -97,6 +97,7 @@ metadata:
 - **Input schema**
   - `from: string` (ISO datetime)
   - `to: string` (ISO datetime)
+  - `fetchItemsLimit?: number` (optional, 1–1000). Caps how many deployments are collected for this request. GitHub pages newest-first, so a small cap keeps the most recent in-range rows. DORA uses this on the pre-window predecessor lookup.
 - **Output schema**
   - `deployments: Array<{ id: string; commitSha: string; environment?: string; createdAt: string; result: 'success' | 'failure' | '' }>`
 - **Annotation requirements**
@@ -111,6 +112,7 @@ metadata:
   - `workflowName: string` (non-empty)
   - `from: string` (ISO datetime)
   - `to: string` (ISO datetime)
+  - `fetchItemsLimit?: number` (optional, 1–1000). Caps how many workflow runs are collected for this request. Combined with GitHub's `created` filter, a small cap keeps the most recent runs in range.
 - **Output schema**
   - `deployments: Array<{ id: string; commitSha: string; environment?: string; createdAt: string; result: 'success' | 'failure' | '' }>`
 - **Annotation requirements**

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentWorkflowRunsCollector.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentWorkflowRunsCollector.test.ts
@@ -121,4 +121,29 @@ describe('GithubDeploymentWorkflowRunsCollector', () => {
     });
     expect(getWorkflowRunsSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('forwards fetchItemsLimit to the GitHub client', async () => {
+    const getWorkflowRunsSpy = jest
+      .spyOn(GithubClient.prototype, 'getWorkflowRuns')
+      .mockResolvedValue([]);
+
+    await collector.collect({
+      entity: testEntity,
+      input: {
+        workflowName: 'Custom deployment',
+        from: '1970-01-01T00:00:00.000Z',
+        to: '2026-07-25T23:59:59.999Z',
+        fetchItemsLimit: 100,
+      },
+    });
+
+    expect(getWorkflowRunsSpy).toHaveBeenCalledWith(
+      'https://github.com/owner/repo',
+      { owner: 'owner', repo: 'repo' },
+      'Custom deployment',
+      new Date('1970-01-01T00:00:00.000Z'),
+      new Date('2026-07-25T23:59:59.999Z'),
+      { fetchItemsLimit: 100 },
+    );
+  });
 });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentWorkflowRunsCollector.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentWorkflowRunsCollector.ts
@@ -25,6 +25,7 @@ import { getRepositoryInformationFromEntity } from '../github/utils';
 import {
   DeploymentResult,
   deploymentsSchema,
+  fetchItemsLimitSchema,
 } from './schemas/deploymentSchemas';
 
 export class GithubDeploymentWorkflowRunsCollector
@@ -38,6 +39,7 @@ export class GithubDeploymentWorkflowRunsCollector
     workflowName: z.string().min(1),
     from: z.string().datetime(),
     to: z.string().datetime(),
+    fetchItemsLimit: fetchItemsLimitSchema,
   });
   static readonly outputSchema = deploymentsSchema;
 
@@ -91,6 +93,7 @@ export class GithubDeploymentWorkflowRunsCollector
       options.input.workflowName,
       from,
       to,
+      { fetchItemsLimit: options.input.fetchItemsLimit },
     );
 
     return {

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentsCollector.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentsCollector.test.ts
@@ -121,4 +121,27 @@ describe('GithubDeploymentsCollector', () => {
     });
     expect(getDeploymentsSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('forwards fetchItemsLimit to the GitHub client', async () => {
+    const getDeploymentsSpy = jest
+      .spyOn(GithubClient.prototype, 'getDeployments')
+      .mockResolvedValue([]);
+
+    await collector.collect({
+      entity: testEntity,
+      input: {
+        from: '1970-01-01T00:00:00.000Z',
+        to: '2026-07-25T23:59:59.999Z',
+        fetchItemsLimit: 100,
+      },
+    });
+
+    expect(getDeploymentsSpy).toHaveBeenCalledWith(
+      'https://github.com/owner/repo',
+      { owner: 'owner', repo: 'repo' },
+      new Date('1970-01-01T00:00:00.000Z'),
+      new Date('2026-07-25T23:59:59.999Z'),
+      { fetchItemsLimit: 100 },
+    );
+  });
 });

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentsCollector.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/GithubDeploymentsCollector.ts
@@ -25,6 +25,7 @@ import { getRepositoryInformationFromEntity } from '../github/utils';
 import {
   DeploymentResult,
   deploymentsSchema,
+  fetchItemsLimitSchema,
 } from './schemas/deploymentSchemas';
 
 export class GithubDeploymentsCollector
@@ -37,6 +38,7 @@ export class GithubDeploymentsCollector
   static readonly inputSchema = z.object({
     from: z.string().datetime(),
     to: z.string().datetime(),
+    fetchItemsLimit: fetchItemsLimitSchema,
   });
   static readonly outputSchema = deploymentsSchema;
 
@@ -85,6 +87,7 @@ export class GithubDeploymentsCollector
       repository,
       from,
       to,
+      { fetchItemsLimit: options.input.fetchItemsLimit },
     );
 
     return {

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/schemas/deploymentSchemas.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/collectors/schemas/deploymentSchemas.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { DEFAULT_DEPLOYMENT_FETCH_ITEMS_LIMIT } from '../../github/constants';
 import { z } from 'zod';
 
 export const deploymentResultSchema = z.enum(['success', 'failure', '']);
@@ -31,3 +32,10 @@ export type DeploymentResult = z.infer<typeof deploymentResultSchema>;
 export const deploymentsSchema = z.object({
   deployments: z.array(deploymentSchema),
 });
+
+export const fetchItemsLimitSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(DEFAULT_DEPLOYMENT_FETCH_ITEMS_LIMIT)
+  .optional();

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GitHubClient.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GitHubClient.test.ts
@@ -204,6 +204,64 @@ describe('GithubClient', () => {
       expect(getCredentialsSpy).toHaveBeenCalledWith({ url });
     });
 
+    it('should keep only the newest in-range deployments when fetchItemsLimit is set', async () => {
+      const url = `https://github.com/owner/repo`;
+      const from = new Date('1970-01-01T00:00:00.000Z');
+      const to = new Date('2026-04-30T23:59:59.000Z');
+      mockedGraphqlClient.mockResolvedValue({
+        repository: {
+          deployments: {
+            nodes: [
+              {
+                databaseId: 103,
+                commitOid: 'sha-after-to',
+                createdAt: '2026-05-20T10:00:00.000Z',
+                environment: 'production',
+                latestStatus: { state: 'SUCCESS' },
+              },
+              {
+                databaseId: 102,
+                commitOid: 'sha-newest-in-range',
+                createdAt: '2026-04-20T10:00:00.000Z',
+                environment: 'production',
+                latestStatus: { state: 'SUCCESS' },
+              },
+              {
+                databaseId: 101,
+                commitOid: 'sha-older-in-range',
+                createdAt: '2026-03-15T10:00:00.000Z',
+                environment: 'production',
+                latestStatus: { state: 'SUCCESS' },
+              },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+            },
+          },
+        },
+      });
+
+      const deployments = await githubClient.getDeployments(
+        url,
+        repository,
+        from,
+        to,
+        { fetchItemsLimit: 1 },
+      );
+
+      expect(deployments).toEqual([
+        {
+          id: 102,
+          sha: 'sha-newest-in-range',
+          createdAt: '2026-04-20T10:00:00.000Z',
+          environment: 'production',
+          status: 'SUCCESS',
+        },
+      ]);
+      expect(mockedGraphqlClient).toHaveBeenCalledTimes(1);
+    });
+
     it('should stop paging once fetchItemsLimit of in-window deployments is reached', async () => {
       const url = `https://github.com/owner/repo`;
       const from = new Date('2026-05-01T00:00:00.000Z');

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GithubClient.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/github/GithubClient.ts
@@ -117,6 +117,12 @@ export class GithubClient {
     return response.repository.pullRequests.totalCount;
   }
 
+  /**
+   * Lists deployments in `[from, to]` (inclusive). GitHub returns newest first;
+   * results are reversed to ASC. `fetchItemsLimit` caps in-range rows so a
+   * predecessor lookback (wide `from`, small cap) does not fetch the default
+   * 1000 historical deployments.
+   */
   async getDeployments(
     url: string,
     repository: GithubRepository,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

First in-window DORA deploy wasn’t getting scored (lead time skipped PRs into it; CFR skipped the gap before it).

We now load the latest successful prod deploy before the 30-day window and use it as the pair/interval start. No prior deploy, same errors as today. DF/MTTR unchanged. Incident after the last in-window deploy still not counted.

GitHub collectors honor fetchItemsLimit (100) on that lookback so we don’t pull 1000 historical rows.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
