### PR TITLE
feat(dcm): forward OIDC tokens and support auth-disabled deployments (FLPATH-4480)

### DIFF
--- a/workspaces/dcm/README.md
+++ b/workspaces/dcm/README.md
@@ -30,3 +30,22 @@ This runs the full app and backend concurrently (frontend at http://localhost:30
 - **yarn start:dev** – Run both plugins in standalone mode (no full app/backend).
 
 Configuration is in `app-config.yaml`. Example catalog data is in `examples/`.
+
+## Authentication
+
+Set `dcm.auth.enabled` to match the DCM control plane's `auth.enabled` setting.
+
+- When enabled, the DCM UI uses the signed-in user's OIDC access token. Configure
+  an OIDC provider in RHDH `auth.providers`, including its metadata URL, client
+  ID, and client secret. The proxy requires normal RHDH/Backstage credentials
+  and the user token, then forwards that token to DCM as an upstream Bearer
+  token.
+- When disabled, the UI does not require an OIDC provider or send an upstream
+  Bearer token. The proxy still requires normal RHDH/Backstage credentials, so
+  the standalone and guest-only configurations use the guest session. DCM then
+  applies its auth-disabled system actor rather than a per-user identity.
+
+The standalone local configuration uses DCM auth-disabled mode. The proxy never
+uses its shared `client_credentials` token for normal UI requests. Do not
+configure or expose OIDC access tokens as static application configuration
+values.

--- a/workspaces/dcm/app-config.production.yaml
+++ b/workspaces/dcm/app-config.production.yaml
@@ -11,9 +11,16 @@ backend:
     connection: ':memory:'
 
 dcm:
+  # Keep this aligned with the DCM control plane's auth.enabled setting.
+  auth:
+    enabled: ${DCM_AUTH_ENABLED:-false}
+  # Base URL of the DCM control plane.
   apiUrl: ${DCM_API_URL:-}
   # Legacy env var; kept until deploy configs switch to DCM_API_URL.
   apiGatewayUrl: ${DCM_API_GATEWAY_URL:-}
+  # These settings are used only by the separately permission-protected token
+  # endpoint. Normal DCM UI proxy requests forward the signed-in user's OIDC
+  # token and do not use this shared client-credentials flow.
   ssoBaseUrl: ${DCM_SSO_BASE_URL:-}
   clientId: ${DCM_CLIENT_ID:-}
   clientSecret: ${DCM_CLIENT_SECRET:-}

--- a/workspaces/dcm/app-config.yaml
+++ b/workspaces/dcm/app-config.yaml
@@ -41,7 +41,15 @@ techdocs:
 
 auth:
   providers:
+    # Local development only. Replace this with the OIDC provider below for
+    # a deployed environment.
     guest: {}
+    # oidc:
+    #   production:
+    #     metadataUrl: https://keycloak.example.com/realms/rhdh/.well-known/openid-configuration
+    #     clientId: rhdh-auth
+    #     clientSecret: ${AUTH_OIDC_CLIENT_SECRET}
+    #     prompt: auto
 
 permission:
   enabled: true
@@ -61,6 +69,9 @@ permission:
 scaffolder: {}
 
 dcm:
+  # The standalone app uses the DCM control plane's auth-disabled mode.
+  auth:
+    enabled: false
   policyPacks:
     - security-baseline
     - compliance-pci
@@ -70,10 +81,10 @@ dcm:
   # Override in app-config.local.yaml for local development.
   # apiUrl: https://your-control-plane.example.com
   #
-  # SSO credentials for the backend to obtain a bearer token:
-  # ssoBaseUrl: https://sso.redhat.com
-  # clientId: your-client-id
-  # clientSecret: your-client-secret
+  # Set auth.enabled to true only when the DCM control plane's auth.enabled is
+  # also true. In that mode, configure an OIDC provider under auth.providers.
+  # The normal RHDH Authorization header authenticates the request to this
+  # backend, while the user's OIDC token is forwarded to DCM by the proxy.
 
 catalog:
   import:

--- a/workspaces/dcm/plugins/dcm-backend/app-config.dynamic.yaml
+++ b/workspaces/dcm/plugins/dcm-backend/app-config.dynamic.yaml
@@ -1,10 +1,13 @@
 dcm:
+  # Keep this aligned with the DCM control plane's auth.enabled setting.
+  auth:
+    enabled: ${DCM_AUTH_ENABLED:-true}
   # Base URL of the DCM control plane (required).
   apiUrl: ${DCM_API_URL}
   # Legacy env var; kept until deploy configs switch to DCM_API_URL.
   apiGatewayUrl: ${DCM_API_GATEWAY_URL}
 
-  # SSO configuration for the backend to obtain bearer tokens via
+  # SSO configuration for the separately permission-protected token endpoint.
   ssoBaseUrl: ${DCM_SSO_BASE_URL}
   clientId: ${DCM_CLIENT_ID}
   clientSecret: ${DCM_CLIENT_SECRET}

--- a/workspaces/dcm/plugins/dcm-backend/config.d.ts
+++ b/workspaces/dcm/plugins/dcm-backend/config.d.ts
@@ -40,6 +40,17 @@ export interface Config {
     apiGatewayUrl?: string;
 
     /**
+     * Whether the DCM control plane requires per-user OIDC authentication.
+     *
+     * Must match the control plane's `auth.enabled` setting.
+     *
+     * @visibility backend
+     */
+    auth?: {
+      enabled?: boolean;
+    };
+
+    /**
      * Base URL for the SSO token endpoint.
      *
      * Defaults to "https://sso.redhat.com".

--- a/workspaces/dcm/plugins/dcm-backend/src/routes/proxy.test.ts
+++ b/workspaces/dcm/plugins/dcm-backend/src/routes/proxy.test.ts
@@ -3,42 +3,29 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 /* eslint-disable @backstage/no-undeclared-imports -- deps in dcm-backend package.json */
 import { mockServices } from '@backstage/backend-test-utils';
+import type { JsonObject } from '@backstage/types';
 import express from 'express';
 import request from 'supertest';
 
 import { createDcmProxy } from './proxy';
 import type { RouterOptions } from '../models/RouterOptions';
 
-const TOKEN_RESPONSE = {
-  ok: true,
-  json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
-} as Response;
-
-function makeApp(configData: Record<string, Record<string, string>> = {}) {
+function makeApp(configData: JsonObject = {}, authenticated = true) {
   const options: RouterOptions = {
     logger: mockServices.rootLogger(),
     config: mockServices.rootConfig({ data: configData }),
     httpAuth: mockServices.httpAuth.mock({
-      credentials: jest.fn().mockResolvedValue({
-        principal: { userEntityRef: 'user:default/test' },
-      }),
+      credentials: authenticated
+        ? jest.fn().mockResolvedValue({
+            principal: { userEntityRef: 'user:default/test' },
+          })
+        : jest.fn().mockRejectedValue(new Error('unauthenticated')),
     }),
-    permissions: mockServices.permissions.mock({
-      authorize: jest.fn().mockResolvedValue([{ result: 'ALLOW' }]),
-    }),
+    permissions: mockServices.permissions.mock(),
     cache: mockServices.cache.mock(),
   };
   const app = express();
@@ -47,10 +34,13 @@ function makeApp(configData: Record<string, Record<string, string>> = {}) {
       type: ['application/json', 'application/merge-patch+json'],
     }),
   );
-  // Mount using a wildcard path matching the router convention
   app.all('/proxy/*', createDcmProxy(options));
   return app;
 }
+
+const dcmToken = 'user-oidc-token';
+const withDcmToken = (requestBuilder: request.Test) =>
+  requestBuilder.set('X-DCM-OIDC-Token', dcmToken);
 
 describe('createDcmProxy', () => {
   let fetchSpy: jest.SpyInstance;
@@ -60,195 +50,159 @@ describe('createDcmProxy', () => {
   });
 
   it('returns 503 when dcm.apiUrl is not configured', async () => {
-    const app = makeApp({ dcm: { clientId: 'id', clientSecret: 'secret' } });
-
-    const res = await request(app).get('/proxy/providers');
-
+    const app = makeApp();
+    const res = await withDcmToken(request(app).get('/proxy/providers'));
     expect(res.status).toBe(503);
-    expect(res.body).toMatchObject({
-      error: expect.stringContaining('not configured'),
-    });
   });
 
-  it('returns 502 when token acquisition fails', async () => {
-    fetchSpy = jest
-      .spyOn(globalThis, 'fetch')
-      .mockRejectedValueOnce(new Error('SSO unreachable'));
+  it('requires normal RHDH authentication', async () => {
+    const app = makeApp(
+      { dcm: { apiUrl: 'https://control-plane.example.com' } },
+      false,
+    );
+    const res = await withDcmToken(request(app).get('/proxy/providers'));
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain('RHDH authentication');
+  });
 
+  it('requires the per-user DCM OIDC token', async () => {
+    const app = makeApp({
+      dcm: { apiUrl: 'https://control-plane.example.com' },
+    });
+    const res = await request(app).get('/proxy/providers');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain('DCM OIDC authentication');
+  });
+
+  it('does not require or forward an OIDC token when DCM authentication is disabled', async () => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: { get: () => null },
+      text: async () => '{}',
+    } as unknown as Response);
     const app = makeApp({
       dcm: {
         apiUrl: 'https://control-plane.example.com',
-        clientId: 'id',
-        clientSecret: 'secret',
+        auth: { enabled: false },
       },
     });
 
     const res = await request(app).get('/proxy/providers');
 
-    expect(res.status).toBe(502);
-    expect(res.body).toMatchObject({
-      error: expect.stringContaining('access token'),
-    });
+    expect(res.status).toBe(200);
+    expect(fetchSpy.mock.calls[0][1].headers).not.toHaveProperty(
+      'Authorization',
+    );
+  });
+
+  it('still requires normal RHDH authentication when DCM authentication is disabled', async () => {
+    const app = makeApp(
+      {
+        dcm: {
+          apiUrl: 'https://control-plane.example.com',
+          auth: { enabled: false },
+        },
+      },
+      false,
+    );
+
+    const res = await request(app).get('/proxy/providers');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain('RHDH authentication');
   });
 
   it('returns 502 when the upstream fetch throws', async () => {
     fetchSpy = jest
       .spyOn(globalThis, 'fetch')
-      // First call: token fetch succeeds
-      .mockResolvedValueOnce(TOKEN_RESPONSE)
-      // Second call: upstream fetch throws
       .mockRejectedValueOnce(new Error('Connection refused'));
-
     const app = makeApp({
-      dcm: {
-        apiUrl: 'https://control-plane.example.com',
-        clientId: 'id',
-        clientSecret: 'secret',
-      },
+      dcm: { apiUrl: 'https://control-plane.example.com' },
     });
-
-    const res = await request(app).get('/proxy/providers');
-
+    const res = await withDcmToken(request(app).get('/proxy/providers'));
     expect(res.status).toBe(502);
-    expect(res.body).toMatchObject({
-      error: expect.stringContaining('DCM API'),
-    });
+    expect(res.body.error).toContain('DCM API');
   });
 
-  it('proxies a GET request and forwards the upstream response', async () => {
+  it('forwards the per-user token and preserves the request path', async () => {
     const upstreamBody = JSON.stringify({ items: [] });
-    fetchSpy = jest
-      .spyOn(globalThis, 'fetch')
-      // Token fetch
-      .mockResolvedValueOnce(TOKEN_RESPONSE)
-      // Upstream GET
-      .mockResolvedValueOnce({
-        status: 200,
-        ok: true,
-        headers: {
-          get: (h: string) =>
-            h === 'content-type' ? 'application/json' : null,
-        },
-        text: async () => upstreamBody,
-      } as unknown as Response);
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: {
+        get: (h: string) => (h === 'content-type' ? 'application/json' : null),
+      },
+      text: async () => upstreamBody,
+    } as unknown as Response);
 
     const app = makeApp({
-      dcm: {
-        apiUrl: 'https://control-plane.example.com',
-        clientId: 'id',
-        clientSecret: 'secret',
-      },
+      dcm: { apiUrl: 'https://control-plane.example.com' },
     });
-
-    const res = await request(app).get('/proxy/providers?foo=bar');
+    const res = await withDcmToken(
+      request(app).get('/proxy/providers?foo=bar'),
+    );
 
     expect(res.status).toBe(200);
     expect(res.text).toBe(upstreamBody);
-
-    // Verify upstream URL contains path and query param
-    const upstreamCall = fetchSpy.mock.calls[1];
-    expect(upstreamCall[0]).toContain('/api/v1alpha1/providers');
-    expect(upstreamCall[0]).toContain('foo=bar');
-
-    // Verify auth header was injected
-    expect(upstreamCall[1].headers.Authorization).toBe('Bearer test-token');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const upstreamCall = fetchSpy.mock.calls[0];
+    expect(upstreamCall[0]).toContain('/api/v1alpha1/providers?foo=bar');
+    expect(upstreamCall[1].headers.Authorization).toBe(`Bearer ${dcmToken}`);
   });
 
-  it('proxies a POST request and forwards the request body', async () => {
+  it('forwards a POST body', async () => {
     const requestBody = { name: 'my-provider' };
-    fetchSpy = jest
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(TOKEN_RESPONSE)
-      .mockResolvedValueOnce({
-        status: 201,
-        ok: true,
-        headers: {
-          get: (h: string) =>
-            h === 'content-type' ? 'application/json' : null,
-        },
-        text: async () => JSON.stringify(requestBody),
-      } as unknown as Response);
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      status: 201,
+      ok: true,
+      headers: {
+        get: (h: string) => (h === 'content-type' ? 'application/json' : null),
+      },
+      text: async () => JSON.stringify(requestBody),
+    } as unknown as Response);
 
     const app = makeApp({
-      dcm: {
-        apiUrl: 'https://control-plane.example.com',
-        clientId: 'id',
-        clientSecret: 'secret',
-      },
+      dcm: { apiUrl: 'https://control-plane.example.com' },
     });
-
-    const res = await request(app)
-      .post('/proxy/providers')
-      .send(requestBody)
-      .set('Content-Type', 'application/json');
+    const res = await withDcmToken(
+      request(app)
+        .post('/proxy/providers')
+        .send(requestBody)
+        .set('Content-Type', 'application/json'),
+    );
 
     expect(res.status).toBe(201);
-
-    const upstreamCall = fetchSpy.mock.calls[1];
+    const upstreamCall = fetchSpy.mock.calls[0];
     expect(upstreamCall[1].method).toBe('POST');
     expect(JSON.parse(upstreamCall[1].body)).toEqual(requestBody);
   });
 
-  it('proxies a PATCH request with application/merge-patch+json and forwards the body', async () => {
+  it('forwards a PATCH body and handles 204 responses', async () => {
     const patch = { display_name: 'updated', spec: { fields: [] } };
-    fetchSpy = jest
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(TOKEN_RESPONSE)
-      .mockResolvedValueOnce({
-        status: 200,
-        ok: true,
-        headers: {
-          get: (h: string) =>
-            h === 'content-type' ? 'application/json' : null,
-        },
-        text: async () => JSON.stringify(patch),
-      } as unknown as Response);
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      status: 204,
+      ok: true,
+      headers: { get: () => null },
+      text: async () => '',
+    } as unknown as Response);
 
     const app = makeApp({
-      dcm: {
-        apiUrl: 'https://control-plane.example.com',
-        clientId: 'id',
-        clientSecret: 'secret',
-      },
+      dcm: { apiGatewayUrl: 'https://gateway.example.com' },
     });
+    const res = await withDcmToken(
+      request(app)
+        .patch('/proxy/catalog-items/test-id')
+        .send(patch)
+        .set('Content-Type', 'application/merge-patch+json'),
+    );
 
-    const res = await request(app)
-      .patch('/proxy/catalog-items/test-id')
-      .send(patch)
-      .set('Content-Type', 'application/merge-patch+json');
-
-    expect(res.status).toBe(200);
-
-    const upstreamCall = fetchSpy.mock.calls[1];
+    expect(res.status).toBe(204);
+    const upstreamCall = fetchSpy.mock.calls[0];
     expect(upstreamCall[1].method).toBe('PATCH');
     expect(upstreamCall[1].headers['Content-Type']).toBe(
       'application/merge-patch+json',
     );
     expect(JSON.parse(upstreamCall[1].body)).toEqual(patch);
-  });
-
-  it('falls back to legacy dcm.apiGatewayUrl and handles 204 No Content', async () => {
-    fetchSpy = jest
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(TOKEN_RESPONSE)
-      .mockResolvedValueOnce({
-        status: 204,
-        ok: true,
-        headers: { get: () => null },
-        text: async () => '',
-      } as unknown as Response);
-
-    const app = makeApp({
-      dcm: {
-        apiGatewayUrl: 'https://gateway.example.com',
-        clientId: 'id',
-        clientSecret: 'secret',
-      },
-    });
-
-    const res = await request(app).delete('/proxy/providers/test-id');
-
-    expect(res.status).toBe(204);
-    expect(res.text).toBe('');
   });
 });

--- a/workspaces/dcm/plugins/dcm-backend/src/routes/proxy.ts
+++ b/workspaces/dcm/plugins/dcm-backend/src/routes/proxy.ts
@@ -16,9 +16,9 @@
 
 import type { Request, Response } from 'express';
 import type { RouterOptions } from '../models/RouterOptions';
-import { getTokenFromApi } from '../util/tokenUtil';
 
 const API_BASE_PATH = '/api/v1alpha1';
+const DCM_OIDC_TOKEN_HEADER = 'x-dcm-oidc-token';
 
 /**
  * Proxies all `ALL /proxy/*` requests to the DCM control plane.
@@ -26,7 +26,9 @@ const API_BASE_PATH = '/api/v1alpha1';
  * The wildcard path segment is appended to:
  *   `{dcm.apiUrl}/api/v1alpha1/<wildcardPath>`
  *
- * An SSO bearer token is injected automatically via `tokenUtil`.
+ * The authenticated user's OIDC access token is forwarded from the dedicated
+ * `X-DCM-OIDC-Token` header. The normal RHDH Authorization header remains
+ * available to Backstage's httpAuth service and is never replaced.
  */
 export function createDcmProxy(options: RouterOptions) {
   return async (req: Request, res: Response): Promise<void> => {
@@ -43,6 +45,26 @@ export function createDcmProxy(options: RouterOptions) {
       res
         .status(503)
         .json({ error: 'DCM API is not configured on the server.' });
+      return;
+    }
+
+    // Authenticate the caller with the normal RHDH/Backstage bearer token.
+    // This deliberately happens before reading the DCM token header so the
+    // custom header cannot be used to bypass RHDH authentication.
+    try {
+      await options.httpAuth.credentials(req);
+    } catch (_err) {
+      res.status(401).json({ error: 'RHDH authentication is required.' });
+      return;
+    }
+
+    const authEnabled = config.getOptionalBoolean('dcm.auth.enabled') ?? true;
+    const dcmOidcToken = req.headers[DCM_OIDC_TOKEN_HEADER];
+    if (
+      authEnabled &&
+      (typeof dcmOidcToken !== 'string' || !dcmOidcToken.trim())
+    ) {
+      res.status(401).json({ error: 'DCM OIDC authentication is required.' });
       return;
     }
 
@@ -63,27 +85,10 @@ export function createDcmProxy(options: RouterOptions) {
       `DCM proxy: ${req.method} ${req.path} → ${targetUrl.toString()}`,
     );
 
-    let tokenResult;
-    try {
-      tokenResult = await getTokenFromApi(options);
-    } catch (err) {
-      logger.error(`DCM proxy: failed to obtain access token — ${err}`);
-      res
-        .status(502)
-        .json({ error: 'Failed to obtain upstream access token.' });
-      return;
-    }
-
     const requestHeaders: Record<string, string> = {
       Accept: (req.headers.accept as string) || 'application/json',
+      ...(authEnabled ? { Authorization: `Bearer ${dcmOidcToken}` } : {}),
     };
-
-    // Only attach the Authorization header when an SSO token was obtained.
-    // When clientId/clientSecret are not configured the token is empty and
-    // the request is forwarded without auth (open/unauthenticated API).
-    if (tokenResult.accessToken) {
-      requestHeaders.Authorization = `Bearer ${tokenResult.accessToken}`;
-    }
 
     // Forward Content-Type for requests that carry a body
     if (req.headers['content-type']) {

--- a/workspaces/dcm/plugins/dcm-common/report.api.md
+++ b/workspaces/dcm/plugins/dcm-common/report.api.md
@@ -275,7 +275,11 @@ export interface DcmApiError {
 
 // @public
 export abstract class DcmBaseClient {
-  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    fetchApi: FetchApi;
+    getAccessToken?: DcmOidcTokenProvider;
+  });
   // (undocumented)
   protected readonly discoveryApi: DiscoveryApi;
   // (undocumented)
@@ -323,6 +327,11 @@ export interface DcmHealth {
   // (undocumented)
   status: string;
 }
+
+// @public
+export type DcmOidcTokenProvider = () =>
+  | Promise<string | undefined>
+  | undefined;
 
 // @public
 export const dcmPluginPermissions: BasicPermission[];

--- a/workspaces/dcm/plugins/dcm-common/src/clients/AgentsClient.test.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/AgentsClient.test.ts
@@ -43,7 +43,14 @@ function makeClient(fetchFn: jest.Mock) {
     getBaseUrl: jest.fn().mockResolvedValue(BASE_URL),
   };
   const fetchApi: FetchApi = { fetch: fetchFn };
-  return new AgentsClient({ discoveryApi, fetchApi });
+  const oidcAuthApi = {
+    getAccessToken: jest.fn().mockResolvedValue('oidc-token'),
+  };
+  return new AgentsClient({
+    discoveryApi,
+    fetchApi,
+    getAccessToken: oidcAuthApi.getAccessToken,
+  });
 }
 
 function okJson(data: unknown): Response {

--- a/workspaces/dcm/plugins/dcm-common/src/clients/CatalogClient.test.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/CatalogClient.test.ts
@@ -36,7 +36,14 @@ function makeClient(fetchFn: jest.Mock) {
     getBaseUrl: jest.fn().mockResolvedValue(BASE_URL),
   };
   const fetchApi: FetchApi = { fetch: fetchFn };
-  return new CatalogClient({ discoveryApi, fetchApi });
+  const oidcAuthApi = {
+    getAccessToken: jest.fn().mockResolvedValue('oidc-token'),
+  };
+  return new CatalogClient({
+    discoveryApi,
+    fetchApi,
+    getAccessToken: oidcAuthApi.getAccessToken,
+  });
 }
 
 function okJson(data: unknown): Response {

--- a/workspaces/dcm/plugins/dcm-common/src/clients/DcmBaseClient.test.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/DcmBaseClient.test.ts
@@ -34,12 +34,19 @@ class TestClient extends DcmBaseClient {
   }
 }
 
-function makeClient(fetchFn: jest.Mock) {
+function makeClient(fetchFn: jest.Mock, authEnabled = true) {
   const discoveryApi: DiscoveryApi = {
     getBaseUrl: jest.fn().mockResolvedValue('http://localhost/api/dcm'),
   };
   const fetchApi: FetchApi = { fetch: fetchFn };
-  return new TestClient({ discoveryApi, fetchApi });
+  const oidcAuthApi = {
+    getAccessToken: jest.fn().mockResolvedValue('oidc-token'),
+  };
+  return new TestClient({
+    discoveryApi,
+    fetchApi,
+    ...(authEnabled ? { getAccessToken: oidcAuthApi.getAccessToken } : {}),
+  });
 }
 
 describe('DcmBaseClient', () => {
@@ -57,8 +64,23 @@ describe('DcmBaseClient', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
+          'X-DCM-OIDC-Token': 'oidc-token',
         }),
       }),
+    );
+  });
+
+  it('does not add an OIDC token header when DCM authentication is disabled', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({}),
+    });
+    const client = makeClient(fetchFn, false);
+    await client.getItem('providers');
+
+    expect(fetchFn.mock.calls[0][1].headers).not.toHaveProperty(
+      'X-DCM-OIDC-Token',
     );
   });
 

--- a/workspaces/dcm/plugins/dcm-common/src/clients/DcmBaseClient.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/DcmBaseClient.ts
@@ -18,6 +18,12 @@ import type { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { DcmClientError } from '../errors/DcmClientError';
 
 const PLUGIN_ID = 'dcm';
+const DCM_OIDC_TOKEN_HEADER = 'X-DCM-OIDC-Token';
+
+/** Supplies a user OIDC access token when DCM authentication is enabled. @public */
+export type DcmOidcTokenProvider = () =>
+  | Promise<string | undefined>
+  | undefined;
 
 /**
  * Base class shared by all DCM API clients.
@@ -30,22 +36,33 @@ const PLUGIN_ID = 'dcm';
 export abstract class DcmBaseClient {
   protected readonly discoveryApi: DiscoveryApi;
   protected readonly fetchApi: FetchApi;
+  private readonly getAccessToken?: DcmOidcTokenProvider;
 
   /** Human-readable service name used in error messages, e.g. "Catalog". */
   protected abstract readonly serviceName: string;
 
-  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi }) {
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    fetchApi: FetchApi;
+    getAccessToken?: DcmOidcTokenProvider;
+  }) {
     this.discoveryApi = options.discoveryApi;
     this.fetchApi = options.fetchApi;
+    this.getAccessToken = options.getAccessToken;
   }
 
   protected async fetch<T>(path: string, init?: RequestInit): Promise<T> {
     const baseUrl = await this.discoveryApi.getBaseUrl(PLUGIN_ID);
     const url = `${baseUrl}/proxy/${path}`;
     const { headers: initHeaders, ...initRest } = init ?? {};
+    const accessToken = await this.getAccessToken?.();
     const response = await this.fetchApi.fetch(url, {
       ...initRest,
-      headers: { 'Content-Type': 'application/json', ...initHeaders },
+      headers: {
+        'Content-Type': 'application/json',
+        ...initHeaders,
+        ...(accessToken ? { [DCM_OIDC_TOKEN_HEADER]: accessToken } : {}),
+      },
     });
     if (response.status === 204) {
       return undefined as unknown as T;

--- a/workspaces/dcm/plugins/dcm-common/src/clients/index.ts
+++ b/workspaces/dcm/plugins/dcm-common/src/clients/index.ts
@@ -19,7 +19,7 @@ export type { PolicyManagerApi } from './PolicyManagerApi';
 export type { AgentsApi } from './AgentsApi';
 export type { ResourcesApi } from './ResourcesApi';
 
-export { DcmBaseClient } from './DcmBaseClient';
+export { DcmBaseClient, type DcmOidcTokenProvider } from './DcmBaseClient';
 export { CatalogClient } from './CatalogClient';
 export { PolicyManagerClient } from './PolicyManagerClient';
 export { AgentsClient } from './AgentsClient';

--- a/workspaces/dcm/plugins/dcm/app-config.dynamic.yaml
+++ b/workspaces/dcm/plugins/dcm/app-config.dynamic.yaml
@@ -1,3 +1,8 @@
+dcm:
+  # Keep this aligned with the DCM control plane's auth.enabled setting.
+  auth:
+    enabled: ${DCM_AUTH_ENABLED:-true}
+
 dynamicPlugins:
   frontend:
     red-hat-developer-hub.backstage-plugin-dcm:

--- a/workspaces/dcm/plugins/dcm/config.d.ts
+++ b/workspaces/dcm/plugins/dcm/config.d.ts
@@ -23,5 +23,16 @@ export interface Config {
      * @visibility frontend
      */
     policyPacks?: string[];
+
+    /**
+     * Whether the DCM control plane requires per-user OIDC authentication.
+     *
+     * Must match the control plane's `auth.enabled` setting.
+     *
+     * @visibility frontend
+     */
+    auth?: {
+      enabled?: boolean;
+    };
   };
 }

--- a/workspaces/dcm/plugins/dcm/src/DcmAuth.test.ts
+++ b/workspaces/dcm/plugins/dcm/src/DcmAuth.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getDcmAccessToken, setDcmAccessTokenProvider } from './DcmAuth';
+
+describe('DcmAuth', () => {
+  afterEach(() => setDcmAccessTokenProvider(undefined));
+
+  it('does not supply a token when DCM authentication is disabled', async () => {
+    setDcmAccessTokenProvider(undefined);
+
+    expect(getDcmAccessToken()).toBeUndefined();
+  });
+
+  it('gets a token from the configured OIDC provider', async () => {
+    const getAccessToken = jest.fn().mockResolvedValue('oidc-token');
+    setDcmAccessTokenProvider(getAccessToken);
+
+    await expect(getDcmAccessToken()).resolves.toBe('oidc-token');
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/workspaces/dcm/plugins/dcm/src/DcmAuth.ts
+++ b/workspaces/dcm/plugins/dcm/src/DcmAuth.ts
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
-import { wrapInTestApp } from '@backstage/test-utils';
-import { Router } from './Router';
+import type { DcmOidcTokenProvider } from '@red-hat-developer-hub/backstage-plugin-dcm-common';
 
-jest.mock('./pages/data-center/DataCenterPage', () => ({
-  DataCenterPage: () => <div>DataCenterPage</div>,
-}));
+let accessTokenProvider: DcmOidcTokenProvider | undefined;
 
-jest.mock('./DcmAuth', () => ({
-  setDcmAccessTokenProvider: jest.fn(),
-}));
+/** Configures the OIDC token provider used by the DCM API clients. */
+export function setDcmAccessTokenProvider(
+  provider: DcmOidcTokenProvider | undefined,
+) {
+  accessTokenProvider = provider;
+}
 
-describe('Router', () => {
-  it('renders DataCenterPage on the default route', () => {
-    render(wrapInTestApp(<Router />));
-    expect(screen.getByText('DataCenterPage')).toBeInTheDocument();
-  });
-});
+/** Gets an OIDC token when DCM authentication is enabled. */
+export function getDcmAccessToken() {
+  return accessTokenProvider?.();
+}

--- a/workspaces/dcm/plugins/dcm/src/Router.tsx
+++ b/workspaces/dcm/plugins/dcm/src/Router.tsx
@@ -15,8 +15,33 @@
  */
 
 import { ErrorBoundary } from '@backstage/core-components';
+import type { ReactNode } from 'react';
+import { configApiRef, useApi, useApiHolder } from '@backstage/core-plugin-api';
 import { Routes, Route } from 'react-router-dom';
 import { DataCenterPage } from './pages/data-center/DataCenterPage';
+import { oidcAuthApiRef } from './api/AuthApiRefs';
+import { setDcmAccessTokenProvider } from './DcmAuth';
+
+function DcmAuthConfigurator({ children }: { children: ReactNode }) {
+  const configApi = useApi(configApiRef);
+  const apiHolder = useApiHolder();
+  const authEnabled = configApi.getOptionalBoolean('dcm.auth.enabled') ?? true;
+  const oidcAuthApi = authEnabled ? apiHolder.get(oidcAuthApiRef) : undefined;
+
+  setDcmAccessTokenProvider(
+    authEnabled
+      ? oidcAuthApi?.getAccessToken.bind(oidcAuthApi) ??
+          (() =>
+            Promise.reject(
+              new Error(
+                'DCM authentication is enabled, but the host does not provide internal.auth.oidc.',
+              ),
+            ))
+      : undefined,
+  );
+
+  return <>{children}</>;
+}
 
 /**
  * Plugin-level router. All DCM routes are defined here (app mounts at /dcm/*).
@@ -26,9 +51,11 @@ import { DataCenterPage } from './pages/data-center/DataCenterPage';
 export function Router() {
   return (
     <ErrorBoundary>
-      <Routes>
-        <Route path="*" element={<DataCenterPage />} />
-      </Routes>
+      <DcmAuthConfigurator>
+        <Routes>
+          <Route path="*" element={<DataCenterPage />} />
+        </Routes>
+      </DcmAuthConfigurator>
     </ErrorBoundary>
   );
 }

--- a/workspaces/dcm/plugins/dcm/src/api/AuthApiRefs.ts
+++ b/workspaces/dcm/plugins/dcm/src/api/AuthApiRefs.ts
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
-import { wrapInTestApp } from '@backstage/test-utils';
-import { Router } from './Router';
+import {
+  createApiRef,
+  type ApiRef,
+  type OAuthApi,
+  type OpenIdConnectApi,
+} from '@backstage/core-plugin-api';
 
-jest.mock('./pages/data-center/DataCenterPage', () => ({
-  DataCenterPage: () => <div>DataCenterPage</div>,
-}));
-
-jest.mock('./DcmAuth', () => ({
-  setDcmAccessTokenProvider: jest.fn(),
-}));
-
-describe('Router', () => {
-  it('renders DataCenterPage on the default route', () => {
-    render(wrapInTestApp(<Router />));
-    expect(screen.getByText('DataCenterPage')).toBeInTheDocument();
-  });
+/** RHDH's OIDC API, provided by the host application. */
+export const oidcAuthApiRef: ApiRef<OAuthApi & OpenIdConnectApi> = createApiRef<
+  OAuthApi & OpenIdConnectApi
+>({
+  id: 'internal.auth.oidc',
 });

--- a/workspaces/dcm/plugins/dcm/src/plugin.ts
+++ b/workspaces/dcm/plugins/dcm/src/plugin.ts
@@ -42,6 +42,7 @@ import {
   policyManagerApiRef,
   resourcesApiRef,
 } from './apis';
+import { getDcmAccessToken } from './DcmAuth';
 
 /**
  * DCM plugin instance.
@@ -64,28 +65,44 @@ export const dcmPlugin = createPlugin({
       api: catalogApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory({ discoveryApi, fetchApi }) {
-        return new CatalogClient({ discoveryApi, fetchApi });
+        return new CatalogClient({
+          discoveryApi,
+          fetchApi,
+          getAccessToken: getDcmAccessToken,
+        });
       },
     }),
     createApiFactory({
       api: policyManagerApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory({ discoveryApi, fetchApi }) {
-        return new PolicyManagerClient({ discoveryApi, fetchApi });
+        return new PolicyManagerClient({
+          discoveryApi,
+          fetchApi,
+          getAccessToken: getDcmAccessToken,
+        });
       },
     }),
     createApiFactory({
       api: agentsApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory({ discoveryApi, fetchApi }) {
-        return new AgentsClient({ discoveryApi, fetchApi });
+        return new AgentsClient({
+          discoveryApi,
+          fetchApi,
+          getAccessToken: getDcmAccessToken,
+        });
       },
     }),
     createApiFactory({
       api: resourcesApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory({ discoveryApi, fetchApi }) {
-        return new ResourcesClient({ discoveryApi, fetchApi });
+        return new ResourcesClient({
+          discoveryApi,
+          fetchApi,
+          getAccessToken: getDcmAccessToken,
+        });
       },
     }),
   ],


### PR DESCRIPTION
FLPATH-4480\n\nhttps://redhat.atlassian.net/browse/FLPATH-4480\n\nForward signed-in users' OIDC access tokens to authenticated DCM control planes while preserving RHDH authentication. Support DCM auth-disabled deployments and guest-only development without an IdP.