### PR TITLE
fix(theme): prevent entity page content clipping

### DIFF
--- a/workspaces/theme/.changeset/entity-page-layout.md
+++ b/workspaces/theme/.changeset/entity-page-layout.md
@@ -1,0 +1,6 @@
+---
+'@red-hat-developer-hub/backstage-plugin-theme': patch
+---
+
+Fix the RHDH entity-page layout so content can grow beyond the viewport without
+being clipped by the main content container.

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.test.ts
@@ -125,12 +125,14 @@ describe('createComponents', () => {
     const desktop = root?.['@media (min-width: 600px)'] as
       | Record<string, unknown>
       | undefined;
-    expect(desktop?.['& > main:not([data-backstage-core-page])']).toEqual(
+    expect(desktop?.['& > main:has([class*="bui-Container"])']).toEqual(
       expect.objectContaining({
         display: 'flex',
         flexDirection: 'column',
-        flex: 1,
-        minHeight: 0,
+        flex: '1 0 auto',
+        minHeight: 'calc(100vh - 2 * 1.5rem)',
+        height: 'auto',
+        maxHeight: 'none !important',
       }),
     );
   });

--- a/workspaces/theme/plugins/theme/src/utils/createComponents.ts
+++ b/workspaces/theme/plugins/theme/src/utils/createComponents.ts
@@ -815,17 +815,17 @@ export const createComponents = (themeConfig: ThemeConfig): Components => {
               // Prevent overflow in the main container due to the margin
               maxHeight: `calc(100vh - 2 * ${general.pageInset})`,
             },
-            // NFS BUI entity pages wrap PluginHeader + tabs + Container in a
-            // classless <main>. BUI Container is flex: 1 1 0% but that only
-            // grows when main is a flex column — otherwise Topology / Scorecard
-            // stay content-height inside a tall well (RHDHBUGS-3543). Do not
-            // override Backstage Page, which uses display:grid on <main>.
-            '& > main:not([data-backstage-core-page])': {
+            // NFS BUI entity pages wrap their content in a BUI Container inside
+            // a classless <main>. The Container is flex: 1 1 0%, but that only
+            // grows when main is a flex column. Keep the main content at least
+            // viewport-height while allowing longer entity pages to grow.
+            '& > main:has([class*="bui-Container"])': {
               display: 'flex',
               flexDirection: 'column',
-              flex: 1,
-              minHeight: 0,
-              maxHeight: `calc(100% - 2 * ${general.pageInset})`,
+              flex: '1 0 auto',
+              minHeight: `calc(100vh - 2 * ${general.pageInset})`,
+              height: 'auto',
+              maxHeight: 'none !important',
             },
             // NFS / BUI pages use Container instead of <main>. Match the content
             // well color (same token as BackstageContent) and rely on flex: 1


### PR DESCRIPTION
## Summary

- Fix the RHDH entity-page main-content layout so longer pages can grow beyond the viewport.
- Scope the flex layout override to BUI entity pages instead of relying on the previous broad main selector.
- Add regression coverage for the updated layout values.
- Include a patch changeset for the published theme package.

## Validation

- Focused theme package tests: 5 suites / 26 tests passed
- yarn prettier:check passed
- Changeset status passed

The workspace-wide theme TypeScript check still reports unrelated existing errors in plugins/bui-test/src/components/OtherExample.tsx.