### PR TITLE
fix(extensions): show restart alert after plugin toggle in NFS

### DIFF
--- a/workspaces/extensions/.changeset/quiet-harbor-rest.md
+++ b/workspaces/extensions/.changeset/quiet-harbor-rest.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-extensions': patch
+---
+
+Navigate to the catalog tab after enable/disable so the NFS restart alert still appears.

--- a/workspaces/extensions/plugins/extensions/src/components/ExtensionsPluginContent.test.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/ExtensionsPluginContent.test.tsx
@@ -19,7 +19,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { mockApis, MockErrorApi, TestApiProvider } from '@backstage/test-utils';
 
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { ExtensionsPluginContent } from './ExtensionsPluginContent';
 import { extensionsApiRef } from '../api';
 import { usePluginConfigurationPermissions } from '../hooks/usePluginConfigurationPermissions';
@@ -32,6 +32,13 @@ import { errorApiRef } from '@backstage/core-plugin-api';
 import { translationApiRef } from '@backstage/core-plugin-api/alpha';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '../queryclient';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
 
 jest.mock('@backstage/core-plugin-api', () => {
   const actual = jest.requireActual('@backstage/core-plugin-api');
@@ -65,6 +72,12 @@ jest.mock('../hooks/usePluginPackages', () => ({
   usePluginPackages: jest.fn(),
 }));
 
+jest.mock('../hooks/useEnablePlugin', () => ({
+  useEnablePlugin: () => ({
+    mutateAsync: jest.fn().mockResolvedValue({ status: 'OK' }),
+  }),
+}));
+
 const usePluginMock = usePlugin as jest.Mock;
 const useNodeEnvironmentMock = useNodeEnvironment as jest.Mock;
 const usePluginPackagesMock = usePluginPackages as jest.Mock;
@@ -96,6 +109,7 @@ beforeEach(() => {
       nodeEnv: 'test',
     },
   });
+  mockNavigate.mockClear();
   jest.clearAllMocks();
 });
 
@@ -313,5 +327,33 @@ describe('ExtensionsPluginContent', () => {
 
     expect(getByTestId('actions-button')).toBeInTheDocument();
     expect(getByTestId('disable-plugin')).toBeInTheDocument();
+  });
+
+  it('navigates to the catalog tab after disabling a plugin', async () => {
+    usePluginPackagesMock.mockReturnValue({
+      isLoading: false,
+      data: packages,
+    });
+
+    const installedPlugin = {
+      ...plugin,
+      spec: {
+        ...plugin.spec,
+        installStatus: ExtensionsPluginInstallStatus.Installed,
+      },
+    };
+
+    const { getByTestId } = renderWithProviders(
+      <ExtensionsPluginContent plugin={installedPlugin} />,
+    );
+    fireEvent.click(getByTestId('plugin-actions'));
+    fireEvent.click(getByTestId('disable-plugin'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      '/extensions/installed-plugins',
+    );
   });
 });

--- a/workspaces/extensions/plugins/extensions/src/components/ExtensionsPluginContent.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/ExtensionsPluginContent.tsx
@@ -64,6 +64,7 @@ import {
   pluginRouteRef,
   packageRouteRef,
   packageInstallRouteRef,
+  catalogTabRouteRef,
 } from '../routes';
 import { usePlugin } from '../hooks/usePlugin';
 import { usePluginPackages } from '../hooks/usePluginPackages';
@@ -314,6 +315,7 @@ export const ExtensionsPluginContent = ({
     isPackage ? packageRouteRef : pluginRouteRef,
   );
   const getIndexPath = useRouteRef(rootRouteRef);
+  const getCatalogPath = useRouteRef(catalogTabRouteRef);
   const getInstallPath = useRouteRef(
     isPackage ? packageInstallRouteRef : pluginInstallRouteRef,
   );
@@ -373,7 +375,9 @@ export const ExtensionsPluginContent = ({
         };
         setInstalledPlugins(updatedPlugins);
         handleClose();
-        navigate(isPackage ? '/extensions' : '/extensions/installed-plugins');
+        // Catalog hosts BackendRestartAlert. `/extensions/installed-plugins` is
+        // not a registered tab and can drop the alert in NFS.
+        navigate(getCatalogPath());
       }
     } catch (err: unknown) {
       // eslint-disable-next-line no-console

--- a/workspaces/extensions/plugins/extensions/src/components/InstallationContext.test.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/InstallationContext.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render } from '@testing-library/react';
+import {
+  InstallationContextProvider,
+  resetInstallationStore,
+  useInstallationContext,
+} from './InstallationContext';
+
+const Consumer = () => {
+  const { installedPlugins, setInstalledPlugins } = useInstallationContext();
+  return (
+    <div>
+      <span data-testid="plugins">
+        {Object.keys(installedPlugins).join(',')}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          setInstalledPlugins({
+            ...installedPlugins,
+            'APIs with 3scale': 'disabled',
+          })
+        }
+      >
+        record
+      </button>
+    </div>
+  );
+};
+
+describe('InstallationContextProvider', () => {
+  beforeEach(() => {
+    resetInstallationStore();
+  });
+
+  afterEach(() => {
+    resetInstallationStore();
+  });
+
+  it('preserves pending restarts when the provider remounts', () => {
+    const { getByText, getByTestId, unmount } = render(
+      <InstallationContextProvider>
+        <Consumer />
+      </InstallationContextProvider>,
+    );
+
+    fireEvent.click(getByText('record'));
+    expect(getByTestId('plugins')).toHaveTextContent('APIs with 3scale');
+
+    unmount();
+
+    const { getByTestId: getByTestIdAfterRemount } = render(
+      <InstallationContextProvider>
+        <Consumer />
+      </InstallationContextProvider>,
+    );
+
+    expect(getByTestIdAfterRemount('plugins')).toHaveTextContent(
+      'APIs with 3scale',
+    );
+  });
+});

--- a/workspaces/extensions/plugins/extensions/src/components/InstallationContext.tsx
+++ b/workspaces/extensions/plugins/extensions/src/components/InstallationContext.tsx
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createContext, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
 export type InstallationType = { [pluginName: string]: string };
 
@@ -22,6 +28,31 @@ type InstallationContextType = {
   installedPackages: InstallationType;
   setInstalledPackages: (plugins: InstallationType) => void;
   setInstalledPlugins: (plugins: InstallationType) => void;
+};
+
+type InstallationStore = {
+  plugins: InstallationType;
+  packages: InstallationType;
+};
+
+const STORE_KEY = '__rhdhExtensionsInstallation';
+
+const getStore = (): InstallationStore => {
+  const globalState = globalThis as typeof globalThis & {
+    [STORE_KEY]?: InstallationStore;
+  };
+  if (!globalState[STORE_KEY]) {
+    globalState[STORE_KEY] = { plugins: {}, packages: {} };
+  }
+  return globalState[STORE_KEY];
+};
+
+/** @internal test-only helper to avoid leaking pending-restart state between tests */
+export const resetInstallationStore = () => {
+  const globalState = globalThis as typeof globalThis & {
+    [STORE_KEY]?: InstallationStore;
+  };
+  globalState[STORE_KEY] = { plugins: {}, packages: {} };
 };
 
 export const InstallationContext = createContext<InstallationContextType>({
@@ -38,12 +69,21 @@ export const InstallationContextProvider = ({
 }: {
   children: React.ReactElement;
 }) => {
-  const [installedPlugins, setInstalledPlugins] = useState<InstallationType>(
-    {},
-  );
-  const [installedPackages, setInstalledPackages] = useState<InstallationType>(
-    {},
-  );
+  const store = getStore();
+  const [installedPlugins, setInstalledPluginsState] =
+    useState<InstallationType>(() => store.plugins);
+  const [installedPackages, setInstalledPackagesState] =
+    useState<InstallationType>(() => store.packages);
+
+  const setInstalledPlugins = useCallback((plugins: InstallationType) => {
+    getStore().plugins = plugins;
+    setInstalledPluginsState(plugins);
+  }, []);
+
+  const setInstalledPackages = useCallback((packages: InstallationType) => {
+    getStore().packages = packages;
+    setInstalledPackagesState(packages);
+  }, []);
 
   const installationContexttProviderValue = useMemo(
     () => ({


### PR DESCRIPTION
## Description

After enabling or disabling a plugin from the Actions menu side drawer on the Extensions catalog page, NFS now stays on the catalog tab so the **Backend restart required** alert still appears.

`handleToggle` previously navigated to `/extensions/installed-plugins`, which is not a registered tab (`/extensions/catalog` and `/extensions/installed-packages` are). In NFS that unregistered path can unmount the extensions page, so the restart alert never appears. OFS still showed catalog content via TabbedLayout fallback, which is why it looked fine there.

Pending-restart state also lived only in React `useState`, so a remount cleared it. It is now kept on `globalThis` so it survives remounts (cleared on a full page reload after a real backend restart).

## Fixed
- [RHDHBUGS-3701](https://redhat.atlassian.net/browse/RHDHBUGS-3701) — In nfs after enabling a plugin, the expected restart alert doesn't appear.in extensions catalog page

## UI before changes
attached file in [RHDHBUGS-3701](https://redhat.atlassian.net/browse/RHDHBUGS-3701)
## UI after changes
![After fix](https://raw.githubusercontent.com/ciiay/rhdh-plugins/screenrecordings/screenrecordings/extensions-RHDHBUGS-3701/after-fix.gif)

## Test Plan
- [ ] Open the Extensions catalog in NFS
- [ ] Open a plugin Actions drawer and disable or enable the plugin
- [ ] Confirm the app lands on `/extensions/catalog`
- [ ] Confirm the **Backend restart required** alert is visible
- [ ] Repeat the same flow in OFS/legacy and confirm the alert still appears

## Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

## Note
> This bug fix was identified and implemented using the [bug-fix](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/bug-fix/SKILL.md) and [raise-pr](https://github.com/redhat-developer/rhdh-skill/blob/main/skills/raise-pr/SKILL.md) agent skills. Please verify the fix thoroughly before merging.

Made with [Cursor](https://cursor.com)