### PR TITLE
test: smoke fullsend review on rhdh-fullsend-code

### DIFF
--- a/.fullsend/vertex-smoke.md
+++ b/.fullsend/vertex-smoke.md
@@ -1,0 +1,3 @@
+# Vertex smoke
+
+Temporary check that Review uses `ghcr.io/redhat-developer/rhdh-fullsend-code:latest` and Vertex STS succeeds after #4496. Safe to close/revert.

--- a/workspaces/boost/README.md
+++ b/workspaces/boost/README.md
@@ -74,3 +74,5 @@ yarn test:all
 # Build all plugins
 yarn build:all
 ```
+
+<!-- Vertex smoke: temporary Fullsend Review path-filter trigger. Safe to revert. -->


### PR DESCRIPTION
## Summary
Temporary PR to exercise Review **after** #4496 merged (sandbox is main). Confirm the job log shows `Image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest` and no `policy_denied`.

Touches `workspaces/boost/**` so `pull_request_target.paths` actually dispatches Review.

Close/revert after inspection.

## Test plan
- [ ] Open this PR so `pull_request_target` runs Review against main
- [ ] Do not merge


Made with [Cursor](https://cursor.com)