### PR TITLE
fix(x2a): run adversarial from /workspace 

### DIFF
--- a/workspaces/x2a/.changeset/quiet-readers-like.md
+++ b/workspaces/x2a/.changeset/quiet-readers-like.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-x2a-backend': patch
+---
+
+run adversarial phase from /workspace to avoid permission denied

--- a/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
+++ b/workspaces/x2a/plugins/x2a-backend/templates/x2a-job-script.sh
@@ -693,20 +693,19 @@ case "${PHASE}" in
     REPORT_MD="${OUTPUT_DIR}/adversarial-report-${ACTUAL_PHASE}.md"
     REPORT_JSON_DEST="${OUTPUT_DIR}/adversarial-report-${ACTUAL_PHASE}.json"
 
-    cd /app
-    # Telemetry lands in /app (Python CWD) — outside the target git repo.
-    # Set SOURCE_BASE before run_x2a so cleanup picks up telemetry even on failure.
-    SOURCE_BASE="/app"
+    # Run from /workspace (writable) so telemetry lands there, not in read-only /app.
+    SOURCE_BASE="/workspace"
+    cd "${SOURCE_BASE}"
 
-    run_x2a uv run app.py adversarial-run \
+    run_x2a uv run --project /app /app/app.py adversarial-run \
       --phase "${ACTUAL_PHASE}" \
       --source-dir "${SOURCE_DIR}" \
       --config "${AGENTS_CONFIG}" \
       --report-path "${REPORT_MD}"
 
-    if [[ -f "/app/agent-adversarial-report.json" ]]; then
-      cp "/app/agent-adversarial-report.json" "${REPORT_JSON_DEST}"
-      ARTIFACTS+=("adversarial_report_json:$(cat /app/agent-adversarial-report.json)")
+    if [[ -f "/workspace/agent-adversarial-report.json" ]]; then
+      cp "/workspace/agent-adversarial-report.json" "${REPORT_JSON_DEST}"
+      ARTIFACTS+=("adversarial_report_json:$(cat /workspace/agent-adversarial-report.json)")
     fi
 
     echo ""


### PR DESCRIPTION
The adversarial phase was failing  with a permission denied  error when writing `.x2a-telemetry.json`. The job would complete successfully, but exit as error .

This issue only appears on RHDH. The script ran `cd /app` before invoking  the Python tool. RHDH runs pods as a random unprivileged user, and `/app` comes from the container image with no writable volume mounted over it 
 likely making it unwritable for that user. 