### PR TITLE
feat(adoption-insights): add if predicate gating

### DIFF
--- a/workspaces/adoption-insights/.changeset/adoption-insights-events-read-if-predicate.md
+++ b/workspaces/adoption-insights/.changeset/adoption-insights-events-read-if-predicate.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-adoption-insights': patch
+---
+
+The Adoption Insights page is only shown when the user is authorized for `adoption-insights.events.read`.

--- a/workspaces/adoption-insights/e2e-tests/insights.test.ts
+++ b/workspaces/adoption-insights/e2e-tests/insights.test.ts
@@ -43,6 +43,7 @@ import {
   visitDocs,
   performSearch,
 } from './utils/events';
+import { installMockAdoptionInsightsPermission } from './utils/permissionUtils';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -56,6 +57,7 @@ test.beforeAll(async ({ browser }) => {
   const currentLocale = await page.evaluate(
     () => globalThis.navigator.language,
   );
+  await installMockAdoptionInsightsPermission(page, 'ALLOW');
   await page.goto('/');
   await page.getByRole('button', { name: 'Enter' }).click();
 

--- a/workspaces/adoption-insights/e2e-tests/permissions.test.ts
+++ b/workspaces/adoption-insights/e2e-tests/permissions.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test, type TestInfo } from '@playwright/test';
+
+import {
+  installMockAdoptionInsightsPermission,
+  loginAsGuest,
+} from './utils/permissionUtils';
+import { navigateToInsights } from './utils/insightsHelpers';
+import {
+  getAdoptionInsightsNavLabel,
+  getTranslations,
+} from './utils/translations';
+
+const isLegacy = process.env.APP_MODE === 'legacy';
+
+function getLocaleContext(testInfo: TestInfo) {
+  const locale = testInfo.project.name;
+  const translations = getTranslations(locale);
+  const navLabel = getAdoptionInsightsNavLabel();
+
+  return { locale, translations, navLabel };
+}
+
+test.describe('Adoption Insights permissions', () => {
+  test('shows Adoption Insights in the sidebar when events.read is allowed', async ({
+    page,
+  }, testInfo) => {
+    const { locale, navLabel } = getLocaleContext(testInfo);
+
+    await installMockAdoptionInsightsPermission(page, 'ALLOW');
+    await loginAsGuest(page, locale);
+
+    await expect(
+      page.locator(`nav a:has-text("${navLabel}")`).first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  test('hides Adoption Insights from the sidebar when events.read is denied', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      isLegacy,
+      'OFS sidebar is a hardcoded SidebarItem and is not gated by permission',
+    );
+
+    const { locale, navLabel } = getLocaleContext(testInfo);
+
+    await installMockAdoptionInsightsPermission(page, 'DENY');
+    await loginAsGuest(page, locale);
+
+    await expect(page.locator(`nav a:has-text("${navLabel}")`)).toHaveCount(0);
+  });
+
+  test('opens the Adoption Insights page when events.read is allowed', async ({
+    page,
+  }, testInfo) => {
+    const { locale, translations, navLabel } = getLocaleContext(testInfo);
+
+    await installMockAdoptionInsightsPermission(page, 'ALLOW');
+    await loginAsGuest(page, locale);
+
+    await navigateToInsights(page, navLabel);
+
+    await expect(
+      page.getByRole('heading', { name: translations.header.title }).first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  test('denies direct navigation when events.read is denied', async ({
+    page,
+  }, testInfo) => {
+    const { locale, translations, navLabel } = getLocaleContext(testInfo);
+
+    await installMockAdoptionInsightsPermission(page, 'DENY');
+    await loginAsGuest(page, locale);
+
+    await page.goto('/adoption-insights');
+
+    if (isLegacy) {
+      await expect(page.getByText(translations.permission.title)).toBeVisible({
+        timeout: 30000,
+      });
+      return;
+    }
+
+    await expect(
+      page.getByRole('heading', { name: translations.header.title }).first(),
+    ).not.toBeVisible();
+    await expect(page.locator(`nav a:has-text("${navLabel}")`)).toHaveCount(0);
+  });
+});

--- a/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-de.yaml
+++ b/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-de.yaml
@@ -8,3 +8,7 @@ backend:
     port: 7008
   cors:
     origin: http://localhost:3001
+
+# Needed so Playwright can intercept POST /api/permission/authorize.
+permission:
+  enabled: true

--- a/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-en.yaml
+++ b/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-en.yaml
@@ -8,3 +8,7 @@ backend:
     port: 7007
   cors:
     origin: http://localhost:3000
+
+# Needed so Playwright can intercept POST /api/permission/authorize.
+permission:
+  enabled: true

--- a/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-es.yaml
+++ b/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-es.yaml
@@ -8,3 +8,7 @@ backend:
     port: 7009
   cors:
     origin: http://localhost:3002
+
+# Needed so Playwright can intercept POST /api/permission/authorize.
+permission:
+  enabled: true

--- a/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-fr.yaml
+++ b/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-fr.yaml
@@ -8,3 +8,7 @@ backend:
     port: 7010
   cors:
     origin: http://localhost:3003
+
+# Needed so Playwright can intercept POST /api/permission/authorize.
+permission:
+  enabled: true

--- a/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-it.yaml
+++ b/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-it.yaml
@@ -8,3 +8,7 @@ backend:
     port: 7011
   cors:
     origin: http://localhost:3004
+
+# Needed so Playwright can intercept POST /api/permission/authorize.
+permission:
+  enabled: true

--- a/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-ja.yaml
+++ b/workspaces/adoption-insights/e2e-tests/test_yamls/app-config-e2e-ja.yaml
@@ -8,3 +8,7 @@ backend:
     port: 7012
   cors:
     origin: http://localhost:3005
+
+# Needed so Playwright can intercept POST /api/permission/authorize.
+permission:
+  enabled: true

--- a/workspaces/adoption-insights/e2e-tests/utils/insightsHelpers.ts
+++ b/workspaces/adoption-insights/e2e-tests/utils/insightsHelpers.ts
@@ -20,6 +20,8 @@ import { Page, expect } from '@playwright/test';
  */
 const LOCALE_DISPLAY_NAMES: Record<string, string> = {
   en: 'English',
+  de: 'Deutsch',
+  es: 'Español',
   fr: 'Français',
   it: 'Italiano',
   ja: '日本語',

--- a/workspaces/adoption-insights/e2e-tests/utils/permissionUtils.ts
+++ b/workspaces/adoption-insights/e2e-tests/utils/permissionUtils.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, Page } from '@playwright/test';
+
+import { switchToLocale } from './insightsHelpers';
+
+export const ADOPTION_INSIGHTS_EVENTS_READ_PERMISSION =
+  'adoption-insights.events.read';
+
+type AuthorizeItem = {
+  id: string;
+  permission?: {
+    name?: string;
+  };
+};
+
+type AuthorizeRequestBody = {
+  items?: AuthorizeItem[];
+};
+
+/**
+ * Mocks /api/permission/authorize for adoption-insights.events.read while
+ * leaving other permission checks to the real backend.
+ */
+export async function installMockAdoptionInsightsPermission(
+  page: Page,
+  result: 'ALLOW' | 'DENY',
+) {
+  await page.route('**/api/permission/authorize', async route => {
+    const request = route.request();
+    if (request.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    let body: AuthorizeRequestBody;
+    try {
+      body = request.postDataJSON() as AuthorizeRequestBody;
+    } catch {
+      await route.continue();
+      return;
+    }
+
+    const items = body.items ?? [];
+    const affectsAdoptionInsights = items.some(
+      item =>
+        item.permission?.name === ADOPTION_INSIGHTS_EVENTS_READ_PERMISSION,
+    );
+
+    if (!affectsAdoptionInsights) {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: items.map(item => ({
+          id: item.id,
+          result:
+            item.permission?.name === ADOPTION_INSIGHTS_EVENTS_READ_PERMISSION
+              ? result
+              : 'ALLOW',
+        })),
+      }),
+    });
+  });
+}
+
+/** Sign in as guest and switch to the project locale. */
+export async function loginAsGuest(page: Page, locale: string) {
+  await page.goto('/');
+  const enterButton = page.getByRole('button', { name: 'Enter' });
+  await expect(enterButton).toBeVisible({ timeout: 30000 });
+  await enterButton.click();
+  await expect(enterButton).toBeHidden({ timeout: 30000 });
+  await switchToLocale(page, locale);
+}

--- a/workspaces/adoption-insights/e2e-tests/utils/translations.ts
+++ b/workspaces/adoption-insights/e2e-tests/utils/translations.ts
@@ -97,3 +97,12 @@ export function replaceTemplate(
 export function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Sidebar label for the Adoption Insights page.
+ * NFS uses the PageBlueprint title and OFS uses a hardcoded SidebarItem, both
+ * English "Adoption Insights" (translated page headings are separate).
+ */
+export function getAdoptionInsightsNavLabel(): string {
+  return 'Adoption Insights';
+}

--- a/workspaces/adoption-insights/plugins/adoption-insights-backend/README.md
+++ b/workspaces/adoption-insights/plugins/adoption-insights-backend/README.md
@@ -37,7 +37,7 @@ app:
 
 #### Permission Framework Support
 
-The Adoption Insights Backend plugin has support for the permission framework.
+The Adoption Insights Backend plugin has support for the permission framework. The frontend NFS page uses an `if` predicate on `adoption-insights.events.read` so unauthorized users do not see the page or navigation entry.
 
 - When [RBAC permission](https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend#installation) framework is enabled, for non-admin users to access Adoption Insights backend API, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file named `rbac-policy.csv`:
 

--- a/workspaces/adoption-insights/plugins/adoption-insights/README.md
+++ b/workspaces/adoption-insights/plugins/adoption-insights/README.md
@@ -35,6 +35,10 @@ yarn workspace app-legacy add @red-hat-developer-hub/backstage-plugin-adoption-i
 
 The Adoption Insights plugin has support for the permission framework.
 
+When using the **new frontend system**, the Adoption Insights page is registered with an `if` predicate for `adoption-insights.events.read`. When permission checks deny access, the page and sidebar entry are not registered for that session.
+
+> **Legacy (OFS) note:** The `./legacy` entry point still uses `usePermission` on the page and shows a permission-required empty state on direct navigation. The legacy sidebar item is not gated.
+
 - When [RBAC permission](https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend#installation) framework is enabled, for non-admin users to access adoption insights UI, the role associated with your user should have the following permission policies associated with it. Add the following in your permission policies configuration file named `rbac-policy.csv`:
 
 ```CSV

--- a/workspaces/adoption-insights/plugins/adoption-insights/dev/index.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/dev/index.tsx
@@ -43,6 +43,7 @@ import {
 } from '@backstage/dev-utils';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { rhdhThemeModule } from '@red-hat-developer-hub/backstage-plugin-theme/alpha';
 
 import adoptionInsightsPlugin, {
@@ -52,6 +53,10 @@ import { adoptionInsightsApiRef } from '../src/api';
 import { MockAdoptionInsightsApiClient, mockCatalogApi } from './mocks';
 
 const DEFAULT_PATH = '/adoption-insights';
+
+function isPermissionDeniedPath(pathname: string): boolean {
+  return pathname.includes('permission-denied');
+}
 
 function makeMockApi<T>(name: string, api: ApiRef<T>, factory: () => T) {
   return ApiBlueprint.make({
@@ -119,6 +124,23 @@ const devNavModule = createFrontendModule({
       params: {
         component: ({ items }) => <DevSidebar items={items} />,
       },
+    }),
+    // Extension `if` predicates need a permission API. Mock it locally so
+    // isolated `yarn start` still shows the page; open /permission-denied to
+    // preview hidden nav for unauthorized users.
+    ApiBlueprint.make({
+      name: 'permission',
+      params: defineParams =>
+        defineParams({
+          api: permissionApiRef,
+          deps: {},
+          factory: () => ({
+            authorize: async () =>
+              isPermissionDeniedPath(window.location.pathname)
+                ? { result: 'DENY' as const }
+                : { result: 'ALLOW' as const },
+          }),
+        }),
     }),
   ],
 });

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/index.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/index.tsx
@@ -30,11 +30,19 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { TranslationBlueprint } from '@backstage/plugin-app-react';
 import MUIAdoptionInsightsIcon from '@mui/icons-material/QueryStatsOutlined';
+import { adoptionInsightsEventsReadPermission } from '@red-hat-developer-hub/backstage-plugin-adoption-insights-common';
 import { rootRouteRef } from './routes';
 import { AdoptionInsightsApiClient, adoptionInsightsApiRef } from './api';
 import { adoptionInsightsTranslations } from './translations';
 
+const adoptionInsightsAccess = {
+  permissions: {
+    $contains: `${adoptionInsightsEventsReadPermission.name}#read`,
+  },
+};
+
 const adoptionInsightsPage = PageBlueprint.make({
+  if: adoptionInsightsAccess,
   params: {
     title: 'Adoption Insights',
     icon: <MUIAdoptionInsightsIcon />,

--- a/workspaces/adoption-insights/plugins/adoption-insights/src/nfsExports.test.tsx
+++ b/workspaces/adoption-insights/plugins/adoption-insights/src/nfsExports.test.tsx
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { coreExtensionData } from '@backstage/frontend-plugin-api';
 import { createExtensionTester } from '@backstage/frontend-test-utils';
 
@@ -23,6 +26,8 @@ import {
   adoptionInsightsTranslations,
 } from './alpha';
 import { rootRouteRef } from './routes';
+
+const nfsPluginSource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf8');
 
 describe('adoption-insights NFS exports', () => {
   it('should export a valid frontend plugin', () => {
@@ -54,6 +59,15 @@ describe('adoption-insights NFS exports', () => {
     expect(adoptionInsightsTranslations).toBeDefined();
     expect(adoptionInsightsTranslationRef).toBeDefined();
     expect(adoptionInsightsTranslationRef.id).toBe('plugin.adoption-insights');
+  });
+
+  it('registers the Adoption Insights page with an events.read permission if predicate', () => {
+    expect(nfsPluginSource).toMatch(
+      /PageBlueprint\.make\(\{[\s\S]*?if:\s*adoptionInsightsAccess/,
+    );
+    expect(nfsPluginSource).toMatch(
+      /\$contains:\s*`\$\{adoptionInsightsEventsReadPermission\.name\}#read`/,
+    );
   });
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Resolves:**
https://redhat.atlassian.net/browse/RHIDP-15543


**Solution description:**
- Register the NFS Adoption Insights page with an **if predicate** (`permissions: { $contains: 'adoption-insights.events.read#read' }`) so the page and sidebar entry are only shown when the user is allowed `adoption-insights.events.read`.
- Keep the existing `usePermission` check on `AdoptionInsightsPage` for the legacy (OFS) flow, which still shows the permission-required empty state on direct navigation. The OFS sidebar item is not gated.
- Add Playwright permission e2e tests (allow/deny for sidebar and page access) with multi-locale support, plus a unit test that the NFS page is registered with the predicate.
- Update the frontend and backend READMEs to document NFS permission-based visibility.

## Screenshot:
<img width="1917" height="1005" alt="image" src="https://github.com/user-attachments/assets/866daaba-7408-4a07-9359-540accd93763" />


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [x] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
