### PR TITLE
feat(scorecard): return threshold config, threholdEvaluation per point

### DIFF
--- a/workspaces/scorecard/.changeset/breezy-numbers-hide.md
+++ b/workspaces/scorecard/.changeset/breezy-numbers-hide.md
@@ -3,4 +3,4 @@
 '@red-hat-developer-hub/backstage-plugin-scorecard-common': minor
 ---
 
-Entity time-series API (`GET /metrics/catalog/:kind/:namespace/:name/time-series`) now returns entity-resolved `thresholds` and per-point `thresholdEvaluation` so clients can render sparkline legends and chart colors without a separate snapshot call.
+Entity time-series API (`GET /metrics/catalog/:kind/:namespace/:name/time-series`) now returns entity-resolved `thresholds` and per-point `thresholdEvaluation` (classified at read time against those current thresholds) so clients can render sparkline legends and chart colors without a separate snapshot call.

--- a/workspaces/scorecard/.changeset/breezy-numbers-hide.md
+++ b/workspaces/scorecard/.changeset/breezy-numbers-hide.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-scorecard-backend': minor
+'@red-hat-developer-hub/backstage-plugin-scorecard-common': minor
+---
+
+Entity time-series API (`GET /metrics/catalog/:kind/:namespace/:name/time-series`) now returns entity-resolved `thresholds` and per-point `thresholdEvaluation` so clients can render sparkline legends and chart colors without a separate snapshot call.

--- a/workspaces/scorecard/plugins/scorecard-backend/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/README.md
@@ -309,7 +309,7 @@ curl -X GET "{{url}}/api/scorecard/metrics/catalog/component/default/my-service?
 
 Returns daily time-series points for one metric on a catalog entity. Each point is the latest sample (`MAX(id)` among success or calculation-error rows) for that UTC calendar day. On a mixed day the later sample wins, so a later error is returned as `{ "value": null, "error": "..." }` (and clients can gap a sparkline). Days with no rows (or only null without `error_message`) are omitted. Returns `200` with `points: []` when the entity and metric are authorized but no data exists in the range.
 
-The response also includes entity-resolved `thresholds` (provider defaults, then app-config, then entity annotation overrides) for sparkline legend rendering. Successful points include `thresholdEvaluation`: the matched threshold rule key from pull-time evaluation (e.g. `success`, `warning`, `error`). Calculation-error points omit `thresholdEvaluation`. When the stored status is missing, `thresholdEvaluation` is `null`.
+The response also includes entity-resolved `thresholds` (provider defaults, then app-config, then entity annotation overrides) for sparkline legend rendering. Successful points include `thresholdEvaluation`: the matched threshold rule key from **read-time** evaluation of the point's `value` against those current `thresholds` (e.g. `success`, `warning`, `error`). This keeps legend keys and point classifications consistent when config changes. Calculation-error points omit `thresholdEvaluation`. When no rule matches, `thresholdEvaluation` is `null`.
 
 #### Path Parameters
 

--- a/workspaces/scorecard/plugins/scorecard-backend/README.md
+++ b/workspaces/scorecard/plugins/scorecard-backend/README.md
@@ -309,6 +309,8 @@ curl -X GET "{{url}}/api/scorecard/metrics/catalog/component/default/my-service?
 
 Returns daily time-series points for one metric on a catalog entity. Each point is the latest sample (`MAX(id)` among success or calculation-error rows) for that UTC calendar day. On a mixed day the later sample wins, so a later error is returned as `{ "value": null, "error": "..." }` (and clients can gap a sparkline). Days with no rows (or only null without `error_message`) are omitted. Returns `200` with `points: []` when the entity and metric are authorized but no data exists in the range.
 
+The response also includes entity-resolved `thresholds` (provider defaults, then app-config, then entity annotation overrides) for sparkline legend rendering. Successful points include `thresholdEvaluation`: the matched threshold rule key from pull-time evaluation (e.g. `success`, `warning`, `error`). Calculation-error points omit `thresholdEvaluation`. When the stored status is missing, `thresholdEvaluation` is `null`.
+
 #### Path Parameters
 
 | Parameter   | Type   | Required | Description                        |
@@ -350,14 +352,29 @@ curl -X GET "{{url}}/api/scorecard/metrics/catalog/component/default/my-service/
     "defaultVisualization": "donut"
   },
   "points": [
-    { "value": 8, "timestamp": "2026-04-27T23:10:00.000Z" },
+    {
+      "value": 8,
+      "timestamp": "2026-04-27T23:10:00.000Z",
+      "thresholdEvaluation": "success"
+    },
     {
       "value": null,
       "timestamp": "2026-04-28T16:00:00.000Z",
       "error": "GitHub API 500"
     },
-    { "value": 7, "timestamp": "2026-04-29T22:55:00.000Z" }
-  ]
+    {
+      "value": 25,
+      "timestamp": "2026-04-29T22:55:00.000Z",
+      "thresholdEvaluation": "warning"
+    }
+  ],
+  "thresholds": {
+    "rules": [
+      { "key": "success", "expression": "<10" },
+      { "key": "warning", "expression": "10-50" },
+      { "key": "error", "expression": ">50" }
+    ]
+  }
 }
 ```
 

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
@@ -676,10 +676,19 @@ describe('CatalogMetricService', () => {
       ]);
     });
 
-    it('should fall back to metric.thresholds when resolveEntityThresholds throws', async () => {
+    it('should fall back to resolveMetricThresholds when resolveEntityThresholds throws', async () => {
+      const metricThresholds = {
+        rules: [
+          { key: 'success', expression: '<5' },
+          { key: 'error', expression: '>=5' },
+        ],
+      };
       mockedThresholdResolver.resolveEntityThresholds.mockImplementation(() => {
         throw new Error('Merge thresholds failed');
       });
+      mockedThresholdResolver.resolveMetricThresholds.mockReturnValue(
+        metricThresholds,
+      );
 
       const result = await service.getEntityMetricTimeSeries(
         entityRef,
@@ -688,7 +697,10 @@ describe('CatalogMetricService', () => {
         to,
       );
 
-      expect(result.thresholds).toEqual(provider.getMetrics()[0].thresholds);
+      expect(
+        mockedThresholdResolver.resolveMetricThresholds,
+      ).toHaveBeenCalledWith(expect.objectContaining({ id: metricId }));
+      expect(result.thresholds).toEqual(metricThresholds);
     });
 
     it('should pass permission filter to filterAuthorizedMetrics', async () => {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
@@ -545,7 +545,7 @@ describe('CatalogMetricService', () => {
       );
     });
 
-    it('should map each daily DB row to a time-series point with thresholdEvaluation', async () => {
+    it('should map each daily DB row to a time-series point with read-time thresholdEvaluation', async () => {
       mockedDatabase.readLatestEntityMetricValuesPerUtcDay.mockResolvedValue([
         {
           id: 3,
@@ -560,10 +560,11 @@ describe('CatalogMetricService', () => {
           id: 2,
           catalogEntityRef: entityRef,
           metricId: metricId,
-          value: 7,
+          value: 25,
           timestamp: new Date('2024-01-02T12:00:00.000Z'),
           errorMessage: null,
-          status: 'warning',
+          // Stale write-time status must be ignored in favor of read-time evaluation
+          status: 'success',
         },
       ] as DbMetricValue[]);
 
@@ -581,7 +582,7 @@ describe('CatalogMetricService', () => {
           thresholdEvaluation: 'success',
         },
         {
-          value: 7,
+          value: 25,
           timestamp: '2024-01-02T12:00:00.000Z',
           thresholdEvaluation: 'warning',
         },
@@ -646,7 +647,7 @@ describe('CatalogMetricService', () => {
       ]);
     });
 
-    it('should set thresholdEvaluation to null when DB status is null on success points', async () => {
+    it('should evaluate thresholdEvaluation from current thresholds even when DB status is null', async () => {
       mockedDatabase.readLatestEntityMetricValuesPerUtcDay.mockResolvedValue([
         {
           id: 1,
@@ -670,7 +671,7 @@ describe('CatalogMetricService', () => {
         {
           value: 5,
           timestamp: '2024-01-01T10:00:00.000Z',
-          thresholdEvaluation: null,
+          thresholdEvaluation: 'success',
         },
       ]);
     });

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.test.ts
@@ -532,13 +532,20 @@ describe('CatalogMetricService', () => {
           defaultVisualization: provider.getMetrics()[0].defaultVisualization,
           collectorIds: provider.getMetrics()[0].collectorIds,
         },
+        thresholds: { rules: mockThresholdRules },
       });
       expect(
         mockedDatabase.readLatestEntityMetricValuesPerUtcDay,
       ).toHaveBeenCalledWith(entityRef, metricId, from, to);
+      expect(
+        mockedThresholdResolver.resolveEntityThresholds,
+      ).toHaveBeenCalledWith(
+        mockEntity,
+        expect.objectContaining({ id: metricId }),
+      );
     });
 
-    it('should map each daily DB row to a time-series point', async () => {
+    it('should map each daily DB row to a time-series point with thresholdEvaluation', async () => {
       mockedDatabase.readLatestEntityMetricValuesPerUtcDay.mockResolvedValue([
         {
           id: 3,
@@ -556,7 +563,7 @@ describe('CatalogMetricService', () => {
           value: 7,
           timestamp: new Date('2024-01-02T12:00:00.000Z'),
           errorMessage: null,
-          status: 'success',
+          status: 'warning',
         },
       ] as DbMetricValue[]);
 
@@ -568,12 +575,21 @@ describe('CatalogMetricService', () => {
       );
 
       expect(result.points).toEqual([
-        { value: 9, timestamp: '2024-01-01T20:00:00.000Z' },
-        { value: 7, timestamp: '2024-01-02T12:00:00.000Z' },
+        {
+          value: 9,
+          timestamp: '2024-01-01T20:00:00.000Z',
+          thresholdEvaluation: 'success',
+        },
+        {
+          value: 7,
+          timestamp: '2024-01-02T12:00:00.000Z',
+          thresholdEvaluation: 'warning',
+        },
       ]);
+      expect(result.thresholds).toEqual({ rules: mockThresholdRules });
     });
 
-    it('should map calculation-error rows to null value with error', async () => {
+    it('should map calculation-error rows to null value with error and omit thresholdEvaluation', async () => {
       mockedDatabase.readLatestEntityMetricValuesPerUtcDay.mockResolvedValue([
         {
           id: 1,
@@ -612,14 +628,66 @@ describe('CatalogMetricService', () => {
       );
 
       expect(result.points).toEqual([
-        { value: 8, timestamp: '2024-01-01T10:00:00.000Z' },
+        {
+          value: 8,
+          timestamp: '2024-01-01T10:00:00.000Z',
+          thresholdEvaluation: 'success',
+        },
         {
           value: null,
           timestamp: '2024-01-02T16:00:00.000Z',
           error: 'GitHub API 500',
         },
-        { value: 7, timestamp: '2024-01-03T10:00:00.000Z' },
+        {
+          value: 7,
+          timestamp: '2024-01-03T10:00:00.000Z',
+          thresholdEvaluation: 'success',
+        },
       ]);
+    });
+
+    it('should set thresholdEvaluation to null when DB status is null on success points', async () => {
+      mockedDatabase.readLatestEntityMetricValuesPerUtcDay.mockResolvedValue([
+        {
+          id: 1,
+          catalogEntityRef: entityRef,
+          metricId: metricId,
+          value: 5,
+          timestamp: new Date('2024-01-01T10:00:00.000Z'),
+          errorMessage: null,
+          status: null,
+        },
+      ] as DbMetricValue[]);
+
+      const result = await service.getEntityMetricTimeSeries(
+        entityRef,
+        metricId,
+        from,
+        to,
+      );
+
+      expect(result.points).toEqual([
+        {
+          value: 5,
+          timestamp: '2024-01-01T10:00:00.000Z',
+          thresholdEvaluation: null,
+        },
+      ]);
+    });
+
+    it('should fall back to metric.thresholds when resolveEntityThresholds throws', async () => {
+      mockedThresholdResolver.resolveEntityThresholds.mockImplementation(() => {
+        throw new Error('Merge thresholds failed');
+      });
+
+      const result = await service.getEntityMetricTimeSeries(
+        entityRef,
+        metricId,
+        from,
+        to,
+      );
+
+      expect(result.thresholds).toEqual(provider.getMetrics()[0].thresholds);
     });
 
     it('should pass permission filter to filterAuthorizedMetrics', async () => {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
@@ -244,8 +244,19 @@ export class CatalogMetricService {
       return {
         value: row.value,
         timestamp: row.timestamp.toISOString(),
+        thresholdEvaluation: row.status ?? null,
       };
     });
+
+    let thresholds: ThresholdConfig;
+    try {
+      thresholds = this.thresholdResolver.resolveEntityThresholds(
+        entity,
+        metric,
+      );
+    } catch {
+      thresholds = metric.thresholds;
+    }
 
     return {
       metricId: metric.id,
@@ -260,6 +271,7 @@ export class CatalogMetricService {
         defaultVisualization: metric.defaultVisualization,
         collectorIds: metric.collectorIds,
       },
+      thresholds,
     };
   }
 

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
@@ -242,7 +242,8 @@ export class CatalogMetricService {
         metric,
       );
     } catch {
-      thresholds = metric.thresholds;
+      // Keep app-config / provider thresholds when entity annotation merge fails
+      thresholds = this.thresholdResolver.resolveMetricThresholds(metric);
     }
 
     const points: MetricTimeSeriesPoint[] = rows.map(row => {

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/CatalogMetricService.ts
@@ -50,6 +50,7 @@ import { isMetricCalculationError } from '../utils/metricCalculationError';
 import { AggregatedMetricMapper } from './mappers';
 import { DbMetricValue } from '../database/types';
 import { ThresholdResolver } from '../threshold/ThresholdResolver';
+import { ThresholdEvaluator } from '../threshold/ThresholdEvaluator';
 
 type CatalogMetricServiceOptions = {
   catalog: CatalogService;
@@ -82,6 +83,7 @@ export class CatalogMetricService {
   private readonly registry: MetricProvidersRegistry;
   private readonly database: DatabaseMetricValues;
   private readonly thresholdResolver: ThresholdResolver;
+  private readonly thresholdEvaluator = new ThresholdEvaluator();
 
   private static readonly MAX_FETCHABLE_ROWS = 10_000;
   private static readonly BATCH_SIZE = 100;
@@ -233,21 +235,6 @@ export class CatalogMetricService {
       to,
     );
 
-    const points: MetricTimeSeriesPoint[] = rows.map(row => {
-      if (isMetricCalculationError(row)) {
-        return {
-          value: null,
-          timestamp: row.timestamp.toISOString(),
-          error: row.errorMessage!,
-        };
-      }
-      return {
-        value: row.value,
-        timestamp: row.timestamp.toISOString(),
-        thresholdEvaluation: row.status ?? null,
-      };
-    });
-
     let thresholds: ThresholdConfig;
     try {
       thresholds = this.thresholdResolver.resolveEntityThresholds(
@@ -257,6 +244,40 @@ export class CatalogMetricService {
     } catch {
       thresholds = metric.thresholds;
     }
+
+    const points: MetricTimeSeriesPoint[] = rows.map(row => {
+      if (isMetricCalculationError(row)) {
+        return {
+          value: null,
+          timestamp: row.timestamp.toISOString(),
+          error: row.errorMessage!,
+        };
+      }
+
+      let thresholdEvaluation: string | null = null;
+      if (row.value !== null) {
+        try {
+          thresholdEvaluation =
+            this.thresholdEvaluator.getFirstMatchingThreshold(
+              row.value,
+              metric.type,
+              thresholds,
+            ) ?? null;
+        } catch (error) {
+          this.logger.warn(
+            `Failed to evaluate thresholds for metric '${
+              metric.id
+            }' on entity '${entityRef}': ${stringifyError(error)}`,
+          );
+        }
+      }
+
+      return {
+        value: row.value,
+        timestamp: row.timestamp.toISOString(),
+        thresholdEvaluation,
+      };
+    });
 
     return {
       metricId: metric.id,

--- a/workspaces/scorecard/plugins/scorecard-backend/src/service/router.test.ts
+++ b/workspaces/scorecard/plugins/scorecard-backend/src/service/router.test.ts
@@ -654,9 +654,24 @@ describe('createRouter', () => {
         defaultVisualization: 'donut',
       },
       points: [
-        { value: 8, timestamp: '2024-01-01T20:00:00.000Z' },
-        { value: 7, timestamp: '2024-01-02T12:00:00.000Z' },
+        {
+          value: 8,
+          timestamp: '2024-01-01T20:00:00.000Z',
+          thresholdEvaluation: 'success',
+        },
+        {
+          value: 7,
+          timestamp: '2024-01-02T12:00:00.000Z',
+          thresholdEvaluation: 'success',
+        },
       ],
+      thresholds: {
+        rules: [
+          { key: 'error', expression: '>40' },
+          { key: 'warning', expression: '>20' },
+          { key: 'success', expression: '<=20' },
+        ],
+      },
     };
 
     const timeSeriesPath =

--- a/workspaces/scorecard/plugins/scorecard-common/report.api.md
+++ b/workspaces/scorecard/plugins/scorecard-common/report.api.md
@@ -181,6 +181,7 @@ export type MetricTimeSeriesPoint = {
   value: MetricValue | null;
   timestamp: string;
   error?: string;
+  thresholdEvaluation?: string | null;
 };
 
 // @public
@@ -197,6 +198,7 @@ export type MetricTimeSeriesResponse = {
     defaultVisualization?: ScorecardVisualizationType;
     collectorIds?: string[];
   };
+  thresholds: ThresholdConfig;
 };
 
 // @public (undocumented)

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
@@ -139,7 +139,8 @@ export type MetricTimeSeriesPoint = {
   /** Present when this point is a calculation failure */
   error?: string;
   /**
-   * Matched threshold rule key from pull-time evaluation (e.g., "elite", "success", "warning").
+   * Matched threshold rule key from read-time evaluation against the response
+   * `thresholds` (e.g., "elite", "success", "warning").
    * `null` when the value could not be classified. Absent on calculation-error points.
    */
   thresholdEvaluation?: string | null;

--- a/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
+++ b/workspaces/scorecard/plugins/scorecard-common/src/types/Metric.ts
@@ -138,6 +138,11 @@ export type MetricTimeSeriesPoint = {
   timestamp: string;
   /** Present when this point is a calculation failure */
   error?: string;
+  /**
+   * Matched threshold rule key from pull-time evaluation (e.g., "elite", "success", "warning").
+   * `null` when the value could not be classified. Absent on calculation-error points.
+   */
+  thresholdEvaluation?: string | null;
 };
 
 /**
@@ -157,4 +162,9 @@ export type MetricTimeSeriesResponse = {
     defaultVisualization?: ScorecardVisualizationType;
     collectorIds?: string[];
   };
+  /**
+   * Entity-resolved threshold rules (provider defaults, then app-config, then entity annotation overrides).
+   * Used for sparkline legend rendering and mapping `thresholdEvaluation` keys to colors.
+   */
+  thresholds: ThresholdConfig;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Entity time-series API (`GET /metrics/catalog/:kind/:namespace/:name/time-series`) now returns entity-resolved thresholds and per-point `thresholdEvaluation`, so the frontend can render sparkline legends and chart colors without calling the snapshot metrics endpoint. Classification happens at read time against the current entity-resolved rules (the DB status column is ignored for this field).

When entity threshold resolution fails (e.g. malformed annotation overrides), the response sets top-level `thresholdsError`, omits thresholds (no silent fallback to app-config / provider defaults), and leaves successful points unclassified (`thresholdEvaluation: null`, no per-point error). Threshold evaluation failures still use the existing per-point error field.

Current types: 
```
export type MetricTimeSeriesResponse = {
  metricId: string;
  entityRef: string;
  points: MetricTimeSeriesPoint[];
  metadata: {
    title: string;
    description: string;
    type: MetricType;
    unit?: string;
    history?: boolean;
    defaultVisualization?: ScorecardVisualizationType;
    collectorIds?: string[];
  };
  /** Entity-resolved rules. Omitted when resolution failed (see thresholdsError). */
  thresholds?: ThresholdConfig;
  /** Set when entity threshold resolution failed. */
  thresholdsError?: string;
};
```

```
export type MetricTimeSeriesPoint = {
  value: MetricValue | null;
  timestamp: string;
  error?: string;
  /** Matched rule key at read time; null when unclassified. Absent on calculation-error points. */
  thresholdEvaluation?: string | null;
};
```

### How to test
Start Postgres locally and point app-config.local.yaml at it, e.g.:
```
backend:
  database:
    client: pg
    connection:
      host: 127.0.0.1
      port: 5432
      user: postgres
      password: postgres
```

From workspaces/scorecard:

`yarn start`

Sign in as Guest, copy a Bearer token from a successful localhost:7007 request, then:
`export TOKEN=<token>`

Default github.openPRs thresholds are:
```
success: <10
warning: 10-50
error: >50
```

thresholdEvaluation is computed at read time from each point’s value against those current rules — the DB status column is ignored for this field.

**Seed data**

`docker exec -it backstage-psql psql -U postgres -d backstage_plugin_scorecard`

```
DELETE FROM metric_values
WHERE metric_id = 'github.openPRs'
  AND catalog_entity_ref = 'component:default/all-scorecards'
  AND timestamp >= '2026-04-27'
  AND timestamp < '2026-05-02';

INSERT INTO metric_values
  (metric_id, catalog_entity_ref, value, timestamp, error_message, status, entity_kind, entity_owner, entity_namespace)
VALUES
  -- Apr 27: value 9 → read-time success (<10)
  ('github.openPRs', 'component:default/all-scorecards', '9',  '2026-04-27 20:00:00', NULL, 'success', 'Component', 'user:development/guest', 'default'),
  -- Apr 28: error-only → no thresholdEvaluation
  ('github.openPRs', 'component:default/all-scorecards', NULL, '2026-04-28 16:00:00', 'timeout', NULL, 'Component', 'user:development/guest', 'default'),
  -- Apr 29: value 25 → read-time warning (10-50); stale DB status must be ignored
  ('github.openPRs', 'component:default/all-scorecards', '25', '2026-04-29 12:00:00', NULL, 'success', 'Component', 'user:development/guest', 'default'),
  -- Apr 30: value 60 → read-time error (>50)
  ('github.openPRs', 'component:default/all-scorecards', '60', '2026-04-30 12:00:00', NULL, 'warning', 'Component', 'user:development/guest', 'default'),
  -- May 1: value 3, null status → still read-time success
  ('github.openPRs', 'component:default/all-scorecards', '3',  '2026-05-01 12:00:00', NULL, NULL, 'Component', 'user:development/guest', 'default');
```

**Scenarios**
1. Happy path — thresholds + read-time thresholdEvaluation:

```
curl -s "http://localhost:7007/api/scorecard/metrics/catalog/component/default/all-scorecards/time-series?metricId=github.openPRs&from=2026-04-27T00:00:00.000Z&to=2026-04-30T23:59:59.999Z" \
  -H "Authorization: Bearer $TOKEN" | jq .
```
Expected:

Top-level thresholds.rules: success / warning / error (or app-config / entity overrides if set)
Points:
Apr 27: `{ "value": 9, "thresholdEvaluation": "success", ... }`
Apr 28: `{ "value": null, "error": "timeout", ... }` — no thresholdEvaluation
Apr 29: `{ "value": 25, "thresholdEvaluation": "warning", ... }` (not "success" from DB)
Apr 30: `{ "value": 60, "thresholdEvaluation": "error", ... }` (not "warning" from DB)

2. Stale DB status ignored (Apr 29):

```
curl -s "http://localhost:7007/api/scorecard/metrics/catalog/component/default/all-scorecards/time-series?metricId=github.openPRs&from=2026-04-29T00:00:00.000Z&to=2026-04-29T23:59:59.999Z" \
  -H "Authorization: Bearer $TOKEN" | jq '.points'
```

Expected: `value: 25, thresholdEvaluation: "warning"` (DB status was success).

3. Error-only day — thresholdEvaluation omitted:

```
curl -s "http://localhost:7007/api/scorecard/metrics/catalog/component/default/all-scorecards/time-series?metricId=github.openPRs&from=2026-04-28T00:00:00.000Z&to=2026-04-28T23:59:59.999Z" \
  -H "Authorization: Bearer $TOKEN" | jq .
```
Expected: one point with `value: null, error: "timeout"`, no thresholdEvaluation. Response still has thresholds.

4. Empty range — still returns thresholds:

```
curl -s "http://localhost:7007/api/scorecard/metrics/catalog/component/default/all-scorecards/time-series?metricId=github.openPRs&from=2025-01-01T00:00:00.000Z&to=2025-01-31T23:59:59.999Z" \
  -H "Authorization: Bearer $TOKEN" | jq .
```
Expected: `"points": []`, metadata present, thresholds present.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
