### PR TITLE
chore: migrate saved-prompts permission to intelligent-assistant chat permission

### DIFF
--- a/workspaces/intelligent-assistant/.changeset/remove-saved-prompts-permission.md
+++ b/workspaces/intelligent-assistant/.changeset/remove-saved-prompts-permission.md
@@ -1,7 +1,7 @@
 ---
-'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common': major
-'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': major
-'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': major
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common': minor
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': minor
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': minor
 ---
 
 Removed public `iaSavedPromptsManagePermission` from the common package. Saved-prompts backend routes now require `intelligent-assistant.chat.use`. Operators should drop `intelligent-assistant.saved-prompts.manage` from RBAC CSVs; `chat.use` is enough.

--- a/workspaces/intelligent-assistant/.changeset/remove-saved-prompts-permission.md
+++ b/workspaces/intelligent-assistant/.changeset/remove-saved-prompts-permission.md
@@ -1,0 +1,7 @@
+---
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common': major
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant-backend': major
+'@red-hat-developer-hub/backstage-plugin-intelligent-assistant': major
+---
+
+Removed public `iaSavedPromptsManagePermission` from the common package. Saved-prompts backend routes now require `intelligent-assistant.chat.use`. Operators should drop `intelligent-assistant.saved-prompts.manage` from RBAC CSVs; `chat.use` is enough.

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/README.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/README.md
@@ -345,9 +345,6 @@ p, role:default/team_a, intelligent-assistant.notebooks.manage, use, allow
 p, role:default/team_a, mcp.tools.use, use, allow
 p, role:default/team_a, mcp.tools.manage, use, allow
 
-# Required for saved prompts
-p, role:default/team_a, intelligent-assistant.saved-prompts.manage, update, allow
-
 g, user:default/<your-user-name>, role:default/team_a
 
 ```

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-backend/src/service/router.ts
@@ -35,7 +35,6 @@ import {
   iaMcpUsePermission,
   iaNotebooksUsePermission,
   iaPermissions,
-  iaSavedPromptsManagePermission,
   iaSkillsAccessPermission,
 } from '@red-hat-developer-hub/backstage-plugin-intelligent-assistant-common';
 
@@ -646,19 +645,19 @@ export async function createRouter(
   router.get(
     '/v1/saved-prompts/config',
     generalRateLimiter,
-    requirePermission(iaSavedPromptsManagePermission),
+    requirePermission(iaChatUsePermission),
     apiProxy, // SKIP_USER_ID_ENDPOINTS prevents user_id injection for this endpoint
   );
   router.get(
     '/v1/saved-prompts',
     generalRateLimiter,
-    requirePermission(iaSavedPromptsManagePermission),
+    requirePermission(iaChatUsePermission),
     apiProxy,
   );
   router.delete(
     '/v1/saved-prompts/:prompt_id',
     generalRateLimiter,
-    requirePermission(iaSavedPromptsManagePermission),
+    requirePermission(iaChatUsePermission),
     apiProxy,
   );
 
@@ -715,7 +714,7 @@ export async function createRouter(
   router.post(
     '/v1/saved-prompts',
     generalRateLimiter,
-    requirePermission(iaSavedPromptsManagePermission),
+    requirePermission(iaChatUsePermission),
     async (request, response) => {
       try {
         const { userEntityRef } = getIdentity(request);

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/report.api.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/report.api.md
@@ -30,9 +30,6 @@ export const iaNotebooksUsePermission: BasicPermission;
 export const iaPermissions: BasicPermission[];
 
 // @public
-export const iaSavedPromptsManagePermission: BasicPermission;
-
-// @public
 export const iaSkillsAccessPermission: BasicPermission;
 
 // @public

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/src/permissions.ts
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant-common/src/permissions.ts
@@ -72,16 +72,6 @@ export const iaNotebooksManagePermission = createPermission({
   attributes: {},
 });
 
-/** This permission is used to list, create, and delete saved prompts and read saved-prompts config
- * @public
- */
-export const iaSavedPromptsManagePermission = createPermission({
-  name: 'intelligent-assistant.saved-prompts.manage',
-  attributes: {
-    action: 'update',
-  },
-});
-
 /** This permission is used to view the list of configured skills
  * @public
  */
@@ -103,6 +93,5 @@ export const iaPermissions = [
   iaMcpManagePermission,
   iaNotebooksManagePermission,
   iaNotebooksUsePermission,
-  iaSavedPromptsManagePermission,
   iaSkillsAccessPermission,
 ];

--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/README.md
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/README.md
@@ -49,9 +49,6 @@ p, role:default/team_a, intelligent-assistant.notebooks.manage, use, allow
 p, role:default/team_a, mcp.tools.use, use, allow
 p, role:default/team_a, mcp.tools.manage, use, allow
 
-# Required for saved prompts
-p, role:default/team_a, intelligent-assistant.saved-prompts.manage, update, allow
-
 g, user:default/<your-user-name>, role:default/team_a
 
 ```


### PR DESCRIPTION
- Removes the `saved-prompts` dedicated permission and instead routes it through the general Intelligent Assistant chat permission

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
