### PR TITLE
test(install-dynamic-plugins): cover {{inherit}} resolution failures (RHIDP-16220)

### DIFF
--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger-inherit.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger-inherit.test.ts
@@ -140,9 +140,12 @@ describe('mergePlugin — OCI {{inherit}} matching several plugins of the same i
   it('refuses to resolve rather than silently adopting the older candidate', async () => {
     const all = await seedTwoPlugins();
 
-    // This is the guard behind "{{inherit}} never resolves to a version older
-    // than the include provides": with two candidates there is no defensible
-    // answer, and picking `matches[0]` would be free to land on OLDER.
+    // "{{inherit}} never resolves to a version older than the include
+    // provides" is not directly assertable: with one candidate the resolution
+    // adopts exactly that candidate's version, so the property holds by
+    // construction. The only way it could break is a future shortcut that
+    // picks `matches[0]` out of several candidates and lands on OLDER, which
+    // is what this guard — and this test — prevent.
     //
     // Asserting the message, not just the type: dropping this guard makes the
     // merge fail later with the "no resolved tag or digest" error instead,
@@ -167,6 +170,11 @@ describe('mergePlugin — OCI {{inherit}} matching a base without a version', ()
     // `mergeOciPlugin` always assigns `plugin.version` before storing a plugin,
     // so this state is not reachable through the merger itself — hence the
     // `Internal:` prefix. The map is seeded by hand to exercise the guard.
+    //
+    // This locks the guard's message given the broken state, not the invariant
+    // that produces it: if the merger ever stopped assigning `version` before
+    // storing, this test would still pass and the guard would fire in
+    // production instead. Do not read it as protecting that invariant.
     const all: PluginMap = {
       [KEY_A]: { package: `${REGISTRY}:${NEWER}!plugin-a` },
     };

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.inherit.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.inherit.test.ts
@@ -15,7 +15,7 @@
  */
 import { InstallException } from './errors';
 import { mergePlugin } from './merger';
-import type { PluginMap } from './types';
+import type { Plugin, PluginMap } from './types';
 
 /**
  * Coverage for the `{{inherit}}` resolution in `mergeOciPlugin` /
@@ -26,44 +26,69 @@ import type { PluginMap } from './types';
  * and the `!path` suffix — so those occurrences exercise none of this file's
  * behaviour.
  *
- * Every case below uses an explicit `!<plugin-path>` on the seed entries and a
- * path-less or explicitly-pathed `{{inherit}}` on the override, so no OCI image
- * cache (and therefore no skopeo call) is ever needed.
+ * Every package string below either carries an explicit `!<plugin-path>` or is
+ * a path-less `{{inherit}}`. Both return from `ociPluginKey` before
+ * `autoDetectPluginPath` is reached, so no OCI image cache — and therefore no
+ * skopeo call — is ever needed.
  */
 
 const REGISTRY = 'oci://registry.example.com/plugin';
+const OTHER_REGISTRY = 'oci://other.example.com/plugin';
 const KEY_A = `${REGISTRY}:!plugin-a`;
 const KEY_B = `${REGISTRY}:!plugin-b`;
+const OTHER_KEY_A = `${OTHER_REGISTRY}:!plugin-a`;
+
+const MAIN_FILE = 'main.yaml';
+const INCLUDE_FILE = 'include.yaml';
 
 /** Version shipped by the include — the one `{{inherit}}` must adopt. */
 const NEWER = '1.10.2';
 /** An older sibling in the same image — must never be picked silently. */
 const OLDER = '1.9.0';
 
+/** Merge an include entry (level 0), the lower-precedence source. */
 async function seedInclude(
   all: PluginMap,
   pkg: string,
-  file = 'include.yaml',
+  file = INCLUDE_FILE,
 ): Promise<void> {
   await mergePlugin({ package: pkg }, all, file, /* level */ 0);
 }
 
-describe('mergeOciPlugin — {{inherit}} with no resolvable base', () => {
+/** Merge an entry from the main config (level 1), which outranks the includes. */
+function mergeMain(all: PluginMap, plugin: Plugin): Promise<void> {
+  return mergePlugin(plugin, all, MAIN_FILE, /* level */ 1);
+}
+
+/**
+ * Run `merge`, assert it failed with an `InstallException`, and hand back the
+ * message so several parts of it can be asserted without merging again —
+ * re-running would assert later parts against a mutated `allPlugins`.
+ */
+async function installErrorMessage(
+  merge: () => Promise<unknown>,
+): Promise<string> {
+  try {
+    await merge();
+  } catch (err) {
+    expect(err).toBeInstanceOf(InstallException);
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error('expected the merge to throw an InstallException');
+}
+
+describe('mergePlugin — OCI {{inherit}} with no resolvable base', () => {
   it('reports the missing base configuration when nothing from the image was merged', async () => {
     const all: PluginMap = {};
-    const merge = () =>
-      mergePlugin(
-        { package: `${REGISTRY}:{{inherit}}` },
-        all,
-        'main.yaml',
-        /* level */ 1,
-      );
 
-    await expect(merge()).rejects.toBeInstanceOf(InstallException);
-    await expect(merge()).rejects.toThrow(
+    const message = await installErrorMessage(() =>
+      mergeMain(all, { package: `${REGISTRY}:{{inherit}}` }),
+    );
+
+    expect(message).toContain(
       `Cannot use {{inherit}} for ${REGISTRY}: no existing plugin configuration found.`,
     );
-    await expect(merge()).rejects.toThrow(
+    expect(message).toContain(
       'Ensure a plugin from this image is defined in an included file with an explicit version.',
     );
     expect(all).toEqual({});
@@ -71,25 +96,20 @@ describe('mergeOciPlugin — {{inherit}} with no resolvable base', () => {
 
   it('does not treat a plugin from a different image as a base', async () => {
     const all: PluginMap = {};
-    await seedInclude(all, `oci://other.example.com/plugin:${NEWER}!plugin-a`);
+    await seedInclude(all, `${OTHER_REGISTRY}:${NEWER}!plugin-a`);
 
-    await expect(
-      mergePlugin(
-        { package: `${REGISTRY}:{{inherit}}` },
-        all,
-        'main.yaml',
-        /* level */ 1,
-      ),
-    ).rejects.toThrow(
+    const message = await installErrorMessage(() =>
+      mergeMain(all, { package: `${REGISTRY}:{{inherit}}` }),
+    );
+
+    expect(message).toContain(
       `Cannot use {{inherit}} for ${REGISTRY}: no existing plugin configuration found.`,
     );
-    expect(Object.keys(all)).toEqual([
-      'oci://other.example.com/plugin:!plugin-a',
-    ]);
+    expect(Object.keys(all)).toEqual([OTHER_KEY_A]);
   });
 });
 
-describe('mergeOciPlugin — {{inherit}} matching several plugins of the same image', () => {
+describe('mergePlugin — OCI {{inherit}} matching several plugins of the same image', () => {
   async function seedTwoPlugins(): Promise<PluginMap> {
     const all: PluginMap = {};
     await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`, 'include-a.yaml');
@@ -99,46 +119,41 @@ describe('mergeOciPlugin — {{inherit}} matching several plugins of the same im
 
   it('lists every candidate and tells the user how to disambiguate', async () => {
     const all = await seedTwoPlugins();
-    const merge = () =>
-      mergePlugin(
-        { package: `${REGISTRY}:{{inherit}}` },
-        all,
-        'main.yaml',
-        /* level */ 1,
-      );
 
-    await expect(merge()).rejects.toBeInstanceOf(InstallException);
-    await expect(merge()).rejects.toThrow(
+    const message = await installErrorMessage(() =>
+      mergeMain(all, { package: `${REGISTRY}:{{inherit}}` }),
+    );
+
+    expect(message).toContain(
       `Cannot use {{inherit}} for ${REGISTRY}: multiple plugins from this image are defined in the included files:`,
     );
     // Each candidate is rendered with the version it currently resolves to, so
     // the operator can see which one they would be inheriting.
-    await expect(merge()).rejects.toThrow(`  - ${REGISTRY}:${NEWER}!plugin-a`);
-    await expect(merge()).rejects.toThrow(`  - ${REGISTRY}:${OLDER}!plugin-b`);
+    expect(message).toContain(`  - ${REGISTRY}:${NEWER}!plugin-a`);
+    expect(message).toContain(`  - ${REGISTRY}:${OLDER}!plugin-b`);
     // The remediation hint is the part the operator actually acts on.
-    await expect(merge()).rejects.toThrow(
+    expect(message).toContain(
       `Please specify which plugin configuration to inherit from using: ${REGISTRY}:{{inherit}}!<plugin_path>`,
     );
   });
 
-  it('refuses to resolve rather than silently adopting one of the candidates', async () => {
+  it('refuses to resolve rather than silently adopting the older candidate', async () => {
     const all = await seedTwoPlugins();
 
-    await expect(
-      mergePlugin(
-        { package: `${REGISTRY}:{{inherit}}` },
-        all,
-        'main.yaml',
-        /* level */ 1,
-      ),
-      // Asserting the message, not just the type: dropping this guard makes the
-      // merge fail later with the "no resolved tag or digest" error instead,
-      // which a bare `toThrow()` would happily accept.
-    ).rejects.toThrow('multiple plugins from this image are defined');
+    // This is the guard behind "{{inherit}} never resolves to a version older
+    // than the include provides": with two candidates there is no defensible
+    // answer, and picking `matches[0]` would be free to land on OLDER.
+    //
+    // Asserting the message, not just the type: dropping this guard makes the
+    // merge fail later with the "no resolved tag or digest" error instead,
+    // which a bare `toThrow()` would happily accept.
+    const message = await installErrorMessage(() =>
+      mergeMain(all, { package: `${REGISTRY}:{{inherit}}` }),
+    );
+    expect(message).toContain('multiple plugins from this image are defined');
 
     // Nothing was resolved: no new key, and both candidates keep the version
-    // and precedence level their include gave them. An ambiguous match that
-    // picked `matches[0]` would be free to land on the older sibling.
+    // and precedence level their include gave them.
     expect(Object.keys(all)).toEqual([KEY_A, KEY_B]);
     expect(all[KEY_A]?.version).toBe(NEWER);
     expect(all[KEY_B]?.version).toBe(OLDER);
@@ -147,7 +162,7 @@ describe('mergeOciPlugin — {{inherit}} matching several plugins of the same im
   });
 });
 
-describe('mergeOciPlugin — {{inherit}} matching a base without a version', () => {
+describe('mergePlugin — OCI {{inherit}} matching a base without a version', () => {
   it('reports the broken invariant instead of inheriting `undefined`', async () => {
     // `mergeOciPlugin` always assigns `plugin.version` before storing a plugin,
     // so this state is not reachable through the merger itself — hence the
@@ -155,35 +170,32 @@ describe('mergeOciPlugin — {{inherit}} matching a base without a version', () 
     const all: PluginMap = {
       [KEY_A]: { package: `${REGISTRY}:${NEWER}!plugin-a` },
     };
-    const merge = () =>
-      mergePlugin(
-        { package: `${REGISTRY}:{{inherit}}` },
-        all,
-        'main.yaml',
-        /* level */ 1,
-      );
 
-    await expect(merge()).rejects.toBeInstanceOf(InstallException);
-    await expect(merge()).rejects.toThrow(
+    const message = await installErrorMessage(() =>
+      mergeMain(all, { package: `${REGISTRY}:{{inherit}}` }),
+    );
+
+    expect(message).toContain(
       `Internal: inherited plugin ${KEY_A} has no version`,
     );
   });
 });
 
-describe('mergeOciPlugin — {{inherit}} with an explicit !plugin-path', () => {
+describe('mergePlugin — OCI {{inherit}} with an explicit !plugin-path', () => {
   it('reports the unresolved tag when the referenced path was never merged', async () => {
     const all: PluginMap = {};
     const pkg = `${REGISTRY}:{{inherit}}!plugin-a`;
-    const merge = () =>
-      mergePlugin({ package: pkg }, all, 'main.yaml', /* level */ 1);
 
-    await expect(merge()).rejects.toBeInstanceOf(InstallException);
-    await expect(merge()).rejects.toThrow(
+    const message = await installErrorMessage(() =>
+      mergeMain(all, { package: pkg }),
+    );
+
+    expect(message).toContain(
       '{{inherit}} tag is set and there is currently no resolved tag or digest',
     );
     // The package and the config file are named so the operator can find the
     // offending entry without reading the whole config.
-    await expect(merge()).rejects.toThrow(`for ${pkg} in main.yaml.`);
+    expect(message).toContain(`for ${pkg} in ${MAIN_FILE}.`);
     expect(all).toEqual({});
   });
 
@@ -191,15 +203,10 @@ describe('mergeOciPlugin — {{inherit}} with an explicit !plugin-path', () => {
     const all: PluginMap = {};
     await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
 
-    await mergePlugin(
-      {
-        package: `${REGISTRY}:{{inherit}}!plugin-a`,
-        pluginConfig: { app: { title: 'overridden' } },
-      },
-      all,
-      'main.yaml',
-      /* level */ 1,
-    );
+    await mergeMain(all, {
+      package: `${REGISTRY}:{{inherit}}!plugin-a`,
+      pluginConfig: { app: { title: 'overridden' } },
+    });
 
     // The `{{inherit}}` literal must never reach the merged record.
     expect(all[KEY_A]?.version).toBe(NEWER);
@@ -210,21 +217,31 @@ describe('mergeOciPlugin — {{inherit}} with an explicit !plugin-path', () => {
   });
 });
 
-describe('mergeOciPlugin — {{inherit}} resolving against a single base', () => {
+describe('mergePlugin — OCI {{inherit}} resolving against a single base', () => {
   it('adopts the version and plugin path of the only candidate', async () => {
     const all: PluginMap = {};
     await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
 
-    const plugin = { package: `${REGISTRY}:{{inherit}}`, disabled: true };
-    await mergePlugin(plugin, all, 'main.yaml', /* level */ 1);
+    const plugin: Plugin = {
+      package: `${REGISTRY}:{{inherit}}`,
+      disabled: true,
+    };
+    await mergeMain(all, plugin);
 
-    // The override is rewritten in place so downstream consumers (hashing,
-    // download) see a concrete reference rather than the `{{inherit}}` literal.
+    // `resolveInherit` documents that it rewrites `plugin.package` in place,
+    // and this is the only assertion of that contract. It is the override
+    // object that gets rewritten, not the merged record: the entry kept in
+    // `allPlugins` is the include's own, whose package was already concrete
+    // (asserted below). `installer.ts` reads only `Object.values(allPlugins)`
+    // afterwards, so nothing downstream depends on this rewrite today.
     expect(plugin.package).toBe(`${REGISTRY}:${NEWER}!plugin-a`);
     // It folds into the existing entry instead of creating a path-less one.
+    // No assertion on the merged `package` here: it is the include's own string
+    // and no mutation of the inherit path can change it, so asserting it would
+    // only restate the fixture. The contract that an override must not clobber
+    // it is enforced by the explicit-!path test above, which does catch that.
     expect(Object.keys(all)).toEqual([KEY_A]);
     expect(all[KEY_A]?.version).toBe(NEWER);
-    expect(all[KEY_A]?.package).toBe(`${REGISTRY}:${NEWER}!plugin-a`);
     expect(all[KEY_A]?.disabled).toBe(true);
     expect(all[KEY_A]?.last_modified_level).toBe(1);
   });
@@ -236,12 +253,7 @@ describe('mergeOciPlugin — {{inherit}} resolving against a single base', () =>
     try {
       const all: PluginMap = {};
       await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
-      await mergePlugin(
-        { package: `${REGISTRY}:{{inherit}}` },
-        all,
-        'main.yaml',
-        /* level */ 1,
-      );
+      await mergeMain(all, { package: `${REGISTRY}:{{inherit}}` });
 
       const out = write.mock.calls.map(args => String(args[0])).join('\n');
       expect(out).toContain(
@@ -252,43 +264,32 @@ describe('mergeOciPlugin — {{inherit}} resolving against a single base', () =>
     }
   });
 
-  it('never resolves to a version older than the one the include provides', async () => {
+  it('ignores a same-named plugin path belonging to a different image', async () => {
     const all: PluginMap = {};
-    // A same-named plugin path in an unrelated image, at an older version, must
-    // not influence the resolution (RHDHBUGS-3503 shipped older versions than
-    // the previous release through this path).
+    // Candidates are matched on the full registry, not on the plugin path, so
+    // an unrelated image publishing `plugin-a` must not enter the selection.
     await seedInclude(
       all,
-      `oci://other.example.com/plugin:${OLDER}!plugin-a`,
+      `${OTHER_REGISTRY}:${OLDER}!plugin-a`,
       'include-other.yaml',
     );
     await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
 
-    await mergePlugin(
-      { package: `${REGISTRY}:{{inherit}}` },
-      all,
-      'main.yaml',
-      /* level */ 1,
-    );
+    await mergeMain(all, { package: `${REGISTRY}:{{inherit}}` });
 
     expect(all[KEY_A]?.version).toBe(NEWER);
-    expect(all['oci://other.example.com/plugin:!plugin-a']?.version).toBe(
-      OLDER,
-    );
+    expect(all[OTHER_KEY_A]?.version).toBe(OLDER);
   });
+});
 
-  it('lets a higher-precedence explicit version override, unlike {{inherit}}', async () => {
+describe('mergePlugin — OCI explicit version override', () => {
+  it('lets the main config outrank an include, unlike {{inherit}}', async () => {
     const all: PluginMap = {};
     await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
 
     // The main config outranks the includes, so an explicit tag there is an
     // intentional override — the case `{{inherit}}` deliberately opts out of.
-    await mergePlugin(
-      { package: `${REGISTRY}:2.0.0!plugin-a` },
-      all,
-      'main.yaml',
-      /* level */ 1,
-    );
+    await mergeMain(all, { package: `${REGISTRY}:2.0.0!plugin-a` });
 
     expect(all[KEY_A]?.version).toBe('2.0.0');
     expect(all[KEY_A]?.package).toBe(`${REGISTRY}:2.0.0!plugin-a`);

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.inherit.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/merger.inherit.test.ts
@@ -1,0 +1,296 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InstallException } from './errors';
+import { mergePlugin } from './merger';
+import type { PluginMap } from './types';
+
+/**
+ * Coverage for the `{{inherit}}` resolution in `mergeOciPlugin` /
+ * `resolveInherit`.
+ *
+ * `merger-pre-merge.test.ts` also spells `{{inherit}}` in its fixtures, but
+ * `preMergeOciDisabledState` never parses the tag — it only reads the registry
+ * and the `!path` suffix — so those occurrences exercise none of this file's
+ * behaviour.
+ *
+ * Every case below uses an explicit `!<plugin-path>` on the seed entries and a
+ * path-less or explicitly-pathed `{{inherit}}` on the override, so no OCI image
+ * cache (and therefore no skopeo call) is ever needed.
+ */
+
+const REGISTRY = 'oci://registry.example.com/plugin';
+const KEY_A = `${REGISTRY}:!plugin-a`;
+const KEY_B = `${REGISTRY}:!plugin-b`;
+
+/** Version shipped by the include — the one `{{inherit}}` must adopt. */
+const NEWER = '1.10.2';
+/** An older sibling in the same image — must never be picked silently. */
+const OLDER = '1.9.0';
+
+async function seedInclude(
+  all: PluginMap,
+  pkg: string,
+  file = 'include.yaml',
+): Promise<void> {
+  await mergePlugin({ package: pkg }, all, file, /* level */ 0);
+}
+
+describe('mergeOciPlugin — {{inherit}} with no resolvable base', () => {
+  it('reports the missing base configuration when nothing from the image was merged', async () => {
+    const all: PluginMap = {};
+    const merge = () =>
+      mergePlugin(
+        { package: `${REGISTRY}:{{inherit}}` },
+        all,
+        'main.yaml',
+        /* level */ 1,
+      );
+
+    await expect(merge()).rejects.toBeInstanceOf(InstallException);
+    await expect(merge()).rejects.toThrow(
+      `Cannot use {{inherit}} for ${REGISTRY}: no existing plugin configuration found.`,
+    );
+    await expect(merge()).rejects.toThrow(
+      'Ensure a plugin from this image is defined in an included file with an explicit version.',
+    );
+    expect(all).toEqual({});
+  });
+
+  it('does not treat a plugin from a different image as a base', async () => {
+    const all: PluginMap = {};
+    await seedInclude(all, `oci://other.example.com/plugin:${NEWER}!plugin-a`);
+
+    await expect(
+      mergePlugin(
+        { package: `${REGISTRY}:{{inherit}}` },
+        all,
+        'main.yaml',
+        /* level */ 1,
+      ),
+    ).rejects.toThrow(
+      `Cannot use {{inherit}} for ${REGISTRY}: no existing plugin configuration found.`,
+    );
+    expect(Object.keys(all)).toEqual([
+      'oci://other.example.com/plugin:!plugin-a',
+    ]);
+  });
+});
+
+describe('mergeOciPlugin — {{inherit}} matching several plugins of the same image', () => {
+  async function seedTwoPlugins(): Promise<PluginMap> {
+    const all: PluginMap = {};
+    await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`, 'include-a.yaml');
+    await seedInclude(all, `${REGISTRY}:${OLDER}!plugin-b`, 'include-b.yaml');
+    return all;
+  }
+
+  it('lists every candidate and tells the user how to disambiguate', async () => {
+    const all = await seedTwoPlugins();
+    const merge = () =>
+      mergePlugin(
+        { package: `${REGISTRY}:{{inherit}}` },
+        all,
+        'main.yaml',
+        /* level */ 1,
+      );
+
+    await expect(merge()).rejects.toBeInstanceOf(InstallException);
+    await expect(merge()).rejects.toThrow(
+      `Cannot use {{inherit}} for ${REGISTRY}: multiple plugins from this image are defined in the included files:`,
+    );
+    // Each candidate is rendered with the version it currently resolves to, so
+    // the operator can see which one they would be inheriting.
+    await expect(merge()).rejects.toThrow(`  - ${REGISTRY}:${NEWER}!plugin-a`);
+    await expect(merge()).rejects.toThrow(`  - ${REGISTRY}:${OLDER}!plugin-b`);
+    // The remediation hint is the part the operator actually acts on.
+    await expect(merge()).rejects.toThrow(
+      `Please specify which plugin configuration to inherit from using: ${REGISTRY}:{{inherit}}!<plugin_path>`,
+    );
+  });
+
+  it('refuses to resolve rather than silently adopting one of the candidates', async () => {
+    const all = await seedTwoPlugins();
+
+    await expect(
+      mergePlugin(
+        { package: `${REGISTRY}:{{inherit}}` },
+        all,
+        'main.yaml',
+        /* level */ 1,
+      ),
+      // Asserting the message, not just the type: dropping this guard makes the
+      // merge fail later with the "no resolved tag or digest" error instead,
+      // which a bare `toThrow()` would happily accept.
+    ).rejects.toThrow('multiple plugins from this image are defined');
+
+    // Nothing was resolved: no new key, and both candidates keep the version
+    // and precedence level their include gave them. An ambiguous match that
+    // picked `matches[0]` would be free to land on the older sibling.
+    expect(Object.keys(all)).toEqual([KEY_A, KEY_B]);
+    expect(all[KEY_A]?.version).toBe(NEWER);
+    expect(all[KEY_B]?.version).toBe(OLDER);
+    expect(all[KEY_A]?.last_modified_level).toBe(0);
+    expect(all[KEY_B]?.last_modified_level).toBe(0);
+  });
+});
+
+describe('mergeOciPlugin — {{inherit}} matching a base without a version', () => {
+  it('reports the broken invariant instead of inheriting `undefined`', async () => {
+    // `mergeOciPlugin` always assigns `plugin.version` before storing a plugin,
+    // so this state is not reachable through the merger itself — hence the
+    // `Internal:` prefix. The map is seeded by hand to exercise the guard.
+    const all: PluginMap = {
+      [KEY_A]: { package: `${REGISTRY}:${NEWER}!plugin-a` },
+    };
+    const merge = () =>
+      mergePlugin(
+        { package: `${REGISTRY}:{{inherit}}` },
+        all,
+        'main.yaml',
+        /* level */ 1,
+      );
+
+    await expect(merge()).rejects.toBeInstanceOf(InstallException);
+    await expect(merge()).rejects.toThrow(
+      `Internal: inherited plugin ${KEY_A} has no version`,
+    );
+  });
+});
+
+describe('mergeOciPlugin — {{inherit}} with an explicit !plugin-path', () => {
+  it('reports the unresolved tag when the referenced path was never merged', async () => {
+    const all: PluginMap = {};
+    const pkg = `${REGISTRY}:{{inherit}}!plugin-a`;
+    const merge = () =>
+      mergePlugin({ package: pkg }, all, 'main.yaml', /* level */ 1);
+
+    await expect(merge()).rejects.toBeInstanceOf(InstallException);
+    await expect(merge()).rejects.toThrow(
+      '{{inherit}} tag is set and there is currently no resolved tag or digest',
+    );
+    // The package and the config file are named so the operator can find the
+    // offending entry without reading the whole config.
+    await expect(merge()).rejects.toThrow(`for ${pkg} in main.yaml.`);
+    expect(all).toEqual({});
+  });
+
+  it('keeps the base version and package when the referenced path exists', async () => {
+    const all: PluginMap = {};
+    await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
+
+    await mergePlugin(
+      {
+        package: `${REGISTRY}:{{inherit}}!plugin-a`,
+        pluginConfig: { app: { title: 'overridden' } },
+      },
+      all,
+      'main.yaml',
+      /* level */ 1,
+    );
+
+    // The `{{inherit}}` literal must never reach the merged record.
+    expect(all[KEY_A]?.version).toBe(NEWER);
+    expect(all[KEY_A]?.package).toBe(`${REGISTRY}:${NEWER}!plugin-a`);
+    expect(all[KEY_A]?.pluginConfig).toEqual({ app: { title: 'overridden' } });
+    expect(all[KEY_A]?.last_modified_level).toBe(1);
+    expect(Object.keys(all)).toEqual([KEY_A]);
+  });
+});
+
+describe('mergeOciPlugin — {{inherit}} resolving against a single base', () => {
+  it('adopts the version and plugin path of the only candidate', async () => {
+    const all: PluginMap = {};
+    await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
+
+    const plugin = { package: `${REGISTRY}:{{inherit}}`, disabled: true };
+    await mergePlugin(plugin, all, 'main.yaml', /* level */ 1);
+
+    // The override is rewritten in place so downstream consumers (hashing,
+    // download) see a concrete reference rather than the `{{inherit}}` literal.
+    expect(plugin.package).toBe(`${REGISTRY}:${NEWER}!plugin-a`);
+    // It folds into the existing entry instead of creating a path-less one.
+    expect(Object.keys(all)).toEqual([KEY_A]);
+    expect(all[KEY_A]?.version).toBe(NEWER);
+    expect(all[KEY_A]?.package).toBe(`${REGISTRY}:${NEWER}!plugin-a`);
+    expect(all[KEY_A]?.disabled).toBe(true);
+    expect(all[KEY_A]?.last_modified_level).toBe(1);
+  });
+
+  it('logs the version and path it inherited', async () => {
+    const write = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    try {
+      const all: PluginMap = {};
+      await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
+      await mergePlugin(
+        { package: `${REGISTRY}:{{inherit}}` },
+        all,
+        'main.yaml',
+        /* level */ 1,
+      );
+
+      const out = write.mock.calls.map(args => String(args[0])).join('\n');
+      expect(out).toContain(
+        `Inheriting version \`${NEWER}\` and plugin path \`plugin-a\` for ${KEY_A}`,
+      );
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it('never resolves to a version older than the one the include provides', async () => {
+    const all: PluginMap = {};
+    // A same-named plugin path in an unrelated image, at an older version, must
+    // not influence the resolution (RHDHBUGS-3503 shipped older versions than
+    // the previous release through this path).
+    await seedInclude(
+      all,
+      `oci://other.example.com/plugin:${OLDER}!plugin-a`,
+      'include-other.yaml',
+    );
+    await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
+
+    await mergePlugin(
+      { package: `${REGISTRY}:{{inherit}}` },
+      all,
+      'main.yaml',
+      /* level */ 1,
+    );
+
+    expect(all[KEY_A]?.version).toBe(NEWER);
+    expect(all['oci://other.example.com/plugin:!plugin-a']?.version).toBe(
+      OLDER,
+    );
+  });
+
+  it('lets a higher-precedence explicit version override, unlike {{inherit}}', async () => {
+    const all: PluginMap = {};
+    await seedInclude(all, `${REGISTRY}:${NEWER}!plugin-a`);
+
+    // The main config outranks the includes, so an explicit tag there is an
+    // intentional override — the case `{{inherit}}` deliberately opts out of.
+    await mergePlugin(
+      { package: `${REGISTRY}:2.0.0!plugin-a` },
+      all,
+      'main.yaml',
+      /* level */ 1,
+    );
+
+    expect(all[KEY_A]?.version).toBe('2.0.0');
+    expect(all[KEY_A]?.package).toBe(`${REGISTRY}:2.0.0!plugin-a`);
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `merger-inherit.test.ts` covering the `{{inherit}}` resolution in
`install-dynamic-plugins`' OCI merger — specifically the four `InstallException`
branches that had no test at all.

Jira: [RHIDP-16220](https://redhat.atlassian.net/browse/RHIDP-16220)

### The gap

`merger.ts` implements the whole `{{inherit}}` resolution, including four
`InstallException` branches. None of them was exercised.

Worth stating plainly, because it is easy to conclude the opposite from a grep:
`merger-pre-merge.test.ts` does spell `{{inherit}}` in eight fixtures, but
`preMergeOciDisabledState` only reads the registry and the `!path` suffix and
never parses the tag. I verified this by replacing all eight occurrences with a
literal `1.0` — its 19 tests stayed green. So the resolution had no coverage
either way: not the failures, and not the success path.

Coverage on `merger.ts`, measured locally:

| | statements | branches | lines | uncovered |
| --- | --- | --- | --- | --- |
| before | 66.36% | 61.58% | 69.15% | 62, 108-125, **165-265**, 310, 322-332 |
| after | 87.27% | 80.13% | 91.04% | 62, 108-125, 170, 193, 310, 322-332 |

Lines 165-265 are `mergeOciPlugin` plus `resolveInherit` in full.

### What is covered now

Failure branches, asserting the **message text** rather than just that it throws:

| `merger.ts` | Case |
| --- | --- |
| `:229` | No candidate from the image was merged — `no existing plugin configuration found`, plus the variant where only a plugin from a *different* image is present (guards the key-prefix filter) |
| `:244` | Several candidates from the same image — the rendered candidate list *and* the remediation hint telling the operator to write `<pluginKey>:{{inherit}}!<plugin_path>` |
| `:254` | A matched base with no version — the `Internal:` guard. Seeded by hand, since `mergeOciPlugin` always assigns a version before storing and the state is unreachable through the merger |
| `:178` | An explicit `:{{inherit}}!<path>` whose path was never merged — `no resolved tag or digest`, with the package and config file named |

And the success path, equally untested before: version and plugin path adopted
from the single candidate, the `{{inherit}}` literal never reaching the merged
record, candidates matched on the full registry rather than the plugin path, and
the contrast case where an explicit higher-precedence tag does legitimately
override.

No `imageCache` mock and no skopeo call is needed anywhere — no package string
in the file reaches `autoDetectPluginPath`.

### Mutation check

Each throw turned into a silent return, one at a time, against the full 236-test
package suite:

| Branch | Result |
| --- | --- |
| `merger.ts:178` | 1 failure, 235 pass |
| `merger.ts:229` | 2 failures, 234 pass (both dedicated to that branch) |
| `merger.ts:244` | 2 failures, 234 pass (both dedicated to that branch) |
| `merger.ts:254` | 1 failure, 235 pass |

No collateral failures in any run. A fifth, more realistic mutation — dropping
the ambiguity guard entirely so `resolveInherit` silently adopts `matches[0]` —
fails 2 tests.

Every success-path behaviour was made to fail too, so no test in the file is
vacuous: removing the in-place `plugin.package` rewrite, the `Inheriting
version` log, the `!parsed.inherit` guard, the full-registry candidate match,
and the explicit-override version assignment each fail exactly the test that
claims to cover them.

That fifth mutation is the reason the messages are asserted rather than the
throws. Mutating `:229` or `:244` to a silent return makes the merge fail
*later* with the `:178` error, so it still throws an `InstallException` — my
first draft of the "refuses to resolve" test used only `toBeInstanceOf` and
survived the mutation. Asserting the message kills it.

### On RHDHBUGS-3503

An earlier revision of this description cited RHDHBUGS-3503 as the bug behind
this work. That was wrong and has been removed. Recording why, since RHIDP-16220
still carries the same premise:

3503 reports `{{inherit}}` resolving three Orchestrator plugins to older versions
after an Operator 1.10.1 → 1.10.2 upgrade. But its own description states that
every resolved digest was valid and installed cleanly in both releases, that the
`{{inherit}}` logic "was reviewed directly against the release-1.10 branch source
and confirmed to behave exactly as designed", and that the regression is in the
content of the 1.10.2 catalog. The merger did what it was told. No test in
`merger.ts` could have caught a catalog that truthfully advertises an older
version.

3503 also carries a Causality link to RHDHBUGS-3455 that its own text refutes —
it calls 3455 a "related but distinct issue" covering unresolvable digests in
1.10.3 pre-release builds, "explicitly confirmed by Red Hat engineering not to
affect the released 1.10.2".

The guard that would catch the reported regression is
[RHIDP-16252](https://redhat.atlassian.net/browse/RHIDP-16252), "Catalog index
gate: fail when a plugin version regresses against the previous release index".
That is where the coverage claim belongs, not here.

### Notes for the reviewer

- **The acceptance criterion in RHIDP-16220 is not directly assertable.** It asks
  that a test assert `{{inherit}}` never resolves to a version older than the
  referenced include provides — but with a single candidate the resolution adopts
  exactly that candidate's version, so the property holds by construction and a
  literal test of it could not fail. The honest reading is the ambiguity guard:
  the only way to land on an older version is a future shortcut that picks
  `matches[0]` out of several candidates. That is what
  `refuses to resolve rather than silently adopting the older candidate` covers,
  and the test says so in-line.
- **The `:254` test locks a message, not an invariant.** It asserts what the
  guard says given a hand-seeded broken state. If the merger ever stopped
  assigning `version` before storing, the test would still pass and the guard
  would fire in production instead. Noted in-line so nobody over-trusts it.
- **No changeset.** Test-only, nothing publishable changes. `verify-changesets.js`
  only checks that changesets do not release private packages; it does not
  require one. Happy to add a `patch` if you would rather see it in the
  CHANGELOG.
- Two branches fail 2 tests each under mutation rather than 1. That is not a lack
  of isolation — each has a deliberate second scenario.
- One behaviour I deliberately did **not** assert: if a level-0 include is merged
  *after* a level-1 `{{inherit}}`, the version is downgraded. `installer.ts`
  always merges level 0 before level 1, so it cannot happen in production, and I
  did not want a test asserting a defensive property the code does not have. If
  we want the merger hardened there, that is a production change and a separate
  ticket.
- The first two commit messages on this branch still carry the RHDHBUGS-3503
  framing corrected above. They are left as-is rather than force-pushed over a
  review in progress; the third commit records the correction.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets)) — n/a, test-only
- [ ] Added or Updated documentation — n/a
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — n/a

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
