### PR TITLE
feat(scorecard): add translation keys for layout group titles and descriptions

### DIFF
--- a/workspaces/scorecard/.changeset/layout-group-translation-keys.md
+++ b/workspaces/scorecard/.changeset/layout-group-translation-keys.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard': minor
+---
+
+Add optional `titleKey` and `descriptionKey` on Scorecard layout groups so group titles and descriptions from app-config can be translated, with fallback to the configured English strings.

--- a/workspaces/scorecard/plugins/scorecard/README.md
+++ b/workspaces/scorecard/plugins/scorecard/README.md
@@ -133,7 +133,9 @@ To align with the legacy EntityPage (Scorecard on component pages and default en
              groups:
                codeQuality:
                  title: 'Code Quality'
+                 titleKey: groups.codeQuality.title
                  description: 'SonarQube code quality metrics'
+                 descriptionKey: groups.codeQuality.description
                  metrics:
                    - sonarqube.reliabilityIssues
                    - sonarqube.codeCoverage
@@ -147,11 +149,13 @@ To align with the legacy EntityPage (Scorecard on component pages and default en
 
    **Groups config schema:**
 
-   | Field         | Type       | Required | Description                                          |
-   | ------------- | ---------- | -------- | ---------------------------------------------------- |
-   | `title`       | `string`   | Yes      | Display title for the group card.                    |
-   | `description` | `string`   | No       | Optional description shown below the title.          |
-   | `metrics`     | `string[]` | Yes      | Ordered list of metric IDs to include in this group. |
+   | Field            | Type       | Required | Description                                                                                      |
+   | ---------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------ |
+   | `title`          | `string`   | Yes      | Display title for the group card. Used when `titleKey` is omitted or the translation is missing. |
+   | `titleKey`       | `string`   | No       | Translation key under `plugin.scorecard` (for example `groups.codeQuality.title`).               |
+   | `description`    | `string`   | No       | Optional description shown below the title. Used when `descriptionKey` is omitted or missing.    |
+   | `descriptionKey` | `string`   | No       | Translation key under `plugin.scorecard` (for example `groups.codeQuality.description`).         |
+   | `metrics`        | `string[]` | Yes      | Ordered list of metric IDs to include in this group.                                             |
 
    **Behavior:**
 
@@ -605,14 +609,19 @@ Translation keys follow this pattern:
 
 - **Metric titles**: `metric.{metric-id}.title`
 - **Metric descriptions**: `metric.{metric-id}.description`
+- **Layout group titles**: set `titleKey` on the group in app-config (for example `groups.codeQuality.title`)
+- **Layout group descriptions**: set `descriptionKey` on the group (for example `groups.codeQuality.description`)
 
-Use the same pattern with a **KPI id** as `{metric-id}` when localizing **`aggregationKPIs`** titles (for example **`metric.openIssuesKpi.title`**).
+Use the same `metric.{id}.{field}` pattern with a **KPI id** as `{metric-id}` when localizing **`aggregationKPIs`** titles (for example **`metric.openIssuesKpi.title`**).
+
+Group titles and descriptions do **not** use the `metric.{id}.{field}` convention. They are customer-defined in `scorecard-layout` config, so you pass explicit `titleKey` / `descriptionKey` values. Provide translations in plugin locale files or via RHDH `i18n.overrides` under `plugin.scorecard`. If a key is omitted or not found, the UI shows the group's `title` / `description` strings and never the raw key.
 
 ### 3. Fallback Behavior
 
 If a translation key is not found, the plugin will automatically fall back to:
 
 - The original `title` and `description` values from the metric definition
+- For layout groups: the `title` and `description` values from app-config
 - For thresholds: capitalized versions of the threshold keys
 
 ### Example: Adding GitHub Open PRs Translation

--- a/workspaces/scorecard/plugins/scorecard/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard/report.api.md
@@ -32,8 +32,8 @@ const _default: OverridableFrontendPlugin<
   {
     root: RouteRef<undefined>;
     drillDown: RouteRef<{
-      metricId: string;
       aggregationId: string;
+      metricId: string;
     }>;
   },
   {},

--- a/workspaces/scorecard/plugins/scorecard/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard/report.api.md
@@ -32,8 +32,8 @@ const _default: OverridableFrontendPlugin<
   {
     root: RouteRef<undefined>;
     drillDown: RouteRef<{
-      aggregationId: string;
       metricId: string;
+      aggregationId: string;
     }>;
   },
   {},
@@ -361,6 +361,8 @@ const _default: OverridableFrontendPlugin<
             title: string;
             metrics: string[];
             description?: string | undefined;
+            titleKey?: string | undefined;
+            descriptionKey?: string | undefined;
           }
         >;
       };
@@ -372,6 +374,8 @@ const _default: OverridableFrontendPlugin<
                 title: string;
                 metrics: string[];
                 description?: string | undefined;
+                titleKey?: string | undefined;
+                descriptionKey?: string | undefined;
               }
             >
           | undefined;
@@ -395,7 +399,9 @@ export interface ScorecardLayoutProps {
     string,
     {
       title: string;
+      titleKey?: string;
       description?: string;
+      descriptionKey?: string;
       metrics: string[];
     }
   >;

--- a/workspaces/scorecard/plugins/scorecard/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard/report.api.md
@@ -360,8 +360,8 @@ const _default: OverridableFrontendPlugin<
           {
             title: string;
             metrics: string[];
-            description?: string | undefined;
             titleKey?: string | undefined;
+            description?: string | undefined;
             descriptionKey?: string | undefined;
           }
         >;
@@ -373,8 +373,8 @@ const _default: OverridableFrontendPlugin<
               {
                 title: string;
                 metrics: string[];
-                description?: string | undefined;
                 titleKey?: string | undefined;
+                description?: string | undefined;
                 descriptionKey?: string | undefined;
               }
             >

--- a/workspaces/scorecard/plugins/scorecard/src/blueprints/ScorecardLayoutBlueprint.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/blueprints/ScorecardLayoutBlueprint.test.tsx
@@ -124,6 +124,42 @@ describe('ScorecardEntityContentLayoutBlueprint', () => {
     });
   });
 
+  it('should pass titleKey and descriptionKey through to the loaded component', async () => {
+    const MockLayout = (props: { groups: Record<string, any> }) => (
+      <div data-testid="mock-layout">{JSON.stringify(props.groups)}</div>
+    );
+
+    const extension = ScorecardEntityContentLayoutBlueprint.make({
+      params: {
+        title: 'Grid',
+        loader: async () => MockLayout,
+      },
+    });
+
+    const groups = {
+      quality: {
+        title: 'Quality',
+        titleKey: 'groups.quality.title',
+        description: 'Quality metrics',
+        descriptionKey: 'groups.quality.description',
+        metrics: ['sonarqube.codeCoverage'],
+      },
+    };
+
+    const tester = createExtensionTester(extension, { config: { groups } });
+
+    renderInTestApp(tester.reactElement());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+    });
+
+    const rendered = screen.getByTestId('mock-layout').textContent;
+    expect(rendered).toContain('groups.quality.title');
+    expect(rendered).toContain('groups.quality.description');
+    expect(rendered).toContain('Quality');
+  });
+
   it('should default groups to empty object when no config is provided', async () => {
     const MockLayout = (props: { groups: Record<string, any> }) => (
       <div data-testid="mock-layout">

--- a/workspaces/scorecard/plugins/scorecard/src/blueprints/ScorecardLayoutBlueprint.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/blueprints/ScorecardLayoutBlueprint.ts
@@ -34,7 +34,13 @@ export interface ScorecardLayoutProps {
    */
   groups: Record<
     string,
-    { title: string; description?: string; metrics: string[] }
+    {
+      title: string;
+      titleKey?: string;
+      description?: string;
+      descriptionKey?: string;
+      metrics: string[];
+    }
   >;
 }
 
@@ -72,7 +78,9 @@ export const ScorecardEntityContentLayoutBlueprint = createExtensionBlueprint({
         z.string(),
         z.object({
           title: z.string(),
+          titleKey: z.string().optional(),
           description: z.string().optional(),
+          descriptionKey: z.string().optional(),
           metrics: z.array(z.string()),
         }),
       )

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/ScorecardEntityContentGridView.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/ScorecardEntityContentGridView.tsx
@@ -29,7 +29,11 @@ import { MetricGroupCard } from '../MetricGroupCard';
 import { dedupeMetricsById } from '../MetricGroupCard/thresholdBucketUtils';
 import { EntityScorecardContent } from './EntityScorecardContent';
 import Scorecard from './Scorecard';
-import { getStatusConfig, resolveMetricTranslation } from '../../utils';
+import {
+  getStatusConfig,
+  getTranslatedTextWithFallback,
+  resolveMetricTranslation,
+} from '../../utils';
 import { hasMetricDataError, hasThresholdError } from '../../utils/statusUtils';
 
 export const ScorecardEntityContentGridView = ({
@@ -79,8 +83,20 @@ export const ScorecardEntityContentGridView = ({
       return (
         <MetricGroupCard
           key={groupKey}
-          title={groupConfig.title}
-          description={groupConfig.description}
+          title={
+            getTranslatedTextWithFallback(
+              t,
+              groupConfig.titleKey,
+              groupConfig.title,
+            ) ?? groupConfig.title
+          }
+          description={
+            getTranslatedTextWithFallback(
+              t,
+              groupConfig.descriptionKey,
+              groupConfig.description,
+            ) ?? groupConfig.description
+          }
           metrics={metricsInGroup}
         />
       );

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/ScorecardEntityContentGridView.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/ScorecardEntityContentGridView.tsx
@@ -90,13 +90,11 @@ export const ScorecardEntityContentGridView = ({
               groupConfig.title,
             ) ?? groupConfig.title
           }
-          description={
-            getTranslatedTextWithFallback(
-              t,
-              groupConfig.descriptionKey,
-              groupConfig.description,
-            ) ?? groupConfig.description
-          }
+          description={getTranslatedTextWithFallback(
+            t,
+            groupConfig.descriptionKey,
+            groupConfig.description,
+          )}
           metrics={metricsInGroup}
         />
       );

--- a/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/ScorecardEntityContentGridView.test.tsx
+++ b/workspaces/scorecard/plugins/scorecard/src/components/Scorecard/__tests__/ScorecardEntityContentGridView.test.tsx
@@ -18,6 +18,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { ScorecardEntityContentGridView } from '../ScorecardEntityContentGridView';
 import { mockScorecardSuccessData } from '../../../../__fixtures__/scorecardData';
 import { useScorecards } from '../../../hooks/useScorecards';
+import { useTranslation } from '../../../hooks/useTranslation';
 import { getStatusConfig } from '../../../utils';
 
 jest.mock('@backstage/core-components', () => ({
@@ -118,13 +119,25 @@ jest.mock('../../../hooks/useScorecards', () => ({
   useScorecards: jest.fn(),
 }));
 
-jest.mock('../../../utils', () => ({
-  getStatusConfig: jest.fn(),
-  resolveMetricTranslation: jest.fn(
-    (_t: any, _metricId: string, _field: string, fallback?: string) =>
-      fallback ?? `metric.${_metricId}.${_field}`,
-  ),
+jest.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+  })),
 }));
+
+jest.mock('../../../utils', () => {
+  const { getTranslatedTextWithFallback } = jest.requireActual(
+    '../../../utils/translationUtils',
+  );
+  return {
+    getStatusConfig: jest.fn(),
+    resolveMetricTranslation: jest.fn(
+      (_t: any, _metricId: string, _field: string, fallback?: string) =>
+        fallback ?? `metric.${_metricId}.${_field}`,
+    ),
+    getTranslatedTextWithFallback,
+  };
+});
 
 jest.mock('../../../utils/statusUtils', () => ({
   hasMetricDataError: jest.fn(() => false),
@@ -132,11 +145,16 @@ jest.mock('../../../utils/statusUtils', () => ({
 }));
 
 const useScorecardsMock = useScorecards as jest.Mock;
+const useTranslationMock = useTranslation as jest.Mock;
 const getStatusConfigMock = getStatusConfig as jest.Mock;
 
 describe('ScorecardEntityContentGridView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    useTranslationMock.mockReturnValue({
+      t: (key: string) => key,
+    });
 
     getStatusConfigMock.mockReturnValue({
       color: 'green',
@@ -359,6 +377,69 @@ describe('ScorecardEntityContentGridView', () => {
     render(<ScorecardEntityContentGridView groups={groups} />);
 
     expect(screen.getByText('All code quality metrics')).toBeInTheDocument();
+  });
+
+  it('should fall back to config title when titleKey is missing from translations', () => {
+    useScorecardsMock.mockReturnValue({
+      data: mockScorecardSuccessData,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const groups = {
+      codeQuality: {
+        title: 'Code Quality',
+        titleKey: 'groups.missing.title',
+        description: 'All code quality metrics',
+        descriptionKey: 'groups.missing.description',
+        metrics: ['github.openPRs'],
+      },
+    };
+
+    render(<ScorecardEntityContentGridView groups={groups} />);
+
+    expect(screen.getByText('Code Quality')).toBeInTheDocument();
+    expect(screen.getByText('All code quality metrics')).toBeInTheDocument();
+    expect(screen.queryByText('groups.missing.title')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('groups.missing.description'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render translated group title and description when keys resolve', () => {
+    useTranslationMock.mockReturnValue({
+      t: (key: string) => {
+        if (key === 'groups.codeQuality.title') return 'Qualität';
+        if (key === 'groups.codeQuality.description')
+          return 'Alle Qualitätsmetriken';
+        return key;
+      },
+    });
+
+    useScorecardsMock.mockReturnValue({
+      data: mockScorecardSuccessData,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const groups = {
+      codeQuality: {
+        title: 'Code Quality',
+        titleKey: 'groups.codeQuality.title',
+        description: 'All code quality metrics',
+        descriptionKey: 'groups.codeQuality.description',
+        metrics: ['github.openPRs'],
+      },
+    };
+
+    render(<ScorecardEntityContentGridView groups={groups} />);
+
+    expect(screen.getByText('Qualität')).toBeInTheDocument();
+    expect(screen.getByText('Alle Qualitätsmetriken')).toBeInTheDocument();
+    expect(screen.queryByText('Code Quality')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('All code quality metrics'),
+    ).not.toBeInTheDocument();
   });
 
   it('should preserve metric order within a group as defined in config', () => {

--- a/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/translationUtils.test.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/__tests__/translationUtils.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { resolveMetricTranslation } from '../translationUtils';
+import {
+  getTranslatedTextWithFallback,
+  resolveMetricTranslation,
+} from '../translationUtils';
 
 type MockT = (key: string, params?: Record<string, string>) => string;
 
@@ -172,5 +175,63 @@ describe('resolveMetricTranslation', () => {
         'Fallback Title',
       ),
     ).toBe('File check: readme');
+  });
+});
+
+describe('getTranslatedTextWithFallback', () => {
+  it('returns fallback without calling t when translationKey is undefined', () => {
+    const t = jest.fn();
+
+    expect(
+      getTranslatedTextWithFallback(t as any, undefined, 'Code Quality'),
+    ).toBe('Code Quality');
+    expect(t).not.toHaveBeenCalled();
+  });
+
+  it('returns translated text when the key resolves', () => {
+    const t = createMockT({
+      'groups.codeQuality.title': 'Qualität',
+    });
+
+    expect(
+      getTranslatedTextWithFallback(
+        t as any,
+        'groups.codeQuality.title',
+        'Code Quality',
+      ),
+    ).toBe('Qualität');
+  });
+
+  it('returns fallback when translation is missing (t returns the key)', () => {
+    const t = createMockT({});
+
+    expect(
+      getTranslatedTextWithFallback(
+        t as any,
+        'groups.missing.title',
+        'Code Quality',
+      ),
+    ).toBe('Code Quality');
+  });
+
+  it('returns undefined when there is no key and fallback is undefined', () => {
+    const t = jest.fn();
+
+    expect(
+      getTranslatedTextWithFallback(t as any, undefined, undefined),
+    ).toBeUndefined();
+    expect(t).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the key is missing and fallback is undefined', () => {
+    const t = createMockT({});
+
+    expect(
+      getTranslatedTextWithFallback(
+        t as any,
+        'groups.missing.description',
+        undefined,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/workspaces/scorecard/plugins/scorecard/src/utils/index.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/index.ts
@@ -43,4 +43,5 @@ export { getThresholdRuleColor, getThresholdRuleIcon } from './thresholdUtils';
 export {
   resolveMetricTranslation,
   extractPluginName,
+  getTranslatedTextWithFallback,
 } from './translationUtils';

--- a/workspaces/scorecard/plugins/scorecard/src/utils/translationUtils.ts
+++ b/workspaces/scorecard/plugins/scorecard/src/utils/translationUtils.ts
@@ -54,6 +54,24 @@ export function resolveMetricTranslation(
 }
 
 /**
+ * Gets a translated text with a fallback.
+ * @param t - The translation function.
+ * @param translationKey - The translation key.
+ * @param fallbackText - The fallback text.
+ * @returns The translated text.
+ */
+export function getTranslatedTextWithFallback(
+  t: ScorecardTranslationFunction,
+  translationKey: string | undefined,
+  fallbackText: string | undefined,
+): string | undefined {
+  if (!translationKey) return fallbackText;
+
+  const translated = t(translationKey as any, {});
+  return translated !== translationKey ? translated : fallbackText;
+}
+
+/**
  * Extracts the plugin name from a metric ID.
  * The plugin name is the first segment of the metric ID.
  * E.g. filecheck.codeowners -> Filecheck


### PR DESCRIPTION
## Summary
Adds optional `titleKey` and `descriptionKey` on Scorecard **layout groups** so titles and descriptions from `app-config.yaml` can be translated. Existing English configs keep working with no extra setup.

Fixes [RHIDP-15806](https://redhat.atlassian.net/browse/RHIDP-15806)

## What changed

Scorecard group strings from app-config were rendered as-is. They now resolve through the `plugin.scorecard` translation system:

1. `titleKey` / `descriptionKey` present **and** a translation exists → show translated text
2. Key present but **missing** from translations → show `title` / `description`
3. No key → show `title` / `description`

The UI never shows a raw translation key.

## How to configure
Enable the grid layout and add optional keys next to the English fallbacks:
```yaml
app:
  extensions:
    - scorecard-layout:scorecard/scorecard-entity-layout-grid:
        disabled: false
        config:
          groups:
            security-vulnerabilities:
              title: Security Vulnerabilities
              titleKey: groups.securityVulnerabilities.title
              description: Track security issues across your repositories
              descriptionKey: groups.securityVulnerabilities.description
              metrics:
                - sonarqube.securityRating
            code-quality:
              title: Code Quality
              description: Code quality and maintainability metrics
              metrics:
                - sonarqube.qualityGate
                - sonarqube.codeCoverage
```

| Field | Required | Notes |
| --- | --- | --- |
| `title` | Yes | English fallback |
| `titleKey` | No | Lookup under `plugin.scorecard` |
| `description` | No | English fallback |
| `descriptionKey` | No | Lookup under `plugin.scorecard` |
| `metrics` | Yes | Unchanged |

`title` / `description` stay required as fallbacks. Keys are optional, so current configs do not break.

## How to override translations
Group names are customer-defined, so they are not shipped in plugin locale files (de.ts, fr.ts, …). Add strings with RHDH i18n.overrides.

```yaml
{
  "plugin.scorecard": {
    "de": {
      "groups.securityVulnerabilities.title": "Sicherheitslücken",
      "groups.securityVulnerabilities.description": "Sicherheitsprobleme in Ihren Repositories verfolgen"
    },
    "fr": {
      "groups.securityVulnerabilities.title": "Vulnérabilités de sécurité",
      "groups.securityVulnerabilities.description": "Suivre les problèmes de sécurité dans vos dépôts"
    }
  }
}
```

## Screenshots
<img width="1912" height="895" alt="image" src="https://github.com/user-attachments/assets/4fb7d61b-6fe9-483f-a864-6563efa0a2d7" />

<img width="1920" height="894" alt="image" src="https://github.com/user-attachments/assets/61ea885d-b026-40a2-871a-213b759e8a2a" />


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
