### PR TITLE
chore(scorecard): add startTestBackend module tests for all 9 backend modules

### DIFF
--- a/workspaces/scorecard/plugins/scorecard-backend-module-catalog/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-catalog/package.json
@@ -46,7 +46,11 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
     "@backstage/cli": "^0.36.3",
-    "@backstage/config": "^1.3.8"
+    "@backstage/config": "^1.3.8",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "config.d.ts",

--- a/workspaces/scorecard/plugins/scorecard-backend-module-catalog/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-catalog/src/module.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleCatalog } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-catalog', () => {
+  describe('without catalog config', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      ({ server } = await startTestBackend({
+        features: [
+          scorecardPlugin,
+          scorecardModuleCatalog,
+          mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+          mockServices.auth.factory(),
+          mockServices.httpAuth.factory(),
+          catalogServiceMock.factory({ entities: [] }),
+        ],
+      }));
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+
+    it('starts the backend without errors when no catalog config is provided', async () => {
+      const res = await request(server).get('/api/scorecard/metrics');
+      expect(res.status).toBe(200);
+      expect(res.body.metrics).toHaveLength(0);
+    });
+  });
+
+  describe('with catalog required-attributes config', () => {
+    let server: Server;
+
+    const CONFIG_WITH_CATALOG = {
+      ...BASE_CONFIG,
+      scorecard: {
+        metricProviders: {
+          catalog: {
+            requiredAttributes: {
+              options: {
+                filter: { kind: 'Component' },
+                metrics: {
+                  hasOwner: {
+                    title: 'Has Owner',
+                    description: 'Entity has an owner set',
+                    field: 'spec.owner',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      ({ server } = await startTestBackend({
+        features: [
+          scorecardPlugin,
+          scorecardModuleCatalog,
+          mockServices.rootConfig.factory({ data: CONFIG_WITH_CATALOG }),
+          mockServices.auth.factory(),
+          mockServices.httpAuth.factory(),
+          catalogServiceMock.factory({ entities: [] }),
+        ],
+      }));
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+
+    it('registers the catalog metric provider', async () => {
+      const res = await request(server).get('/api/scorecard/metrics');
+
+      expect(res.status).toBe(200);
+      expect(res.body.metrics.length).toBeGreaterThanOrEqual(1);
+
+      const ids = res.body.metrics.map((m: { id: string }) => m.id);
+      expect(ids).toContain('catalog.hasOwner');
+    });
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-code-coverage/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-code-coverage/package.json
@@ -37,8 +37,12 @@
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
   },
   "devDependencies": {
-    "@backstage/backend-test-utils": "^1.11.1",
-    "@backstage/cli": "^0.36.0"
+    "@backstage/backend-test-utils": "^1.11.4",
+    "@backstage/cli": "^0.36.3",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "dist"

--- a/workspaces/scorecard/plugins/scorecard-backend-module-code-coverage/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-code-coverage/src/module.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleCodeCoverage } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-code-coverage', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardModuleCodeCoverage,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the code-coverage module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers the code-coverage metric providers', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+
+    expect(res.status).toBe(200);
+    const ids = res.body.metrics.map((m: { id: string }) => m.id);
+    expect(ids).toHaveLength(8);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'codeCoverage.linePercentage',
+        'codeCoverage.lineCovered',
+        'codeCoverage.branchPercentage',
+        'codeCoverage.branchCovered',
+      ]),
+    );
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dependabot/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dependabot/package.json
@@ -41,7 +41,11 @@
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
-    "@backstage/cli": "^0.36.3"
+    "@backstage/cli": "^0.36.3",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "dist"

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dependabot/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dependabot/src/module.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleDependabot } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-dependabot', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardModuleDependabot,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the dependabot module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers all 4 dependabot metric providers', async () => {
+    const res = await request(server).get(
+      '/api/scorecard/metrics?datasource=dependabot',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics).toHaveLength(4);
+
+    const ids = res.body.metrics.map((m: { id: string }) => m.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'dependabot.alertsCritical',
+        'dependabot.alertsHigh',
+        'dependabot.alertsMedium',
+        'dependabot.alertsLow',
+      ]),
+    );
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/package.json
@@ -49,8 +49,11 @@
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
-    "@backstage/catalog-model": "^1.9.0",
-    "@backstage/cli": "^0.36.3"
+    "@backstage/cli": "^0.36.3",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "config.d.ts",

--- a/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-dora/src/module.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleDora } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-dora', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardModuleDora,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the dora module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers all 4 DORA metric providers', async () => {
+    const res = await request(server).get(
+      '/api/scorecard/metrics?datasource=dora',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics).toHaveLength(4);
+
+    const ids = res.body.metrics.map((m: { id: string }) => m.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'dora.deploymentFrequency',
+        'dora.medianLeadTimeForChanges',
+        'dora.meanTimeToRestore',
+        'dora.changeFailureRate',
+      ]),
+    );
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/package.json
@@ -49,7 +49,10 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
     "@backstage/cli": "^0.36.3",
-    "@backstage/config": "^1.3.8"
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "config.d.ts",

--- a/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-filecheck/src/module.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleFilecheck } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-filecheck', () => {
+  describe('without filecheck config', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      ({ server } = await startTestBackend({
+        features: [
+          scorecardPlugin,
+          scorecardModuleFilecheck,
+          mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+          mockServices.auth.factory(),
+          mockServices.httpAuth.factory(),
+          catalogServiceMock.factory({ entities: [] }),
+        ],
+      }));
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+
+    it('starts the backend without errors when no filecheck config is provided', async () => {
+      const res = await request(server).get('/api/scorecard/metrics');
+      expect(res.status).toBe(200);
+      expect(res.body.metrics).toHaveLength(0);
+    });
+  });
+
+  describe('with filecheck config', () => {
+    let server: Server;
+
+    const CONFIG_WITH_FILECHECK = {
+      ...BASE_CONFIG,
+      scorecard: {
+        metricProviders: {
+          filecheck: {
+            fileExistence: {
+              options: {
+                files: {
+                  license: 'LICENSE',
+                  readme: 'README.md',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      ({ server } = await startTestBackend({
+        features: [
+          scorecardPlugin,
+          scorecardModuleFilecheck,
+          mockServices.rootConfig.factory({ data: CONFIG_WITH_FILECHECK }),
+          mockServices.auth.factory(),
+          mockServices.httpAuth.factory(),
+          catalogServiceMock.factory({ entities: [] }),
+        ],
+      }));
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+
+    it('registers the filecheck metric providers from config', async () => {
+      const res = await request(server).get('/api/scorecard/metrics');
+
+      expect(res.status).toBe(200);
+      expect(res.body.metrics.length).toBeGreaterThanOrEqual(2);
+
+      const ids = res.body.metrics.map((m: { id: string }) => m.id);
+      expect(ids).toContain('filecheck.license');
+      expect(ids).toContain('filecheck.readme');
+    });
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/package.json
@@ -52,7 +52,11 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
     "@backstage/cli": "^0.36.3",
-    "@backstage/config": "^1.3.8"
+    "@backstage/config": "^1.3.8",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "config.d.ts",

--- a/workspaces/scorecard/plugins/scorecard-backend-module-github/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-github/src/module.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleGithub } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-github', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardModuleGithub,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the github module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers the github.openPRs metric provider', async () => {
+    const res = await request(server).get(
+      '/api/scorecard/metrics?datasource=github',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics).toHaveLength(1);
+    expect(res.body.metrics[0].id).toBe('github.openPRs');
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-jira/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-jira/package.json
@@ -49,8 +49,10 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
     "@backstage/cli": "^0.36.3",
-    "@backstage/config": "^1.3.8",
-    "@backstage/types": "^1.2.2"
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "config.d.ts",

--- a/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-jira/src/module.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleJira } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+  jira: {
+    baseUrl: 'https://jira.example.com',
+    token: 'dummy-token',
+    product: 'cloud',
+  },
+};
+
+describe('scorecard-backend-module-jira', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardModuleJira,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the jira module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers the jira.openIssues metric provider', async () => {
+    const res = await request(server).get(
+      '/api/scorecard/metrics?datasource=jira',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics).toHaveLength(1);
+    expect(res.body.metrics[0].id).toBe('jira.openIssues');
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-openssf/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-openssf/package.json
@@ -38,7 +38,11 @@
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
-    "@backstage/cli": "^0.36.3"
+    "@backstage/cli": "^0.36.3",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "dist"

--- a/workspaces/scorecard/plugins/scorecard-backend-module-openssf/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-openssf/src/module.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardOpenSFFModule } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-openssf', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardOpenSFFModule,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the openssf module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers all 18 OpenSSF metric providers', async () => {
+    const res = await request(server).get(
+      '/api/scorecard/metrics?datasource=openssf',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics).toHaveLength(18);
+  });
+});

--- a/workspaces/scorecard/plugins/scorecard-backend-module-sonarqube/package.json
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-sonarqube/package.json
@@ -39,7 +39,11 @@
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.4",
-    "@backstage/cli": "^0.36.3"
+    "@backstage/cli": "^0.36.3",
+    "@backstage/plugin-catalog-node": "^2.2.2",
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "configSchema": "config.d.ts",
   "files": [

--- a/workspaces/scorecard/plugins/scorecard-backend-module-sonarqube/src/module.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend-module-sonarqube/src/module.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import scorecardPlugin from '@red-hat-developer-hub/backstage-plugin-scorecard-backend';
+import { scorecardModuleSonarqube } from './module';
+import request from 'supertest';
+import type { Server } from 'http';
+
+const BASE_CONFIG = {
+  backend: {
+    database: { client: 'better-sqlite3', connection: ':memory:' },
+  },
+};
+
+describe('scorecard-backend-module-sonarqube', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    ({ server } = await startTestBackend({
+      features: [
+        scorecardPlugin,
+        scorecardModuleSonarqube,
+        mockServices.rootConfig.factory({ data: BASE_CONFIG }),
+        mockServices.auth.factory(),
+        mockServices.httpAuth.factory(),
+        catalogServiceMock.factory({ entities: [] }),
+      ],
+    }));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('starts the backend with the sonarqube module without errors', async () => {
+    const res = await request(server).get('/api/scorecard/metrics');
+    expect(res.status).toBe(200);
+  });
+
+  it('registers all 12 sonarqube metric providers', async () => {
+    const res = await request(server).get(
+      '/api/scorecard/metrics?datasource=sonarqube',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.metrics).toHaveLength(12);
+
+    const ids = res.body.metrics.map((m: { id: string }) => m.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'sonarqube.qualityGate',
+        'sonarqube.openIssues',
+        'sonarqube.securityRating',
+        'sonarqube.reliabilityRating',
+        'sonarqube.maintainabilityRating',
+        'sonarqube.codeCoverage',
+      ]),
+    );
+  });
+});

--- a/workspaces/scorecard/yarn.lock
+++ b/workspaces/scorecard/yarn.lock
@@ -1762,7 +1762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-test-utils@npm:^1.11.1, @backstage/backend-test-utils@npm:^1.11.4":
+"@backstage/backend-test-utils@npm:^1.11.4":
   version: 1.11.5
   resolution: "@backstage/backend-test-utils@npm:1.11.5"
   dependencies:
@@ -2210,7 +2210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.36.0, @backstage/cli@npm:^0.36.3":
+"@backstage/cli@npm:^0.36.3":
   version: 0.36.4
   resolution: "@backstage/cli@npm:0.36.4"
   dependencies:
@@ -9657,8 +9657,12 @@ __metadata:
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.3"
     "@backstage/config": "npm:^1.3.8"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 
@@ -9667,12 +9671,16 @@ __metadata:
   resolution: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-code-coverage@workspace:plugins/scorecard-backend-module-code-coverage"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.8.0"
-    "@backstage/backend-test-utils": "npm:^1.11.1"
+    "@backstage/backend-test-utils": "npm:^1.11.4"
     "@backstage/catalog-client": "npm:^1.14.0"
     "@backstage/catalog-model": "npm:^1.7.7"
-    "@backstage/cli": "npm:^0.36.0"
+    "@backstage/cli": "npm:^0.36.3"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 
@@ -9687,9 +9695,13 @@ __metadata:
     "@backstage/cli": "npm:^0.36.3"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/integration": "npm:^2.0.3"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
     "@octokit/rest": "npm:^19.0.3"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 
@@ -9703,9 +9715,13 @@ __metadata:
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.3"
     "@backstage/config": "npm:^1.3.8"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
     "@backstage/types": "npm:^1.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
@@ -9719,11 +9735,14 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.16.0"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.3"
-    "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/integration": "npm:^2.0.3"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 
@@ -9741,8 +9760,11 @@ __metadata:
     "@backstage/plugin-catalog-node": "npm:^2.2.2"
     "@octokit/graphql": "npm:^9.0.1"
     "@octokit/rest": "npm:^20.1.1"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
@@ -9756,11 +9778,12 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.16.0"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.3"
-    "@backstage/config": "npm:^1.3.8"
     "@backstage/plugin-catalog-node": "npm:^2.2.2"
-    "@backstage/types": "npm:^1.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
@@ -9774,8 +9797,12 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.16.0"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.3"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 
@@ -9789,8 +9816,12 @@ __metadata:
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.3"
     "@backstage/config": "npm:^1.3.8"
+    "@backstage/plugin-catalog-node": "npm:^2.2.2"
+    "@red-hat-developer-hub/backstage-plugin-scorecard-backend": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-common": "workspace:^"
     "@red-hat-developer-hub/backstage-plugin-scorecard-node": "workspace:^"
+    "@types/supertest": "npm:^2.0.12"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

[RHIDP-15181](https://redhat.atlassian.net/browse/RHIDP-15181)

Adds `startTestBackend` integration tests for all 9 scorecard backend modules. Each test verifies
that the module registers its metric providers (and collectors, where applicable) with the scorecard
plugin at runtime without errors.

Follow-up to the scorecard backend POC in [#3414](https://github.com/redhat-developer/rhdh-plugins/pull/3414)

### What's included

- **9 new `module.test.ts` files** - one per module, each using `startTestBackend` with `scorecardPlugin` + the module under test
- **9 updated `package.json` files** - adds `supertest`, `@types/supertest`, `@backstage/plugin-catalog-node`, and `scorecard-backend` as devDependencies
- **`yarn.lock`** updated for the new dependencies

### Modules covered

| Module | Metrics verified | Notes |
|---|---|---|
| openssf | 18 | — |
| code-coverage | 8 | — |
| dependabot | 4 | — |
| sonarqube | 12 | — |
| dora | 4 | Uses `scorecardCollectorsServiceRef` |
| github | 1 + 3 collectors | — |
| jira | 1 + 1 collector | Requires minimal `jira` config |
| catalog | config-driven | Tests with and without config |
| filecheck | config-driven | Tests with and without config |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)