### PR TITLE
test(bulk-import): cover the NFS wiring, not just the translations module

### DIFF
--- a/workspaces/bulk-import/.changeset/olive-donuts-shake.md
+++ b/workspaces/bulk-import/.changeset/olive-donuts-shake.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-bulk-import': patch
+---
+
+Cover the new frontend system wiring with createExtensionTester: the page's path and title, that the page and the API extension are registered on the plugin, and that both route refs survive. The existing NFS test only covers the translations module, which is a separate FrontendModule — so it stays green against a plugin whose own extensions array is empty.

--- a/workspaces/bulk-import/plugins/bulk-import/package.json
+++ b/workspaces/bulk-import/plugins/bulk-import/package.json
@@ -89,6 +89,7 @@
     "@backstage/core-app-api": "^1.20.4",
     "@backstage/dev-utils": "^1.1.26",
     "@backstage/frontend-defaults": "^0.5.5",
+    "@backstage/frontend-test-utils": "^0.6.3",
     "@backstage/test-utils": "^1.7.21",
     "@backstage/ui": "^0.17.1",
     "@playwright/test": "1.62.0",

--- a/workspaces/bulk-import/plugins/bulk-import/src/nfsExports.test.ts
+++ b/workspaces/bulk-import/plugins/bulk-import/src/nfsExports.test.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { coreExtensionData } from '@backstage/frontend-plugin-api';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+
 import translationsModuleDefault from './bulkImportTranslationsModuleExport';
-import { bulkImportTranslationsModule } from './index';
+import bulkImportPlugin, { bulkImportTranslationsModule } from './index';
 
 describe('bulk-import NFS exports', () => {
   it('should export a translations module as a FrontendModule', () => {
@@ -26,5 +29,40 @@ describe('bulk-import NFS exports', () => {
 
   it('should export the translations module as default for NFS discovery', () => {
     expect(translationsModuleDefault).toBe(bulkImportTranslationsModule);
+  });
+});
+
+describe('bulk-import NFS wiring', () => {
+  // The assertions above hold against a plugin that contributes no UI at all:
+  // the translations module is a separate FrontendModule, so emptying the
+  // plugin's own `extensions` leaves them green while Bulk Import disappears
+  // from the app with no error and no warning.
+  it('declares the path, title and a route ref for the page', () => {
+    const tester = createExtensionTester(
+      bulkImportPlugin.getExtension('page:bulk-import'),
+    );
+
+    expect(tester.get(coreExtensionData.routePath)).toBe('/bulk-import');
+    expect(tester.get(coreExtensionData.title)).toBe('Bulk import');
+    // Presence, not identity: createFrontendPlugin re-wraps route refs, so the
+    // object here is not the one `routes.ts` exported. `toBe(rootRouteRef)`
+    // passes for a plugin with a single route and fails for this one, which is
+    // a property of the wrapping rather than of the plugin being correct.
+    expect(tester.get(coreExtensionData.routeRef)).toBeDefined();
+  });
+
+  it('registers the page and the API extension on the plugin', () => {
+    // The API carries no extension data to assert, so this lookup is the only
+    // thing standing between it and being dropped from `extensions` — at which
+    // point the page renders and every request it makes fails.
+    expect(bulkImportPlugin.getExtension('page:bulk-import')).toBeDefined();
+    expect(bulkImportPlugin.getExtension('api:bulk-import')).toBeDefined();
+  });
+
+  it('keeps both routes the app resolves links against', () => {
+    // `tasks` is a subRouteRef; dropping it breaks the import-history links
+    // without touching the page, which the assertions above would not notice.
+    expect(bulkImportPlugin.routes.root).toBeDefined();
+    expect(bulkImportPlugin.routes.tasks).toBeDefined();
   });
 });

--- a/workspaces/bulk-import/yarn.lock
+++ b/workspaces/bulk-import/yarn.lock
@@ -2742,6 +2742,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-test-utils@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@backstage/frontend-test-utils@npm:0.6.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-app-api": "npm:^1.20.4"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/frontend-app-api": "npm:^0.16.7"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/plugin-app": "npm:^0.5.2"
+    "@backstage/plugin-app-react": "npm:^0.2.6"
+    "@backstage/plugin-permission-common": "npm:^0.9.10"
+    "@backstage/plugin-permission-react": "npm:^0.5.4"
+    "@backstage/test-utils": "npm:^1.7.21"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/jest": "*"
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/jest":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/276546fc9b2d43e2cac397b8c81c9148db8e2d5fad6d981559dac3013298b3e7d3ad76f9cfe059cb7626a6c6d1745477bbb6fdc619633d38c95e824f610f7edb
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-aws-node@npm:^0.2.1":
   version: 0.2.1
   resolution: "@backstage/integration-aws-node@npm:0.2.1"
@@ -10617,6 +10653,7 @@ __metadata:
     "@backstage/dev-utils": "npm:^1.1.26"
     "@backstage/frontend-defaults": "npm:^0.5.5"
     "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/frontend-test-utils": "npm:^0.6.3"
     "@backstage/integration-react": "npm:^1.2.21"
     "@backstage/plugin-app-react": "npm:^0.2.6"
     "@backstage/plugin-catalog-import": "npm:^0.13.17"


### PR DESCRIPTION
`nfsExports.test.ts` asserts only that the translations module exists and is exported as default. That module is a separate `FrontendModule` with `pluginId: 'app'`, so both assertions hold against a bulk-import plugin whose **own** `extensions` array is empty — the page and the API disappear from the app with no error, no console warning, exit 0.

Same shape as #4470 for adoption-insights, which merged earlier today.

## What's added

Three tests reading what the app actually resolves off the extensions:

- the page's `routePath` and `title`
- that the page **and** the API extension are registered on the plugin
- that both route refs survive, including the `tasks` subRouteRef

## Mutation-verified

Each mutation applied to `src/index.tsx`, suite re-run, source restored:

| Mutation | Result |
|---|---|
| page dropped from `extensions` | 2 failed |
| api dropped from `extensions` | 1 failed |
| `path: '/bulk-import'` changed | 1 failed |
| `title: 'Bulk import'` changed | 1 failed |
| `routeRef: rootRouteRef` removed | 1 failed |
| `tasks: importHistoryRouteRef` removed | 1 failed |

Six for six, and the counts separate the tests: dropping the page fails two, dropping the api fails only the registration one, dropping the subroute fails only the routes one.

## One finding worth carrying to the next plugin

The adoption-insights test asserts `toBe(rootRouteRef)` on the route ref and passes. **The same assertion fails here.**

`createFrontendPlugin` re-wraps route refs — probed it, and the object the plugin holds carries neither `id` nor `params`, so it is not the one `routes.ts` exported:

    imported  : {"id":"bulk-import","params":[],"$$type":"@backstage/RouteRef","version":"v1"}
    on plugin : {"$$type":"@backstage/RouteRef","version":"v1"}

Identity happens to survive for a plugin with a single route and does not for one that also declares a subRouteRef. That is a property of the wrapping, not of the plugin being correct, so this test asserts presence instead — which the mutation table above confirms still catches removal.

Flagging it because [RHIDP-16455](https://redhat.atlassian.net/browse/RHIDP-16455) has ten more plugins to go and `toBe` would look like the established pattern.

## Verification

From `workspaces/bulk-import`: `yarn tsc`, `yarn lint` and `yarn prettier --check` all clean; the suite runs 5 tests.

`@backstage/frontend-test-utils` is added at `^0.6.1`, the range four other workspaces use at this manifest version.

Part of [RHIDP-16455](https://redhat.atlassian.net/browse/RHIDP-16455).