### PR TITLE
[release-1.10] chore(lightspeed): upgrade fast-uri in lightspeed to >= 3.1.7

### DIFF
--- a/workspaces/lightspeed/yarn.lock
+++ b/workspaces/lightspeed/yarn.lock
@@ -21399,9 +21399,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fast-uri in lightspeed is vulnerable due to CVE-2026-84394, CVE-2026-84292, CVE-2026-76172, CVE-2026-75975, CVE-2026-75931, CVE-2026-75899, CVE-2026-6322. Fix by upgrading to versions >= 3.1.7.

Fixed with simple `yarn up -R fast-uri`

## Which issue(s) does this PR fix

- Fixes [RHIDP-16772](https://redhat.atlassian.net/browse/RHIDP-16772)
- Fixes [RHIDP-16764](https://redhat.atlassian.net/browse/RHIDP-16764)
- Fixes [RHIDP-16641](https://redhat.atlassian.net/browse/RHIDP-16641)
- Fixes [RHIDP-16632](https://redhat.atlassian.net/browse/RHIDP-16632)
- Fixes [RHIDP-16622](https://redhat.atlassian.net/browse/RHIDP-16622)
- Fixes [RHIDP-16595](https://redhat.atlassian.net/browse/RHIDP-16595)

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
