### PR TITLE
test(install-dynamic-plugins): cover the unrecognised pullPolicy path, document two unreachable guards (RHIDP-16761)

### DIFF
--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.test.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.test.ts
@@ -248,6 +248,32 @@ describe('installOciPlugin — floating tags (RHDHBUGS-1077)', () => {
     expect(result.pluginPath).toBeNull();
     expect(calls.getDigest).toEqual([]);
   });
+
+  it('re-installs rather than skipping when the configured pullPolicy is not a recognised value', async () => {
+    // `dynamic-plugins.yaml` is read with `parseYaml(...) as DynamicPluginsConfig`
+    // (installer.ts) — a type assertion, not a runtime check — so a typo like
+    // `pullPolicy: Never` reaches here as an unrecognised string. It must fall
+    // through to a re-install; silently skipping would strand the plugin at
+    // whatever version happened to be on disk.
+    const installed = await seedInstalled('digest-aaaa');
+    const tarball = await makeLayerTarball(PLUGIN_PATH, '{"name":"my-plugin"}');
+    const { cache, calls } = recordingImageCache({
+      digest: 'digest-aaaa',
+      tarball,
+    });
+
+    const result = await installOciPlugin(
+      ociPlugin({ pullPolicy: 'Never' as PullPolicy }),
+      destination,
+      cache,
+      installed,
+    );
+
+    expect(result.pluginPath).toBe(PLUGIN_PATH);
+    expect(calls.getTarball).toHaveLength(1);
+    // Never consults the registry for a digest it would not know how to act on.
+    expect(calls.getDigest).toEqual(['oci://registry.io/org/plugin:latest']);
+  });
 });
 
 describe('installOciPlugin — package spec handling', () => {

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.ts
@@ -42,6 +42,9 @@ function splitOciPackage(
   if (bang === -1) return null;
   const imagePart = pkg.slice(0, bang);
   const pluginPath = pkg.slice(bang + 1);
+  /* istanbul ignore next -- unreachable while OCI_REGEX rejects a leading or
+     trailing `!` upstream (see oci-key.test.ts `invalidCases`); kept so this
+     function stays total if that validation is ever relaxed. */
   if (!imagePart || !pluginPath) return null;
   return { imagePart, pluginPath };
 }
@@ -137,6 +140,9 @@ async function isAlreadyInstalled(
     return true;
   }
 
+  /* istanbul ignore next -- unreachable while PullPolicy has exactly two
+     members and IF_NOT_PRESENT already returned above; kept so a third policy
+     defaults to re-installing rather than silently skipping. */
   if (pullPolicy !== PullPolicy.ALWAYS) return false;
 
   const digestFile = path.join(destination, pathInstalled, IMAGE_HASH_FILE);
@@ -144,6 +150,8 @@ async function isAlreadyInstalled(
 
   const localDigest = (await fs.readFile(digestFile, 'utf8')).trim();
   const parts = splitOciPackage(pkg);
+  /* istanbul ignore next -- unreachable for the same reason as the guard in
+     splitOciPackage: `pkg` reached installOciPlugin through ociPluginKey. */
   if (!parts) return false;
   const remoteDigest = await imageCache.getDigest(parts.imagePart);
   if (localDigest !== remoteDigest) return false;

--- a/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.ts
+++ b/workspaces/install-dynamic-plugins/packages/install-dynamic-plugins/src/installer-oci.ts
@@ -42,9 +42,11 @@ function splitOciPackage(
   if (bang === -1) return null;
   const imagePart = pkg.slice(0, bang);
   const pluginPath = pkg.slice(bang + 1);
-  /* istanbul ignore next -- unreachable while OCI_REGEX rejects a leading or
-     trailing `!` upstream (see oci-key.test.ts `invalidCases`); kept so this
-     function stays total if that validation is ever relaxed. */
+  /* istanbul ignore next -- unreachable on the install path: OCI_REGEX rejects
+     a leading or trailing `!` (oci-key.test.ts `invalidCases`), and a package
+     with no `!` at all has one appended by the merger before it gets here
+     (merger.ts, `!plugin.package.includes('!')` and resolveInherit). Kept so
+     this function stays total if either changes. */
   if (!imagePart || !pluginPath) return null;
   return { imagePart, pluginPath };
 }
@@ -140,9 +142,9 @@ async function isAlreadyInstalled(
     return true;
   }
 
-  /* istanbul ignore next -- unreachable while PullPolicy has exactly two
-     members and IF_NOT_PRESENT already returned above; kept so a third policy
-     defaults to re-installing rather than silently skipping. */
+  // Not unreachable: `dynamic-plugins.yaml` is parsed with a type assertion,
+  // not a runtime check, so a typo'd `pullPolicy` arrives here as an
+  // unrecognised string and must fall through to a re-install.
   if (pullPolicy !== PullPolicy.ALWAYS) return false;
 
   const digestFile = path.join(destination, pathInstalled, IMAGE_HASH_FILE);
@@ -151,7 +153,8 @@ async function isAlreadyInstalled(
   const localDigest = (await fs.readFile(digestFile, 'utf8')).trim();
   const parts = splitOciPackage(pkg);
   /* istanbul ignore next -- unreachable for the same reason as the guard in
-     splitOciPackage: `pkg` reached installOciPlugin through ociPluginKey. */
+     splitOciPackage: every `pkg` that reaches here carries a `!<path>`, either
+     from the user or appended by the merger. */
   if (!parts) return false;
   const remoteDigest = await imageCache.getDigest(parts.imagePart);
   if (localDigest !== remoteDigest) return false;


### PR DESCRIPTION
## What

Covers one branch in `installer-oci.ts` that a review of this PR's own first commit proved is reachable, and documents two that are not.

Closes RHIDP-16761. Follow-up to #4526 (RHIDP-16222).

## The correction that shaped this PR

The first commit claimed three guards were unreachable and put an `istanbul ignore` on each. One of those claims was wrong, and the pragma was hiding a real branch rather than documenting a dead one.

```ts
if (pullPolicy !== PullPolicy.ALWAYS) return false;   // isAlreadyInstalled
```

The justification was that `PullPolicy` has exactly two members and `IF_NOT_PRESENT` already returned above. That only holds if the value really is one of the two, and nothing checks. `installer.ts` reads the config with `parseYaml(rawContent) as DynamicPluginsConfig` — a type assertion, no runtime validation — and `effectivePullPolicy` returns `plugin.pullPolicy` whenever it is truthy. So `pullPolicy: Never`, or a lower-cased `always`, travels from a user's `dynamic-plugins.yaml` straight into this comparison.

The behaviour on that path is the right one: fall through and re-install, rather than silently skip and strand the plugin at whatever version happens to be on disk. It simply had no test. It has one now, and removing the guard fails exactly that test and nothing else.

## What is ignored, and why

The two remaining pragmas stand, with better reasons than the first commit gave. The original comments cited `OCI_REGEX`, which only explains why a *trailing* `!` is rejected. The reason a package with **no** `!` at all never reaches `splitOciPackage` with an empty side is that the merger appends the resolved path first — `!plugin.package.includes('!')` in `mergePlugin`, and `resolveInherit` for the `{{inherit}}` case. Both mechanisms are named in the comments now, so a reader can check whether the pragma still holds after changing either.

```
:45  splitOciPackage    if (!imagePart || !pluginPath) return null
:152 isAlreadyInstalled if (!parts) return false
```

They stay rather than being deleted: dropping the second downgrades a clean skip into a `TypeError` on `parts.imagePart` the moment upstream validation is relaxed, and both cost nothing at runtime.

The `/* istanbul ignore next -- reason */` form follows the one existing use in this repo, `augment-backend`'s `HttpEmbedder.ts:47`.

## Coverage

`installer-oci.ts` was 95.08% statements / 90% branches with lines 45, 140 and 147 uncovered. It is 100% on all four metrics now — but the difference that matters is that the `pullPolicy` branch got there by being **tested**, not by being excluded.

## Mutation

| Mutation | Failures | Which test |
| --- | --- | --- |
| `if (pullPolicy !== PullPolicy.ALWAYS) return false` removed | 1 | `re-installs rather than skipping when the configured pullPolicy is not a recognised value` |

## Checks

- `yarn tsc` — clean
- `yarn prettier:check` — clean
- `yarn lint:all` — clean
- `CI=true yarn test` — 19 suites, 259 tests, all passing

No behaviour change, no changeset.

## Follow-up worth considering, not done here

`pullPolicy` is not validated at parse time. Falling through to a re-install is a safe default, but an operator who typos it gets no warning and a plugin that re-downloads on every run. Validating the value and logging when it is unrecognised would be a small, separate change — out of scope for a PR about coverage pragmas.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
