### PR TITLE
test(install-dynamic-plugins): cover floating tags, skopeo stderr, and the dynamic-packages annotation (RHIDP-16222)

### DIFF
--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InstallException } from './errors';
+import { OciImageCache } from './image-cache';
+import type { Skopeo, SkopeoInspect } from './skopeo';
+
+const IMAGE = 'oci://registry.io/org/plugin:1.0';
+const DOCKER_URL = 'docker://registry.io/org/plugin:1.0';
+const ANNOTATION = 'io.backstage.dynamic-packages';
+
+/**
+ * Fake `Skopeo` returning canned `inspect`/`inspectRaw` payloads. Same seam as
+ * `image-resolver.test.ts` — the registry is never contacted.
+ */
+function fakeSkopeo(responses: {
+  inspectRaw?: unknown;
+  inspect?: SkopeoInspect;
+}): { skopeo: Skopeo; urls: string[] } {
+  const urls: string[] = [];
+  const skopeo = {
+    exists: async () => true,
+    inspectRaw: async (url: string) => {
+      urls.push(url);
+      return responses.inspectRaw;
+    },
+    inspect: async (url: string) => {
+      urls.push(url);
+      return responses.inspect;
+    },
+  } as unknown as Skopeo;
+  return { skopeo, urls };
+}
+
+function encodeAnnotation(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64');
+}
+
+function cacheFor(responses: {
+  inspectRaw?: unknown;
+  inspect?: SkopeoInspect;
+}): { cache: OciImageCache; urls: string[] } {
+  const { skopeo, urls } = fakeSkopeo(responses);
+  return { cache: new OciImageCache(skopeo, '/unused-tmp-dir'), urls };
+}
+
+describe('OciImageCache.getPluginPaths — dynamic-packages annotation', () => {
+  it('reads the declared plugin paths from the annotation', async () => {
+    const { cache, urls } = cacheFor({
+      inspectRaw: {
+        annotations: {
+          [ANNOTATION]: encodeAnnotation([
+            { 'backstage-plugin-one': { version: '1.0.0' } },
+            { 'backstage-plugin-two': { version: '2.0.0' } },
+          ]),
+        },
+      },
+    });
+
+    await expect(cache.getPluginPaths(IMAGE)).resolves.toEqual([
+      'backstage-plugin-one',
+      'backstage-plugin-two',
+    ]);
+    // The manifest is read over docker://, not oci:// — skopeo inspect --raw
+    // does not accept the oci:// form for a remote registry.
+    expect(urls).toEqual([DOCKER_URL]);
+  });
+
+  it('returns no paths when the image carries no annotation at all (RHDHBUGS-2530)', async () => {
+    const { cache } = cacheFor({ inspectRaw: { layers: [{ digest: 'x' }] } });
+    await expect(cache.getPluginPaths(IMAGE)).resolves.toEqual([]);
+  });
+
+  it('returns no paths when the annotation is present but encodes an empty list (RHDHBUGS-3556)', async () => {
+    // `W10=` is base64 for `[]` — the exact value found on the two community
+    // backend artifacts. The code deliberately does NOT distinguish this from a
+    // missing annotation: both collapse to `[]`, so the caller
+    // (`oci-key.ts:autoDetectPluginPath`) raises the same
+    // "No plugins found in OCI image ..." error for either. Asserting the
+    // shared outcome is the honest test; there is no separate branch to cover.
+    const { cache } = cacheFor({
+      inspectRaw: { annotations: { [ANNOTATION]: 'W10=' } },
+    });
+    await expect(cache.getPluginPaths(IMAGE)).resolves.toEqual([]);
+    expect('W10=').toBe(encodeAnnotation([]));
+  });
+
+  it('returns no paths when the annotation decodes to something other than a list', async () => {
+    const { cache } = cacheFor({
+      inspectRaw: {
+        annotations: { [ANNOTATION]: encodeAnnotation({ 'a-plugin': {} }) },
+      },
+    });
+    await expect(cache.getPluginPaths(IMAGE)).resolves.toEqual([]);
+  });
+
+  it('names the annotation and the image when the payload cannot be decoded', async () => {
+    const { cache } = cacheFor({
+      inspectRaw: {
+        annotations: {
+          [ANNOTATION]: Buffer.from('this is not json').toString('base64'),
+        },
+      },
+    });
+
+    const error = await cache.getPluginPaths(IMAGE).then(
+      () => {
+        throw new Error('expected getPluginPaths to reject');
+      },
+      (err: unknown) => err as Error,
+    );
+
+    expect(error).toBeInstanceOf(InstallException);
+    expect(error.message).toContain(`Could not decode '${ANNOTATION}'`);
+    expect(error.message).toContain(IMAGE);
+    // The underlying parser message is appended but not asserted verbatim — its
+    // wording is a V8 implementation detail and varies across Node versions.
+  });
+});
+
+describe('OciImageCache.getDigest', () => {
+  it('returns the hash portion of the digest reported by the registry', async () => {
+    const { cache, urls } = cacheFor({ inspect: { Digest: 'sha256:abc123' } });
+    await expect(cache.getDigest(IMAGE)).resolves.toBe('abc123');
+    expect(urls).toEqual([DOCKER_URL]);
+  });
+
+  it('rejects when the registry reports no digest', async () => {
+    const { cache } = cacheFor({ inspect: { Name: 'plugin' } });
+    await expect(cache.getDigest(IMAGE)).rejects.toThrow(
+      `No digest returned for ${IMAGE}`,
+    );
+  });
+
+  it('rejects a digest with no algorithm separator', async () => {
+    const { cache } = cacheFor({ inspect: { Digest: 'abc123' } });
+    await expect(cache.getDigest(IMAGE)).rejects.toThrow(
+      `Malformed digest abc123 for ${IMAGE}`,
+    );
+  });
+});

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { InstallException } from './errors';
 import { OciImageCache } from './image-cache';
-import type { Skopeo, SkopeoInspect } from './skopeo';
+import { ociPluginKey } from './oci-key';
+import { Skopeo, type SkopeoInspect } from './skopeo';
 
 const IMAGE = 'oci://registry.io/org/plugin:1.0';
 const DOCKER_URL = 'docker://registry.io/org/plugin:1.0';
@@ -24,6 +28,9 @@ const ANNOTATION = 'io.backstage.dynamic-packages';
 /**
  * Fake `Skopeo` returning canned `inspect`/`inspectRaw` payloads. Same seam as
  * `image-resolver.test.ts` — the registry is never contacted.
+ *
+ * No `exists` stub: `resolveImage` only probes it for images under
+ * `RHDH_REGISTRY` (types.ts), and `IMAGE` deliberately is not one.
  */
 function fakeSkopeo(responses: {
   inspectRaw?: unknown;
@@ -31,7 +38,6 @@ function fakeSkopeo(responses: {
 }): { skopeo: Skopeo; urls: string[] } {
   const urls: string[] = [];
   const skopeo = {
-    exists: async () => true,
     inspectRaw: async (url: string) => {
       urls.push(url);
       return responses.inspectRaw;
@@ -83,18 +89,16 @@ describe('OciImageCache.getPluginPaths — dynamic-packages annotation', () => {
     await expect(cache.getPluginPaths(IMAGE)).resolves.toEqual([]);
   });
 
-  it('returns no paths when the annotation is present but encodes an empty list (RHDHBUGS-3556)', async () => {
-    // `W10=` is base64 for `[]` — the exact value found on the two community
-    // backend artifacts. The code deliberately does NOT distinguish this from a
-    // missing annotation: both collapse to `[]`, so the caller
-    // (`oci-key.ts:autoDetectPluginPath`) raises the same
-    // "No plugins found in OCI image ..." error for either. Asserting the
-    // shared outcome is the honest test; there is no separate branch to cover.
+  it('returns no paths when the annotation encodes an empty list (RHDHBUGS-3556)', async () => {
+    // Built rather than pasted as the literal `W10=` it is on the wire, so the
+    // fixture provably encodes `[]` and this case cannot silently drift into
+    // the "not a list" branch below. The code does NOT distinguish this from a
+    // missing annotation: both collapse to `[]` and raise the same error. See
+    // the end-to-end test at the bottom of this file for that shared outcome.
     const { cache } = cacheFor({
-      inspectRaw: { annotations: { [ANNOTATION]: 'W10=' } },
+      inspectRaw: { annotations: { [ANNOTATION]: encodeAnnotation([]) } },
     });
     await expect(cache.getPluginPaths(IMAGE)).resolves.toEqual([]);
-    expect('W10=').toBe(encodeAnnotation([]));
   });
 
   it('returns no paths when the annotation decodes to something other than a list', async () => {
@@ -115,16 +119,11 @@ describe('OciImageCache.getPluginPaths — dynamic-packages annotation', () => {
       },
     });
 
-    const error = await cache.getPluginPaths(IMAGE).then(
-      () => {
-        throw new Error('expected getPluginPaths to reject');
-      },
-      (err: unknown) => err as Error,
-    );
+    const failing = cache.getPluginPaths(IMAGE);
 
-    expect(error).toBeInstanceOf(InstallException);
-    expect(error.message).toContain(`Could not decode '${ANNOTATION}'`);
-    expect(error.message).toContain(IMAGE);
+    await expect(failing).rejects.toBeInstanceOf(InstallException);
+    await expect(failing).rejects.toThrow(`Could not decode '${ANNOTATION}'`);
+    await expect(failing).rejects.toThrow(IMAGE);
     // The underlying parser message is appended but not asserted verbatim — its
     // wording is a V8 implementation detail and varies across Node versions.
   });
@@ -148,6 +147,59 @@ describe('OciImageCache.getDigest', () => {
     const { cache } = cacheFor({ inspect: { Digest: 'abc123' } });
     await expect(cache.getDigest(IMAGE)).rejects.toThrow(
       `Malformed digest abc123 for ${IMAGE}`,
+    );
+  });
+});
+
+describe('an image with no usable annotation, end to end (RHDHBUGS-2530 / RHDHBUGS-3556)', () => {
+  let skopeoDir: string;
+
+  beforeEach(() => {
+    skopeoDir = mkdtempSync(join(tmpdir(), 'fake-skopeo-manifest-'));
+  });
+
+  afterEach(() => rmSync(skopeoDir, { recursive: true, force: true }));
+
+  /** Fake `skopeo` whose `inspect --raw` returns `manifest` verbatim. */
+  function makeInspectingSkopeo(manifest: string): Skopeo {
+    const binPath = join(skopeoDir, 'skopeo');
+    writeFileSync(
+      binPath,
+      `#!/bin/sh
+cat <<'MANIFEST'
+${manifest}
+MANIFEST
+`,
+    );
+    chmodSync(binPath, 0o755);
+    return new Skopeo(binPath);
+  }
+
+  /**
+   * The two halves of this bug are asserted separately above and in
+   * oci-key.test.ts, but each is driven by a stub of the other. This crosses
+   * the seam: a real manifest off a real `skopeo inspect`, through the real
+   * `OciImageCache`, into the real `ociPluginKey` — the only test here that
+   * reproduces what the customer actually hit.
+   */
+  it.each([
+    ['carries no annotation', '{"layers":[{"digest":"sha256:abc"}]}'],
+    // W10= is base64 for [] — the exact value found on the two artifacts in
+    // RHDHBUGS-3556, which published cleanly but declared nothing.
+    [
+      'declares an empty package list',
+      `{"annotations":{"${ANNOTATION}":"W10="}}`,
+    ],
+  ])('fails with a readable message when the image %s', async (_, manifest) => {
+    const cache = new OciImageCache(
+      makeInspectingSkopeo(manifest),
+      '/unused-tmp-dir',
+    );
+
+    await expect(ociPluginKey(IMAGE, cache)).rejects.toThrow(
+      `No plugins found in OCI image ${IMAGE}. ` +
+        `The image might not contain the '${ANNOTATION}' annotation. ` +
+        'Please ensure it was packaged using the @red-hat-developer-hub/cli plugin package command.',
     );
   });
 });

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.test.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as tar from 'tar';
+import { InstallException } from './errors';
+import { OciImageCache } from './image-cache';
+import { installOciPlugin } from './installer-oci';
+import { Skopeo } from './skopeo';
+import {
+  CONFIG_HASH_FILE,
+  IMAGE_HASH_FILE,
+  type Plugin,
+  PullPolicy,
+} from './types';
+
+const PLUGIN_PATH = 'my-plugin';
+const CONFIG_HASH = 'config-hash-unchanged';
+
+function ociPlugin(overrides: Partial<Plugin> = {}): Plugin {
+  return {
+    package: `oci://registry.io/org/plugin:latest!${PLUGIN_PATH}`,
+    version: 'latest',
+    plugin_hash: CONFIG_HASH,
+    pullPolicy: PullPolicy.ALWAYS,
+    pluginConfig: { dynamicPlugins: { frontend: {} } },
+    ...overrides,
+  };
+}
+
+/**
+ * Fake `OciImageCache` recording every call. Faking at this seam (rather than
+ * at `skopeo`) keeps the digest tests free of any registry interaction — the
+ * behaviour under test is `isAlreadyInstalled`, not the download itself.
+ */
+function fakeImageCache(opts: { digest: string; tarball?: string }): {
+  cache: OciImageCache;
+  calls: { getTarball: string[]; getDigest: string[] };
+} {
+  const calls = { getTarball: [] as string[], getDigest: [] as string[] };
+  const cache = {
+    getTarball: async (image: string) => {
+      calls.getTarball.push(image);
+      if (!opts.tarball) {
+        throw new Error(`unexpected getTarball(${image}) — no tarball staged`);
+      }
+      return opts.tarball;
+    },
+    getDigest: async (image: string) => {
+      calls.getDigest.push(image);
+      return opts.digest;
+    },
+  } as unknown as OciImageCache;
+  return { cache, calls };
+}
+
+/** Pack `<PLUGIN_PATH>/package.json` into a layer tarball `extractOciPlugin` can read. */
+async function makeLayerTarball(dir: string, body: string): Promise<string> {
+  const stage = mkdtempSync(join(tmpdir(), 'oci-layer-stage-'));
+  mkdirSync(join(stage, PLUGIN_PATH), { recursive: true });
+  writeFileSync(join(stage, PLUGIN_PATH, 'package.json'), body);
+  const tarPath = join(dir, 'layer.tar');
+  await tar.c({ gzip: false, file: tarPath, cwd: stage }, [PLUGIN_PATH]);
+  rmSync(stage, { recursive: true, force: true });
+  return tarPath;
+}
+
+describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
+  let destination: string;
+  let workDir: string;
+
+  beforeEach(() => {
+    destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
+    workDir = mkdtempSync(join(tmpdir(), 'oci-work-'));
+  });
+
+  afterEach(() => {
+    rmSync(destination, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  /** Simulate a previous install of `PLUGIN_PATH` pinned to `digest`. */
+  async function seedInstalled(digest: string): Promise<Map<string, string>> {
+    await fs.mkdir(join(destination, PLUGIN_PATH), { recursive: true });
+    await fs.writeFile(join(destination, PLUGIN_PATH, IMAGE_HASH_FILE), digest);
+    await fs.writeFile(
+      join(destination, PLUGIN_PATH, CONFIG_HASH_FILE),
+      CONFIG_HASH,
+    );
+    return new Map([[CONFIG_HASH, PLUGIN_PATH]]);
+  }
+
+  it('skips the download when the remote digest matches the one on disk', async () => {
+    const installed = await seedInstalled('digest-aaaa');
+    const { cache, calls } = fakeImageCache({ digest: 'digest-aaaa' });
+
+    const result = await installOciPlugin(
+      ociPlugin(),
+      destination,
+      cache,
+      installed,
+    );
+
+    expect(result.pluginPath).toBeNull();
+    expect(result.pluginConfig).toEqual({ dynamicPlugins: { frontend: {} } });
+    expect(calls.getDigest).toEqual(['oci://registry.io/org/plugin:latest']);
+    expect(calls.getTarball).toEqual([]);
+    // The hash is dropped from `installed` so the cleanup phase does not treat
+    // the still-current directory as stale.
+    expect(installed.has(CONFIG_HASH)).toBe(false);
+  });
+
+  it('re-downloads when the remote digest changed even though the config hash did not', async () => {
+    const installed = await seedInstalled('digest-aaaa');
+    const tarball = await makeLayerTarball(workDir, '{"name":"my-plugin"}');
+    const { cache, calls } = fakeImageCache({
+      digest: 'digest-bbbb',
+      tarball,
+    });
+
+    const result = await installOciPlugin(
+      ociPlugin(),
+      destination,
+      cache,
+      installed,
+    );
+
+    expect(result.pluginPath).toBe(PLUGIN_PATH);
+    expect(calls.getTarball).toEqual(['oci://registry.io/org/plugin:latest']);
+    await expect(
+      fs.readFile(join(destination, PLUGIN_PATH, 'package.json'), 'utf8'),
+    ).resolves.toBe('{"name":"my-plugin"}');
+    // The recorded digest must advance to the new one, otherwise the next run
+    // would compare against a stale value and skip forever.
+    await expect(
+      fs.readFile(join(destination, PLUGIN_PATH, IMAGE_HASH_FILE), 'utf8'),
+    ).resolves.toBe('digest-bbbb');
+    await expect(
+      fs.readFile(join(destination, PLUGIN_PATH, CONFIG_HASH_FILE), 'utf8'),
+    ).resolves.toBe(CONFIG_HASH);
+  });
+
+  it('installs when a previous install left no recorded digest', async () => {
+    await fs.mkdir(join(destination, PLUGIN_PATH), { recursive: true });
+    const installed = new Map([[CONFIG_HASH, PLUGIN_PATH]]);
+    const tarball = await makeLayerTarball(workDir, '{"name":"my-plugin"}');
+    const { cache, calls } = fakeImageCache({ digest: 'digest-cccc', tarball });
+
+    const result = await installOciPlugin(
+      ociPlugin(),
+      destination,
+      cache,
+      installed,
+    );
+
+    expect(result.pluginPath).toBe(PLUGIN_PATH);
+    expect(calls.getTarball).toHaveLength(1);
+  });
+
+  it('skips under IfNotPresent without consulting the registry, even when the digest changed', async () => {
+    const installed = await seedInstalled('digest-aaaa');
+    const { cache, calls } = fakeImageCache({ digest: 'digest-bbbb' });
+
+    const result = await installOciPlugin(
+      ociPlugin({ pullPolicy: PullPolicy.IF_NOT_PRESENT }),
+      destination,
+      cache,
+      installed,
+    );
+
+    expect(result.pluginPath).toBeNull();
+    // Delimits the previous test: the re-download is driven by `Always`, not by
+    // an unconditional digest check. IfNotPresent must not even ask the registry.
+    expect(calls.getDigest).toEqual([]);
+    expect(calls.getTarball).toEqual([]);
+  });
+});
+
+describe('installOciPlugin — skopeo failures (RHDHBUGS-2439)', () => {
+  const TLS_ERROR =
+    'level=fatal msg=pinging container registry fake-registry.example.com: ' +
+    'tls: failed to verify certificate: x509: certificate signed by unknown authority';
+
+  let destination: string;
+  let workDir: string;
+  let skopeoDir: string;
+
+  beforeEach(() => {
+    destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
+    workDir = mkdtempSync(join(tmpdir(), 'oci-work-'));
+    skopeoDir = mkdtempSync(join(tmpdir(), 'fake-skopeo-copy-'));
+  });
+
+  afterEach(() => {
+    rmSync(destination, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+    rmSync(skopeoDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Fake `skopeo` binary that fails `copy` the way a registry with an untrusted
+   * TLS certificate does: a diagnostic on stderr and a non-zero exit.
+   */
+  function makeFailingSkopeo(): string {
+    const binPath = join(skopeoDir, 'skopeo');
+    writeFileSync(
+      binPath,
+      `#!/bin/sh
+echo '${TLS_ERROR}' >&2
+exit 1
+`,
+    );
+    chmodSync(binPath, 0o755);
+    return binPath;
+  }
+
+  it("surfaces skopeo's stderr in the error instead of only the exit status", async () => {
+    const skopeo = new Skopeo(makeFailingSkopeo());
+    const imageCache = new OciImageCache(skopeo, workDir);
+    const plugin = ociPlugin({
+      package: `oci://fake-registry.example.com/my-org/my-plugin:1.2.3!${PLUGIN_PATH}`,
+      version: '1.2.3',
+    });
+
+    const error = await installOciPlugin(
+      plugin,
+      destination,
+      imageCache,
+      new Map(),
+    ).then(
+      () => {
+        throw new Error('expected installOciPlugin to reject');
+      },
+      (err: unknown) => err as Error,
+    );
+
+    expect(error).toBeInstanceOf(InstallException);
+    // The whole point of the bug: the operator must be able to read the cause
+    // here rather than exec into the container and re-run skopeo by hand.
+    expect(error.message).toContain(
+      'x509: certificate signed by unknown authority',
+    );
+    expect(error.message).toContain('tls: failed to verify certificate');
+    expect(error.message).toContain(
+      'skopeo copy failed: docker://fake-registry.example.com/my-org/my-plugin:1.2.3',
+    );
+    expect(error.message).toContain('exit code 1');
+  });
+});
+
+describe('installOciPlugin — rejected inputs', () => {
+  let destination: string;
+
+  beforeEach(() => {
+    destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
+  });
+
+  afterEach(() => rmSync(destination, { recursive: true, force: true }));
+
+  // No tarball staged: every case below must fail before any download starts.
+  const unusedCache = fakeImageCache({ digest: 'unused' }).cache;
+
+  it('returns nothing for a disabled plugin', async () => {
+    const result = await installOciPlugin(
+      ociPlugin({ disabled: true }),
+      destination,
+      unusedCache,
+      new Map(),
+    );
+    expect(result).toEqual({ pluginPath: null, pluginConfig: {} });
+  });
+
+  it('rejects a plugin whose hash was never computed', async () => {
+    await expect(
+      installOciPlugin(
+        ociPlugin({ plugin_hash: undefined }),
+        destination,
+        unusedCache,
+        new Map(),
+      ),
+    ).rejects.toThrow(
+      'Internal error: plugin oci://registry.io/org/plugin:latest!my-plugin missing plugin_hash',
+    );
+  });
+
+  it('rejects a plugin with no resolved version', async () => {
+    await expect(
+      installOciPlugin(
+        ociPlugin({ version: undefined }),
+        destination,
+        unusedCache,
+        new Map(),
+      ),
+    ).rejects.toThrow(
+      'No version for oci://registry.io/org/plugin:latest!my-plugin',
+    );
+  });
+
+  it('rejects an image reference with no !plugin-path suffix', async () => {
+    await expect(
+      installOciPlugin(
+        ociPlugin({ package: 'oci://registry.io/org/plugin:latest' }),
+        destination,
+        unusedCache,
+        new Map(),
+      ),
+    ).rejects.toThrow(
+      'OCI package oci://registry.io/org/plugin:latest missing !plugin-path suffix',
+    );
+  });
+});

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.test.ts
@@ -38,27 +38,38 @@ import {
 const PLUGIN_PATH = 'my-plugin';
 const CONFIG_HASH = 'config-hash-unchanged';
 
+/**
+ * A `:latest!` package with no explicit `pullPolicy`. The absent policy is
+ * deliberate: `effectivePullPolicy` (types.ts) derives `Always` from the
+ * `:latest!` marker, and that derivation is what makes the RHDHBUGS-1077 fix
+ * reach a real `dynamic-plugins.yaml`, which never spells the policy out.
+ * Hard-coding `pullPolicy` here would leave that default unexercised.
+ */
 function ociPlugin(overrides: Partial<Plugin> = {}): Plugin {
   return {
     package: `oci://registry.io/org/plugin:latest!${PLUGIN_PATH}`,
     version: 'latest',
     plugin_hash: CONFIG_HASH,
-    pullPolicy: PullPolicy.ALWAYS,
     pluginConfig: { dynamicPlugins: { frontend: {} } },
     ...overrides,
   };
 }
 
+type CacheCalls = { getTarball: string[]; getDigest: string[] };
+
 /**
  * Fake `OciImageCache` recording every call. Faking at this seam (rather than
  * at `skopeo`) keeps the digest tests free of any registry interaction — the
  * behaviour under test is `isAlreadyInstalled`, not the download itself.
+ *
+ * Named for what it does rather than `fakeImageCache`, which already exists in
+ * oci-key.test.ts with a different contract.
  */
-function fakeImageCache(opts: { digest: string; tarball?: string }): {
+function recordingImageCache(opts: { digest: string; tarball?: string }): {
   cache: OciImageCache;
-  calls: { getTarball: string[]; getDigest: string[] };
+  calls: CacheCalls;
 } {
-  const calls = { getTarball: [] as string[], getDigest: [] as string[] };
+  const calls: CacheCalls = { getTarball: [], getDigest: [] };
   const cache = {
     getTarball: async (image: string) => {
       calls.getTarball.push(image);
@@ -75,45 +86,51 @@ function fakeImageCache(opts: { digest: string; tarball?: string }): {
   return { cache, calls };
 }
 
-/** Pack `<PLUGIN_PATH>/package.json` into a layer tarball `extractOciPlugin` can read. */
-async function makeLayerTarball(dir: string, body: string): Promise<string> {
+let destination: string;
+let workDir: string;
+let skopeoDir: string;
+
+beforeEach(() => {
+  destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
+  workDir = mkdtempSync(join(tmpdir(), 'oci-work-'));
+  skopeoDir = mkdtempSync(join(tmpdir(), 'fake-skopeo-copy-'));
+});
+
+afterEach(() => {
+  for (const dir of [destination, workDir, skopeoDir]) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Pack `<pluginPath>/package.json` into a layer tarball `extractOciPlugin` can read. */
+async function makeLayerTarball(
+  pluginPath: string,
+  body: string,
+): Promise<string> {
   const stage = mkdtempSync(join(tmpdir(), 'oci-layer-stage-'));
-  mkdirSync(join(stage, PLUGIN_PATH), { recursive: true });
-  writeFileSync(join(stage, PLUGIN_PATH, 'package.json'), body);
-  const tarPath = join(dir, 'layer.tar');
-  await tar.c({ gzip: false, file: tarPath, cwd: stage }, [PLUGIN_PATH]);
+  mkdirSync(join(stage, pluginPath), { recursive: true });
+  writeFileSync(join(stage, pluginPath, 'package.json'), body);
+  const tarPath = join(workDir, 'layer.tar');
+  await tar.c({ gzip: false, file: tarPath, cwd: stage }, [pluginPath]);
   rmSync(stage, { recursive: true, force: true });
   return tarPath;
 }
 
+/** Simulate a previous install of `PLUGIN_PATH` pinned to `digest`. */
+async function seedInstalled(digest: string): Promise<Map<string, string>> {
+  await fs.mkdir(join(destination, PLUGIN_PATH), { recursive: true });
+  await fs.writeFile(join(destination, PLUGIN_PATH, IMAGE_HASH_FILE), digest);
+  await fs.writeFile(
+    join(destination, PLUGIN_PATH, CONFIG_HASH_FILE),
+    CONFIG_HASH,
+  );
+  return new Map([[CONFIG_HASH, PLUGIN_PATH]]);
+}
+
 describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
-  let destination: string;
-  let workDir: string;
-
-  beforeEach(() => {
-    destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
-    workDir = mkdtempSync(join(tmpdir(), 'oci-work-'));
-  });
-
-  afterEach(() => {
-    rmSync(destination, { recursive: true, force: true });
-    rmSync(workDir, { recursive: true, force: true });
-  });
-
-  /** Simulate a previous install of `PLUGIN_PATH` pinned to `digest`. */
-  async function seedInstalled(digest: string): Promise<Map<string, string>> {
-    await fs.mkdir(join(destination, PLUGIN_PATH), { recursive: true });
-    await fs.writeFile(join(destination, PLUGIN_PATH, IMAGE_HASH_FILE), digest);
-    await fs.writeFile(
-      join(destination, PLUGIN_PATH, CONFIG_HASH_FILE),
-      CONFIG_HASH,
-    );
-    return new Map([[CONFIG_HASH, PLUGIN_PATH]]);
-  }
-
   it('skips the download when the remote digest matches the one on disk', async () => {
     const installed = await seedInstalled('digest-aaaa');
-    const { cache, calls } = fakeImageCache({ digest: 'digest-aaaa' });
+    const { cache, calls } = recordingImageCache({ digest: 'digest-aaaa' });
 
     const result = await installOciPlugin(
       ociPlugin(),
@@ -133,8 +150,8 @@ describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
 
   it('re-downloads when the remote digest changed even though the config hash did not', async () => {
     const installed = await seedInstalled('digest-aaaa');
-    const tarball = await makeLayerTarball(workDir, '{"name":"my-plugin"}');
-    const { cache, calls } = fakeImageCache({
+    const tarball = await makeLayerTarball(PLUGIN_PATH, '{"name":"my-plugin"}');
+    const { cache, calls } = recordingImageCache({
       digest: 'digest-bbbb',
       tarball,
     });
@@ -159,13 +176,19 @@ describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
     await expect(
       fs.readFile(join(destination, PLUGIN_PATH, CONFIG_HASH_FILE), 'utf8'),
     ).resolves.toBe(CONFIG_HASH);
+    // markAsFresh: the directory was just rewritten, so the stale entry must go
+    // or the cleanup phase deletes what this call installed.
+    expect(installed.has(CONFIG_HASH)).toBe(false);
   });
 
   it('installs when a previous install left no recorded digest', async () => {
     await fs.mkdir(join(destination, PLUGIN_PATH), { recursive: true });
     const installed = new Map([[CONFIG_HASH, PLUGIN_PATH]]);
-    const tarball = await makeLayerTarball(workDir, '{"name":"my-plugin"}');
-    const { cache, calls } = fakeImageCache({ digest: 'digest-cccc', tarball });
+    const tarball = await makeLayerTarball(PLUGIN_PATH, '{"name":"my-plugin"}');
+    const { cache, calls } = recordingImageCache({
+      digest: 'digest-cccc',
+      tarball,
+    });
 
     const result = await installOciPlugin(
       ociPlugin(),
@@ -176,11 +199,16 @@ describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
 
     expect(result.pluginPath).toBe(PLUGIN_PATH);
     expect(calls.getTarball).toHaveLength(1);
+    // The repair is only complete once the digest is recorded, otherwise every
+    // subsequent run re-downloads.
+    await expect(
+      fs.readFile(join(destination, PLUGIN_PATH, IMAGE_HASH_FILE), 'utf8'),
+    ).resolves.toBe('digest-cccc');
   });
 
-  it('skips under IfNotPresent without consulting the registry, even when the digest changed', async () => {
+  it('skips under an explicit IfNotPresent without consulting the registry, even when the digest changed', async () => {
     const installed = await seedInstalled('digest-aaaa');
-    const { cache, calls } = fakeImageCache({ digest: 'digest-bbbb' });
+    const { cache, calls } = recordingImageCache({ digest: 'digest-bbbb' });
 
     const result = await installOciPlugin(
       ociPlugin({ pullPolicy: PullPolicy.IF_NOT_PRESENT }),
@@ -190,10 +218,78 @@ describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
     );
 
     expect(result.pluginPath).toBeNull();
-    // Delimits the previous test: the re-download is driven by `Always`, not by
-    // an unconditional digest check. IfNotPresent must not even ask the registry.
+    // Delimits the previous test: the re-download is driven by the policy, not
+    // by an unconditional digest check. IfNotPresent must not even ask.
     expect(calls.getDigest).toEqual([]);
     expect(calls.getTarball).toEqual([]);
+  });
+
+  it('skips a pinned tag with no explicit policy, since only :latest! defaults to Always', async () => {
+    await fs.mkdir(join(destination, PLUGIN_PATH), { recursive: true });
+    await fs.writeFile(
+      join(destination, PLUGIN_PATH, IMAGE_HASH_FILE),
+      'digest-aaaa',
+    );
+    const installed = new Map([[CONFIG_HASH, PLUGIN_PATH]]);
+    const { cache, calls } = recordingImageCache({ digest: 'digest-bbbb' });
+
+    const result = await installOciPlugin(
+      ociPlugin({
+        package: `oci://registry.io/org/plugin:1.2.3!${PLUGIN_PATH}`,
+        version: '1.2.3',
+      }),
+      destination,
+      cache,
+      installed,
+    );
+
+    // The other direction of the same default: a pinned tag must NOT be
+    // re-pulled on every run just because its digest moved.
+    expect(result.pluginPath).toBeNull();
+    expect(calls.getDigest).toEqual([]);
+  });
+});
+
+describe('installOciPlugin — package spec handling', () => {
+  it('keeps a plugin path containing ! on the right of the first separator', async () => {
+    // installer-oci.ts documents that `!` is legal inside a plugin path and
+    // that the split is on the FIRST separator. lastIndexOf would silently
+    // install `plugin` from an image named `...:latest!my`.
+    const bangPath = 'my!plugin';
+    const tarball = await makeLayerTarball(bangPath, '{"name":"bang"}');
+    const { cache, calls } = recordingImageCache({
+      digest: 'digest-dddd',
+      tarball,
+    });
+
+    const result = await installOciPlugin(
+      ociPlugin({ package: `oci://registry.io/org/plugin:latest!${bangPath}` }),
+      destination,
+      cache,
+      new Map(),
+    );
+
+    expect(result.pluginPath).toBe(bangPath);
+    expect(calls.getTarball).toEqual(['oci://registry.io/org/plugin:latest']);
+    await expect(
+      fs.readFile(join(destination, bangPath, 'package.json'), 'utf8'),
+    ).resolves.toBe('{"name":"bang"}');
+  });
+
+  it('returns an empty config for a plugin that declares none', async () => {
+    const tarball = await makeLayerTarball(PLUGIN_PATH, '{"name":"my-plugin"}');
+    const { cache } = recordingImageCache({ digest: 'digest-eeee', tarball });
+
+    const result = await installOciPlugin(
+      ociPlugin({ pluginConfig: undefined }),
+      destination,
+      cache,
+      new Map(),
+    );
+
+    // The merger receives this verbatim; `undefined` and `{}` are not the same
+    // thing at that boundary.
+    expect(result.pluginConfig).toEqual({});
   });
 });
 
@@ -201,22 +297,6 @@ describe('installOciPlugin — skopeo failures (RHDHBUGS-2439)', () => {
   const TLS_ERROR =
     'level=fatal msg=pinging container registry fake-registry.example.com: ' +
     'tls: failed to verify certificate: x509: certificate signed by unknown authority';
-
-  let destination: string;
-  let workDir: string;
-  let skopeoDir: string;
-
-  beforeEach(() => {
-    destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
-    workDir = mkdtempSync(join(tmpdir(), 'oci-work-'));
-    skopeoDir = mkdtempSync(join(tmpdir(), 'fake-skopeo-copy-'));
-  });
-
-  afterEach(() => {
-    rmSync(destination, { recursive: true, force: true });
-    rmSync(workDir, { recursive: true, force: true });
-    rmSync(skopeoDir, { recursive: true, force: true });
-  });
 
   /**
    * Fake `skopeo` binary that fails `copy` the way a registry with an untrusted
@@ -243,49 +323,36 @@ exit 1
       version: '1.2.3',
     });
 
-    const error = await installOciPlugin(
+    const failing = installOciPlugin(
       plugin,
       destination,
       imageCache,
       new Map(),
-    ).then(
-      () => {
-        throw new Error('expected installOciPlugin to reject');
-      },
-      (err: unknown) => err as Error,
     );
 
-    expect(error).toBeInstanceOf(InstallException);
+    await expect(failing).rejects.toBeInstanceOf(InstallException);
     // The whole point of the bug: the operator must be able to read the cause
     // here rather than exec into the container and re-run skopeo by hand.
-    expect(error.message).toContain(
+    await expect(failing).rejects.toThrow(
       'x509: certificate signed by unknown authority',
     );
-    expect(error.message).toContain('tls: failed to verify certificate');
-    expect(error.message).toContain(
+    await expect(failing).rejects.toThrow('tls: failed to verify certificate');
+    await expect(failing).rejects.toThrow(
       'skopeo copy failed: docker://fake-registry.example.com/my-org/my-plugin:1.2.3',
     );
-    expect(error.message).toContain('exit code 1');
+    await expect(failing).rejects.toThrow('exit code 1');
   });
 });
 
 describe('installOciPlugin — rejected inputs', () => {
-  let destination: string;
+  /** No tarball staged: every case below must fail before any download starts. */
+  const unusedCache = () => recordingImageCache({ digest: 'unused' }).cache;
 
-  beforeEach(() => {
-    destination = mkdtempSync(join(tmpdir(), 'oci-dest-'));
-  });
-
-  afterEach(() => rmSync(destination, { recursive: true, force: true }));
-
-  // No tarball staged: every case below must fail before any download starts.
-  const unusedCache = fakeImageCache({ digest: 'unused' }).cache;
-
-  it('returns nothing for a disabled plugin', async () => {
+  it('drops the config of a disabled plugin instead of merging it', async () => {
     const result = await installOciPlugin(
       ociPlugin({ disabled: true }),
       destination,
-      unusedCache,
+      unusedCache(),
       new Map(),
     );
     expect(result).toEqual({ pluginPath: null, pluginConfig: {} });
@@ -296,7 +363,7 @@ describe('installOciPlugin — rejected inputs', () => {
       installOciPlugin(
         ociPlugin({ plugin_hash: undefined }),
         destination,
-        unusedCache,
+        unusedCache(),
         new Map(),
       ),
     ).rejects.toThrow(
@@ -309,7 +376,7 @@ describe('installOciPlugin — rejected inputs', () => {
       installOciPlugin(
         ociPlugin({ version: undefined }),
         destination,
-        unusedCache,
+        unusedCache(),
         new Map(),
       ),
     ).rejects.toThrow(
@@ -322,7 +389,7 @@ describe('installOciPlugin — rejected inputs', () => {
       installOciPlugin(
         ociPlugin({ package: 'oci://registry.io/org/plugin:latest' }),
         destination,
-        unusedCache,
+        unusedCache(),
         new Map(),
       ),
     ).rejects.toThrow(

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/oci-key.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/oci-key.test.ts
@@ -206,9 +206,16 @@ describe('ociPluginKey — auto-detect from image cache', () => {
   });
 
   it('errors when no plugins are declared', async () => {
+    // RHDHBUGS-2530: an image without the io.backstage.dynamic-packages
+    // annotation used to fail unreadably. Assert the full message — it must
+    // name the image and the annotation, and point at the packaging command.
     await expect(
       ociPluginKey('oci://registry.io/plugin:v1.0', fakeImageCache([])),
-    ).rejects.toThrow(/No plugins found/);
+    ).rejects.toThrow(
+      'No plugins found in OCI image oci://registry.io/plugin:v1.0. ' +
+        "The image might not contain the 'io.backstage.dynamic-packages' annotation. " +
+        'Please ensure it was packaged using the @red-hat-developer-hub/cli plugin package command.',
+    );
   });
 
   it('errors with list when multiple plugins are declared', async () => {


### PR DESCRIPTION
## What

`installer-oci.ts` had no test file. RHIDP-16222 asks for regression coverage of three customer bugs said to live in it. Two of them do not, so the tests go where the code actually is — `installer-oci.test.ts` for the two behaviours that run through that file, and a new `image-cache.test.ts` plus a strengthened assertion in `oci-key.test.ts` for the third.

18 test suites / 247 tests, up from 16 / 225.

## Where each bug actually lives

I checked the mechanism of each RHDHBUGS ticket before writing anything, rather than trusting the issue's placement.

| Bug | Mechanism | Runs through `installer-oci.ts`? |
| --- | --- | --- |
| RHDHBUGS-1077 — floating tag never re-downloaded | `isAlreadyInstalled`, `installer-oci.ts:124-153` | Yes, entirely |
| RHDHBUGS-2439 — skopeo errors swallowed | message assembled in `run.ts:53-54`; propagation via `imageCache.getTarball` → `skopeo.copy` | Yes, the propagation |
| RHDHBUGS-2530 — missing `io.backstage.dynamic-packages` annotation | `oci-key.ts:autoDetectPluginPath` → `image-cache.ts:getPluginPaths` | **No** |

On 2530: the traceback in the ticket itself dies in `parse_plugin_key`, which is the merger path, not the installer. In the TypeScript port, `installOciPlugin` receives an already-resolved `!plugin-path` and never calls `getPluginPaths`. A test placed in `installer-oci.test.ts` would have had to inject a stub into a call the file never makes — the same trap flagged on RHIDP-16220, where a ticket claimed a customer bug lived in the code under test and it did not.

## RHDHBUGS-3556: the code does not distinguish the empty case

The ticket asks whether an annotation that is present but empty is a different case. It is not, in this code.

A missing annotation returns `[]` at `image-cache.ts:81`; an annotation encoding `[]` (`W10=`, the exact value found on the two affected community artifacts) falls through the loop at `:92-98` and also returns `[]`. `autoDetectPluginPath` then raises the identical `No plugins found in OCI image ...` error for either. RHDHBUGS-3556's own text confirms this: "Through the harness both fail install with `InstallException: No plugins found in OCI image ...`".

Both paths are tested, and a comment on the `W10=` test records that the shared outcome is deliberate rather than implying a branch that does not exist.

## Seams faked

No network, no registry, no `jest.mock` — there is not a single one in this directory. Both seams are ones the sibling tests already use:

- **`as unknown as OciImageCache` / `as unknown as Skopeo` stub** — as in `oci-key.test.ts:192` and `image-resolver.test.ts:20`. Used for the digest and annotation cases, where the behaviour under test is the comparison logic, not the download.
- **Fake `skopeo` shell binary** (`writeFileSync` + `chmodSync 0o755`, passed to `new Skopeo(binPath)`) — as in `skopeo.test.ts:33` and `extra-catalog-index.test.ts:175`. Used for the stderr case, driving the real `Skopeo` and real `OciImageCache` so the propagation is genuinely exercised.

## Tests

**`installer-oci.test.ts`** (new)

- Unchanged remote digest skips the download; `getTarball` is never called and the hash is dropped from `installed`.
- Changed remote digest re-downloads even though the config hash is identical, **and rewrites `dynamic-plugin-image.hash` to the new digest** — otherwise the next run compares against a stale value and skips forever. A skip-only test would have passed while RHDHBUGS-1077 was live, so both directions are covered.
- A previous install with no recorded digest installs rather than skipping.
- `IfNotPresent` with a changed digest still skips, without even asking the registry. This delimits the re-download as policy-driven rather than unconditional.
- A failing `skopeo copy` surfaces the stderr text: the assertion is on `x509: certificate signed by unknown authority` and `tls: failed to verify certificate`, not on the error merely existing. The regression was silence.
- The three `InstallException` branches: missing `plugin_hash`, missing version, missing `!plugin-path` suffix — full message asserted in each case.

**`image-cache.test.ts`** (new — the file had no tests at all)

- `getPluginPaths`: annotation absent, annotation decoding to `[]`, a populated list, a non-list payload, an undecodable payload (message names both the annotation and the image).
- `getDigest`: returns the hash portion, rejects a missing digest, rejects a digest with no algorithm separator. This is what the floating-tag comparison consumes.

**`oci-key.test.ts`** (strengthened, not duplicated)

The existing test already exercised the throw, so it is tightened rather than copied. `rejects.toThrow(/No plugins found/)` would pass against a message carrying none of the diagnostic detail — which is precisely what RHDHBUGS-2530 was about. It now asserts the full text naming the image, the annotation, and the packaging command.

## Mutation results

Each test was mutation-checked by breaking the behaviour it covers, running the full suite, and reverting. Eleven mutants, all killed.

| Mutation | Failures | Which tests |
| --- | --- | --- |
| `isAlreadyInstalled` returns `true` right after the `IfNotPresent` branch — the pre-fix "compare only the config hash" behaviour | 3 | all three floating-tag tests |
| `if (localDigest !== remoteDigest) return false` -> unconditional `return false` | 1 | `skips the download when the remote digest matches the one on disk` |
| `effectivePullPolicy` never derives `Always` from `:latest!` | 3 | all three floating-tag tests |
| `effectivePullPolicy` always derives `Always` | 1 | `skips a pinned tag with no explicit policy` |
| `markAsFresh` call dropped from the install path | 1 | `re-downloads when the remote digest changed` |
| `splitOciPackage` uses `lastIndexOf('!')` instead of `indexOf` | 1 | `keeps a plugin path containing ! on the right of the first separator` |
| `plugin.pluginConfig ?? {}` -> `plugin.pluginConfig` | 1 | `returns an empty config for a plugin that declares none` |
| `run.ts` drops the `stderr:` line from the error message | 1 | `surfaces skopeo's stderr in the error` |
| `if (!annotation) return []` -> returns a fabricated path | 2 | the unit case and the end-to-end case |
| `getPluginPaths` falls back to a path when the decoded list is empty | 2 | the unit case and the end-to-end case |
| `autoDetectPluginPath`'s message reduced to `No plugins found` | 3 | the oci-key case and both end-to-end cases |

The first mutant kills three tests rather than one: `return true` bypasses the entire `Always` branch, including the `fileExists` guard, so every test asserting that `Always` must re-check fails. That is the faithful pre-fix behaviour, and the three failures are exactly that family. Reported as measured.

No test survived its own mutation.

## What a deep review changed after the first push

The first two commits shipped a six-mutant battery. A three-pass review found holes that battery could not see, because it only mutated inside `isAlreadyInstalled` and `run.ts` and never the code feeding them.

- **The floating-tag suite never exercised the floating-tag default.** Every fixture hard-coded `pullPolicy: Always`, so `effectivePullPolicy` short-circuited and the `:latest!` -> `Always` derivation was never reached — even though that derivation is the half of RHDHBUGS-1077 that reaches a real `dynamic-plugins.yaml`, which never spells the policy out. Neutering `types.ts:125-127` left all 242 tests green. Fixed in both directions.
- **`markAsFresh` could be deleted with the suite still green.** "Re-download" was covered; "and don't then delete what you just downloaded" was not.
- **The RHDHBUGS-2530/3556 seam was asserted from both sides and never crossed.** `image-cache.test.ts` stopped at `[]`; `oci-key.test.ts` asserted the message but drove it from a stub. There is now one test that crosses it end to end — a real fake-skopeo binary, a real `OciImageCache`, a real `ociPluginKey` — for both the missing and the empty-list manifest. It is the only test here that reproduces what the customer hit.
- **One earlier fix in this review was wrong and is reversed.** Removing `expect('W10=').toBe(encodeAnnotation([]))` as a fixture-asserting-itself antipattern left the literal unverified, and `e30=` / `bnVsbA==` also yield `[]` through the not-a-list branch — so the test stopped distinguishing the case its own name claimed. The fixture is now built with `encodeAnnotation([])`: right by construction rather than by assertion.
- **`indexOf('!')` could become `lastIndexOf('!')`** with nothing failing, despite `splitOciPackage`'s docblock stating the first-separator contract.
- **`plugin.pluginConfig ?? {}` was never taken.** `undefined` and `{}` differ to the merger.

Also applied: triplicated temp-dir setup collapsed into one file-level `beforeEach`/`afterEach`; `fakeImageCache` renamed to `recordingImageCache` (`oci-key.test.ts` already exports that name with a different contract); the shared `unusedCache` became a per-test factory so no fixture carries state between cases; two `[] as string[]` assertions replaced by a type annotation.

### Left out on purpose

- `getTarball` / `downloadAndLocateTarball`, including its two `InstallException` guards and the promise-cache dedup the class docblock advertises, is still untested. So is `run.ts`'s `child.on('error')` path. Real gaps, all in pre-existing code this PR neither touches nor breaks — folding them in turns a regression-test PR into a coverage sweep. Worth a follow-up.
- Reviewers proposed deleting the unreachable guards at `installer-oci.ts:45` and `:140`. `installOciPlugin` is only reached via `installer.ts:487` after `merger.ts:165` -> `ociPluginKey`, whose regex already rejects those forms, so the guards are defensive-only. Deleting them is a production change on a test-only PR, and whether an exported function keeps its defensive guards is a call for a human, not for a coverage metric.

## Checks

Run from the workspace's own `package.json`, not assumed:

- `yarn tsc` — clean
- `yarn prettier:check` — clean
- `yarn lint:all` — 43 files, clean
- `CI=true yarn test` — 18 suites, 247 tests, all passing

No changeset: test-only, no published behaviour change.

## Notes on the ticket's ground truth

Two details in RHIDP-16222 did not hold up and are worth correcting for whoever picks up the next one:

- The directory has **16** sibling `*.test.ts` files, not 12.
- `merger.inherit.test.ts` is not on `main`. It is on the RHIDP-16220 branch, where it was already renamed to `merger-inherit.test.ts` to match sibling style. The new files here follow that convention (module name, `.test.ts`).

Closes RHIDP-16222.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
