### PR TITLE
test(intelligent-assistant): RHIDP-14721 /skills RTL todos (QE-only)

### DIFF
--- a/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/LightspeedChat.test.tsx
+++ b/workspaces/intelligent-assistant/plugins/intelligent-assistant/src/components/__tests__/LightspeedChat.test.tsx
@@ -1203,4 +1203,20 @@ describe('LightspeedChat', () => {
       ).toBeInTheDocument();
     });
   });
+
+  /**
+   * RHIDP-14721 — L3 /skills command UI (mocked API).
+   * Blocked on frontend implementation in RHIDP-14222; QE adds tests only.
+   */
+  describe('RHIDP-14721 /skills slash command', () => {
+    it.todo(
+      'lists skill name and description when GET /v1/skills returns skills (blocked on RHIDP-14222)',
+    );
+    it.todo(
+      'shows empty-state copy when GET /v1/skills returns no skills (blocked on RHIDP-14222)',
+    );
+    it.todo(
+      'shows permission-denied copy when user lacks intelligent-assistant.skills (blocked on RHIDP-14222)',
+    );
+  });
 });


### PR DESCRIPTION
## Description

QE-only PR for [RHIDP-14721](https://redhat.atlassian.net/browse/RHIDP-14721). Adds `it.todo` placeholders in `LightspeedChat.test.tsx` for the three L3 acceptance criteria (loaded skills list, empty state, permission-denied).

**No production code** and **no changeset** — runnable RTL assertions are blocked until frontend [RHIDP-14222](https://redhat.atlassian.net/browse/RHIDP-14222) ships `/skills` slash command UI.

## Related
- [RHIDP-14721](https://redhat.atlassian.net/browse/RHIDP-14721) — [L3] /skills command UI — list, empty, and permission-denied (mocked API)
- [RHIDP-14222](https://redhat.atlassian.net/browse/RHIDP-14222) — Frontend `/skills` slash command (blocker)

## Test Plan
- [x] `yarn test src/components/__tests__/LightspeedChat.test.tsx --watchAll=false` (35 passed, 3 todo)

## Checklist
- [ ] A changeset describing the change and affected packages — **N/A (test-only)**
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)