### PR TITLE
test: assert ActiveTextInput clears on empty fetch RHIDP-16715

### DIFF
--- a/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.test.tsx
+++ b/workspaces/orchestrator/plugins/orchestrator-form-widgets/src/widgets/ActiveTextInput.test.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { OrchestratorFormContextProps } from '@red-hat-developer-hub/backstage-plugin-orchestrator-form-api';
 import { ActiveTextInput } from './ActiveTextInput';
 import * as utils from '../utils';
 
@@ -34,6 +36,46 @@ const mockedUseTemplateUnitEvaluator =
 const mockedUseRetriggerEvaluate = utils.useRetriggerEvaluate as jest.Mock;
 const mockedUseFetch = utils.useFetch as jest.Mock;
 const mockedUseProcessingState = utils.useProcessingState as jest.Mock;
+
+type HarnessProps = { initialValue?: string };
+
+const WidgetHarness = ({ initialValue = '' }: HarnessProps) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <ActiveTextInput
+      id="ati"
+      name="ati"
+      label="ATI"
+      required={false}
+      readonly={false}
+      disabled={false}
+      autofocus={false}
+      schema={{ type: 'string' }}
+      uiSchema={{}}
+      options={{
+        props: {
+          'fetch:response:value': 'observers',
+          'fetch:retrigger': ['current.step.xParams.platformProfileID'],
+          'fetch:clearOnRetrigger': true,
+        },
+      }}
+      value={value}
+      onChange={changed => setValue(changed as string)}
+      onBlur={() => {}}
+      onFocus={() => {}}
+      formContext={
+        {
+          formData: { current: { step: { xParams: {} } } },
+          getIsChangedByUser: () => false,
+          setIsChangedByUser: () => {},
+        } as unknown as OrchestratorFormContextProps
+      }
+      rawErrors={[]}
+      registry={{} as any}
+    />
+  );
+};
 
 describe('ActiveTextInput', () => {
   beforeEach(() => {
@@ -166,5 +208,22 @@ describe('ActiveTextInput', () => {
 
     expect(setIsChangedByUser).toHaveBeenCalledWith('ati', true);
     expect(onChange).toHaveBeenCalledWith('new value');
+  });
+
+  it('clears stale initial value when fetch returns an empty string', async () => {
+    mockedUseRetriggerEvaluate.mockImplementation(() => ['67890']);
+    mockedUseFetch.mockImplementation(() => ({
+      data: { observers: '' },
+      error: undefined,
+      loading: false,
+    }));
+
+    render(<WidgetHarness initialValue="group-A" />);
+
+    await waitFor(() => {
+      const input = screen.getByTestId('ati-textfield').querySelector('input');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveValue('');
+    });
   });
 });


### PR DESCRIPTION
## Description

Add an L3 regression test in `ActiveTextInput.test.tsx` that verifies the widget clears stale text when a fetch returns an empty string. This guards against [RHDHBUGS-2480](https://redhat.atlassian.net/browse/RHDHBUGS-2480) returning after the product fix shipped in #2012.

The test mirrors the `WidgetHarness` / mocked `useFetch` pattern from `ActiveMultiSelect.test.tsx`, driving `data: { observers: '' }` after a non-empty initial value.

## Fixed

- [RHIDP-16715](https://redhat.atlassian.net/browse/RHIDP-16715) — [L3] ActiveTextInput clears when fetch returns an empty string (RHDHBUGS-2480)

## Test plan

- [x] `yarn workspace @red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets test ActiveTextInput.test.tsx --watchAll=false --coverage=false` — all 4 cases pass
- [x] Temporarily reverted PR #2012 guard (`fetchedValue &&`) — new test fails with stale `group-A`, existing cases still pass
- [x] No product code changes; no changeset (test-only)

Ref: https://redhat.atlassian.net/browse/RHIDP-16715

Generated-by: cursor

Made with [Cursor](https://cursor.com)