### PR TITLE
chore(fullsend): use rhdh-fullsend-code and allowlist claude.exe

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -12,6 +12,8 @@ agents:
       source: rhdh/harness/code.yaml
     - name: fix
       source: rhdh/harness/fix.yaml
+    - name: review
+      source: rhdh/harness/review.yaml
 roles:
     - triage
     - coder

--- a/.fullsend/rhdh/harness/code.yaml
+++ b/.fullsend/rhdh/harness/code.yaml
@@ -1,5 +1,6 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/code.yaml#sha256=050382941bb4c4a3dad5f00253de854684c0d22dd8cc1ca0a548079774470aad
 agent: rhdh/agents/code.md
+image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 policy: rhdh/policies/code.yaml
 skills:
   - https://github.com/redhat-developer/rhdh-skill/tree/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded

--- a/.fullsend/rhdh/harness/fix.yaml
+++ b/.fullsend/rhdh/harness/fix.yaml
@@ -1,5 +1,6 @@
 base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/fix.yaml#sha256=f966f0b8cd9b58289f19b446cfc4fd343c9079d9c9acee0260824b57e896e068
 agent: rhdh/agents/fix.md
+image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 policy: rhdh/policies/code.yaml
 skills:
   - https://github.com/redhat-developer/rhdh-skill/tree/e84109919ae6085e3dcfe568c695e6dda54874ce/skills/rhdh-coding#sha256=5a4bc35476108a215091ccf1180cee68547c7668c6b193de4402674bc7b6cded

--- a/.fullsend/rhdh/harness/review.yaml
+++ b/.fullsend/rhdh/harness/review.yaml
@@ -1,0 +1,3 @@
+base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/review.yaml#sha256=08456e534c7d1251b3a3b2bc1236643403809ecab27832c273764769f219a45b
+image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
+policy: rhdh/policies/review.yaml

--- a/.fullsend/rhdh/policies/code.yaml
+++ b/.fullsend/rhdh/policies/code.yaml
@@ -33,6 +33,8 @@ network_policies:
         access: read-write
     binaries:
       - path: "**/claude"
+      # Claude Code 2.1+ ships the bun compile as claude.exe; **/claude does not match it.
+      - path: "**/claude.exe"
       - path: "**/node"
 
   github_api:

--- a/.fullsend/rhdh/policies/review.yaml
+++ b/.fullsend/rhdh/policies/review.yaml
@@ -1,0 +1,66 @@
+---
+version: 1
+
+# Sandbox policy for the review agent.
+#
+# Forked from fullsend-ai/agents policies/review.yaml so we can allowlist
+# Claude Code's bun binary (claude.exe). **/claude does not match claude.exe,
+# which is what 2.1+ uses to call sts.googleapis.com for Vertex.
+#
+# Read-only agent: needs GitHub API (gh pr view, gh pr diff, gh issue view)
+# and Vertex AI for inference. No write access to GitHub — the post-script
+# handles mutations on the runner with a separate write-scoped token.
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log]
+  read_write: [/sandbox, /tmp, /dev/null]
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  vertex_ai:
+    name: vertex-ai
+    endpoints:
+      - host: "api.anthropic.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "*.googleapis.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+    binaries:
+      - path: "**/claude"
+      - path: "**/claude.exe"
+      - path: "**/node"
+
+  github_api:
+    name: github-api
+    endpoints:
+      - host: "api.github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      # gh CLI uses POST /graphql for reads; protocol: graphql allows
+      # queries but blocks mutations at the AST level
+      - host: "api.github.com"
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        access: read-only
+        path: "/graphql"
+      - host: "github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: "**/gh"
+      - path: "**/node"


### PR DESCRIPTION
## Summary
- Pin code/fix/review harnesses to `ghcr.io/redhat-developer/rhdh-fullsend-code:latest`.
- Allowlist `claude.exe` (Claude Code 2.1+ bun compile) so Vertex STS is not `policy_denied`.
- Add a review harness/policy so review agents use the same image and binary allowlist.

## Proven
Same fix as rhdh-agentic #124 / #125:
- https://github.com/redhat-developer/rhdh-agentic/pull/124
- https://github.com/redhat-developer/rhdh-agentic/pull/125
- Successful run: https://github.com/redhat-developer/rhdh-agentic/actions/runs/33403845734
  - Image `ghcr.io/redhat-developer/rhdh-fullsend-code:latest`
  - Claude v2.1.243
  - no `policy_denied`

## Why now
rhdh-plugins code agents are already failing with `policy_denied` on:
https://github.com/redhat-developer/rhdh-plugins/actions/runs/33389059456

`**/claude` does not match `claude.exe`, which is what Claude Code 2.1+ uses to call `sts.googleapis.com` for Vertex.


Made with [Cursor](https://cursor.com)