### PR TITLE
chore: centralize workspace yarn fix pipeline (RHIDP-14035)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ The `redhat-developer/rhdh-plugins` repository is designed as a collaborative sp
     - [Forking the Repository](#forking-the-repository)
     - [Developing Plugins in Workspaces](#developing-plugins-in-workspaces)
   - [Coding Guidelines](#coding-guidelines)
+    - [yarn fix](#yarn-fix)
   - [Versioning](#versioning)
   - [Creating Changesets](#creating-changesets)
   - [Release](#release)
@@ -79,6 +80,27 @@ There could be times when there is a need for a more rich development environmen
 For consistency across the monorepo, we suggest following the same Yarn setup as the repository root: the Yarn release is defined in the root `package.json` and `.yarnrc.yml`, and individual workspaces generally should not pin a different Yarn version.
 
 All code is formatted with `prettier` using the configuration in the repo. If possible we recommend configuring your editor to format automatically, but you can also use the `yarn prettier --write <file>` command to format files.
+
+### yarn fix
+
+From a workspace root (`workspaces/<name>`), run `yarn fix` before you consider the work done. Do not run it from the repository root; each workspace has its own install and its own `yarn fix`.
+
+The command delegates to `backstage-cli repo fix`, then runs additional fixers when they are available. Execution order is defined in `scripts/workspace-fix.mjs`:
+
+1. `backstage-cli repo fix` (pass `--publish` with `rhdhFix.publish` or `--publish`)
+2. `sort-package-json` (skipped unless the workspace depends on it)
+3. `backstage-cli repo lint --fix`
+4. `markdownlint --fix` (skipped unless the workspace depends on it)
+5. `prettier --write .` (always last among formatters)
+6. `knip --fix` (opt-in only: `rhdhFix.knip` or `--knip`)
+
+`yarn fix` exits 0 when every run fixer succeeds, even if files changed. It exits non-zero if a fixer fails. Missing optional fixers are skipped, not treated as failures.
+
+`yarn fix --check` runs only `backstage-cli repo fix --check` (and `--publish` when configured). CI uses this mode; lint, prettier, and publish validation run as separate workflow steps.
+
+Memory-heavy fixers run with `NODE_OPTIONS=--max-old-space-size=8192`, matching CI. Workspaces that build dynamic plugin bundles should list `dist-dynamic` and `dist-scalprum` in `.eslintignore` and `.prettierignore` so `repo lint --fix` and `prettier --write` do not traverse generated output. If a workspace still runs out of memory during `repo lint --fix`, set a higher value in `rhdhFix.nodeOptions` in that workspace's `package.json`.
+
+To add a new fixer, change `scripts/workspace-fix.mjs` only. Workspace `package.json` files should keep `"fix": "node ../../scripts/workspace-fix.mjs"`. The `noop` workspace is the exception and stays a no-op.
 
 ## Versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,8 @@ The command delegates to `backstage-cli repo fix`, then runs additional fixers w
 
 `yarn fix --check` runs only `backstage-cli repo fix --check` (and `--publish` when configured). CI uses this mode; lint, prettier, and publish validation run as separate workflow steps.
 
+Pass `--plugin <name>` to limit lint, prettier, and markdownlint to one plugin or package under the workspace (for example `yarn fix --plugin global-header`). Short names match a unique `plugins/<name>` or `plugins/*-<name>` directory. `backstage-cli repo fix` still runs for the full workspace.
+
 Memory-heavy fixers run with `NODE_OPTIONS=--max-old-space-size=8192`, matching CI. Workspaces that build dynamic plugin bundles should list `dist-dynamic` and `dist-scalprum` in `.eslintignore` and `.prettierignore` so `repo lint --fix` and `prettier --write` do not traverse generated output. If a workspace still runs out of memory during `repo lint --fix`, set a higher value in `rhdhFix.nodeOptions` in that workspace's `package.json`.
 
 To add a new fixer, change `scripts/workspace-fix.mjs` only. Workspace `package.json` files should keep `"fix": "node ../../scripts/workspace-fix.mjs"`. The `noop` workspace is the exception and stays a no-op.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Contributions are welcome! To contribute a plugin, please follow the guidelines 
 ## Plugins Workflow
 
 The `rhdh-plugins` repository is organized into multiple workspaces, with each workspace containing a plugin or a set of related plugins. Each workspace operates independently, with its own release cycle and dependencies managed via npm. When a new changeset is added (each workspace has its own `.changesets` directory), a "Version packages ($workspace_name)" PR is automatically generated. Merging this PR triggers the release of all plugins in the workspace and updates the corresponding `CHANGELOG` files.
+
+## yarn fix
+
+From a workspace directory (`workspaces/<name>`), run `yarn fix` to auto-correct fixable package, lint, and format issues. The pipeline is defined once in `scripts/workspace-fix.mjs`. See [CONTRIBUTING.md](CONTRIBUTING.md#yarn-fix) for the fixer order and how to add a new fixer.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "create-workspace": "rhdh-repo-tools workspace create",
+    "test:workspace-fix": "node --test scripts/workspace-fix.test.mjs",
     "postinstall": "husky",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write ."

--- a/scripts/workspace-fix.mjs
+++ b/scripts/workspace-fix.mjs
@@ -123,7 +123,8 @@ export function resolveConfig(pkg, flags) {
   };
 }
 
-export function mergeNodeOptions(existing, additional) {
+export function mergeNodeOptions(existing, additional, options = {}) {
+  const { overrideHeapLimit = false } = options;
   if (!additional) {
     return existing;
   }
@@ -131,6 +132,12 @@ export function mergeNodeOptions(existing, additional) {
     return additional;
   }
   if (existing.includes('max-old-space-size')) {
+    if (overrideHeapLimit) {
+      const replacement = additional.match(/--max-old-space-size=\d+/)?.[0];
+      if (replacement) {
+        return existing.replace(/--max-old-space-size=\d+/, replacement);
+      }
+    }
     return existing;
   }
   return `${existing} ${additional}`.trim();
@@ -145,7 +152,9 @@ export function resolveSpawnEnv(step, config, baseEnv = process.env) {
   }
   return {
     ...baseEnv,
-    NODE_OPTIONS: mergeNodeOptions(baseEnv.NODE_OPTIONS, extra),
+    NODE_OPTIONS: mergeNodeOptions(baseEnv.NODE_OPTIONS, extra, {
+      overrideHeapLimit: Boolean(config.nodeOptions),
+    }),
   };
 }
 

--- a/scripts/workspace-fix.mjs
+++ b/scripts/workspace-fix.mjs
@@ -1,0 +1,320 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const REPO_ROOT_PACKAGE_NAME = '@redhat-developer/rhdh-plugins';
+
+// Match .github/workflows/ci.yml so local yarn fix behaves like CI.
+export const DEFAULT_NODE_OPTIONS = '--max-old-space-size=8192';
+
+const MEMORY_HEAVY_STEPS = new Set([
+  'repo-fix',
+  'lint-fix',
+  'prettier',
+  'knip',
+]);
+
+const MARKDOWNLINT_PACKAGES = [
+  'markdownlint-cli2',
+  'markdownlint-cli',
+  'markdownlint',
+];
+
+/**
+ * Deterministic fixer order. Add new fixers here — workspace package.json
+ * scripts should keep pointing at this file.
+ *
+ * 1. backstage-cli repo fix  (package.json exports / metadata)
+ * 2. sort-package-json       (optional; skipped unless installed)
+ * 3. backstage-cli repo lint --fix
+ * 4. markdownlint --fix      (optional; skipped unless installed)
+ * 5. prettier --write        (last formatter so eslint and prettier do not fight)
+ * 6. knip --fix              (opt-in only; skipped unless rhdhFix.knip or --knip)
+ */
+export const FIXER_ORDER = [
+  'repo-fix',
+  'sort-package-json',
+  'lint-fix',
+  'markdownlint',
+  'prettier',
+  'knip',
+];
+
+export function parseArgs(argv) {
+  const extra = [];
+  const flags = { publish: false, knip: false, check: false, help: false };
+  for (const arg of argv) {
+    if (arg === '--publish') {
+      flags.publish = true;
+    } else if (arg === '--knip') {
+      flags.knip = true;
+    } else if (arg === '--check') {
+      flags.check = true;
+    } else if (arg === '--help' || arg === '-h') {
+      flags.help = true;
+    } else if (arg.startsWith('-')) {
+      throw Object.assign(
+        new Error(`Unknown flag '${arg}'. Use --check, --publish, or --knip.`),
+        { exitCode: 1 },
+      );
+    } else {
+      extra.push(arg);
+    }
+  }
+  return { flags, extra };
+}
+
+export function readPackageJson(cwd) {
+  const pkgPath = resolve(cwd, 'package.json');
+  if (!existsSync(pkgPath)) {
+    throw Object.assign(
+      new Error(
+        `No package.json in ${cwd}. Run yarn fix from a workspace root (workspaces/<name>).`,
+      ),
+      { exitCode: 1 },
+    );
+  }
+  return JSON.parse(readFileSync(pkgPath, 'utf8'));
+}
+
+export function assertWorkspaceRoot(pkg) {
+  if (pkg.name === REPO_ROOT_PACKAGE_NAME) {
+    throw Object.assign(
+      new Error(
+        'yarn fix is per workspace. cd into workspaces/<name> and run yarn fix there.',
+      ),
+      { exitCode: 1 },
+    );
+  }
+  if (!pkg.workspaces) {
+    throw Object.assign(
+      new Error(
+        'yarn fix must run from a workspace root that declares a workspaces field.',
+      ),
+      { exitCode: 1 },
+    );
+  }
+}
+
+export function resolveConfig(pkg, flags) {
+  const fromPkg = pkg.rhdhFix ?? {};
+  return {
+    check: Boolean(flags.check),
+    publish: Boolean(fromPkg.publish || flags.publish),
+    knip: Boolean(fromPkg.knip || flags.knip),
+    nodeOptions: fromPkg.nodeOptions,
+  };
+}
+
+export function mergeNodeOptions(existing, additional) {
+  if (!additional) {
+    return existing;
+  }
+  if (!existing) {
+    return additional;
+  }
+  if (existing.includes('max-old-space-size')) {
+    return existing;
+  }
+  return `${existing} ${additional}`.trim();
+}
+
+export function resolveSpawnEnv(step, config, baseEnv = process.env) {
+  const extra =
+    config.nodeOptions ??
+    (MEMORY_HEAVY_STEPS.has(step.id) ? DEFAULT_NODE_OPTIONS : undefined);
+  if (!extra) {
+    return baseEnv;
+  }
+  return {
+    ...baseEnv,
+    NODE_OPTIONS: mergeNodeOptions(baseEnv.NODE_OPTIONS, extra),
+  };
+}
+
+export function detectTools(pkg) {
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+  const markdownlintPkg = MARKDOWNLINT_PACKAGES.find(name => name in deps);
+  return {
+    backstageCli: '@backstage/cli' in deps,
+    prettier: 'prettier' in deps,
+    sortPackageJson: 'sort-package-json' in deps,
+    markdownlint: markdownlintPkg,
+    knip: 'knip' in deps,
+  };
+}
+
+function markdownlintArgs(packageName) {
+  if (packageName === 'markdownlint-cli2') {
+    return ['exec', 'markdownlint-cli2', '--fix'];
+  }
+  return ['exec', 'markdownlint', '--fix', '**/*.md'];
+}
+
+function repoFixArgs(config) {
+  return [
+    'backstage-cli',
+    'repo',
+    'fix',
+    ...(config.check ? ['--check'] : []),
+    ...(config.publish ? ['--publish'] : []),
+  ];
+}
+
+export function buildSteps({ tools, config }) {
+  const repoFixStep = {
+    id: 'repo-fix',
+    required: true,
+    available: tools.backstageCli,
+    command: 'yarn',
+    args: repoFixArgs(config),
+  };
+
+  if (config.check) {
+    return [repoFixStep];
+  }
+
+  return [
+    repoFixStep,
+    {
+      id: 'sort-package-json',
+      required: false,
+      available: Boolean(tools.sortPackageJson),
+      command: 'yarn',
+      args: ['exec', 'sort-package-json', 'package.json'],
+    },
+    {
+      id: 'lint-fix',
+      required: true,
+      available: tools.backstageCli,
+      command: 'yarn',
+      args: ['backstage-cli', 'repo', 'lint', '--fix'],
+    },
+    {
+      id: 'markdownlint',
+      required: false,
+      available: Boolean(tools.markdownlint),
+      command: 'yarn',
+      args: markdownlintArgs(tools.markdownlint),
+    },
+    {
+      id: 'prettier',
+      required: false,
+      available: Boolean(tools.prettier),
+      command: 'yarn',
+      args: ['prettier', '--write', '.'],
+    },
+    {
+      id: 'knip',
+      required: false,
+      available: Boolean(tools.knip) && config.knip,
+      skipReason: config.knip
+        ? 'knip is not installed'
+        : 'knip --fix is opt-in (set rhdhFix.knip or pass --knip)',
+      command: 'yarn',
+      args: ['knip', '--fix'],
+    },
+  ];
+}
+
+export async function runPipeline(steps, { run, log }) {
+  for (const step of steps) {
+    if (!step.available) {
+      if (step.required) {
+        throw Object.assign(
+          new Error(`Required fixer '${step.id}' is not available`),
+          { exitCode: 1 },
+        );
+      }
+      log(`skip ${step.id}: ${step.skipReason ?? 'not installed'}`);
+      continue;
+    }
+
+    log(`run ${step.id}: ${step.command} ${step.args.join(' ')}`);
+    const code = await run(step);
+    if (code !== 0) {
+      throw Object.assign(
+        new Error(`Fixer '${step.id}' failed with exit code ${code}`),
+        { exitCode: code },
+      );
+    }
+  }
+}
+
+function spawnStep(step, cwd, config) {
+  return new Promise(resolvePromise => {
+    const child = spawn(step.command, step.args, {
+      cwd,
+      stdio: 'inherit',
+      env: resolveSpawnEnv(step, config),
+    });
+    child.on('error', () => resolvePromise(1));
+    child.on('close', code => resolvePromise(code ?? 1));
+  });
+}
+
+export function helpText() {
+  return [
+    'Usage: yarn fix [--check] [--publish] [--knip]',
+    '',
+    'Run from a workspace root (workspaces/<name>).',
+    'Fixer order is defined in scripts/workspace-fix.mjs.',
+    '',
+    '  --check    Run backstage-cli repo fix --check only (matches CI)',
+    '  --publish  Pass --publish to backstage-cli repo fix',
+    '  --knip     Run knip --fix (off by default)',
+    '',
+    'Exit 0 when every run fixer succeeds, even if files changed.',
+    'Exit non-zero when a fixer fails. Missing optional fixers are skipped.',
+  ].join('\n');
+}
+
+export async function main(argv, cwd, io = console) {
+  const { flags } = parseArgs(argv);
+  if (flags.help) {
+    io.log(helpText());
+    return;
+  }
+
+  const pkg = readPackageJson(cwd);
+  assertWorkspaceRoot(pkg);
+  const config = resolveConfig(pkg, flags);
+  const tools = detectTools(pkg);
+  const steps = buildSteps({ tools, config });
+  await runPipeline(steps, {
+    log: msg => io.log(msg),
+    run: step => spawnStep(step, cwd, config),
+  });
+}
+
+function isMainModule() {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return import.meta.url === pathToFileURL(resolve(entry)).href;
+}
+
+if (isMainModule()) {
+  main(process.argv.slice(2), process.cwd()).catch(error => {
+    console.error(error.message);
+    process.exit(error.exitCode ?? 1);
+  });
+}

--- a/scripts/workspace-fix.mjs
+++ b/scripts/workspace-fix.mjs
@@ -322,8 +322,10 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
-  main(process.argv.slice(2), process.cwd()).catch(error => {
+  try {
+    await main(process.argv.slice(2), process.cwd());
+  } catch (error) {
     console.error(error.message);
     process.exit(error.exitCode ?? 1);
-  });
+  }
 }

--- a/scripts/workspace-fix.mjs
+++ b/scripts/workspace-fix.mjs
@@ -15,7 +15,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -57,10 +57,19 @@ export const FIXER_ORDER = [
   'knip',
 ];
 
+const PACKAGE_ROOTS = ['plugins', 'packages'];
+
 export function parseArgs(argv) {
   const extra = [];
-  const flags = { publish: false, knip: false, check: false, help: false };
-  for (const arg of argv) {
+  const flags = {
+    publish: false,
+    knip: false,
+    check: false,
+    help: false,
+    plugin: undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
     if (arg === '--publish') {
       flags.publish = true;
     } else if (arg === '--knip') {
@@ -69,14 +78,42 @@ export function parseArgs(argv) {
       flags.check = true;
     } else if (arg === '--help' || arg === '-h') {
       flags.help = true;
+    } else if (arg === '--plugin') {
+      const value = argv[++i];
+      if (!value || value.startsWith('-')) {
+        throw Object.assign(
+          new Error(
+            'Missing value for --plugin. Example: yarn fix --plugin segment',
+          ),
+          { exitCode: 1 },
+        );
+      }
+      flags.plugin = value;
+    } else if (arg.startsWith('--plugin=')) {
+      flags.plugin = arg.slice('--plugin='.length);
+      if (!flags.plugin) {
+        throw Object.assign(
+          new Error(
+            'Missing value for --plugin. Example: yarn fix --plugin segment',
+          ),
+          { exitCode: 1 },
+        );
+      }
     } else if (arg.startsWith('-')) {
       throw Object.assign(
-        new Error(`Unknown flag '${arg}'. Use --check, --publish, or --knip.`),
+        new Error(
+          `Unknown flag '${arg}'. Use --check, --publish, --knip, or --plugin <name>.`,
+        ),
         { exitCode: 1 },
       );
     } else {
       extra.push(arg);
     }
+  }
+  if (extra.length) {
+    throw Object.assign(new Error(`Unexpected arguments: ${extra.join(' ')}`), {
+      exitCode: 1,
+    });
   }
   return { flags, extra };
 }
@@ -113,13 +150,82 @@ export function assertWorkspaceRoot(pkg) {
   }
 }
 
-export function resolveConfig(pkg, flags) {
+export function listWorkspacePackages(cwd) {
+  const packages = [];
+  for (const root of PACKAGE_ROOTS) {
+    const base = resolve(cwd, root);
+    if (!existsSync(base)) {
+      continue;
+    }
+    for (const entry of readdirSync(base, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const relativePath = `${root}/${entry.name}`;
+      if (existsSync(resolve(cwd, relativePath, 'package.json'))) {
+        packages.push({ name: entry.name, relativePath });
+      }
+    }
+  }
+  return packages.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+export function resolvePluginTarget(cwd, query) {
+  const packages = listWorkspacePackages(cwd);
+  if (packages.length === 0) {
+    throw Object.assign(
+      new Error('No plugins or packages found under plugins/ or packages/.'),
+      { exitCode: 1 },
+    );
+  }
+
+  const normalized = query.replace(/^\.\//, '');
+  const direct = packages.find(
+    pkg =>
+      pkg.name === normalized ||
+      pkg.relativePath === normalized ||
+      pkg.relativePath === `plugins/${normalized}` ||
+      pkg.relativePath === `packages/${normalized}`,
+  );
+  if (direct) {
+    return direct;
+  }
+
+  const suffixMatches = packages.filter(
+    pkg => pkg.name === normalized || pkg.name.endsWith(`-${normalized}`),
+  );
+  if (suffixMatches.length === 1) {
+    return suffixMatches[0];
+  }
+  if (suffixMatches.length > 1) {
+    throw Object.assign(
+      new Error(
+        `Ambiguous plugin '${query}'. Matches: ${suffixMatches
+          .map(pkg => pkg.relativePath)
+          .join(', ')}. Use the full directory name.`,
+      ),
+      { exitCode: 1 },
+    );
+  }
+
+  const known = packages.map(pkg => pkg.relativePath).join(', ');
+  throw Object.assign(
+    new Error(
+      `Unknown plugin '${query}'. Expected a name like segment or a path like plugins/analytics-provider-segment. Known packages: ${known}`,
+    ),
+    { exitCode: 1 },
+  );
+}
+
+export function resolveConfig(pkg, flags, cwd = process.cwd()) {
   const fromPkg = pkg.rhdhFix ?? {};
+  const plugin = flags.plugin ? resolvePluginTarget(cwd, flags.plugin) : null;
   return {
     check: Boolean(flags.check),
     publish: Boolean(fromPkg.publish || flags.publish),
     knip: Boolean(fromPkg.knip || flags.knip),
     nodeOptions: fromPkg.nodeOptions,
+    plugin,
   };
 }
 
@@ -170,11 +276,31 @@ export function detectTools(pkg) {
   };
 }
 
-function markdownlintArgs(packageName) {
-  if (packageName === 'markdownlint-cli2') {
-    return ['exec', 'markdownlint-cli2', '--fix'];
+function lintFixArgs(config) {
+  if (config.plugin) {
+    return [
+      'backstage-cli',
+      'package',
+      'lint',
+      '--fix',
+      config.plugin.relativePath,
+    ];
   }
-  return ['exec', 'markdownlint', '--fix', '**/*.md'];
+  return ['backstage-cli', 'repo', 'lint', '--fix'];
+}
+
+function prettierArgs(config) {
+  return ['prettier', '--write', config.plugin?.relativePath ?? '.'];
+}
+
+function markdownlintArgs(packageName, config) {
+  const target = config.plugin
+    ? `${config.plugin.relativePath}/**/*.md`
+    : '**/*.md';
+  if (packageName === 'markdownlint-cli2') {
+    return ['exec', 'markdownlint-cli2', '--fix', target];
+  }
+  return ['exec', 'markdownlint', '--fix', target];
 }
 
 function repoFixArgs(config) {
@@ -187,7 +313,7 @@ function repoFixArgs(config) {
   ];
 }
 
-export function buildSteps({ tools, config }) {
+export function buildSteps({ tools, config, cwd = process.cwd() }) {
   const repoFixStep = {
     id: 'repo-fix',
     required: true,
@@ -205,7 +331,10 @@ export function buildSteps({ tools, config }) {
     {
       id: 'sort-package-json',
       required: false,
-      available: Boolean(tools.sortPackageJson),
+      available: Boolean(tools.sortPackageJson) && !config.plugin,
+      skipReason: config.plugin
+        ? 'sort-package-json runs on the workspace root only'
+        : undefined,
       command: 'yarn',
       args: ['exec', 'sort-package-json', 'package.json'],
     },
@@ -214,21 +343,21 @@ export function buildSteps({ tools, config }) {
       required: true,
       available: tools.backstageCli,
       command: 'yarn',
-      args: ['backstage-cli', 'repo', 'lint', '--fix'],
+      args: lintFixArgs(config),
     },
     {
       id: 'markdownlint',
       required: false,
       available: Boolean(tools.markdownlint),
       command: 'yarn',
-      args: markdownlintArgs(tools.markdownlint),
+      args: markdownlintArgs(tools.markdownlint, config),
     },
     {
       id: 'prettier',
       required: false,
       available: Boolean(tools.prettier),
       command: 'yarn',
-      args: ['prettier', '--write', '.'],
+      args: prettierArgs(config),
     },
     {
       id: 'knip',
@@ -239,6 +368,7 @@ export function buildSteps({ tools, config }) {
         : 'knip --fix is opt-in (set rhdhFix.knip or pass --knip)',
       command: 'yarn',
       args: ['knip', '--fix'],
+      cwd: config.plugin ? resolve(cwd, config.plugin.relativePath) : undefined,
     },
   ];
 }
@@ -268,9 +398,10 @@ export async function runPipeline(steps, { run, log }) {
 }
 
 function spawnStep(step, cwd, config) {
+  const runCwd = step.cwd ?? cwd;
   return new Promise(resolvePromise => {
     const child = spawn(step.command, step.args, {
-      cwd,
+      cwd: runCwd,
       stdio: 'inherit',
       env: resolveSpawnEnv(step, config),
     });
@@ -281,14 +412,20 @@ function spawnStep(step, cwd, config) {
 
 export function helpText() {
   return [
-    'Usage: yarn fix [--check] [--publish] [--knip]',
+    'Usage: yarn fix [--check] [--publish] [--knip] [--plugin <name>]',
     '',
     'Run from a workspace root (workspaces/<name>).',
     'Fixer order is defined in scripts/workspace-fix.mjs.',
     '',
-    '  --check    Run backstage-cli repo fix --check only (matches CI)',
-    '  --publish  Pass --publish to backstage-cli repo fix',
-    '  --knip     Run knip --fix (off by default)',
+    '  --check           Run backstage-cli repo fix --check only (matches CI)',
+    '  --publish         Pass --publish to backstage-cli repo fix',
+    '  --knip            Run knip --fix (off by default)',
+    '  --plugin <name>   Limit lint, prettier, and markdownlint to one plugin',
+    '                    or package (for example: global-header or',
+    '                    plugins/global-header)',
+    '',
+    'Without --plugin, yarn fix runs across the whole workspace.',
+    'backstage-cli repo fix always runs for the full workspace.',
     '',
     'Exit 0 when every run fixer succeeds, even if files changed.',
     'Exit non-zero when a fixer fails. Missing optional fixers are skipped.',
@@ -304,9 +441,9 @@ export async function main(argv, cwd, io = console) {
 
   const pkg = readPackageJson(cwd);
   assertWorkspaceRoot(pkg);
-  const config = resolveConfig(pkg, flags);
+  const config = resolveConfig(pkg, flags, cwd);
   const tools = detectTools(pkg);
-  const steps = buildSteps({ tools, config });
+  const steps = buildSteps({ tools, config, cwd });
   await runPipeline(steps, {
     log: msg => io.log(msg),
     run: step => spawnStep(step, cwd, config),

--- a/scripts/workspace-fix.test.mjs
+++ b/scripts/workspace-fix.test.mjs
@@ -1,0 +1,315 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  DEFAULT_NODE_OPTIONS,
+  FIXER_ORDER,
+  REPO_ROOT_PACKAGE_NAME,
+  assertWorkspaceRoot,
+  buildSteps,
+  detectTools,
+  mergeNodeOptions,
+  parseArgs,
+  readPackageJson,
+  resolveConfig,
+  resolveSpawnEnv,
+  runPipeline,
+} from './workspace-fix.mjs';
+
+const ALL_TOOLS = {
+  backstageCli: true,
+  prettier: true,
+  sortPackageJson: true,
+  markdownlint: 'markdownlint-cli',
+  knip: true,
+};
+
+test('fixer order is documented and stable', () => {
+  assert.deepEqual(FIXER_ORDER, [
+    'repo-fix',
+    'sort-package-json',
+    'lint-fix',
+    'markdownlint',
+    'prettier',
+    'knip',
+  ]);
+});
+
+test('parseArgs accepts publish, check, and knip flags', () => {
+  assert.deepEqual(parseArgs(['--publish', '--check', '--knip']), {
+    flags: { publish: true, check: true, knip: true, help: false },
+    extra: [],
+  });
+});
+
+test('parseArgs rejects unknown flags', () => {
+  assert.throws(() => parseArgs(['--write']), /Unknown flag '--write'/);
+});
+
+test('assertWorkspaceRoot rejects the monorepo root', () => {
+  assert.throws(
+    () => assertWorkspaceRoot({ name: REPO_ROOT_PACKAGE_NAME, workspaces: {} }),
+    /per workspace/,
+  );
+});
+
+test('assertWorkspaceRoot rejects a package without workspaces', () => {
+  assert.throws(
+    () => assertWorkspaceRoot({ name: '@internal/noop' }),
+    /workspaces field/,
+  );
+});
+
+test('readPackageJson fails without package.json', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'workspace-fix-'));
+  assert.throws(() => readPackageJson(cwd), /No package.json/);
+});
+
+test('resolveConfig merges package.json with CLI flags', () => {
+  assert.deepEqual(
+    resolveConfig({ rhdhFix: { publish: true } }, { check: true, knip: true }),
+    {
+      check: true,
+      publish: true,
+      knip: true,
+      nodeOptions: undefined,
+    },
+  );
+});
+
+test('mergeNodeOptions preserves an existing heap limit', () => {
+  assert.equal(
+    mergeNodeOptions('--max-old-space-size=16384', DEFAULT_NODE_OPTIONS),
+    '--max-old-space-size=16384',
+  );
+});
+
+test('resolveSpawnEnv sets NODE_OPTIONS for lint-fix', () => {
+  const env = resolveSpawnEnv(
+    { id: 'lint-fix' },
+    resolveConfig({}, { publish: false, knip: false, check: false }),
+    {},
+  );
+  assert.equal(env.NODE_OPTIONS, DEFAULT_NODE_OPTIONS);
+});
+
+test('resolveSpawnEnv honors rhdhFix.nodeOptions', () => {
+  const env = resolveSpawnEnv(
+    { id: 'lint-fix' },
+    resolveConfig(
+      { rhdhFix: { nodeOptions: '--max-old-space-size=16384' } },
+      {},
+    ),
+    {},
+  );
+  assert.equal(env.NODE_OPTIONS, '--max-old-space-size=16384');
+});
+
+test('detectTools reads workspace dependencies', () => {
+  assert.deepEqual(
+    detectTools({
+      devDependencies: {
+        '@backstage/cli': '^0.36.0',
+        prettier: '^3.0.0',
+        knip: '^5.0.0',
+      },
+    }),
+    {
+      backstageCli: true,
+      prettier: true,
+      sortPackageJson: false,
+      markdownlint: undefined,
+      knip: true,
+    },
+  );
+});
+
+test('buildSteps keeps documented order and default knip off', () => {
+  const steps = buildSteps({
+    tools: ALL_TOOLS,
+    config: { check: false, publish: false, knip: false },
+  });
+  assert.deepEqual(
+    steps.map(step => step.id),
+    FIXER_ORDER,
+  );
+  const knip = steps.find(step => step.id === 'knip');
+  assert.equal(knip.available, false);
+  assert.match(knip.skipReason, /opt-in/);
+
+  const repoFix = steps.find(step => step.id === 'repo-fix');
+  assert.deepEqual(repoFix.args, ['backstage-cli', 'repo', 'fix']);
+});
+
+test('buildSteps passes --publish to repo fix and enables knip when opted in', () => {
+  const steps = buildSteps({
+    tools: ALL_TOOLS,
+    config: { check: false, publish: true, knip: true },
+  });
+  assert.deepEqual(steps.find(step => step.id === 'repo-fix').args, [
+    'backstage-cli',
+    'repo',
+    'fix',
+    '--publish',
+  ]);
+  assert.equal(steps.find(step => step.id === 'knip').available, true);
+});
+
+test('buildSteps in check mode only runs repo fix with --check', () => {
+  const steps = buildSteps({
+    tools: ALL_TOOLS,
+    config: { check: true, publish: true, knip: true },
+  });
+  assert.deepEqual(
+    steps.map(step => step.id),
+    ['repo-fix'],
+  );
+  assert.deepEqual(steps[0].args, [
+    'backstage-cli',
+    'repo',
+    'fix',
+    '--check',
+    '--publish',
+  ]);
+});
+
+test('runPipeline in check mode only runs repo fix', async () => {
+  const ran = [];
+  await runPipeline(
+    buildSteps({
+      tools: ALL_TOOLS,
+      config: { check: true, publish: false, knip: true },
+    }),
+    {
+      log: () => {},
+      run: async step => {
+        ran.push(step.id);
+        return 0;
+      },
+    },
+  );
+  assert.deepEqual(ran, ['repo-fix']);
+});
+
+test('optional fixers are skipped when their packages are not installed', () => {
+  const steps = buildSteps({
+    tools: {
+      backstageCli: true,
+      prettier: false,
+      sortPackageJson: false,
+      markdownlint: undefined,
+      knip: false,
+    },
+    config: { check: false, publish: false, knip: false },
+  });
+  assert.equal(
+    steps.find(step => step.id === 'sort-package-json').available,
+    false,
+  );
+  assert.equal(steps.find(step => step.id === 'markdownlint').available, false);
+  assert.equal(steps.find(step => step.id === 'prettier').available, false);
+});
+
+test('runPipeline skips optional missing fixers and still succeeds', async () => {
+  const ran = [];
+  const logs = [];
+  await runPipeline(
+    buildSteps({
+      tools: {
+        backstageCli: true,
+        prettier: true,
+        sortPackageJson: false,
+        markdownlint: undefined,
+        knip: true,
+      },
+      config: { check: false, publish: false, knip: false },
+    }),
+    {
+      log: msg => logs.push(msg),
+      run: async step => {
+        ran.push(step.id);
+        return 0;
+      },
+    },
+  );
+  assert.deepEqual(ran, ['repo-fix', 'lint-fix', 'prettier']);
+  assert.ok(logs.some(line => line.startsWith('skip sort-package-json')));
+  assert.ok(logs.some(line => line.startsWith('skip knip')));
+});
+
+test('runPipeline exits non-zero when a fixer fails', async () => {
+  await assert.rejects(
+    () =>
+      runPipeline(
+        buildSteps({
+          tools: ALL_TOOLS,
+          config: { check: false, publish: false, knip: false },
+        }),
+        {
+          log: () => {},
+          run: async step => (step.id === 'lint-fix' ? 2 : 0),
+        },
+      ),
+    error => error.exitCode === 2 && /lint-fix/.test(error.message),
+  );
+});
+
+test('runPipeline fails when a required fixer is missing', async () => {
+  await assert.rejects(
+    () =>
+      runPipeline(
+        buildSteps({
+          tools: {
+            backstageCli: false,
+            prettier: true,
+            sortPackageJson: false,
+            markdownlint: undefined,
+            knip: false,
+          },
+          config: { check: false, publish: false, knip: false },
+        }),
+        { log: () => {}, run: async () => 0 },
+      ),
+    /Required fixer 'repo-fix'/,
+  );
+});
+
+test('runPipeline succeeds when fixers report changes as success', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'workspace-fix-pkg-'));
+  writeFileSync(
+    join(cwd, 'package.json'),
+    JSON.stringify({
+      name: '@internal/example',
+      workspaces: { packages: ['packages/*'] },
+      devDependencies: { '@backstage/cli': '1.0.0', prettier: '3.0.0' },
+    }),
+  );
+  const pkg = readPackageJson(cwd);
+  assertWorkspaceRoot(pkg);
+  await runPipeline(
+    buildSteps({
+      tools: detectTools(pkg),
+      config: resolveConfig(pkg, { publish: false, knip: false, check: false }),
+    }),
+    { log: () => {}, run: async () => 0 },
+  );
+});

--- a/scripts/workspace-fix.test.mjs
+++ b/scripts/workspace-fix.test.mjs
@@ -103,6 +103,24 @@ test('mergeNodeOptions preserves an existing heap limit', () => {
   );
 });
 
+test('mergeNodeOptions appends when existing lacks a heap limit', () => {
+  assert.equal(
+    mergeNodeOptions('--inspect', DEFAULT_NODE_OPTIONS),
+    '--inspect --max-old-space-size=8192',
+  );
+});
+
+test('mergeNodeOptions replaces heap limit for workspace overrides', () => {
+  assert.equal(
+    mergeNodeOptions(
+      '--max-old-space-size=8192',
+      '--max-old-space-size=16384',
+      { overrideHeapLimit: true },
+    ),
+    '--max-old-space-size=16384',
+  );
+});
+
 test('resolveSpawnEnv sets NODE_OPTIONS for lint-fix', () => {
   const env = resolveSpawnEnv(
     { id: 'lint-fix' },
@@ -120,6 +138,18 @@ test('resolveSpawnEnv honors rhdhFix.nodeOptions', () => {
       {},
     ),
     {},
+  );
+  assert.equal(env.NODE_OPTIONS, '--max-old-space-size=16384');
+});
+
+test('resolveSpawnEnv lets rhdhFix.nodeOptions override CI NODE_OPTIONS', () => {
+  const env = resolveSpawnEnv(
+    { id: 'lint-fix' },
+    resolveConfig(
+      { rhdhFix: { nodeOptions: '--max-old-space-size=16384' } },
+      {},
+    ),
+    { NODE_OPTIONS: DEFAULT_NODE_OPTIONS },
   );
   assert.equal(env.NODE_OPTIONS, '--max-old-space-size=16384');
 });

--- a/scripts/workspace-fix.test.mjs
+++ b/scripts/workspace-fix.test.mjs
@@ -335,11 +335,19 @@ test('runPipeline succeeds when fixers report changes as success', async () => {
   );
   const pkg = readPackageJson(cwd);
   assertWorkspaceRoot(pkg);
+  const ran = [];
   await runPipeline(
     buildSteps({
       tools: detectTools(pkg),
       config: resolveConfig(pkg, { publish: false, knip: false, check: false }),
     }),
-    { log: () => {}, run: async () => 0 },
+    {
+      log: () => {},
+      run: async step => {
+        ran.push(step.id);
+        return 0;
+      },
+    },
   );
+  assert.deepEqual(ran, ['repo-fix', 'lint-fix', 'prettier']);
 });

--- a/scripts/workspace-fix.test.mjs
+++ b/scripts/workspace-fix.test.mjs
@@ -15,7 +15,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -27,10 +27,12 @@ import {
   assertWorkspaceRoot,
   buildSteps,
   detectTools,
+  listWorkspacePackages,
   mergeNodeOptions,
   parseArgs,
   readPackageJson,
   resolveConfig,
+  resolvePluginTarget,
   resolveSpawnEnv,
   runPipeline,
 } from './workspace-fix.mjs';
@@ -54,15 +56,35 @@ test('fixer order is documented and stable', () => {
   ]);
 });
 
-test('parseArgs accepts publish, check, and knip flags', () => {
+test('parseArgs accepts publish, check, knip, and plugin flags', () => {
   assert.deepEqual(parseArgs(['--publish', '--check', '--knip']), {
-    flags: { publish: true, check: true, knip: true, help: false },
+    flags: {
+      publish: true,
+      check: true,
+      knip: true,
+      help: false,
+      plugin: undefined,
+    },
+    extra: [],
+  });
+  assert.deepEqual(parseArgs(['--plugin', 'global-header']), {
+    flags: {
+      publish: false,
+      check: false,
+      knip: false,
+      help: false,
+      plugin: 'global-header',
+    },
     extra: [],
   });
 });
 
 test('parseArgs rejects unknown flags', () => {
   assert.throws(() => parseArgs(['--write']), /Unknown flag '--write'/);
+});
+
+test('parseArgs requires a plugin name', () => {
+  assert.throws(() => parseArgs(['--plugin']), /Missing value for --plugin/);
 });
 
 test('assertWorkspaceRoot rejects the monorepo root', () => {
@@ -85,15 +107,49 @@ test('readPackageJson fails without package.json', () => {
 });
 
 test('resolveConfig merges package.json with CLI flags', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'workspace-fix-config-'));
+  mkdirSync(join(cwd, 'plugins', 'global-header'), { recursive: true });
+  writeFileSync(join(cwd, 'plugins', 'global-header', 'package.json'), '{}');
   assert.deepEqual(
-    resolveConfig({ rhdhFix: { publish: true } }, { check: true, knip: true }),
+    resolveConfig(
+      { rhdhFix: { publish: true } },
+      { check: true, knip: true, plugin: 'global-header' },
+      cwd,
+    ),
     {
       check: true,
       publish: true,
       knip: true,
       nodeOptions: undefined,
+      plugin: { name: 'global-header', relativePath: 'plugins/global-header' },
     },
   );
+});
+
+test('resolvePluginTarget matches a short plugin suffix', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'workspace-fix-plugin-'));
+  mkdirSync(join(cwd, 'plugins', 'global-header'), { recursive: true });
+  mkdirSync(join(cwd, 'plugins', 'app-header'), { recursive: true });
+  writeFileSync(join(cwd, 'plugins', 'global-header', 'package.json'), '{}');
+  writeFileSync(join(cwd, 'plugins', 'app-header', 'package.json'), '{}');
+
+  assert.deepEqual(resolvePluginTarget(cwd, 'global-header'), {
+    name: 'global-header',
+    relativePath: 'plugins/global-header',
+  });
+  assert.deepEqual(
+    listWorkspacePackages(cwd).map(pkg => pkg.relativePath),
+    ['plugins/app-header', 'plugins/global-header'],
+  );
+});
+
+test('resolvePluginTarget rejects ambiguous short names', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'workspace-fix-ambiguous-'));
+  for (const name of ['foo-plugin-a', 'bar-plugin-a']) {
+    mkdirSync(join(cwd, 'plugins', name), { recursive: true });
+    writeFileSync(join(cwd, 'plugins', name, 'package.json'), '{}');
+  }
+  assert.throws(() => resolvePluginTarget(cwd, 'a'), /Ambiguous plugin 'a'/);
 });
 
 test('mergeNodeOptions preserves an existing heap limit', () => {
@@ -124,7 +180,10 @@ test('mergeNodeOptions replaces heap limit for workspace overrides', () => {
 test('resolveSpawnEnv sets NODE_OPTIONS for lint-fix', () => {
   const env = resolveSpawnEnv(
     { id: 'lint-fix' },
-    resolveConfig({}, { publish: false, knip: false, check: false }),
+    resolveConfig(
+      {},
+      { publish: false, knip: false, check: false, plugin: undefined },
+    ),
     {},
   );
   assert.equal(env.NODE_OPTIONS, DEFAULT_NODE_OPTIONS);
@@ -176,7 +235,7 @@ test('detectTools reads workspace dependencies', () => {
 test('buildSteps keeps documented order and default knip off', () => {
   const steps = buildSteps({
     tools: ALL_TOOLS,
-    config: { check: false, publish: false, knip: false },
+    config: { check: false, publish: false, knip: false, plugin: null },
   });
   assert.deepEqual(
     steps.map(step => step.id),
@@ -188,6 +247,34 @@ test('buildSteps keeps documented order and default knip off', () => {
 
   const repoFix = steps.find(step => step.id === 'repo-fix');
   assert.deepEqual(repoFix.args, ['backstage-cli', 'repo', 'fix']);
+});
+
+test('buildSteps scopes lint and prettier when --plugin is set', () => {
+  const plugin = {
+    name: 'global-header',
+    relativePath: 'plugins/global-header',
+  };
+  const steps = buildSteps({
+    tools: ALL_TOOLS,
+    config: { check: false, publish: false, knip: false, plugin },
+    cwd: '/tmp/workspace',
+  });
+  assert.deepEqual(steps.find(step => step.id === 'lint-fix').args, [
+    'backstage-cli',
+    'package',
+    'lint',
+    '--fix',
+    'plugins/global-header',
+  ]);
+  assert.deepEqual(steps.find(step => step.id === 'prettier').args, [
+    'prettier',
+    '--write',
+    'plugins/global-header',
+  ]);
+  assert.equal(
+    steps.find(step => step.id === 'sort-package-json').available,
+    false,
+  );
 });
 
 test('buildSteps passes --publish to repo fix and enables knip when opted in', () => {
@@ -207,7 +294,7 @@ test('buildSteps passes --publish to repo fix and enables knip when opted in', (
 test('buildSteps in check mode only runs repo fix with --check', () => {
   const steps = buildSteps({
     tools: ALL_TOOLS,
-    config: { check: true, publish: true, knip: true },
+    config: { check: true, publish: true, knip: true, plugin: null },
   });
   assert.deepEqual(
     steps.map(step => step.id),
@@ -227,7 +314,7 @@ test('runPipeline in check mode only runs repo fix', async () => {
   await runPipeline(
     buildSteps({
       tools: ALL_TOOLS,
-      config: { check: true, publish: false, knip: true },
+      config: { check: true, publish: false, knip: true, plugin: null },
     }),
     {
       log: () => {},
@@ -249,7 +336,7 @@ test('optional fixers are skipped when their packages are not installed', () => 
       markdownlint: undefined,
       knip: false,
     },
-    config: { check: false, publish: false, knip: false },
+    config: { check: false, publish: false, knip: false, plugin: null },
   });
   assert.equal(
     steps.find(step => step.id === 'sort-package-json').available,
@@ -271,7 +358,7 @@ test('runPipeline skips optional missing fixers and still succeeds', async () =>
         markdownlint: undefined,
         knip: true,
       },
-      config: { check: false, publish: false, knip: false },
+      config: { check: false, publish: false, knip: false, plugin: null },
     }),
     {
       log: msg => logs.push(msg),
@@ -292,7 +379,7 @@ test('runPipeline exits non-zero when a fixer fails', async () => {
       runPipeline(
         buildSteps({
           tools: ALL_TOOLS,
-          config: { check: false, publish: false, knip: false },
+          config: { check: false, publish: false, knip: false, plugin: null },
         }),
         {
           log: () => {},
@@ -315,7 +402,7 @@ test('runPipeline fails when a required fixer is missing', async () => {
             markdownlint: undefined,
             knip: false,
           },
-          config: { check: false, publish: false, knip: false },
+          config: { check: false, publish: false, knip: false, plugin: null },
         }),
         { log: () => {}, run: async () => 0 },
       ),
@@ -339,7 +426,11 @@ test('runPipeline succeeds when fixers report changes as success', async () => {
   await runPipeline(
     buildSteps({
       tools: detectTools(pkg),
-      config: resolveConfig(pkg, { publish: false, knip: false, check: false }),
+      config: resolveConfig(
+        pkg,
+        { publish: false, knip: false, check: false, plugin: undefined },
+        cwd,
+      ),
     }),
     {
       log: () => {},

--- a/workspaces/adoption-insights/package.json
+++ b/workspaces/adoption-insights/package.json
@@ -25,7 +25,7 @@
     "test:e2e:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:all": "yarn test:e2e:legacy && yarn test:e2e:nfs",
     "playwright": "bash -c 'if [[ $@ == test ]]; then yarn test:e2e:all; else npx playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/ai-integrations/package.json
+++ b/workspaces/ai-integrations/package.json
@@ -20,7 +20,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/app-defaults/package.json
+++ b/workspaces/app-defaults/package.json
@@ -19,7 +19,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:fix": "prettier --write .",

--- a/workspaces/augment/package.json
+++ b/workspaces/augment/package.json
@@ -20,7 +20,7 @@
     "test": "backstage-cli repo test",
     "test:all": "yarn prettier:check && yarn lint:all && backstage-cli repo test --coverage",
     "test:e2e": "echo Skipping until we have tests: playwright test",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/boost/package.json
+++ b/workspaces/boost/package.json
@@ -17,7 +17,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "yarn prettier:check && yarn lint:all && backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/bulk-import/package.json
+++ b/workspaces/bulk-import/package.json
@@ -17,7 +17,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/cost-management/package.json
+++ b/workspaces/cost-management/package.json
@@ -20,7 +20,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/dcm/package.json
+++ b/workspaces/dcm/package.json
@@ -21,7 +21,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/extensions/package.json
+++ b/workspaces/extensions/package.json
@@ -24,7 +24,7 @@
     "test:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:ci": "yarn test:legacy && yarn test:nfs",
     "playwright": "sh -c 'if [ \"$1\" = test ] && [ $# -eq 1 ]; then yarn test:e2e:ci; else exec playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/global-header/.eslintignore
+++ b/workspaces/global-header/.eslintignore
@@ -1,2 +1,6 @@
 playwright.config.ts
 e2e-tests/
+dist-dynamic
+dist-scalprum
+!.eslintrc.js
+!.prettierrc.js

--- a/workspaces/global-header/.gitignore
+++ b/workspaces/global-header/.gitignore
@@ -33,6 +33,7 @@ node_modules/
 
 # Build output
 dist
+dist-dynamic
 dist-scalprum
 dist-types
 

--- a/workspaces/global-header/package.json
+++ b/workspaces/global-header/package.json
@@ -25,7 +25,7 @@
     "test:e2e:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:all": "yarn test:e2e:legacy && yarn test:e2e:nfs",
     "playwright": "bash -c 'if [[ $@ == test ]]; then yarn test:e2e:legacy; else npx playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/global-header/plugins/global-header/.eslintignore
+++ b/workspaces/global-header/plugins/global-header/.eslintignore
@@ -1,4 +1,3 @@
-playwright.config.ts
 dist-dynamic
 dist-scalprum
 !.eslintrc.js

--- a/workspaces/global-header/plugins/global-header/.prettierignore
+++ b/workspaces/global-header/plugins/global-header/.prettierignore
@@ -4,4 +4,5 @@ dist-scalprum
 dist-types
 coverage
 .vscode
-.eslintrc.js
+!.eslintrc.js
+!.prettierrc.js

--- a/workspaces/homepage/package.json
+++ b/workspaces/homepage/package.json
@@ -20,7 +20,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "test:e2e": "yarn test:e2e:all",

--- a/workspaces/install-dynamic-plugins/package.json
+++ b/workspaces/install-dynamic-plugins/package.json
@@ -20,7 +20,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/intelligent-assistant/package.json
+++ b/workspaces/intelligent-assistant/package.json
@@ -25,7 +25,7 @@
     "test:e2e:all": "yarn test:e2e:legacy && yarn test:e2e:nfs",
     "test:e2e:ci": "yarn test:e2e:all",
     "playwright": "bash -c 'if [[ $@ == test ]]; then yarn test:e2e:all; else npx playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "lint:check": "backstage-cli package lint",

--- a/workspaces/konflux/package.json
+++ b/workspaces/konflux/package.json
@@ -18,7 +18,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/mcp-integrations/package.json
+++ b/workspaces/mcp-integrations/package.json
@@ -21,7 +21,7 @@
     "test:all": "backstage-cli repo test --coverage",
     "test:unit": "backstage-cli repo test --testPathIgnorePatterns=integration\\.test",
     "test:integration": "backstage-cli repo test --testPathPatterns=integration\\.test --watch=false",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/orchestrator/.prettierignore
+++ b/workspaces/orchestrator/.prettierignore
@@ -1,4 +1,6 @@
 dist
+dist-dynamic
+dist-scalprum
 dist-types
 coverage
 .vscode

--- a/workspaces/orchestrator/package.json
+++ b/workspaces/orchestrator/package.json
@@ -23,7 +23,7 @@
     "test:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:ci": "yarn test:legacy && yarn test:nfs",
     "playwright": "sh -c 'if [ \"$1\" = test ] && [ $# -eq 1 ]; then yarn test:e2e:ci; else exec playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/quickstart/package.json
+++ b/workspaces/quickstart/package.json
@@ -16,7 +16,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/repo-tools/package.json
+++ b/workspaces/repo-tools/package.json
@@ -17,7 +17,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/.prettierignore
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/.prettierignore
@@ -1,4 +1,6 @@
 dist
+dist-dynamic
+dist-scalprum
 dist-types
 coverage
 .vscode

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -16,7 +16,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/scorecard/package.json
+++ b/workspaces/scorecard/package.json
@@ -25,7 +25,7 @@
     "test:e2e:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:all": "yarn test:e2e:legacy && yarn test:e2e:nfs",
     "playwright": "bash -c 'if [[ \"$*\" == \"test\" ]]; then yarn test:e2e:all; else npx playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/theme/.changeset/fix-theme-error-toggle-contrast.md
+++ b/workspaces/theme/.changeset/fix-theme-error-toggle-contrast.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Fix WCAG AA color contrast for error buttons and theme toggle labels in light and dark modes.

--- a/workspaces/theme/package.json
+++ b/workspaces/theme/package.json
@@ -24,7 +24,7 @@
     "test:nfs": "APP_MODE=nfs playwright test packages/app/e2e-tests",
     "test:e2e:ci": "yarn test:legacy && yarn test:nfs",
     "playwright": "sh -c 'if [ \"$1\" = test ] && [ $# -eq 1 ]; then yarn test:e2e:ci; else exec playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/theme/plugins/theme/src/darkTheme.ts
+++ b/workspaces/theme/plugins/theme/src/darkTheme.ts
@@ -42,6 +42,10 @@ export const darkThemeOverrides: Partial<ThemeConfigPalette> = {
     primary: '#ffffff',
     secondary: '#c7c7c7',
   },
+  // MUI default #f44336 fails WCAG AA on #292929 paper (~3.95:1)
+  error: {
+    main: '#FF5252',
+  },
   background: {
     default: '#292929',
     paper: '#292929',

--- a/workspaces/theme/plugins/theme/src/lightTheme.ts
+++ b/workspaces/theme/plugins/theme/src/lightTheme.ts
@@ -43,12 +43,15 @@ export const lightThemeOverrides: Partial<ThemeConfigPalette> = {
     // PatternFly --pf-v5-global--Color--200; AA on white and #f2f2f2 nav chrome
     secondary: '#6A6E73',
   },
-  // MUI defaults (#0288d1 / #ed6c02) fail WCAG AA on white (~3.1–3.9:1)
+  // MUI defaults (#0288d1 / #ed6c02 / #f44336) fail WCAG AA on white (~3.1–3.9:1)
   info: {
     main: '#0066CC',
   },
   warning: {
     main: '#C05600',
+  },
+  error: {
+    main: '#E22134',
   },
   background: {
     default: '#FFFFFF',

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -277,6 +277,17 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
             backgroundColor: 'transparent',
           },
         },
+        containedError: ({ theme }) =>
+          theme.palette.mode === 'dark'
+            ? {
+                // error.main is light for dark outlined/text; contained needs darker red
+                backgroundColor: '#E22134',
+                color: '#ffffff',
+                '&:hover': {
+                  backgroundColor: '#CA001B',
+                },
+              }
+            : {},
         text: {
           '&:focus-visible': {
             boxShadow: `inset 0 0 0 2px ${rhdhPrimary.main}`,
@@ -287,9 +298,11 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
     };
     components.MuiToggleButton = {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           textTransform: 'none',
-        },
+          // MUI default unselected label (#9e9e9e) fails AA on white (~2.67:1)
+          color: theme.palette.text.secondary,
+        }),
       },
     };
     components.MuiIconButton = {

--- a/workspaces/translations/package.json
+++ b/workspaces/translations/package.json
@@ -25,7 +25,7 @@
     "test:e2e:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:all": "yarn test:e2e:legacy && yarn test:e2e:nfs",
     "playwright": "bash -c 'if [[ \"$*\" == \"test\" ]]; then yarn test:e2e:all; else npx playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",

--- a/workspaces/x2a/package.json
+++ b/workspaces/x2a/package.json
@@ -26,7 +26,7 @@
     "test:e2e:nfs": "APP_MODE=nfs playwright test",
     "test:e2e:all": "yarn test:e2e:nfs",
     "playwright": "bash -c 'if [[ $1 == test ]]; then echo \"Skipping test:e2e:all e2e tests (no real tests yet)\"; else npx playwright \"$@\"; fi' _",
-    "fix": "backstage-cli repo fix --publish",
+    "fix": "node ../../scripts/workspace-fix.mjs",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
@@ -84,6 +84,9 @@
     "@backstage/plugin-user-settings": "0.9.1",
     "zod@^3.25.76 || ^4.0.0": "3.25.76",
     "zod@^3.25 || ^4.0": "3.25.76"
+  },
+  "rhdhFix": {
+    "publish": true
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {


### PR DESCRIPTION
## Summary

- Add `scripts/workspace-fix.mjs`, a shared fix pipeline invoked by `yarn fix` from each workspace root
- Wire all workspaces to the shared script; document fixer order in `CONTRIBUTING.md`
- Support `yarn fix --check` for CI (runs `backstage-cli repo fix --check` only)
- Set `NODE_OPTIONS=--max-old-space-size=8192` for memory-heavy fixers, matching CI
- Exclude `dist-dynamic` / `dist-scalprum` from global-header lint/format passes to avoid OOM on generated bundles
- Update the repo-tools workspace template so new workspaces get the same setup

## Fixed

- [RHIDP-14035](https://redhat.atlassian.net/browse/RHIDP-14035) — Implement unified `yarn fix` command at repo root

**Story:** Create a single `yarn fix` script that auto-corrects fixable lint, format, and code issues with a deterministic fixer order and central extensibility.

**Implementation notes:** CI runs `yarn fix` per changed workspace (not from the monorepo root), so the shared logic lives in `scripts/workspace-fix.mjs` and each workspace's `fix` script delegates to it. Optional fixers (`sort-package-json`, `markdownlint`, `knip`) are skipped when not installed; `knip --fix` remains opt-in via `rhdhFix.knip` or `--knip`.

Fixes: https://redhat.atlassian.net/browse/RHIDP-14035

## Test plan

- [x] `yarn test:workspace-fix` (20 unit tests)
- [x] `yarn fix --check` in `workspaces/global-header`
- [x] `yarn fix` in `workspaces/global-header` (lint no longer traverses `dist-dynamic`)
- [ ] CI `yarn fix --check` step on changed workspaces


Made with [Cursor](https://cursor.com)