### PR TITLE
[release-1.10] chore(orchestrator): upgrade fast-uri in orchestrator to >= 3.1.6

### DIFF
--- a/workspaces/orchestrator/yarn.lock
+++ b/workspaces/orchestrator/yarn.lock
@@ -24461,9 +24461,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.3
-  resolution: "fast-uri@npm:3.1.3"
-  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes multiple fast-uri security vulnerabilities in orchestrator by upgrading to version 3.1.7, which patches all six CVEs affecting the package.

**Fast-URI Vulnerabilities Fixed:**
- **CVE-2026-76172** (GHSA-jqff-g426-hqxp): Host confusion via percent-encoded scheme normalization
- **CVE-2026-75899** (GHSA-fph4-wmhf-6fwf): Server-Side Request Forgery via repeated hostname percent-decoding  
- **CVE-2026-6322** (GHSA-v39h-62p7-jpjc): Host confusion via percent-encoded authority delimiters
- **CVE-2026-75931** (GHSA-5jgf-p345-68v8): Host confusion via skipped IDN canonicalization
- **CVE-2026-84394**: Host confusion via unbalanced URI brackets can bypass security policies
- **CVE-2026-84292**: Authority Injection via Unvalidated Port Serialization

**Version:** fast-uri 3.1.3 → 3.1.7

Fixed with simple `yarn up -R fast-uri`.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)