### PR TITLE
test(intelligent-assistant): add BYOK RAG source label e2e tests

### DIFF
--- a/workspaces/intelligent-assistant/e2e-tests/fixtures/responses.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/fixtures/responses.ts
@@ -227,42 +227,100 @@ export function notebookRagConversationChatHistoryForUploadTitle(
   ];
 }
 
+/** BYOK rag_id used in local testing guide (PR #4178). */
+export const BYOK_E2E_RAG_ID = 'my-knowledge';
+
+export const BYOK_E2E_DOC_TITLE = 'my-knowledge.md';
+
+export const BYOK_E2E_DOC_URL = 'https://example.com/my-doc';
+
+/** LCORE `referenced_documents` payload for BYOK-attributed responses. */
+export const byokReferencedDocuments = [
+  {
+    doc_title: BYOK_E2E_DOC_TITLE,
+    doc_url: BYOK_E2E_DOC_URL,
+    doc_description:
+      'Custom knowledge document used to validate BYOK source labeling.',
+    source: BYOK_E2E_RAG_ID,
+  },
+  {
+    doc_title: 'product-docs.md',
+    doc_url: 'https://example.com/product-docs',
+    doc_description: 'Secondary BYOK source for multi-source labeling.',
+    source: 'product-docs',
+  },
+];
+
+export const byokReferencedDocumentWithoutSource = [
+  {
+    doc_title: 'generic-doc.md',
+    doc_url: 'https://example.com/generic',
+    doc_description: 'Document without a LCORE source id.',
+  },
+];
+
 /** SSE `start.request_id` in {@link generateQueryResponse}. */
 const mockStreamRequestId = '0e3c4cd7-2817-4c34-91a2-6944550364df';
 
-export const generateQueryResponse = (conversationId: string) => {
-  const tokens = botResponse.match(/(\s+|[^\s]+)/g) || [];
+type QuerySseEvent = {
+  event: string;
+  data?: Record<string, unknown>;
+  done?: boolean;
+};
 
-  const events: {
-    event: string;
-    data?: Record<string, any>;
-    done?: boolean;
-  }[] = [];
-
-  events.push({
-    event: 'start',
-    data: {
-      conversation_id: conversationId,
-      request_id: mockStreamRequestId,
-    },
-  });
-
-  tokens.forEach((token, index) => {
-    events.push({
-      event: 'token',
-      data: { id: index, token, role: 'inference' },
-    });
-  });
-
-  events.push({
-    event: 'end',
-    done: true,
-  });
-
+function serializeQuerySseEvents(events: QuerySseEvent[]): string {
   return `${events
     .map(({ event, data }) => `data: ${JSON.stringify({ event, data })}\n\n`)
     .join('')}\n`;
+}
+
+function buildTokenEvents(text: string): QuerySseEvent[] {
+  const tokens = text.match(/(\s+|[^\s]+)/g) || [text];
+  return tokens.map((token, index) => ({
+    event: 'token',
+    data: { id: index, token, role: 'inference' },
+  }));
+}
+
+export const generateQueryResponse = (conversationId: string) => {
+  const events: QuerySseEvent[] = [
+    {
+      event: 'start',
+      data: {
+        conversation_id: conversationId,
+        request_id: mockStreamRequestId,
+      },
+    },
+    ...buildTokenEvents(botResponse),
+    { event: 'end', done: true },
+  ];
+
+  return serializeQuerySseEvents(events);
 };
+
+/** SSE stream ending with BYOK `referenced_documents` (LCORE `end` event). */
+export function generateQueryResponseWithReferencedDocuments(
+  conversationId: string,
+  referencedDocuments: Record<string, unknown>[] = byokReferencedDocuments,
+): string {
+  const events: QuerySseEvent[] = [
+    {
+      event: 'start',
+      data: {
+        conversation_id: conversationId,
+        request_id: mockStreamRequestId,
+      },
+    },
+    ...buildTokenEvents(botResponse),
+    {
+      event: 'end',
+      data: { referenced_documents: referencedDocuments },
+      done: true,
+    },
+  ];
+
+  return serializeQuerySseEvents(events);
+}
 
 const e2eMcpToolCallId = 'mcp_list_e2e-00000000-0000-4000-8000-000000000001';
 
@@ -270,49 +328,34 @@ const e2eMcpToolCallId = 'mcp_list_e2e-00000000-0000-4000-8000-000000000001';
 export function generateQueryResponseWithMcpToolCall(
   conversationId: string,
 ): string {
-  const events: {
-    event: string;
-    data?: Record<string, any>;
-    done?: boolean;
-  }[] = [];
-
-  events.push({
-    event: 'start',
-    data: {
-      conversation_id: conversationId,
-      request_id: mockStreamRequestId,
+  const events: QuerySseEvent[] = [
+    {
+      event: 'start',
+      data: {
+        conversation_id: conversationId,
+        request_id: mockStreamRequestId,
+      },
     },
-  });
-  events.push({
-    event: 'tool_call',
-    data: {
-      id: e2eMcpToolCallId,
-      name: 'mcp_list_tools',
-      args: { server_label: 'mcp-integration-tools' },
-      type: 'mcp_list_tools',
+    {
+      event: 'tool_call',
+      data: {
+        id: e2eMcpToolCallId,
+        name: 'mcp_list_tools',
+        args: { server_label: 'mcp-integration-tools' },
+        type: 'mcp_list_tools',
+      },
     },
-  });
-  events.push({
-    event: 'tool_result',
-    data: {
-      id: e2eMcpToolCallId,
-      status: 'success',
-      content: '{"server_label":"mcp-integration-tools","tools":[]}',
+    {
+      event: 'tool_result',
+      data: {
+        id: e2eMcpToolCallId,
+        status: 'success',
+        content: '{"server_label":"mcp-integration-tools","tools":[]}',
+      },
     },
-  });
-
-  const tokens = assistantResponse.match(/(\s+|[^\s]+)/g) || [
-    assistantResponse,
+    ...buildTokenEvents(assistantResponse),
+    { event: 'end', done: true },
   ];
-  tokens.forEach((token, index) => {
-    events.push({
-      event: 'token',
-      data: { id: index, token, role: 'inference' },
-    });
-  });
-  events.push({ event: 'end', done: true });
 
-  return `${events
-    .map(({ event, data }) => `data: ${JSON.stringify({ event, data })}\n\n`)
-    .join('')}\n`;
+  return serializeQuerySseEvents(events);
 }

--- a/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
@@ -60,7 +60,7 @@ import {
 const BYOK_MATCH_PROMPT = 'What does my custom knowledge document cover?';
 const NO_BYOK_MATCH_PROMPT = 'Tell me a generic fact with no citations';
 
-test.describe('BYOK RAG source labeling (RHIDP-14772)', () => {
+test.describe('BYOK RAG source labeling', () => {
   let sharedPage: Page;
   let translations: LightspeedMessages;
   let locale: string;

--- a/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
@@ -78,6 +78,11 @@ test.describe('BYOK RAG source labeling', () => {
   });
 
   test.beforeEach(async () => {
+    if (endMocks) {
+      await endMocks();
+      endMocks = undefined;
+    }
+
     await mockConversations(sharedPage, conversations, true);
     await mockChatHistory(sharedPage, []);
     await mockQuery(

--- a/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
@@ -63,13 +63,18 @@ const NO_BYOK_MATCH_PROMPT = 'Tell me a generic fact with no citations';
 test.describe('BYOK RAG source labeling', () => {
   let sharedPage: Page;
   let translations: LightspeedMessages;
-  let locale: string;
+  let notebooks: NotebookSurfacePage;
+  let endMocks: (() => Promise<void>) | undefined;
 
   test.beforeAll(async ({ browser }) => {
     const boot = await bootstrapLightspeedE2ePage(browser);
     sharedPage = boot.page;
     translations = boot.translations;
-    locale = boot.locale;
+    notebooks = new NotebookSurfacePage(sharedPage, translations, boot.locale);
+  });
+
+  test.afterAll(async () => {
+    await endMocks?.();
   });
 
   test.beforeEach(async () => {
@@ -130,67 +135,61 @@ test.describe('BYOK RAG source labeling', () => {
 
   test('notebook sources popover lists rag_id labels next to document titles', async ({}, testInfo) => {
     const { fileName } = localeNotebookUpload1Path(testInfo.project.name);
-    const notebooks = new NotebookSurfacePage(sharedPage, translations, locale);
-    let endMocks: (() => Promise<void>) | undefined;
 
-    try {
-      endMocks = await withNotebookTabSeededConversation(sharedPage, {
-        conversationId: 'byok-rag-label-e2e',
-        chatHistory: [
-          {
-            provider: 'vllm',
-            model: 'llama3.2:3b',
-            messages: [
-              {
-                content: `Tell me about ${fileName}`,
-                type: 'user',
-                referenced_documents: null,
-              },
-              {
-                content: `Summary from ${fileName}.`,
-                type: 'assistant',
-                referenced_documents: [
-                  {
-                    doc_title: fileName,
-                    doc_url: 'https://example.com/my-doc',
-                    source: BYOK_E2E_RAG_ID,
-                  },
-                ],
-              },
-            ],
-            started_at: '2026-05-04T12:08:13Z',
-            completed_at: '2026-05-04T12:08:26Z',
-          },
-        ],
-      });
+    endMocks = await withNotebookTabSeededConversation(sharedPage, {
+      conversationId: 'byok-rag-label-e2e',
+      chatHistory: [
+        {
+          provider: 'vllm',
+          model: 'llama3.2:3b',
+          messages: [
+            {
+              content: `Tell me about ${fileName}`,
+              type: 'user',
+              referenced_documents: null,
+            },
+            {
+              content: `Summary from ${fileName}.`,
+              type: 'assistant',
+              referenced_documents: [
+                {
+                  doc_title: fileName,
+                  doc_url: 'https://example.com/my-doc',
+                  source: BYOK_E2E_RAG_ID,
+                },
+              ],
+            },
+          ],
+          started_at: '2026-05-04T12:08:13Z',
+          completed_at: '2026-05-04T12:08:26Z',
+        },
+      ],
+    });
 
-      await notebooks.gotoFullscreenNotebooksTab();
-      await notebooks.clickPrimaryNotebookCreate();
-      await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+    await notebooks.gotoFullscreenNotebooksTab();
+    await notebooks.clickPrimaryNotebookCreate();
+    await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
 
-      const chipLabel = formatSourcesChipLabel(translations, 1);
-      await expect(
-        sharedPage.getByRole('button', { name: chipLabel }),
-      ).toBeVisible();
-      await openSourcesPopover(sharedPage, translations);
-      await expectSourcesPopoverRagLabels(sharedPage, translations, [
-        BYOK_E2E_RAG_ID,
-      ]);
-      await expect(
-        sharedPage.getByRole('dialog', {
-          name: translations['sources.modal.title'],
-        }),
-      ).toContainText(fileName);
+    const chipLabel = formatSourcesChipLabel(translations, 1);
+    await expect(
+      sharedPage.getByRole('button', { name: chipLabel }),
+    ).toBeVisible();
+    await openSourcesPopover(sharedPage, translations);
+    await expectSourcesPopoverRagLabels(sharedPage, translations, [
+      BYOK_E2E_RAG_ID,
+    ]);
+    await expect(
+      sharedPage.getByRole('dialog', {
+        name: translations['sources.modal.title'],
+      }),
+    ).toContainText(fileName);
 
-      await notebooks.clickCloseNotebookEditor();
-      const card = notebooks.newestUntitledNotebookCard();
-      await notebooks.notebookCardOverflowMenuButton(card).click();
-      await notebooks.deleteNotebookOverflowMenuItem().click();
-      await notebooks
-        .notebookDeleteConfirmationDialog(NOTEBOOK_UNTITLED_GRID_NAME)
-        .confirmDeletion();
-    } finally {
-      await endMocks?.();
-    }
+    await notebooks.clickCloseNotebookEditor();
+    const card = notebooks.newestUntitledNotebookCard();
+    await notebooks.notebookCardOverflowMenuButton(card).click();
+    await notebooks.deleteNotebookOverflowMenuItem().click();
+    await notebooks
+      .notebookDeleteConfirmationDialog(NOTEBOOK_UNTITLED_GRID_NAME)
+      .confirmDeletion();
   });
 });

--- a/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  BYOK_E2E_DOC_TITLE,
+  BYOK_E2E_DOC_URL,
+  BYOK_E2E_RAG_ID,
+  botResponse,
+  byokReferencedDocumentWithoutSource,
+  byokReferencedDocuments,
+  conversations,
+} from './fixtures/responses';
+import {
+  botMessageRegion,
+  expectInlineRagSourceLabels,
+  expectNoInlineSourceCards,
+  expectSourcesPopoverRagLabels,
+  openSourcesPopover,
+} from './pages/LightspeedPage';
+import {
+  NotebookSurfacePage,
+  NOTEBOOK_UNTITLED_GRID_NAME,
+} from './pages/NotebookSurfacePage';
+import {
+  mockChatHistory,
+  mockConversations,
+  mockQuery,
+  mockQueryWithReferencedDocuments,
+  withNotebookTabSeededConversation,
+} from './utils/devMode';
+import {
+  bootstrapLightspeedE2ePage,
+  LIGHTSPEED_E2E_DEFAULT_BOT_QUERY,
+} from './utils/lightspeedE2eSetup';
+import {
+  localeNotebookUpload1Path,
+  NOTEBOOK_EDITOR_URL_RE,
+} from './utils/notebooks';
+import { openLightspeed, sendMessage } from './utils/testHelper';
+import {
+  formatSourcesChipLabel,
+  type LightspeedMessages,
+} from './utils/translations';
+
+const BYOK_MATCH_PROMPT = 'What does my custom knowledge document cover?';
+const NO_BYOK_MATCH_PROMPT = 'Tell me a generic fact with no citations';
+
+test.describe('BYOK RAG source labeling (RHIDP-14772)', () => {
+  let sharedPage: Page;
+  let translations: LightspeedMessages;
+  let locale: string;
+
+  test.beforeAll(async ({ browser }) => {
+    const boot = await bootstrapLightspeedE2ePage(browser);
+    sharedPage = boot.page;
+    translations = boot.translations;
+    locale = boot.locale;
+  });
+
+  test.beforeEach(async () => {
+    await mockConversations(sharedPage, conversations, true);
+    await mockChatHistory(sharedPage, []);
+    await mockQuery(
+      sharedPage,
+      LIGHTSPEED_E2E_DEFAULT_BOT_QUERY,
+      conversations,
+    );
+    await openLightspeed(sharedPage);
+  });
+
+  test('attributed BYOK response shows rag_id labels on inline source cards', async () => {
+    await mockQueryWithReferencedDocuments(
+      sharedPage,
+      BYOK_MATCH_PROMPT,
+      conversations,
+      byokReferencedDocuments,
+    );
+
+    await sendMessage(BYOK_MATCH_PROMPT, sharedPage, translations);
+
+    const botMessage = botMessageRegion(sharedPage);
+    await expect(botMessage).toContainText(botResponse);
+    await expect(botMessage.getByText(BYOK_E2E_DOC_TITLE)).toBeVisible();
+    await expect(
+      botMessage.getByRole('link', { name: BYOK_E2E_DOC_TITLE }),
+    ).toHaveAttribute('href', BYOK_E2E_DOC_URL);
+    await expectInlineRagSourceLabels(sharedPage, [
+      BYOK_E2E_RAG_ID,
+      'product-docs',
+    ]);
+  });
+
+  test('response without BYOK citations renders with no source cards', async () => {
+    await sendMessage(NO_BYOK_MATCH_PROMPT, sharedPage, translations);
+
+    const botMessage = botMessageRegion(sharedPage);
+    await expect(botMessage).toContainText(botResponse);
+    await expectNoInlineSourceCards(sharedPage);
+  });
+
+  test('referenced documents without source omit rag_id labels', async () => {
+    await mockQueryWithReferencedDocuments(
+      sharedPage,
+      BYOK_MATCH_PROMPT,
+      conversations,
+      byokReferencedDocumentWithoutSource,
+    );
+
+    await sendMessage(BYOK_MATCH_PROMPT, sharedPage, translations);
+
+    const botMessage = botMessageRegion(sharedPage);
+    await expect(botMessage.getByText('generic-doc.md')).toBeVisible();
+    await expect(botMessage.getByText(BYOK_E2E_RAG_ID)).toHaveCount(0);
+  });
+
+  test('notebook sources popover lists rag_id labels next to document titles', async ({}, testInfo) => {
+    const { fileName } = localeNotebookUpload1Path(testInfo.project.name);
+    const notebooks = new NotebookSurfacePage(sharedPage, translations, locale);
+    let endMocks: (() => Promise<void>) | undefined;
+
+    try {
+      endMocks = await withNotebookTabSeededConversation(sharedPage, {
+        conversationId: 'byok-rag-label-e2e',
+        chatHistory: [
+          {
+            provider: 'vllm',
+            model: 'llama3.2:3b',
+            messages: [
+              {
+                content: `Tell me about ${fileName}`,
+                type: 'user',
+                referenced_documents: null,
+              },
+              {
+                content: `Summary from ${fileName}.`,
+                type: 'assistant',
+                referenced_documents: [
+                  {
+                    doc_title: fileName,
+                    doc_url: 'https://example.com/my-doc',
+                    source: BYOK_E2E_RAG_ID,
+                  },
+                ],
+              },
+            ],
+            started_at: '2026-05-04T12:08:13Z',
+            completed_at: '2026-05-04T12:08:26Z',
+          },
+        ],
+      });
+
+      await notebooks.gotoFullscreenNotebooksTab();
+      await notebooks.clickPrimaryNotebookCreate();
+      await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+
+      const chipLabel = formatSourcesChipLabel(translations, 1);
+      await expect(
+        sharedPage.getByRole('button', { name: chipLabel }),
+      ).toBeVisible();
+      await openSourcesPopover(sharedPage, translations);
+      await expectSourcesPopoverRagLabels(sharedPage, translations, [
+        BYOK_E2E_RAG_ID,
+      ]);
+      await expect(
+        sharedPage.getByRole('dialog', {
+          name: translations['sources.modal.title'],
+        }),
+      ).toContainText(fileName);
+
+      await notebooks.clickCloseNotebookEditor();
+      const card = notebooks.newestUntitledNotebookCard();
+      await notebooks.notebookCardOverflowMenuButton(card).click();
+      await notebooks.deleteNotebookOverflowMenuItem().click();
+      await notebooks
+        .notebookDeleteConfirmationDialog(NOTEBOOK_UNTITLED_GRID_NAME)
+        .confirmDeletion();
+    } finally {
+      await endMocks?.();
+    }
+  });
+});

--- a/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/lightspeed.byok-rag-sources.test.ts
@@ -51,7 +51,7 @@ import {
   localeNotebookUpload1Path,
   NOTEBOOK_EDITOR_URL_RE,
 } from './utils/notebooks';
-import { openLightspeed, sendMessage } from './utils/testHelper';
+import { sendMessage } from './utils/testHelper';
 import {
   formatSourcesChipLabel,
   type LightspeedMessages,
@@ -63,138 +63,142 @@ const NO_BYOK_MATCH_PROMPT = 'Tell me a generic fact with no citations';
 test.describe('BYOK RAG source labeling', () => {
   let sharedPage: Page;
   let translations: LightspeedMessages;
-  let notebooks: NotebookSurfacePage;
-  let endMocks: (() => Promise<void>) | undefined;
+  let locale: string;
 
   test.beforeAll(async ({ browser }) => {
     const boot = await bootstrapLightspeedE2ePage(browser);
     sharedPage = boot.page;
     translations = boot.translations;
-    notebooks = new NotebookSurfacePage(sharedPage, translations, boot.locale);
+    locale = boot.locale;
   });
 
-  test.afterAll(async () => {
-    await endMocks?.();
-  });
-
-  test.beforeEach(async () => {
-    if (endMocks) {
-      await endMocks();
-      endMocks = undefined;
-    }
-
-    await mockConversations(sharedPage, conversations, true);
-    await mockChatHistory(sharedPage, []);
-    await mockQuery(
-      sharedPage,
-      LIGHTSPEED_E2E_DEFAULT_BOT_QUERY,
-      conversations,
-    );
-    await openLightspeed(sharedPage);
-  });
-
-  test('attributed BYOK response shows rag_id labels on inline source cards', async () => {
-    await mockQueryWithReferencedDocuments(
-      sharedPage,
-      BYOK_MATCH_PROMPT,
-      conversations,
-      byokReferencedDocuments,
-    );
-
-    await sendMessage(BYOK_MATCH_PROMPT, sharedPage, translations);
-
-    const botMessage = botMessageRegion(sharedPage);
-    await expect(botMessage).toContainText(botResponse);
-    await expect(botMessage.getByText(BYOK_E2E_DOC_TITLE)).toBeVisible();
-    await expect(
-      botMessage.getByRole('link', { name: BYOK_E2E_DOC_TITLE }),
-    ).toHaveAttribute('href', BYOK_E2E_DOC_URL);
-    await expectInlineRagSourceLabels(sharedPage, [
-      BYOK_E2E_RAG_ID,
-      'product-docs',
-    ]);
-  });
-
-  test('response without BYOK citations renders with no source cards', async () => {
-    await sendMessage(NO_BYOK_MATCH_PROMPT, sharedPage, translations);
-
-    const botMessage = botMessageRegion(sharedPage);
-    await expect(botMessage).toContainText(botResponse);
-    await expectNoInlineSourceCards(sharedPage);
-  });
-
-  test('referenced documents without source omit rag_id labels', async () => {
-    await mockQueryWithReferencedDocuments(
-      sharedPage,
-      BYOK_MATCH_PROMPT,
-      conversations,
-      byokReferencedDocumentWithoutSource,
-    );
-
-    await sendMessage(BYOK_MATCH_PROMPT, sharedPage, translations);
-
-    const botMessage = botMessageRegion(sharedPage);
-    await expect(botMessage.getByText('generic-doc.md')).toBeVisible();
-    await expect(botMessage.getByText(BYOK_E2E_RAG_ID)).toHaveCount(0);
-  });
-
-  test('notebook sources popover lists rag_id labels next to document titles', async ({}, testInfo) => {
-    const { fileName } = localeNotebookUpload1Path(testInfo.project.name);
-
-    endMocks = await withNotebookTabSeededConversation(sharedPage, {
-      conversationId: 'byok-rag-label-e2e',
-      chatHistory: [
-        {
-          provider: 'vllm',
-          model: 'llama3.2:3b',
-          messages: [
-            {
-              content: `Tell me about ${fileName}`,
-              type: 'user',
-              referenced_documents: null,
-            },
-            {
-              content: `Summary from ${fileName}.`,
-              type: 'assistant',
-              referenced_documents: [
-                {
-                  doc_title: fileName,
-                  doc_url: 'https://example.com/my-doc',
-                  source: BYOK_E2E_RAG_ID,
-                },
-              ],
-            },
-          ],
-          started_at: '2026-05-04T12:08:13Z',
-          completed_at: '2026-05-04T12:08:26Z',
-        },
-      ],
+  test.describe('Chat', () => {
+    test.beforeEach(async () => {
+      await mockConversations(sharedPage, conversations, true);
+      await mockChatHistory(sharedPage, []);
+      await mockQuery(
+        sharedPage,
+        LIGHTSPEED_E2E_DEFAULT_BOT_QUERY,
+        conversations,
+      );
     });
 
-    await notebooks.gotoFullscreenNotebooksTab();
-    await notebooks.clickPrimaryNotebookCreate();
-    await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+    test('attributed BYOK response shows rag_id labels on inline source cards', async () => {
+      await mockQueryWithReferencedDocuments(
+        sharedPage,
+        BYOK_MATCH_PROMPT,
+        conversations,
+        byokReferencedDocuments,
+      );
 
-    const chipLabel = formatSourcesChipLabel(translations, 1);
-    await expect(
-      sharedPage.getByRole('button', { name: chipLabel }),
-    ).toBeVisible();
-    await openSourcesPopover(sharedPage, translations);
-    await expectSourcesPopoverRagLabels(sharedPage, translations, [
-      BYOK_E2E_RAG_ID,
-    ]);
-    await expect(
-      sharedPage.getByRole('dialog', {
-        name: translations['sources.modal.title'],
-      }),
-    ).toContainText(fileName);
+      await sendMessage(BYOK_MATCH_PROMPT, sharedPage, translations);
 
-    await notebooks.clickCloseNotebookEditor();
-    const card = notebooks.newestUntitledNotebookCard();
-    await notebooks.notebookCardOverflowMenuButton(card).click();
-    await notebooks.deleteNotebookOverflowMenuItem().click();
-    await notebooks
-      .notebookDeleteConfirmationDialog(NOTEBOOK_UNTITLED_GRID_NAME)
-      .confirmDeletion();
+      const botMessage = botMessageRegion(sharedPage);
+      await expect(botMessage).toContainText(botResponse);
+      await expect(botMessage.getByText(BYOK_E2E_DOC_TITLE)).toBeVisible();
+      await expect(
+        botMessage.getByRole('link', { name: BYOK_E2E_DOC_TITLE }),
+      ).toHaveAttribute('href', BYOK_E2E_DOC_URL);
+      await expectInlineRagSourceLabels(sharedPage, [
+        BYOK_E2E_RAG_ID,
+        'product-docs',
+      ]);
+    });
+
+    test('response without BYOK citations renders with no source cards', async () => {
+      await sendMessage(NO_BYOK_MATCH_PROMPT, sharedPage, translations);
+
+      const botMessage = botMessageRegion(sharedPage);
+      await expect(botMessage).toContainText(botResponse);
+      await expectNoInlineSourceCards(sharedPage);
+    });
+
+    test('referenced documents without source omit rag_id labels', async () => {
+      await mockQueryWithReferencedDocuments(
+        sharedPage,
+        BYOK_MATCH_PROMPT,
+        conversations,
+        byokReferencedDocumentWithoutSource,
+      );
+
+      await sendMessage(BYOK_MATCH_PROMPT, sharedPage, translations);
+
+      const botMessage = botMessageRegion(sharedPage);
+      await expect(botMessage.getByText('generic-doc.md')).toBeVisible();
+      await expect(botMessage.getByText(BYOK_E2E_RAG_ID)).toHaveCount(0);
+    });
+  });
+
+  test.describe('Notebook', () => {
+    let notebooks: NotebookSurfacePage;
+    let endMocks: (() => Promise<void>) | undefined;
+
+    test.beforeAll(() => {
+      notebooks = new NotebookSurfacePage(sharedPage, translations, locale);
+    });
+
+    test.afterAll(async () => {
+      await endMocks?.();
+    });
+
+    test('sources popover lists rag_id labels next to document titles', async ({}, testInfo) => {
+      const { fileName } = localeNotebookUpload1Path(testInfo.project.name);
+
+      endMocks = await withNotebookTabSeededConversation(sharedPage, {
+        conversationId: 'byok-rag-label-e2e',
+        chatHistory: [
+          {
+            provider: 'vllm',
+            model: 'llama3.2:3b',
+            messages: [
+              {
+                content: `Tell me about ${fileName}`,
+                type: 'user',
+                referenced_documents: null,
+              },
+              {
+                content: `Summary from ${fileName}.`,
+                type: 'assistant',
+                referenced_documents: [
+                  {
+                    doc_title: fileName,
+                    doc_url: 'https://example.com/my-doc',
+                    source: BYOK_E2E_RAG_ID,
+                  },
+                ],
+              },
+            ],
+            started_at: '2026-05-04T12:08:13Z',
+            completed_at: '2026-05-04T12:08:26Z',
+          },
+        ],
+      });
+
+      await notebooks.gotoFullscreenNotebooksTab();
+      await notebooks.clickPrimaryNotebookCreate();
+      await expect(sharedPage).toHaveURL(NOTEBOOK_EDITOR_URL_RE);
+
+      const chipLabel = formatSourcesChipLabel(translations, 1);
+      await expect(
+        sharedPage.getByRole('button', { name: chipLabel }),
+      ).toBeVisible();
+      await openSourcesPopover(sharedPage, translations);
+      await expectSourcesPopoverRagLabels(sharedPage, translations, [
+        BYOK_E2E_RAG_ID,
+      ]);
+      await expect(
+        sharedPage.getByRole('dialog', {
+          name: translations['sources.modal.title'],
+        }),
+      ).toContainText(fileName);
+
+      await notebooks.clickCloseNotebookEditor();
+      const card = notebooks.newestUntitledNotebookCard();
+      await notebooks.notebookCardOverflowMenuButton(card).click();
+      await notebooks.deleteNotebookOverflowMenuItem().click();
+      await notebooks
+        .notebookDeleteConfirmationDialog(NOTEBOOK_UNTITLED_GRID_NAME)
+        .confirmDeletion();
+    });
   });
 });

--- a/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
@@ -25,6 +25,7 @@ import {
   LightspeedMessages,
   evaluateMessage,
   formatMcpSelectedCount,
+  formatSourcesChipLabel,
 } from '../utils/translations';
 
 export type DisplayMode = 'Overlay' | 'Dock to window' | 'Fullscreen';
@@ -459,6 +460,63 @@ const buttonCounts: Record<DisplayMode, number> = {
   'Dock to window': 2,
   Fullscreen: 3,
 };
+
+export function botMessageRegion(page: Page): Locator {
+  return page.locator('.pf-chatbot__message--bot').last();
+}
+
+export function inlineSourceCards(page: Page): Locator {
+  return page.locator('.pf-chatbot__sources-card');
+}
+
+export async function expectInlineRagSourceLabels(
+  page: Page,
+  ragIds: string[],
+) {
+  const botMessage = botMessageRegion(page);
+  await expect(inlineSourceCards(page)).toHaveCount(1);
+
+  for (let index = 0; index < ragIds.length; index++) {
+    await expect(
+      botMessage.getByText(ragIds[index], { exact: true }),
+    ).toBeVisible();
+    if (index < ragIds.length - 1) {
+      await botMessage.getByRole('button', { name: 'Go to next page' }).click();
+    }
+  }
+}
+
+export async function expectNoInlineSourceCards(page: Page) {
+  await expect(inlineSourceCards(page)).toHaveCount(0);
+  await expect(
+    botMessageRegion(page).getByRole('navigation', { name: 'Pagination' }),
+  ).toHaveCount(0);
+}
+
+export async function openSourcesPopover(page: Page, t: LightspeedMessages) {
+  const chipLabel = formatSourcesChipLabel(t, 1);
+  const sourcesChip = page.getByRole('button', { name: chipLabel });
+  if (await sourcesChip.isVisible().catch(() => false)) {
+    await sourcesChip.click();
+    return;
+  }
+  const pluralChip = page.getByRole('button', {
+    name: formatSourcesChipLabel(t, 2),
+  });
+  await pluralChip.click();
+}
+
+export async function expectSourcesPopoverRagLabels(
+  page: Page,
+  t: LightspeedMessages,
+  ragIds: string[],
+) {
+  const dialog = page.getByRole('dialog', { name: t['sources.modal.title'] });
+  await expect(dialog).toBeVisible();
+  for (const ragId of ragIds) {
+    await expect(dialog.getByText(ragId, { exact: true })).toBeVisible();
+  }
+}
 
 export async function expectConversationArea(
   page: Page,

--- a/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/pages/LightspeedPage.ts
@@ -474,7 +474,7 @@ export async function expectInlineRagSourceLabels(
   ragIds: string[],
 ) {
   const botMessage = botMessageRegion(page);
-  await expect(inlineSourceCards(page)).toHaveCount(1);
+  await expect(botMessage.locator('.pf-chatbot__sources-card')).toHaveCount(1);
 
   for (let index = 0; index < ragIds.length; index++) {
     await expect(
@@ -487,9 +487,10 @@ export async function expectInlineRagSourceLabels(
 }
 
 export async function expectNoInlineSourceCards(page: Page) {
-  await expect(inlineSourceCards(page)).toHaveCount(0);
+  const botMessage = botMessageRegion(page);
+  await expect(botMessage.locator('.pf-chatbot__sources-card')).toHaveCount(0);
   await expect(
-    botMessageRegion(page).getByRole('navigation', { name: 'Pagination' }),
+    botMessage.getByRole('navigation', { name: 'Pagination' }),
   ).toHaveCount(0);
 }
 

--- a/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/utils/devMode.ts
@@ -21,6 +21,7 @@ import {
   contentsWithRedactedThinking,
   E2E_MCP_VALID_TOKEN,
   generateQueryResponse,
+  generateQueryResponseWithReferencedDocuments,
   mockedMcpServersResponse,
   modelBaseUrl,
   type McpServersListMock,
@@ -607,6 +608,7 @@ export async function mockQuery(
   query: string,
   conversations: any[],
 ) {
+  await page.unroute(`${modelBaseUrl}/v1/query`);
   await page.route(`${modelBaseUrl}/v1/query`, async route => {
     const payload = route.request().postDataJSON();
 
@@ -618,6 +620,32 @@ export async function mockQuery(
         ? conversations[1].conversation_id
         : conversations[0].conversation_id,
     );
+    await route.fulfill({ body });
+  });
+}
+
+/** Mock query SSE that returns BYOK `referenced_documents` on the `end` event. */
+export async function mockQueryWithReferencedDocuments(
+  page: Page,
+  query: string,
+  conversations: any[],
+  referencedDocuments: Record<string, unknown>[],
+) {
+  await page.unroute(`${modelBaseUrl}/v1/query`);
+  await page.route(`${modelBaseUrl}/v1/query`, async route => {
+    const payload = route.request().postDataJSON();
+    if (payload.conversation_id) {
+      conversations[1].conversation_id = payload.conversation_id;
+    }
+    const conversationId =
+      conversations[1].conversation_id ?? conversations[0].conversation_id;
+    const body =
+      payload.query === query
+        ? generateQueryResponseWithReferencedDocuments(
+            conversationId,
+            referencedDocuments,
+          )
+        : generateQueryResponse(conversationId);
     await route.fulfill({ body });
   });
 }

--- a/workspaces/intelligent-assistant/e2e-tests/utils/translations.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/utils/translations.ts
@@ -70,6 +70,16 @@ export function formatMcpSelectedCount(
     .replace(/\{\{totalCount\}\}/g, String(totalCount));
 }
 
+/** Renders `sources.chip.label` for the given count (matches i18n plural rules). */
+export function formatSourcesChipLabel(
+  t: LightspeedMessages,
+  count: number,
+): string {
+  const key =
+    count === 1 ? 'sources.chip.label_one' : 'sources.chip.label_other';
+  return t[key].replace(/\{\{count\}\}/g, String(count));
+}
+
 /** Status cell detail for a connected server tool count (singular vs plural). */
 export function formatMcpToolCountStatus(
   t: LightspeedMessages,


### PR DESCRIPTION
## Description

Adds Playwright e2e coverage for BYOK RAG source labeling introduced in #4178. Tests mock LCORE `referenced_documents` SSE payloads and verify:

- Attributed BYOK responses show `rag_id` pill labels on paginated inline source cards with correct citation links
- Queries without citations render a normal bot reply with no source cards
- Referenced documents missing a `source` field do not show rag labels
- Notebook sources popover lists `rag_id` labels next to document titles

## Fixed
- [RHIDP-14772](https://redhat.atlassian.net/browse/RHIDP-14772) — Testing BYOK E2E Validation

## Test Plan
- [x] `APP_MODE=legacy npx playwright test e2e-tests/lightspeed.byok-rag-sources.test.ts --project=en`
- [ ] `yarn test:e2e:all` in `workspaces/intelligent-assistant` (legacy + NFS, all locales)

## Checklist
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets)) — N/A (e2e-only)
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

Made with [Cursor](https://cursor.com)