### PR TITLE
test(install-dynamic-plugins): cover getTarball's manifest guards and download dedup (RHIDP-16760)

### DIFF
--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { InstallException } from './errors';
 import { OciImageCache } from './image-cache';
 import { ociPluginKey } from './oci-key';
@@ -201,5 +208,161 @@ MANIFEST
         `The image might not contain the '${ANNOTATION}' annotation. ` +
         'Please ensure it was packaged using the @red-hat-developer-hub/cli plugin package command.',
     );
+  });
+});
+
+describe('OciImageCache.getTarball', () => {
+  const LAYER = 'deadbeefcafe';
+  const GOOD_MANIFEST = `{"layers":[{"digest":"sha256:${LAYER}"}]}`;
+
+  let skopeoDir: string;
+  let cacheDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    skopeoDir = mkdtempSync(join(tmpdir(), 'fake-skopeo-copy-'));
+    cacheDir = mkdtempSync(join(tmpdir(), 'oci-cache-'));
+    logPath = join(skopeoDir, 'invocations.log');
+  });
+
+  afterEach(() => {
+    for (const dir of [skopeoDir, cacheDir]) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /** Every `skopeo` invocation, one per line, in call order. */
+  function invocations(): string[] {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, 'utf8').split('\n').filter(Boolean);
+  }
+
+  /**
+   * Fake `skopeo` that materialises a `manifest.json` and the layer blob at the
+   * `dir:` destination, the way a real `copy` does. Same technique as
+   * `extra-catalog-index.test.ts`, plus the invocation log from
+   * `skopeo.test.ts` so the dedup tests can count forks.
+   *
+   * With `failFirstCall` the first invocation exits non-zero and every later
+   * one succeeds, which is what a transient registry error looks like.
+   */
+  function makeCopyingSkopeo(opts: {
+    manifest?: string;
+    failFirstCall?: boolean;
+  }): Skopeo {
+    const binPath = join(skopeoDir, 'skopeo');
+    const marker = join(skopeoDir, 'first-call-done');
+    const failBlock = opts.failFirstCall
+      ? `if [ ! -f "${marker}" ]; then
+  touch "${marker}"
+  echo 'simulated transport failure' >&2
+  exit 1
+fi
+`
+      : '';
+    writeFileSync(
+      binPath,
+      `#!/bin/sh
+echo "$@" >> "${logPath}"
+${failBlock}DST=""
+for arg in "$@"; do
+  case "$arg" in
+    dir:*) DST="\${arg#dir:}" ;;
+  esac
+done
+mkdir -p "$DST"
+: > "$DST/${LAYER}"
+cat > "$DST/manifest.json" <<'MANIFEST'
+${opts.manifest ?? GOOD_MANIFEST}
+MANIFEST
+`,
+    );
+    chmodSync(binPath, 0o755);
+    return new Skopeo(binPath);
+  }
+
+  function cacheWith(opts: {
+    manifest?: string;
+    failFirstCall?: boolean;
+  }): OciImageCache {
+    return new OciImageCache(makeCopyingSkopeo(opts), cacheDir);
+  }
+
+  it('copies the image and returns the path to its single layer blob', async () => {
+    const cache = cacheWith({});
+
+    const tarball = await cache.getTarball(IMAGE);
+
+    // The directory is keyed by sha256 of the resolved ref, so assert the leaf
+    // and the containment rather than re-deriving the hash here.
+    expect(basename(tarball)).toBe(LAYER);
+    expect(tarball.startsWith(cacheDir)).toBe(true);
+    expect(existsSync(tarball)).toBe(true);
+    expect(invocations()).toEqual([
+      `copy --override-os=linux --override-arch=amd64 ${DOCKER_URL} dir:${dirname(tarball)}`,
+    ]);
+  });
+
+  it('names the image when the manifest declares no layers', async () => {
+    const cache = cacheWith({ manifest: '{"layers":[]}' });
+    await expect(cache.getTarball(IMAGE)).rejects.toThrow(
+      `OCI manifest for ${IMAGE} has no layers`,
+    );
+  });
+
+  it('names the image when the manifest has no layers key at all', async () => {
+    const cache = cacheWith({ manifest: '{}' });
+    await expect(cache.getTarball(IMAGE)).rejects.toThrow(
+      `OCI manifest for ${IMAGE} has no layers`,
+    );
+  });
+
+  it('names the offending digest when a layer digest carries no algorithm', async () => {
+    const cache = cacheWith({ manifest: '{"layers":[{"digest":"nocolon"}]}' });
+    const failing = cache.getTarball(IMAGE);
+
+    await expect(failing).rejects.toBeInstanceOf(InstallException);
+    await expect(failing).rejects.toThrow(
+      `Malformed layer digest nocolon in ${IMAGE}`,
+    );
+  });
+
+  it('shares one skopeo copy between concurrent callers for the same image', async () => {
+    const cache = cacheWith({});
+
+    // The multi-plugin overlay case the class docblock is written for: several
+    // plugins in one image, all asking for the tarball at once.
+    const [a, b, c] = await Promise.all([
+      cache.getTarball(IMAGE),
+      cache.getTarball(IMAGE),
+      cache.getTarball(IMAGE),
+    ]);
+
+    expect(invocations()).toHaveLength(1);
+    expect(b).toBe(a);
+    expect(c).toBe(a);
+  });
+
+  it('still copies once per image when two different images are requested', async () => {
+    const cache = cacheWith({});
+    const other = 'oci://registry.io/org/other:2.0';
+
+    await Promise.all([cache.getTarball(IMAGE), cache.getTarball(other)]);
+
+    // Delimits the previous test: the cache keys on the image, it does not
+    // collapse every caller onto one download.
+    expect(invocations()).toHaveLength(2);
+  });
+
+  it('evicts a failed download so the next caller retries instead of replaying the rejection', async () => {
+    const cache = cacheWith({ failFirstCall: true });
+
+    await expect(cache.getTarball(IMAGE)).rejects.toThrow(
+      'simulated transport failure',
+    );
+    // Without the eviction the rejected promise stays in the map and every
+    // later caller gets the first failure back, forever.
+    await expect(cache.getTarball(IMAGE)).resolves.toContain(LAYER);
+    expect(invocations()).toHaveLength(2);
   });
 });

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/image-cache.test.ts
@@ -303,15 +303,15 @@ MANIFEST
     ]);
   });
 
-  it('names the image when the manifest declares no layers', async () => {
-    const cache = cacheWith({ manifest: '{"layers":[]}' });
-    await expect(cache.getTarball(IMAGE)).rejects.toThrow(
-      `OCI manifest for ${IMAGE} has no layers`,
-    );
-  });
-
-  it('names the image when the manifest has no layers key at all', async () => {
-    const cache = cacheWith({ manifest: '{}' });
+  // One error, two manifest shapes that reach it through the same optional
+  // chain. Measured: dropping either case changes no covered branch, so they
+  // are a table of equivalent inputs rather than two independent tests — the
+  // form oci-key.test.ts already uses for its invalidCases.
+  it.each([
+    ['declares an empty layer list', '{"layers":[]}'],
+    ['has no layers key at all', '{}'],
+  ])('names the image when the manifest %s', async (_, manifest) => {
+    const cache = cacheWith({ manifest });
     await expect(cache.getTarball(IMAGE)).rejects.toThrow(
       `OCI manifest for ${IMAGE} has no layers`,
     );


### PR DESCRIPTION
## What

Adds seven tests for `OciImageCache.getTarball` and its private helper `downloadAndLocateTarball`, which had no coverage at all. Test-only; no production file is touched.

Closes RHIDP-16760. Follow-up to #4526 (RHIDP-16222), where this gap was found and deliberately left out.

## Why this was not in #4526

#4526 added `image-cache.test.ts` for `getPluginPaths` and `getDigest` only. Three independent review passes on that PR flagged the same remaining hole, and it was left out on purpose: it is pre-existing code that PR neither touched nor broke, and folding it in would have turned a regression-test PR into a coverage sweep.

Measured on `main` before this PR, `image-cache.ts` sits at 85.24% statements / 66.66% branches with **lines 109-123 uncovered** — the whole of `downloadAndLocateTarball`.

## What is covered

**The two readable-failure guards.** These matter for the same reason RHDHBUGS-2439 did: they are what an operator reads out of the init container log. Drop either one and the failure becomes `path.join(localDir, undefined)` instead of a message naming the image.

- a manifest with `"layers": []` and one with no `layers` key at all, as one `it.each` table — measured, the two shapes cover no distinct branch, so they are equivalent inputs to one assertion rather than two tests
- a layer digest with no algorithm separator (`nocolon`), asserting both the `InstallException` type and the message naming the offending digest

**The promise cache**, which is the class docblock's stated reason to exist — several plugins in one overlay image sharing a single `skopeo copy` — and which had no test.

- three concurrent `getTarball` calls for one image fork `skopeo` **once**, and all three resolve to the same path
- two calls for **different** images fork **twice**

Both directions, because a dedup test on its own would pass against a cache that collapsed every image onto one download.

**The failure eviction** (`pending.catch(() => this.tarballs.delete(resolved))`), which is what stops one transient registry error from being replayed to every later caller for the life of the process. The fake fails its first invocation and succeeds afterwards; the test asserts the second call retries and succeeds.

**The success path** — the returned path is the layer blob inside the cache directory, and the `skopeo` argv is asserted verbatim.

## Seam

No network, no registry, no `jest.mock` — there is not one in this directory. The fake `skopeo` is a shell binary that materialises `manifest.json` plus the layer blob at the `dir:` destination, exactly as `extra-catalog-index.test.ts` does, with the invocation log from `skopeo.test.ts` so the dedup tests can count forks.

## Mutation results

Each test was made to fail before being kept: break the behaviour it covers, run the full suite, revert.

| Mutation | Failures | Which tests |
| --- | --- | --- |
| no-layers guard returns a path instead of throwing | 2 | both rows of the no-layers table |
| malformed-digest guard returns a path instead of throwing | 1 | `names the offending digest ...` |
| layer path returned unjoined (`return localDir`) | 2 | the success test and the retry test |
| promise cache removed from `getTarball` | 1 | `shares one skopeo copy between concurrent callers` |
| `pending.catch` eviction removed | 1 | `evicts a failed download ...` |

No test survived its own mutation.

## Checks

- `yarn tsc` — clean
- `yarn prettier:check` — clean
- `yarn lint:all` — clean
- `CI=true yarn test` — 19 suites, 265 tests, all passing

No changeset: test-only, no published behaviour change.

## Still not covered

`image-cache.ts` line 94, `if (entry && typeof entry === 'object')` in `getPluginPaths` — the falsy-entry path, which a malformed annotation like `[null, "x", {"plugin":{}}]` would exercise. It leaves the file at 94.44% branches. Left alone deliberately: it is pre-existing code in a different method from this PR's subject, and the same blast-radius rule that kept `getTarball` out of #4526 keeps this out of here.

`run.ts`'s `child.on('error')` path — the variant where the binary exists but cannot be executed. Separate gap, not filed; `Skopeo`'s constructor already throws for a `skopeo` that is missing from `PATH`, so the common field case is handled elsewhere.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
