### PR TITLE
chore: bump fullsend from v0.37.0 to v0.41.0

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -51,7 +51,7 @@ jobs:
       issues: write
       packages: read
       pull-requests: write
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@84c8bbbb821ff85136854150b06740253709b3b8 # v0.37.0
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@094191b0151e3261d65ce2b032a4586654eb44ab # v0.41.0
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo

--- a/.github/workflows/prioritize.yml
+++ b/.github/workflows/prioritize.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   prioritize:
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-prioritize.yml@84c8bbbb821ff85136854150b06740253709b3b8 # v0.37.0
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-prioritize.yml@094191b0151e3261d65ce2b032a4586654eb44ab # v0.41.0
     with:
       event_type: ${{ inputs.event_type }}
       source_repo: ${{ inputs.source_repo }}


### PR DESCRIPTION
## Summary
- Bump `reusable-dispatch.yml` and `reusable-prioritize.yml` from **v0.37.0** (`84c8bbb`) to **v0.41.0** (`094191b`).
- Shim template is already current; `.fullsend/config.yaml` is unchanged (code/fix/review/grillme stay registered).
- Unblocks ci-diagnose → fix: v0.38+ matches the shared `fullsend-ai-review[bot]` identity (`SHARED_REVIEW_BOT`). Same reason as overlays #3554, rolled to latest 0.41.0 instead of stopping at 0.40.0.

Companion fleet manifest: https://github.com/redhat-developer/rhdh-fullsend/pull/47

Release: https://github.com/fullsend-ai/fullsend/releases/tag/v0.41.0

## Test plan
- [ ] Workflow files render; pin is `@094191b # v0.41.0`
- [ ] Existing agents (`/fs-code`, `/fs-fix`, `/fs-grillme`, triage, review) still dispatch
- [ ] Mint URL repo variable stays `https://fullsend-mint-gljhbkcloq-uc.a.run.app`
- [ ] After merge: smoke-test `/fs-grillme` on an open PR

Made with [Cursor](https://cursor.com)